### PR TITLE
fix: align setup ide card actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,16 +262,19 @@ jobs:
       matrix:
         include:
           # Ubuntu — cover every supported Python version (cheapest runner).
-          - { os: ubuntu-latest,  python-version: "3.8"  }
-          - { os: ubuntu-latest,  python-version: "3.10" }
-          - { os: ubuntu-latest,  python-version: "3.13" }
+          - { os: ubuntu-latest,  python-version: "3.8",  wheel_os: ubuntu-latest }
+          - { os: ubuntu-latest,  python-version: "3.10", wheel_os: ubuntu-latest }
+          - { os: ubuntu-latest,  python-version: "3.13", wheel_os: ubuntu-latest }
           # Windows + macOS — cover oldest + newest only. Middle versions
           # are exercised on ubuntu and rarely surface OS-specific Python
           # bugs; python-matrix-full.yml runs the full matrix weekly.
-          - { os: windows-latest, python-version: "3.8"  }
-          - { os: windows-latest, python-version: "3.13" }
-          - { os: macos-latest,   python-version: "3.8"  }
-          - { os: macos-latest,   python-version: "3.13" }
+          # Python 3.8 is not available in the windows-latest hosted-tool cache.
+          # Reuse the ABI3 Windows wheel, but run the oldest-version test on
+          # windows-2022 where actions/setup-python still provides 3.8.
+          - { os: windows-2022,   python-version: "3.8",  wheel_os: windows-latest }
+          - { os: windows-latest, python-version: "3.13", wheel_os: windows-latest }
+          - { os: macos-latest,   python-version: "3.8",  wheel_os: macos-latest }
+          - { os: macos-latest,   python-version: "3.13", wheel_os: macos-latest }
     runs-on: ${{ matrix.os }}
     # id-token: write enables Codecov tokenless OIDC on the upload step below.
     permissions:
@@ -294,7 +297,7 @@ jobs:
       - name: Download wheel
         uses: actions/download-artifact@v8
         with:
-          name: wheel-${{ matrix.os }}
+          name: wheel-${{ matrix.wheel_os }}
           path: dist/
       - name: Install wheel + test deps
         run: |

--- a/.github/workflows/python-matrix-full.yml
+++ b/.github/workflows/python-matrix-full.yml
@@ -25,6 +25,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        exclude:
+          # Python 3.8 is no longer present in the windows-latest hosted-tool
+          # cache; keep the oldest Windows cell on windows-2022.
+          - os: windows-latest
+            python-version: "3.8"
+        include:
+          - os: windows-2022
+            python-version: "3.8"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/admin-ui/src/styles.css
+++ b/admin-ui/src/styles.css
@@ -2506,17 +2506,20 @@ pre.empty {
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 8px;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 0.75rem;
+  height: 100%;
   min-width: 0;
   padding: 1rem;
 }
 
 .ide-card-head {
-  align-items: center;
+  align-items: start;
   display: grid;
   gap: 0.75rem;
   grid-template-columns: auto minmax(0, 1fr);
+  min-height: 3.15rem;
 }
 
 .ide-card-head h3 {
@@ -2546,6 +2549,7 @@ pre.empty {
   border: 1px solid var(--border);
   border-radius: 8px;
   color: var(--foreground);
+  flex: 1 1 auto;
   font-family: var(--font-mono);
   font-size: 0.76rem;
   line-height: 1.45;
@@ -2557,11 +2561,26 @@ pre.empty {
 }
 
 .ide-card-actions {
-  align-items: center;
+  align-items: end;
+  border-top: 1px solid var(--border);
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  justify-content: flex-end;
+  justify-content: stretch;
+  margin-top: auto;
+  min-height: 3.25rem;
+  padding-top: 0.75rem;
+}
+
+.ide-card-actions .copy-btn,
+.ide-card-actions .refresh-btn {
+  align-items: center;
+  display: inline-flex;
+  flex: 1 1 8.5rem;
+  justify-content: center;
+  margin-top: 0;
+  min-height: 2.35rem;
+  white-space: nowrap;
 }
 
 .mono-path {

--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -881,6 +881,77 @@ test.describe('Admin Page', () => {
     await expect(page.locator('.health-panel')).toContainText('toon / dcc-mcp-byte4-v1');
   });
 
+  test('keeps setup IDE card action rows aligned', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto('/admin/');
+    const cards = page.locator('.setup-panel .ide-card');
+    await expect(cards).toHaveCount(6);
+
+    const firstRow = await cards.evaluateAll((elements) => {
+      const firstTop = elements[0]?.getBoundingClientRect().top ?? 0;
+      return elements
+        .filter((card) => Math.abs(card.getBoundingClientRect().top - firstTop) < 4)
+        .map((card) => {
+          const cardRect = card.getBoundingClientRect();
+          const actions = card.querySelector('.ide-card-actions')?.getBoundingClientRect();
+          const copy = card.querySelector('.copy-btn')?.getBoundingClientRect();
+          const open = card.querySelector('.refresh-btn')?.getBoundingClientRect();
+          return {
+            cardBottom: cardRect.bottom,
+            actionsTop: actions?.top ?? 0,
+            actionsBottom: actions?.bottom ?? 0,
+            copyTop: copy?.top ?? 0,
+            copyBottom: copy?.bottom ?? 0,
+            openTop: open?.top ?? 0,
+            openBottom: open?.bottom ?? 0,
+          };
+        });
+    });
+    expect(firstRow.length).toBeGreaterThan(1);
+    const actionTops = firstRow.map((row) => row.actionsTop);
+    const actionBottomOffsets = firstRow.map((row) => row.cardBottom - row.actionsBottom);
+    expect(Math.max(...actionTops) - Math.min(...actionTops)).toBeLessThanOrEqual(4);
+    expect(Math.max(...actionBottomOffsets) - Math.min(...actionBottomOffsets)).toBeLessThanOrEqual(2);
+    for (const row of firstRow) {
+      expect(row.cardBottom - row.actionsBottom).toBeLessThanOrEqual(20);
+      expect(Math.abs(row.copyTop - row.openTop)).toBeLessThanOrEqual(2);
+      expect(Math.abs(row.copyBottom - row.openBottom)).toBeLessThanOrEqual(2);
+    }
+
+    await page.setViewportSize({ width: 420, height: 900 });
+    await page.goto('/admin/');
+    const narrowRows = await cards.evaluateAll((elements) => elements.map((card) => {
+      const cardRect = card.getBoundingClientRect();
+      const actions = card.querySelector('.ide-card-actions')?.getBoundingClientRect();
+      const copy = card.querySelector('.copy-btn')?.getBoundingClientRect();
+      const open = card.querySelector('.refresh-btn')?.getBoundingClientRect();
+      return {
+        cardLeft: cardRect.left,
+        cardRight: cardRect.right,
+        cardBottom: cardRect.bottom,
+        actionsBottom: actions?.bottom ?? 0,
+        copyLeft: copy?.left ?? 0,
+        copyRight: copy?.right ?? 0,
+        copyTop: copy?.top ?? 0,
+        copyBottom: copy?.bottom ?? 0,
+        openLeft: open?.left ?? 0,
+        openRight: open?.right ?? 0,
+        openTop: open?.top ?? 0,
+        openBottom: open?.bottom ?? 0,
+      };
+    }));
+    for (const row of narrowRows) {
+      expect(row.copyLeft).toBeGreaterThanOrEqual(row.cardLeft);
+      expect(row.openLeft).toBeGreaterThanOrEqual(row.cardLeft);
+      expect(row.copyRight).toBeLessThanOrEqual(row.cardRight);
+      expect(row.openRight).toBeLessThanOrEqual(row.cardRight);
+      expect(row.cardBottom - row.actionsBottom).toBeLessThanOrEqual(20);
+      const separatedHorizontally = row.openLeft >= row.copyRight || row.copyLeft >= row.openRight;
+      const separatedVertically = row.openTop >= row.copyBottom || row.copyTop >= row.openBottom;
+      expect(separatedHorizontally || separatedVertically).toBeTruthy();
+    }
+  });
+
   test('normalizes the browser locale onto the document element', async ({ browser }) => {
     const context = await browser.newContext({ locale: 'ja-JP' });
     const page = await context.newPage();


### PR DESCRIPTION
Summary:
- make setup IDE cards reserve a consistent bottom action area
- align Copy and Open file buttons across card rows and remove inherited action button margin drift
- add Playwright layout assertions for wide setup grids and narrow responsive cards
- pin Windows Python 3.8 CI tests to windows-2022 while reusing the Windows ABI3 wheel artifact

Validation:
- `vx npm run build`
- `vx npx playwright test tests/admin.spec.ts -g "connect panel|setup IDE card|platform-specific IDE|gateway sentinel"`
- `vx npx playwright test tests/admin.spec.ts`
- `vx npx playwright test tests/i18n.spec.ts`
- `vx actionlint .github/workflows/ci.yml .github/workflows/python-matrix-full.yml`
- `vx git diff --check`

Skill Guidance:
- No update needed; Admin UI layout is presentation-only and the CI runner pin does not change public gateway/adapter contracts.

Closes #1306