### PR TITLE
fix: sync generated core stub version

### DIFF
--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -9,7 +9,7 @@ import typing
 
 # ── Module metadata ──
 
-__version__: builtins.str = "0.17.35"
+__version__: builtins.str = "0.17.36"
 __author__: builtins.str = "Hal Long <hal.long@outlook.com>"
 
 # ── Constants (registered via m.add() in src/lib.rs::register_constants) ──


### PR DESCRIPTION
## Summary
- update the generated Python core stub to advertise version 0.17.36 after the release bump
- keep the committed stub aligned with stubgen output so CI drift checks stay green

## Validation
- DCC_MCP_ADMIN_UI_PREBUILT=1 vx just stubgen-check
- vx git diff --check