### PR TITLE
feat: make debug endpoints compact-aware

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/activity.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/activity.rs
@@ -192,11 +192,19 @@ pub async fn build_debug_bundle(state: &AdminState, lookup_id: &str) -> Option<V
     let postmortem = build_postmortem(state, primary_trace, gateway_events).await;
     let primary_trace_value = primary_trace.cloned();
     let hints = debug_hints(primary_trace);
+    let root_cause = primary_audit
+        .and_then(|record| record.error.clone())
+        .or_else(|| {
+            primary_trace
+                .filter(|trace| !trace.ok)
+                .and_then(|_| hints.first().cloned())
+        });
     Some(json!({
         "lookup_id": lookup_id,
         "request_id": primary_request_id,
         "trace_id": trace_id,
         "request_ids": request_ids,
+        "root_cause": root_cause,
         "audit": primary_audit.map(audit_event),
         "audits": matching_audits.iter().map(audit_event).collect::<Vec<_>>(),
         "trace": primary_trace_value,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/compact.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/compact.rs
@@ -1,0 +1,259 @@
+//! Compact projections for agent-facing admin/debug responses.
+
+use serde_json::{Value, json};
+
+#[derive(Default)]
+struct PayloadPreviewStats {
+    preview_count: usize,
+    truncated_count: usize,
+    redacted_marker_count: usize,
+}
+
+pub(crate) fn compact_debug_bundle_payload(bundle: &Value) -> Value {
+    let postmortem = bundle.get("postmortem").unwrap_or(&Value::Null);
+    let trace = bundle.get("trace").unwrap_or(&Value::Null);
+    json!({
+        "schema_version": "dcc-mcp.admin.debug-summary.v1",
+        "lookup_id": field(bundle, &["lookup_id"]),
+        "request_id": field(bundle, &["request_id"]),
+        "trace_id": field(bundle, &["trace_id"]),
+        "request_ids": field(bundle, &["request_ids"]),
+        "status": status_for_bundle(bundle),
+        "root_cause": sanitized_root_cause(first_present(&[
+            field(bundle, &["root_cause"]),
+            first_hint(bundle),
+        ])),
+        "tool": first_present(&[
+            field(trace, &["tool_slug"]),
+            field(trace, &["method"]),
+            field(postmortem, &["target", "tool"]),
+        ]),
+        "dcc_type": first_present(&[
+            field(trace, &["dcc_type"]),
+            field(postmortem, &["target", "dcc_type"]),
+        ]),
+        "total_ms": first_present(&[
+            field(trace, &["total_ms"]),
+            field(postmortem, &["target", "total_ms"]),
+        ]),
+        "token_accounting": first_present(&[
+            field(trace, &["token_accounting"]),
+            field(bundle, &["audit", "token_accounting"]),
+        ]),
+        "redaction": payload_preview_summary(bundle),
+        "postmortem": {
+            "previous_call_count": array_len(postmortem, &["previous_calls"]),
+            "gateway_event_count": array_len(postmortem, &["gateway_events"]),
+        },
+        "links": field(bundle, &["links"]),
+        "hints": field(bundle, &["hints"]),
+    })
+}
+
+pub(crate) fn compact_trace_detail_payload(trace: &Value) -> Value {
+    json!({
+        "schema_version": "dcc-mcp.admin.trace-summary.v1",
+        "request_id": field(trace, &["request_id"]),
+        "trace_id": field(trace, &["trace_id"]),
+        "parent_request_id": field(trace, &["parent_request_id"]),
+        "status": status_for_trace(trace),
+        "tool": first_present(&[
+            field(trace, &["tool_slug"]),
+            field(trace, &["tool"]),
+            field(trace, &["method"]),
+        ]),
+        "dcc_type": field(trace, &["dcc_type"]),
+        "instance_id": field(trace, &["instance_id"]),
+        "transport": field(trace, &["transport"]),
+        "total_ms": field(trace, &["total_ms"]),
+        "span_count": array_len(trace, &["spans"]),
+        "slowest_span": slowest_span(trace),
+        "payload_tokens": {
+            "input_tokens": field(trace, &["input_tokens"]),
+            "output_tokens": field(trace, &["output_tokens"]),
+            "total_tokens": first_present(&[
+                field(trace, &["total_tokens"]),
+                field(trace, &["estimated_total_tokens"]),
+            ]),
+            "token_estimator": field(trace, &["payload_token_estimator"]),
+        },
+        "response_token_accounting": field(trace, &["token_accounting"]),
+        "redaction": payload_preview_summary(trace),
+        "links": field(trace, &["links"]),
+    })
+}
+
+pub(crate) fn compact_trace_list_payload(payload: &Value) -> Value {
+    let traces: Vec<Value> = payload
+        .get("traces")
+        .and_then(Value::as_array)
+        .map(|items| items.iter().map(compact_trace_detail_payload).collect())
+        .unwrap_or_default();
+    json!({
+        "total": field(payload, &["total"]),
+        "traces": traces,
+        "links": field(payload, &["links"]),
+    })
+}
+
+pub(crate) fn compact_trace_context_payload(payload: &Value) -> Value {
+    json!({
+        "lookup_id": field(payload, &["lookup_id"]),
+        "request_id": field(payload, &["request_id"]),
+        "trace_id": field(payload, &["trace_id"]),
+        "request_ids": field(payload, &["request_ids"]),
+        "trace": compact_trace_detail_payload(payload.get("trace").unwrap_or(&Value::Null)),
+        "trace_count": array_len(payload, &["traces"]),
+        "links": field(payload, &["links"]),
+    })
+}
+
+fn field(value: &Value, path: &[&str]) -> Value {
+    let mut current = value;
+    for key in path {
+        let Some(next) = current.get(*key) else {
+            return Value::Null;
+        };
+        current = next;
+    }
+    current.clone()
+}
+
+fn first_present(values: &[Value]) -> Value {
+    values
+        .iter()
+        .find(|value| !value.is_null())
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
+fn sanitized_root_cause(value: Value) -> Value {
+    let Some(text) = value.as_str() else {
+        return value;
+    };
+    let lower = text.to_ascii_lowercase();
+    let kind = if lower.contains("timeout") || lower.contains("timed out") {
+        "timeout"
+    } else if lower.contains("auth") || lower.contains("permission") || lower.contains("forbidden")
+    {
+        "auth"
+    } else if lower.contains("not found") || lower.contains("unknown") {
+        "not found"
+    } else if lower.contains("host_died")
+        || lower.contains("host died")
+        || lower.contains("connection refused")
+        || lower.contains("unreachable")
+        || lower.contains("disconnected")
+        || lower.contains("backend unavailable")
+    {
+        "host died"
+    } else if lower.contains("invalid") || lower.contains("validation") {
+        "validation"
+    } else if text.trim().is_empty() {
+        return Value::Null;
+    } else {
+        "error"
+    };
+    json!(kind)
+}
+
+fn first_hint(bundle: &Value) -> Value {
+    bundle
+        .get("hints")
+        .and_then(Value::as_array)
+        .and_then(|hints| hints.first())
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
+fn array_len(value: &Value, path: &[&str]) -> usize {
+    path.iter()
+        .try_fold(value, |current, key| current.get(*key))
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0)
+}
+
+fn status_for_bundle(bundle: &Value) -> Value {
+    first_present(&[
+        field(bundle, &["audit", "status"]),
+        status_for_trace(bundle.get("trace").unwrap_or(&Value::Null)),
+        field(bundle, &["postmortem", "target", "status"]),
+    ])
+}
+
+fn status_for_trace(trace: &Value) -> Value {
+    if let Some(status) = trace.get("status").filter(|value| !value.is_null()) {
+        return status.clone();
+    }
+    match trace.get("ok").and_then(Value::as_bool) {
+        Some(true) => json!("ok"),
+        Some(false) => json!("err"),
+        None => Value::Null,
+    }
+}
+
+fn slowest_span(trace: &Value) -> Value {
+    let Some(spans) = trace.get("spans").and_then(Value::as_array) else {
+        return Value::Null;
+    };
+    spans
+        .iter()
+        .max_by_key(|span| span.get("duration_ns").and_then(Value::as_u64).unwrap_or(0))
+        .map(|span| {
+            json!({
+                "name": field(span, &["name"]),
+                "duration_ms": span
+                    .get("duration_ns")
+                    .and_then(Value::as_u64)
+                    .map(|ns| ns / 1_000_000)
+                    .unwrap_or(0),
+                "ok": field(span, &["ok"]),
+            })
+        })
+        .unwrap_or(Value::Null)
+}
+
+fn payload_preview_summary(value: &Value) -> Value {
+    let mut stats = PayloadPreviewStats::default();
+    visit_payloads(value, &mut stats);
+    json!({
+        "payload_previews_omitted": true,
+        "payload_preview_count": stats.preview_count,
+        "truncated_payload_count": stats.truncated_count,
+        "redacted_marker_count": stats.redacted_marker_count,
+    })
+}
+
+fn visit_payloads(value: &Value, stats: &mut PayloadPreviewStats) {
+    match value {
+        Value::Object(map) => {
+            if map.contains_key("mime_type") && map.contains_key("original_size") {
+                stats.preview_count += 1;
+                if map.get("truncated").and_then(Value::as_bool) == Some(true) {
+                    stats.truncated_count += 1;
+                }
+                if map
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        let lower = content.to_ascii_lowercase();
+                        lower.contains("redacted") || content.contains("[REDACTED]")
+                    })
+                {
+                    stats.redacted_marker_count += 1;
+                }
+                return;
+            }
+            for child in map.values() {
+                visit_payloads(child, stats);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                visit_payloads(child, stats);
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/debug_response.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/debug_response.rs
@@ -1,0 +1,59 @@
+//! Shared response negotiation for stable admin/debug endpoints.
+
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::Response;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::gateway::response_codec::{ResponseFormat, negotiated_response_with_default};
+
+#[derive(Debug, Default, Deserialize)]
+pub struct DebugListQuery {
+    limit: Option<String>,
+    range: Option<String>,
+    response_format: Option<String>,
+    compact: Option<bool>,
+}
+
+impl DebugListQuery {
+    pub(crate) fn limit(&self, default: usize, max: usize) -> usize {
+        self.limit
+            .as_deref()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(default)
+            .clamp(1, max)
+    }
+
+    pub(crate) fn range(&self) -> &str {
+        self.range.as_deref().unwrap_or("all")
+    }
+
+    fn response_format_body(&self) -> Value {
+        let mut body = serde_json::Map::new();
+        if let Some(format) = self.response_format.as_deref() {
+            body.insert("response_format".to_string(), json!(format));
+        }
+        if let Some(compact) = self.compact {
+            body.insert("compact".to_string(), json!(compact));
+        }
+        Value::Object(body)
+    }
+}
+
+pub(crate) fn debug_response(
+    headers: &HeaderMap,
+    params: &DebugListQuery,
+    status: StatusCode,
+    legacy_json: Value,
+    compact_json: Option<Value>,
+) -> Response {
+    let request_body = params.response_format_body();
+    negotiated_response_with_default(
+        headers,
+        &request_body,
+        status,
+        legacy_json,
+        compact_json,
+        ResponseFormat::Json,
+    )
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -12,6 +12,7 @@ use dcc_mcp_gateway_core::naming::instance_short;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+use super::debug_response::{DebugListQuery, debug_response};
 use super::html::ADMIN_HTML;
 use super::issue_report::{IssueReportMode, issue_report_filename, issue_report_json};
 use super::links::AdminLinkBuilder;
@@ -116,21 +117,6 @@ pub async fn handle_admin_traffic_export(
         .unwrap_or_else(|_| HeaderValue::from_static("attachment")),
     );
     response
-}
-
-#[derive(Debug, Default, Deserialize)]
-pub struct DebugListQuery {
-    limit: Option<String>,
-}
-
-impl DebugListQuery {
-    fn limit(&self, default: usize, max: usize) -> usize {
-        self.limit
-            .as_deref()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(default)
-            .clamp(1, max)
-    }
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -918,14 +904,16 @@ pub async fn handle_admin_traces(
         .iter()
         .map(|trace| dispatch_trace_to_admin_row(trace, Some(links.clone())))
         .collect();
-    Json(json!({
+    let payload = json!({
         "total": mapped.len(),
         "traces": mapped,
         "links": {
             "admin_traces_url": links.panel_url("traces"),
             "stats_url": links.panel_url("stats"),
         }
-    }))
+    });
+    let compact = crate::gateway::admin::compact::compact_trace_list_payload(&payload);
+    debug_response(&headers, &params, StatusCode::OK, payload, Some(compact))
 }
 
 /// `GET /admin/api/traces/{request_id}` — full waterfall for one call.
@@ -935,30 +923,21 @@ pub async fn handle_admin_trace_detail(
     State(s): State<AdminState>,
     headers: HeaderMap,
     OriginalUri(uri): OriginalUri,
+    axum::extract::Query(params): axum::extract::Query<DebugListQuery>,
     axum::extract::Path(request_id): axum::extract::Path<String>,
 ) -> impl IntoResponse {
     let links = AdminLinkBuilder::from_request(&headers, &uri);
     if let Some(trace) = s.trace_log.as_ref().and_then(|log| log.get(&request_id)) {
-        return (
-            StatusCode::OK,
-            Json(trace_detail_json(
-                &trace,
-                Some(links.request_links(&request_id)),
-            )),
-        )
-            .into_response();
+        let payload = trace_detail_json(&trace, Some(links.request_links(&request_id)));
+        let compact = crate::gateway::admin::compact::compact_trace_detail_payload(&payload);
+        return debug_response(&headers, &params, StatusCode::OK, payload, Some(compact));
     }
     if let Some(ref lane) = s.admin_sqlite_lane {
         let r = lane.reader();
         if let Some(trace) = r.get_trace(&request_id) {
-            return (
-                StatusCode::OK,
-                Json(trace_detail_json(
-                    &trace,
-                    Some(links.request_links(&request_id)),
-                )),
-            )
-                .into_response();
+            let payload = trace_detail_json(&trace, Some(links.request_links(&request_id)));
+            let compact = crate::gateway::admin::compact::compact_trace_detail_payload(&payload);
+            return debug_response(&headers, &params, StatusCode::OK, payload, Some(compact));
         }
     }
     (
@@ -995,6 +974,7 @@ pub async fn handle_admin_debug_bundle(
     State(s): State<AdminState>,
     headers: HeaderMap,
     OriginalUri(uri): OriginalUri,
+    axum::extract::Query(params): axum::extract::Query<DebugListQuery>,
     axum::extract::Path(request_id): axum::extract::Path<String>,
 ) -> impl IntoResponse {
     let links = AdminLinkBuilder::from_request(&headers, &uri);
@@ -1006,7 +986,8 @@ pub async fn handle_admin_debug_bundle(
                 .unwrap_or(&request_id)
                 .to_string();
             bundle["links"] = links.request_links(&resolved_request_id);
-            (StatusCode::OK, Json(bundle)).into_response()
+            let compact = crate::gateway::admin::compact::compact_debug_bundle_payload(&bundle);
+            debug_response(&headers, &params, StatusCode::OK, bundle, Some(compact))
         }
         None => (
             StatusCode::NOT_FOUND,
@@ -1021,6 +1002,7 @@ pub async fn handle_v1_debug_trace_lookup(
     State(s): State<AdminState>,
     headers: HeaderMap,
     OriginalUri(uri): OriginalUri,
+    Query(params): Query<DebugListQuery>,
     Path(lookup_id): Path<String>,
 ) -> impl IntoResponse {
     let links = AdminLinkBuilder::from_request(&headers, &uri);
@@ -1039,7 +1021,8 @@ pub async fn handle_v1_debug_trace_lookup(
                 "traces": bundle.get("traces").cloned().unwrap_or_else(|| json!([])),
                 "links": links.request_links(request_id),
             });
-            (StatusCode::OK, Json(payload)).into_response()
+            let compact = crate::gateway::admin::compact::compact_trace_context_payload(&payload);
+            debug_response(&headers, &params, StatusCode::OK, payload, Some(compact))
         }
         None => (
             StatusCode::NOT_FOUND,
@@ -1089,11 +1072,12 @@ pub async fn handle_admin_issue_report(
 /// distribution.  Returns `{"range":"...", "total_calls":N, ...}`.
 pub async fn handle_admin_stats(
     State(s): State<AdminState>,
-    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+    headers: HeaderMap,
+    axum::extract::Query(params): axum::extract::Query<DebugListQuery>,
 ) -> impl IntoResponse {
     use crate::gateway::admin::stats::StatsRange;
 
-    let range_str = params.get("range").map(String::as_str).unwrap_or("all");
+    let range_str = params.range();
     let range = StatsRange::from_str(range_str);
 
     match &s.stats {
@@ -1121,9 +1105,10 @@ pub async fn handle_admin_stats(
                     json!(stats.success_rate * 100.0),
                 );
             }
-            Json(root)
+            debug_response(&headers, &params, StatusCode::OK, root.clone(), Some(root))
         }
-        None => Json(json!({
+        None => {
+            let root = json!({
             "error": "stats aggregator not available — admin feature may be disabled",
             "range": range_str,
             "total_calls": 0,
@@ -1141,7 +1126,9 @@ pub async fn handle_admin_stats(
             "payload_token_usage": crate::gateway::admin::stats::PayloadTokenUsageStats::empty(0),
             "token_usage": crate::gateway::admin::stats::TokenUsageStats::default(),
             "governance": crate::gateway::admin::governance::build_governance_stats(&s),
-        })),
+            });
+            debug_response(&headers, &params, StatusCode::OK, root.clone(), Some(root))
+        }
     }
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -45,6 +45,8 @@
 
 pub mod activity;
 mod agent_trace;
+mod compact;
+mod debug_response;
 pub mod governance;
 mod html;
 #[cfg(feature = "admin")]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -9,7 +9,7 @@ mod admin_tests {
 
     use axum::Router;
     use axum::body::to_bytes;
-    use axum::http::{Request, StatusCode};
+    use axum::http::{HeaderMap, Request, StatusCode, header};
     use parking_lot::Mutex;
     use serde_json::{Value, json};
     use tokio::sync::{RwLock, broadcast, oneshot, watch};
@@ -174,6 +174,27 @@ mod admin_tests {
         let status = resp.status();
         let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
         (status, String::from_utf8(bytes.to_vec()).unwrap())
+    }
+
+    async fn body_text_with_accept(
+        router: Router,
+        uri: &str,
+        accept: &str,
+    ) -> (StatusCode, HeaderMap, String) {
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header(header::ACCEPT, accept)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        (status, headers, String::from_utf8(bytes.to_vec()).unwrap())
     }
 
     fn audit_record(
@@ -1752,6 +1773,70 @@ sinks:
                 .as_str()
                 .is_some_and(|url| url.ends_with("/admin/api/debug-bundle/req-task"))
         );
+
+        let (compact_bundle_status, compact_bundle_headers, compact_bundle_text) =
+            body_text_with_accept(
+                v1_router.clone(),
+                "/v1/debug/bundles/trace-task",
+                crate::gateway::response_codec::TOON_MIME,
+            )
+            .await;
+        assert_eq!(compact_bundle_status, StatusCode::OK);
+        assert!(
+            compact_bundle_headers
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.starts_with(crate::gateway::response_codec::TOON_MIME))
+        );
+        assert_eq!(
+            compact_bundle_headers
+                .get(crate::gateway::response_codec::HEADER_RESPONSE_FORMAT)
+                .and_then(|value| value.to_str().ok()),
+            Some("toon")
+        );
+        assert!(
+            compact_bundle_headers
+                .get(crate::gateway::response_codec::HEADER_SAVED_TOKENS)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<usize>().ok())
+                .is_some_and(|value| value > 0)
+        );
+        assert!(compact_bundle_text.len() < serde_json::to_string(&v1_body).unwrap().len());
+        let compact_bundle: Value = toon_format::decode_default(&compact_bundle_text).unwrap();
+        assert_eq!(
+            compact_bundle["schema_version"],
+            "dcc-mcp.admin.debug-summary.v1"
+        );
+        assert_eq!(compact_bundle["request_id"], "req-task");
+        assert_eq!(compact_bundle["root_cause"], "host died");
+        assert_eq!(
+            compact_bundle["redaction"]["payload_previews_omitted"],
+            true
+        );
+        assert!(compact_bundle.get("trace").is_none());
+        assert!(!compact_bundle_text.contains("scene.ma"));
+        assert!(!compact_bundle_text.contains("[REDACTED]"));
+
+        let (compact_trace_status, compact_trace_headers, compact_trace_text) =
+            body_text_with_accept(
+                v1_router.clone(),
+                "/v1/debug/traces/req-task?response_format=toon",
+                "application/json",
+            )
+            .await;
+        assert_eq!(compact_trace_status, StatusCode::OK);
+        assert_eq!(
+            compact_trace_headers
+                .get(crate::gateway::response_codec::HEADER_RESPONSE_FORMAT)
+                .and_then(|value| value.to_str().ok()),
+            Some("toon")
+        );
+        let compact_trace: Value = toon_format::decode_default(&compact_trace_text).unwrap();
+        assert_eq!(
+            compact_trace["schema_version"],
+            "dcc-mcp.admin.trace-summary.v1"
+        );
+        assert_eq!(compact_trace["request_id"], "req-task");
 
         let (v1_report_status, v1_report_body) =
             body_json(v1_router.clone(), "/v1/debug/issue-reports/req-task").await;

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
@@ -41,8 +41,33 @@ pub(crate) fn add_gateway_debug_openapi_paths(doc: &mut Value) {
     ];
     let mut list_params = limit_params.clone();
     list_params.extend(time_filter_params.clone());
+    let compact_params = vec![
+        header_param(
+            "Accept",
+            json!({"type": "string", "enum": ["application/json", "application/toon"]}),
+            "Set application/toon to receive compact TOON output on compact-aware debug routes.",
+        ),
+        query_param(
+            "response_format",
+            json!({"type": "string", "enum": ["json", "toon"]}),
+            "Optional response-format override for clients that cannot set Accept.",
+        ),
+        query_param(
+            "compact",
+            json!({"type": "boolean"}),
+            "Alias for response_format=toon when true.",
+        ),
+    ];
+    let mut compact_list_params = list_params.clone();
+    compact_list_params.extend(compact_params.clone());
+    let mut compact_stats_params = compact_params.clone();
+    compact_stats_params.push(query_param(
+        "range",
+        json!({"type": "string", "enum": ["1h", "24h", "7d", "all"]}),
+        "Aggregation range.",
+    ));
 
-    for (path, summary, description, params) in [
+    for (path, summary, description, params, compact_capable) in [
         (
             "/v1/debug/instances",
             "List gateway debug instances",
@@ -64,60 +89,79 @@ pub(crate) fn add_gateway_debug_openapi_paths(doc: &mut Value) {
                     "Include rows whose owner process is gone.",
                 ),
             ],
+            false,
         ),
         (
             "/v1/debug/activity",
             "List gateway debug activity",
             "Stable agent-facing activity feed built from audits, traces, and gateway events.",
             list_params.clone(),
+            false,
         ),
         (
             "/v1/debug/calls",
             "List recent debug calls",
             "Stable agent-facing recent call list backed by audit rows.",
             list_params.clone(),
+            false,
         ),
         (
             "/v1/debug/traces",
             "List gateway debug traces",
             "Stable agent-facing recent dispatch trace list.",
-            list_params.clone(),
+            compact_list_params.clone(),
+            true,
         ),
         (
             "/v1/debug/traffic",
             "List live traffic capture frames",
             "Stable agent-facing retained traffic.frame list from an explicit admin_live traffic sink.",
             list_params.clone(),
+            false,
         ),
         (
             "/v1/debug/traces/{request_id}",
             "Get one debug trace by request id",
             "Stable agent-facing dispatch trace detail lookup.",
-            vec![path_param("request_id", "Gateway request id.")],
+            compact_path_params(
+                path_param("request_id", "Gateway request id."),
+                &compact_params,
+            ),
+            true,
         ),
         (
             "/v1/debug/trace-context/{lookup_id}",
             "Resolve a trace context",
             "Lookup by trace id or request id and return the primary trace plus related request ids.",
-            vec![path_param("lookup_id", "Trace id or request id.")],
+            compact_path_params(
+                path_param("lookup_id", "Trace id or request id."),
+                &compact_params,
+            ),
+            true,
         ),
         (
             "/v1/debug/agent-traces/{lookup_id}",
             "Get an agent trace packet",
             "Compact public-safe trace packet for agents, resolved by trace id or request id.",
             vec![path_param("lookup_id", "Trace id or request id.")],
+            false,
         ),
         (
             "/v1/debug/tasks",
             "List task-like debug snapshots",
             "Stable task projection reconstructed from dispatch traces.",
             list_params.clone(),
+            false,
         ),
         (
             "/v1/debug/bundles/{request_id}",
             "Get a debug bundle",
-            "Full-chain debug bundle by request id or trace id.",
-            vec![path_param("request_id", "Request id or trace id.")],
+            "Full-chain debug bundle by request id or trace id. Set Accept: application/toon for a compact public-safe summary with links to the full JSON bundle.",
+            compact_path_params(
+                path_param("request_id", "Request id or trace id."),
+                &compact_params,
+            ),
+            true,
         ),
         (
             "/v1/debug/issue-reports/{request_id}",
@@ -136,52 +180,57 @@ pub(crate) fn add_gateway_debug_openapi_paths(doc: &mut Value) {
                     "Compatibility flag for explicit raw bundle exports.",
                 ),
             ],
+            false,
         ),
         (
             "/v1/debug/logs",
             "List merged debug logs",
             "Merged gateway contention events, file logs, and audited call summaries.",
             list_params.clone(),
+            false,
         ),
         (
             "/v1/debug/deregistered",
             "List auto-deregistered instances",
             "Recently auto-deregistered registry rows retained for forensic debugging.",
             limit_params.clone(),
+            false,
         ),
         (
             "/v1/debug/stats",
             "Get debug statistics",
             "Aggregated gateway call statistics.",
-            vec![query_param(
-                "range",
-                json!({"type": "string", "enum": ["1h", "24h", "7d", "all"]}),
-                "Aggregation range.",
-            )],
+            compact_stats_params,
+            true,
         ),
         (
             "/v1/debug/governance",
             "Get traffic governance state",
             "Effective gateway policy, traffic capture, redaction, middleware controls, and recent allow/deny/throttle decisions.",
             limit_params.clone(),
+            false,
         ),
         (
             "/v1/debug/search-telemetry",
             "Get search-quality telemetry",
             "Recent prompt-safe search records and aggregate search-to-describe/load/call hit-rate metrics.",
             limit_params.clone(),
+            false,
         ),
         (
             "/v1/debug/health",
             "Get debug subsystem health",
             "Compact health and readiness summary for debug providers.",
             Vec::new(),
+            false,
         ),
     ] {
-        paths.insert(
-            path.to_string(),
-            debug_get_path(summary, description, params),
-        );
+        let path_doc = if compact_capable {
+            debug_get_path_compact(summary, description, params)
+        } else {
+            debug_get_path(summary, description, params)
+        };
+        paths.insert(path.to_string(), path_doc);
     }
     paths.insert(
         "/v1/debug/traffic/export".to_string(),
@@ -231,6 +280,24 @@ fn debug_get_path(summary: &str, description: &str, parameters: Vec<Value>) -> V
         "application/json",
         json!({"$ref": "#/components/schemas/GatewayDebugPayload"}),
     )
+}
+
+#[cfg(feature = "admin")]
+fn debug_get_path_compact(summary: &str, description: &str, parameters: Vec<Value>) -> Value {
+    let mut path = debug_get_path(summary, description, parameters);
+    if let Some(content) = path
+        .pointer_mut("/get/responses/200/content")
+        .and_then(Value::as_object_mut)
+    {
+        content.insert(
+            crate::gateway::response_codec::TOON_MIME.to_string(),
+            json!({
+                "schema": {"type": "string"},
+                "description": "TOON-encoded compact debug payload.",
+            }),
+        );
+    }
+    path
 }
 
 #[cfg(feature = "admin")]
@@ -287,4 +354,22 @@ fn query_param(name: &str, schema: Value, description: &str) -> Value {
         "description": description,
         "schema": schema
     })
+}
+
+#[cfg(feature = "admin")]
+fn header_param(name: &str, schema: Value, description: &str) -> Value {
+    json!({
+        "name": name,
+        "in": "header",
+        "required": false,
+        "description": description,
+        "schema": schema
+    })
+}
+
+#[cfg(feature = "admin")]
+fn compact_path_params(path: Value, compact_params: &[Value]) -> Vec<Value> {
+    let mut params = vec![path];
+    params.extend(compact_params.iter().cloned());
+    params
 }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -529,6 +529,16 @@ async fn gateway_openapi_lists_stable_debug_routes() {
             .get("GatewayDebugPayload")
             .is_some()
     );
+    assert!(
+        doc["paths"]["/v1/debug/bundles/{request_id}"]["get"]["responses"]["200"]["content"]
+            .get(crate::gateway::response_codec::TOON_MIME)
+            .is_some()
+    );
+    assert!(
+        doc["paths"]["/v1/debug/bundles/{request_id}"]["get"]["parameters"]
+            .as_array()
+            .is_some_and(|params| params.iter().any(|param| param["name"] == "compact"))
+    );
 }
 
 #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -131,7 +131,7 @@ pub(crate) fn default_rest_response_format() -> ResponseFormat {
         .unwrap_or(DEFAULT_REST_RESPONSE_FORMAT)
 }
 
-fn negotiate_response_format_with_default(
+pub(crate) fn negotiate_response_format_with_default(
     headers: &HeaderMap,
     body: &Value,
     default: ResponseFormat,
@@ -215,6 +215,24 @@ pub(crate) fn negotiated_response(
         &legacy_json,
         compact_json.as_ref(),
         negotiate_response_format(headers, body),
+    ) {
+        Ok(encoded) => encoded_response(status, encoded),
+        Err(err) => json_error_response(StatusCode::INTERNAL_SERVER_ERROR, &err),
+    }
+}
+
+pub(crate) fn negotiated_response_with_default(
+    headers: &HeaderMap,
+    body: &Value,
+    status: StatusCode,
+    legacy_json: Value,
+    compact_json: Option<Value>,
+    default: ResponseFormat,
+) -> Response {
+    match encode_response(
+        &legacy_json,
+        compact_json.as_ref(),
+        negotiate_response_format_with_default(headers, body, default),
     ) {
         Ok(encoded) => encoded_response(status, encoded),
         Err(err) => json_error_response(StatusCode::INTERNAL_SERVER_ERROR, &err),

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -207,6 +207,16 @@ navigation only. Historical `/admin?agent=traces&trace=<id>` links should be
 treated the same way; automation and agents should resolve the machine-readable
 packet through `GET /v1/debug/agent-traces/{lookup_id}`.
 
+Compact-aware debug routes keep JSON as the default for browser downloads and
+GitHub issue attachments. Agents can request TOON on `/v1/debug/traces`,
+`/v1/debug/traces/{request_id}`, `/v1/debug/trace-context/{lookup_id}`,
+`/v1/debug/bundles/{request_id_or_trace_id}`, and `/v1/debug/stats` with
+`Accept: application/toon`, `?response_format=toon`, or `?compact=true`.
+Responses include `x-dcc-mcp-response-format`, byte counts, estimated token
+counts, and savings headers. Debug bundle compact output is a summary with root
+cause, tool, DCC type, status, timing, token accounting, redaction summary, and
+links to the full JSON bundle.
+
 ## Optional Agent / Caller Context
 
 MCP and REST callers may attach optional context so the Admin UI can correlate

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -133,6 +133,15 @@ so operators and agents can compare results one-to-one:
 | `/v1/debug/governance?limit=300` | `/admin/api/governance?limit=300` | Effective policy, read-only state, traffic capture/redaction controls, middleware pressure, and recent allow/deny/throttle decisions. |
 | `/v1/debug/health` | `/admin/api/health` | Debug provider health summary. |
 
+Compact-aware debug routes (`/v1/debug/traces`, `/v1/debug/traces/{request_id}`,
+`/v1/debug/trace-context/{lookup_id}`, `/v1/debug/bundles/{request_id}`, and
+`/v1/debug/stats`) default to JSON for browser and GitHub compatibility. Agents
+can request TOON with `Accept: application/toon`, `?response_format=toon`, or
+`?compact=true`. The response includes `x-dcc-mcp-*` byte/token accounting
+headers. Debug bundle compact output is a public-safe summary with root cause,
+tool, DCC type, status, timing, token accounting, redaction summary, postmortem
+counts, hints, and links to the full JSON material.
+
 Every list endpoint supports the existing `limit` parameter where the Admin
 provider already accepted one. The OpenAPI contract reserves `cursor`,
 `since`, and `until` for the follow-up normalized envelope work; callers should

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -170,6 +170,15 @@ Admin 路由仍作为 dashboard 兼容层；自动化调用优先使用：
 和自动化客户端应使用 `GET /v1/debug/agent-traces/{lookup_id}` 读取稳定的
 机器可读包。
 
+compact-aware debug routes 默认仍返回 JSON，方便浏览器下载和 GitHub issue
+附件。agent 可以在 `/v1/debug/traces`、`/v1/debug/traces/{request_id}`、
+`/v1/debug/trace-context/{lookup_id}`、`/v1/debug/bundles/{request_id_or_trace_id}`
+和 `/v1/debug/stats` 上使用 `Accept: application/toon`、`?response_format=toon`
+或 `?compact=true` 请求 TOON。响应会包含 `x-dcc-mcp-response-format`、byte
+counts、estimated token counts 和 savings headers。debug bundle compact 输出是
+summary，包含 root cause、tool、DCC type、status、timing、token accounting、
+redaction summary 和指向完整 JSON bundle 的 links。
+
 ## API 响应格式
 
 ```json

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -130,6 +130,15 @@ Phase-1 debug routes 会保留现有 Admin payload 字段，让 operator 和 age
 | `/v1/debug/governance?limit=300` | `/admin/api/governance?limit=300` | 当前 policy、read-only 状态、traffic capture/redaction 控制、中间件压力和最近 allow/deny/throttle 决策。 |
 | `/v1/debug/health` | `/admin/api/health` | debug provider health summary。 |
 
+compact-aware debug routes（`/v1/debug/traces`、
+`/v1/debug/traces/{request_id}`、`/v1/debug/trace-context/{lookup_id}`、
+`/v1/debug/bundles/{request_id}`、`/v1/debug/stats`）默认仍返回 JSON，保证
+浏览器和 GitHub issue 附件兼容。agent 可以用 `Accept: application/toon`、
+`?response_format=toon` 或 `?compact=true` 请求 TOON。响应会带
+`x-dcc-mcp-*` byte/token accounting headers。debug bundle 的 compact 输出是
+public-safe summary，包含 root cause、tool、DCC type、status、timing、token
+accounting、redaction summary、postmortem counts、hints 和指向完整 JSON 的 links。
+
 所有 list endpoint 在底层 Admin provider 已支持时都支持 `limit` 参数。
 OpenAPI contract 预留了 `cursor`、`since`、`until` 给后续 normalized envelope
 工作；在该阶段落地前，调用方应忽略缺失的 `next_cursor`。

--- a/skills/dcc-mcp-creator/references/ADAPTER_WORKFLOW.md
+++ b/skills/dcc-mcp-creator/references/ADAPTER_WORKFLOW.md
@@ -93,7 +93,7 @@ Escalate to core when more than one adapter would need the same helper:
 - gateway search/describe/call response shape;
 - app UI automation contracts;
 - file/artifact handoff;
-- diagnostics, agent trace packets, and issue-report exports.
+- diagnostics, agent trace packets, compact debug negotiation, and issue-report exports.
 
 Adapter repositories should contain host facts and host API calls. Core should
 own reusable MCP, gateway, catalog, lifecycle, and wire contracts.

--- a/tests/vrs/README.md
+++ b/tests/vrs/README.md
@@ -91,7 +91,7 @@ python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tes
 | `traces/core-995-list-skills-respects-limit.jsonl` | Yes (any DCC) | `POST /v1/list_skills` MUST honour `limit` and `fields` and report a `truncated` flag (core#995). |
 | `traces/core-996-instance-offline-carries-previous-status.jsonl` | No | `instance-offline` (or `unknown-slug`) error envelope MUST carry `previous_status` so agents can distinguish manual restart from crash (core#996). |
 | `traces/core-1037-gateway-yield-unsupported-envelope.jsonl` | No | `POST /gateway/yield` unsupported/invalid optional-capability path MUST return a structured envelope that tells runners to poll instead of treating it as a crash. |
-| `traces/core-1092-stable-debug-api.jsonl` | No | Stable `/v1/debug/*` routes expose the route family and compact agent trace packet needed for diagnostics without scraping Admin HTML. |
+| `traces/core-1092-stable-debug-api.jsonl` | No | Stable `/v1/debug/*` routes expose agent diagnostics without scraping Admin HTML, including compact agent trace packets, compact TOON debug-bundle summaries, and public-safe issue reports. |
 | `traces/core-1093-trace-context-debug-bundle.jsonl` | No | `X-Request-Id` and W3C `traceparent` stay distinct, and `/v1/debug/bundles/{trace_id}` can retrieve the retained trace. |
 | `traces/core-1108-deregistered-history.jsonl` | Optional booting row | Stable debug route exposes recently auto-deregistered history and, when present, keeps port=0 booting diagnostics visible across debug health reads. |
 | `traces/core-1124-3dsmax-main-affinity-host-bridge.jsonl` | Yes (3ds Max) | A main-affinity 3ds Max tool called through `/v1/call` must route through the attached host dispatcher instead of `THREAD_AFFINITY_UNAVAILABLE`. |

--- a/tests/vrs/traces/core-1092-stable-debug-api.jsonl
+++ b/tests/vrs/traces/core-1092-stable-debug-api.jsonl
@@ -12,6 +12,7 @@
 {"id": "debug_stats", "http": {"method": "GET", "path": "/v1/debug/stats?range=all"}, "expect": {"status": 200, "json_subset": {"range": "all"}}}
 {"id": "debug_health", "http": {"method": "GET", "path": "/v1/debug/health"}, "expect": {"status": 200, "body_contains": "status"}}
 {"id": "debug_bundle_by_trace_id", "http": {"method": "GET", "path": "/v1/debug/bundles/7bf92f3577b34da6a3ce929d0e0e1092"}, "expect": {"status": 200, "json_subset": {"trace_id": "7bf92f3577b34da6a3ce929d0e0e1092", "request_id": "vrs-core-1092-request"}}}
+{"id": "debug_bundle_compact_toon", "http": {"method": "GET", "path": "/v1/debug/bundles/7bf92f3577b34da6a3ce929d0e0e1092", "headers": {"Accept": "application/toon"}}, "expect": {"status": 200, "body_contains": "dcc-mcp.admin.debug-summary.v1"}}
 {"id": "debug_issue_report", "http": {"method": "GET", "path": "/v1/debug/issue-reports/vrs-core-1092-request"}, "expect": {"status": 200, "json_subset": {"request_id": "vrs-core-1092-request", "privacy_mode": "public-safe", "report_type": "github_issue_public_safe"}}}
 {"id": "debug_issue_report_raw", "http": {"method": "GET", "path": "/v1/debug/issue-reports/vrs-core-1092-request?mode=raw"}, "expect": {"status": 200, "json_subset": {"request_id": "vrs-core-1092-request", "privacy_mode": "raw-local-evidence", "debug_bundle": {"trace_id": "7bf92f3577b34da6a3ce929d0e0e1092"}}}}
 {"id": "openapi_lists_debug_routes", "http": {"method": "GET", "path": "/v1/openapi.json"}, "expect": {"status": 200, "body_contains": "/v1/debug/health"}}


### PR DESCRIPTION
## Summary
- make selected `/v1/debug/*` routes compact-aware while keeping JSON as the default for browser and GitHub compatibility
- add compact debug-bundle and trace summaries that omit raw payload previews but preserve root cause, status, timing, token accounting, redaction summary, and links
- advertise TOON negotiation in OpenAPI, docs, VRS, and adapter guidance

## Validation
- `vx cargo test -p dcc-mcp-gateway --features admin test_admin_tasks_and_debug_bundle_from_trace -- --nocapture`
- `vx cargo test -p dcc-mcp-gateway --features admin gateway_openapi_lists_stable_debug_routes -- --nocapture`
- `vx cargo test -p dcc-mcp-gateway --features admin admin_stats -- --nocapture`
- `vx cargo test -p dcc-mcp-gateway --features admin response_codec -- --nocapture`
- `python scripts\vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tests\vrs\traces\core-1092-stable-debug-api.jsonl`
- `vx cargo clippy -p dcc-mcp-gateway --features admin --lib -- -D warnings`
- `vx git diff --check`

## Skill Guidance
- Updated `dcc-mcp-creator` guidance because this change affects core-owned gateway diagnostic negotiation.

Closes #1303