### PR TITLE
docs: clarify DCC discovery workflow

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -84,9 +84,11 @@ handle = server.start()
 print(f"Maya MCP server: {handle.mcp_url()}")
 
 # Agents connect and use on-demand skill discovery:
-# → search_skills(query="modeling") to find relevant skills
-# → load_skill("maya-bevel") to activate
+# → search_tools(query="bevel") or search_skills(query="modeling")
+# → get_skill_info(skill_name="maya-bevel") to inspect schemas
+# → load_skill("maya-bevel") only when selected
 # → tools/call maya_bevel__bevel to execute
+# Do not treat the first tools/list page as complete; follow nextCursor if listing.
 handle.shutdown()
 ```
 

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -63,6 +63,28 @@ else:
 
 When an MCP `tools/call` response includes `CallToolResult._meta["dcc.next_tools"].on_success` or `.on_failure`, **always consider calling those tools next**. This creates a guided workflow chain; the declarations live per tool in sibling `tools.yaml`, not as top-level `SKILL.md` keys.
 
+### Direct Per-DCC MCP Discovery
+
+If your MCP connection is a direct Maya/Blender/Houdini/etc. server, do not
+treat the first `tools/list` page as the complete tool index. `tools/list` is
+paginated and may put a newly loaded tool on a later page.
+
+Use this compact flow instead:
+
+```python
+# Direct per-DCC MCP workflow
+hits = search_tools(query="capture viewport", limit=5)
+info = get_skill_info(skill_name=hits["skill_candidates"][0]["skill_name"])
+load_skill(skill_name=info["name"])
+result = tools_call(name="maya_render__capture_viewport", arguments={})
+```
+
+Use `search_tools` for active tools and unloaded skill candidates. Use
+`search_skills` when you are looking for a skill by intent rather than a known
+tool name. Use `get_skill_info` to inspect a selected skill's full tool schemas
+before loading it. If you intentionally call `tools/list`, follow every
+`nextCursor` until it is absent.
+
 ### Gateway Dynamic-Capability / REST Surfaces
 
 If your MCP connection is the multi-DCC gateway, do not expect backend actions to appear directly in `tools/list`. The gateway surface is intentionally fixed and bounded; use the dynamic-capability workflow instead:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,44 @@ Use it when you want agents to operate production DCC sessions without flooding 
 | Debug live workstation state | Admin UI, viewport diagnostics, audit logs, traces, metrics |
 | Survive production constraints | Main-thread dispatch, async jobs, sidecar/server binaries, workflow and artefact primitives |
 
+## Why This Matters
+
+Generic MCP servers and CLI wrappers expose commands. `dcc-mcp-core` exposes a
+live DCC control plane built for production sessions:
+
+- Agents can reason from active scenes, documents, selections, viewport captures,
+  output streams, and host-published resources instead of blind shell output.
+- Progressive discovery keeps context small: search compact capability records
+  first, inspect only the selected schema, then load or call the chosen tool.
+- One gateway can route across many DCC instances, versions, scenes, and custom
+  studio hosts without merging every backend action into one huge `tools/list`.
+- Main-thread dispatch, readiness probes, async jobs, cancellation, persistence,
+  and artefact hand-off match the constraints of embedded desktop hosts.
+- Skills are packages: `SKILL.md`, `tools.yaml`, scripts, reference docs, and
+  Rez/context bundles can travel through normal studio distribution workflows.
+- Audit logs, security annotations, diagnostics, telemetry, and Admin UI panels
+  give operators enough evidence to trust what agents did.
+
+## Recommended Agent Workflow
+
+1. Discover live context only when needed: gateway clients can read
+   `gateway://instances`, while direct per-DCC clients can use adapter resources
+   for scene, document, or viewport context.
+2. Search compactly: use gateway MCP `search` or REST `POST /v1/search` for
+   multi-DCC routing; use direct per-DCC `search_tools` for active tools and
+   `search_skills` for unloaded skill candidates.
+3. Inspect before loading or calling: use gateway `describe` /
+   `POST /v1/describe` for one `tool_slug`, or direct per-DCC
+   `get_skill_info(skill_name=...)` for the selected skill's schemas.
+4. Load only what the task needs with `load_skill`, then activate any collapsed
+   tool group if the chosen hit says so.
+5. Call the typed tool and inspect structured results, job updates, resources,
+   prompts, diagnostics, and follow-up hints.
+
+`tools/list` is MCP-compatible and paginated. Treat it as a transport listing,
+not as a complete search index; never assume the first page contains every
+loaded or discoverable tool.
+
 ## Quick Start
 
 ### Install the standalone CLI
@@ -89,7 +127,12 @@ handle = server.start()
 print(handle.mcp_url())   # "http://127.0.0.1:8765/mcp"
 ```
 
-Agents then use `search_skills` -> `load_skill` on a per-DCC server, or MCP `search` -> `describe` through the gateway before executing via REST `POST /v1/call`.
+Agents then search compactly before they load or call tools. On a direct
+per-DCC server, use `search_tools` for active tools, `search_skills` for
+unloaded skill candidates, `get_skill_info` for schema inspection, then
+`load_skill` and `tools/call`. Through the gateway, use MCP `search` ->
+`describe` -> `load_skill` if needed -> `call`, or the REST twin
+`POST /v1/search` -> `/v1/describe` -> `/v1/call`.
 
 ---
 
@@ -247,7 +290,11 @@ Every release attaches raw `dcc-mcp-cli` and `dcc-mcp-server` binaries for Linux
 
 ### Serve a DCC over MCP — Skills-First (recommended)
 
-`create_skill_server` wires up the full Skills-First entry point: `tools/list` returns a small set of discovery/lifecycle tools plus one stub per unloaded skill. Agents call `search_skills` → `load_skill` to activate the tools they need, keeping the context window small.
+`create_skill_server` wires up the full Skills-First entry point: `tools/list`
+returns a paginated transport list with discovery/lifecycle tools plus one stub
+per unloaded skill. Agents should not scrape only page one. Use `search_tools`
+or `search_skills` to find candidates, `get_skill_info` to inspect selected
+schemas, then `load_skill` to activate only the tools the task needs.
 
 ```python
 from dcc_mcp_core import create_skill_server, McpHttpConfig

--- a/crates/dcc-mcp-http-server/src/rmcp_handler.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_handler.rs
@@ -119,8 +119,9 @@ impl ServerHandler for DccMcpHandler {
             self.state.server_version.clone(),
         );
         info.instructions = Some(
-            "Use search_skills to discover available DCC tools, \
-             then load_skill to activate a skill before calling its tools."
+            "Use search_tools or search_skills for compact discovery, \
+             get_skill_info for selected schemas, then load_skill only when needed. \
+             tools/list is paginated; follow nextCursor if you list it."
                 .to_string(),
         );
         info

--- a/crates/dcc-mcp-http-server/src/rmcp_initialize.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_initialize.rs
@@ -47,7 +47,7 @@ pub(crate) fn build_initialize_result(
     result.server_info =
         rmcp::model::Implementation::new(state.server_name.clone(), state.server_version.clone());
     result.instructions = Some(
-        "Search skills with search_skills(query), load with load_skill(name). See get_skill_info or tools/list for details."
+        "Direct DCC workflow: search_tools(query) or search_skills(query), inspect get_skill_info(skill_name), load_skill only when needed, then tools/call. tools/list is paginated; follow nextCursor if you list it."
             .to_string(),
     );
     result

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -202,7 +202,7 @@ Every `McpHttpServer` emits a fixed set of built-in tools in `tools/list` in add
 | `unload_skill` | Unloads a skill; emits `tools/list_changed`. Idempotent. | `load_skill(...)` again if needed |
 | `activate_tool_group` | Expands a `__group__<name>` stub into its member tools. | Re-call `tools/list`, then the tool |
 | `deactivate_tool_group` | Collapses a tool group back to a stub to shrink the token footprint. | `activate_tool_group(...)` |
-| `search_tools` | Full-text search over **already-registered** tools. If nothing matches, try `search_skills`. | Call the matched tool |
+| `search_tools` | Full-text search over active tools plus unloaded skill candidates, returned without full schemas. | `get_skill_info(...)`, `load_skill(...)`, or call the matched active tool |
 | `list_roots` | Returns the filesystem roots the client advertised via `roots/list`. Rarely needed. | — |
 
 ### Lazy-actions fast-path (opt-in)
@@ -585,7 +585,7 @@ you control how much of the schema surface is pushed into the agent's context.
 | Default (eager) | All tool definitions + schemas | High | ≤ 20 tools |
 | `lazy_actions = True` | 3 meta-tools only | Very low | Large static catalogs |
 | Skill stubs (default) | `__skill__<name>` stubs for unloaded skills | Low | Dynamic loading workflows |
-| `search` (gateway) / `search_tools` (direct server) | Compact search results; fetch schema with gateway `describe` or direct-server `describe_tool` | Low | Large catalogs and multi-DCC gateways |
+| `search` (gateway) / `search_tools` (direct server) | Compact search results; fetch schema with gateway `describe` or direct-server `get_skill_info` | Low | Large catalogs and multi-DCC gateways |
 
 ### 1. Default: Skill Stubs
 
@@ -594,7 +594,10 @@ Without any config, `tools/list` emits:
 - A `__skill__<name>` stub for every **unloaded** skill (name + 1-line description, no input schemas)
 - Full tool definitions for every **loaded** skill
 
-Agent workflow: `search_skills(query)` → `load_skill(name)` → re-call `tools/list`.
+Agent workflow: `search_tools(query)` or `search_skills(query)` →
+`get_skill_info(skill_name=...)` for the selected skill → `load_skill(name)` →
+call the typed tool. If a client needs to inspect `tools/list`, it must follow
+every `nextCursor`; the first page is not a complete index.
 
 ```python
 from dcc_mcp_core import create_skill_server, McpHttpConfig
@@ -637,8 +640,13 @@ cfg.lazy_tool_schemas = True  # omit inputSchema from tools/list (planned)
 
 ### 4. `search_tools` and gateway dynamic search
 
-Direct per-DCC servers expose `search_tools` for enabled tools, while the
-gateway advertises the canonical MCP workflow `search` → `describe` →
+Direct per-DCC servers expose `search_tools` for active tools and unloaded skill
+candidates. Use `get_skill_info(skill_name=...)` to inspect the selected
+skill's full declared tool schemas before `load_skill`, then call the concrete
+tool by name. `tools/list` remains MCP-compatible and paginated, but production
+agents should not treat its first page as a complete discovery index.
+
+The gateway advertises the canonical MCP workflow `search` → `describe` →
 `load_skill` (when needed) → `call`. REST `/v1/search`, `/v1/describe`,
 `/v1/load_skill`, `/v1/call`, and `/v1/call_batch` remain the pure HTTP twin.
 Gateway search returns compact records only; `describe` fetches one full schema
@@ -646,10 +654,6 @@ on demand, keeping `tools/list` bounded even when many backends are live. The
 gateway REST workflow returns compact TOON by default; clients that require
 legacy JSON should send `Accept: application/json` or body
 `response_format: "json"`.
-
-For unloaded skills, keep using the Skills-First workflow:
-MCP `search(kind="skill", query=...)` or REST `/v1/search`, then `load_skill`
-or `/v1/load_skill`, `describe`, and `call`.
 
 ### Token Usage Decision Guide
 

--- a/tests/test_tools_list_pagination.py
+++ b/tests/test_tools_list_pagination.py
@@ -143,6 +143,54 @@ class TestToolsListPagination:
         assert len(result2["tools"]) == 54 - self.PAGE_SIZE
         assert result2.get("nextCursor") is None, "Last page must not have nextCursor"
 
+    def test_search_tools_finds_tool_outside_first_page(self, big_server):
+        """Agents should use search_tools instead of treating page one as complete."""
+        code, first_page = _post(
+            big_server,
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+        assert code == 200
+        first_names = {tool["name"] for tool in first_page["result"]["tools"]}
+        cursor = first_page["result"].get("nextCursor")
+        assert cursor is not None
+
+        target = None
+        while cursor is not None:
+            code, page = _post(
+                big_server,
+                {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {"cursor": cursor}},
+            )
+            assert code == 200
+            for tool in page["result"]["tools"]:
+                name = tool["name"]
+                if name.startswith("tool_") and name not in first_names:
+                    target = name
+                    break
+            if target is not None:
+                break
+            cursor = page["result"].get("nextCursor")
+
+        assert target is not None, "Expected at least one registered test tool outside the first tools/list page"
+
+        code, body = _post(
+            big_server,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_tools",
+                    "arguments": {"query": target, "limit": 5},
+                },
+            },
+        )
+        assert code == 200
+        text = body["result"]["content"][0]["text"]
+        payload = json.loads(text)
+        assert any(hit.get("name") == target for hit in payload.get("tools", [])), (
+            f"search_tools should find loaded tools beyond the first tools/list page; got {payload}"
+        )
+
 
 # ── delta notification capability negotiation ─────────────────────────────
 
@@ -172,6 +220,28 @@ class TestDeltaNotificationCapability:
         assert experimental is None or DELTA_CAP_KEY not in (experimental or {}), (
             f"Server must not advertise delta cap without client opt-in, got: {experimental}"
         )
+
+    def test_initialize_instructions_prefer_search_over_page_one_scans(self, small_server):
+        """Initialize instructions should teach compact discovery before tools/list scans."""
+        code, body = _post(
+            small_server,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "instruction-client", "version": "1.0"},
+                },
+            },
+        )
+        assert code == 200
+        instructions = body["result"].get("instructions", "")
+        assert "search_tools" in instructions
+        assert "get_skill_info" in instructions
+        assert "nextCursor" in instructions
+        assert "tools/list is paginated" in instructions
 
     def test_server_echoes_delta_capability_when_client_opts_in(self, small_server):
         """When client opts in, server must echo the delta capability back."""


### PR DESCRIPTION
## Summary
- Refresh the README opening with production DCC-MCP positioning, concrete advantages, and the recommended discover -> inspect -> load -> call workflow.
- Teach direct per-DCC clients to use `search_tools` / `search_skills` and `get_skill_info` instead of treating the first `tools/list` page as complete.
- Update initialize instructions and add regression coverage that `search_tools` finds a loaded tool outside page one.

Closes #1318
Closes #1319

## Validation
- `vx cargo fmt --check`
- `vx ruff format --check tests/test_tools_list_pagination.py`
- `vx ruff check tests/test_tools_list_pagination.py`
- `.\.venv\Scripts\python.exe -m pytest tests/test_tools_list_pagination.py -q`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo test -p dcc-mcp-http-server --lib`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx just preflight`

Agent guidance check: updated `.agents/skills/dcc-mcp-core/SKILL.md`; `skills/dcc-mcp-creator/` and `skills/dcc-mcp-skills-creator/` do not need changes because this does not alter adapter scaffolding or skill authoring contracts.