### PR TITLE
chore: unblock dependency dashboard

### DIFF
--- a/.github/workflows/check-file-size.yml
+++ b/.github/workflows/check-file-size.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check Rust file sizes
         run: |
@@ -101,4 +101,3 @@ jobs:
             exit 1
           fi
           echo "✅ All Python files are within the ${MAX_PY}-line limit."
-

--- a/.github/workflows/clawhub.yml
+++ b/.github/workflows/clawhub.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout-ref || github.ref }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
  "clap",
  "dcc-mcp-catalog",
  "dcc-mcp-skills",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -871,7 +871,7 @@ dependencies = [
  "dcc-mcp-workflow",
  "pyo3",
  "pyo3-stub-gen",
- "reqwest 0.13.4",
+ "reqwest",
  "serde_json",
  "workspace-hack",
 ]
@@ -913,7 +913,7 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "proptest",
- "reqwest 0.13.4",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1022,7 +1022,7 @@ dependencies = [
  "pyo3",
  "pyo3-stub-gen",
  "pyo3-stub-gen-derive",
- "reqwest 0.13.4",
+ "reqwest",
  "rmcp",
  "rstest",
  "serde",
@@ -1321,7 +1321,7 @@ dependencies = [
  "dcc-mcp-telemetry",
  "dcc-mcp-transport",
  "futures-util",
- "reqwest 0.13.4",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1496,7 +1496,7 @@ dependencies = [
  "dcc-mcp-tunnel-protocol",
  "futures-util",
  "parking_lot",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
@@ -3184,9 +3184,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3198,22 +3198,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -3221,18 +3221,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3243,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-stdout"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
+checksum = "a1b1c6a247d79091f0062a5f4bd058589525cf987a8d4c169440d9c1be72f0ad"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3254,15 +3254,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror",
  "tokio",
@@ -3712,6 +3713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4100,40 +4110,6 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "reqwest"
@@ -5275,6 +5251,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "toon-format"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5396,9 +5383,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -6379,6 +6366,7 @@ dependencies = [
  "rand_core 0.6.4",
  "regex-automata",
  "regex-syntax",
+ "reqwest",
  "serde",
  "serde_core",
  "serde_json",

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -21,7 +21,7 @@ dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
 dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
 dcc-mcp-skills = { path = "../dcc-mcp-skills", default-features = false }
 dcc-mcp-catalog = { path = "../dcc-mcp-catalog" }
-opentelemetry = { version = "0.31", features = ["trace"], optional = true }
+opentelemetry = { version = "0.32", features = ["trace"], optional = true }
 prometheus = { version = "0.14", default-features = false, optional = true }
 
 # Workspace shared

--- a/crates/dcc-mcp-telemetry/Cargo.toml
+++ b/crates/dcc-mcp-telemetry/Cargo.toml
@@ -21,13 +21,13 @@ pyo3-stub-gen = { workspace = true, optional = true }
 pyo3-stub-gen-derive = { workspace = true, optional = true }
 
 # OpenTelemetry core
-opentelemetry = { version = "0.31", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.31", features = ["trace", "metrics", "rt-tokio"] }
-opentelemetry-stdout = { version = "0.31", features = ["trace", "metrics"] }
-tracing-opentelemetry = { version = "0.32" }
+opentelemetry = { version = "0.32", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.32", features = ["trace", "metrics", "rt-tokio"] }
+opentelemetry-stdout = { version = "0.32", features = ["trace", "metrics"] }
+tracing-opentelemetry = { version = "0.33" }
 
 # OTLP exporter (optional — only for production export to Jaeger/Tempo/etc.)
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "trace", "metrics"], optional = true }
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "trace", "metrics"], optional = true }
 
 # Prometheus exporter (optional — enabled via the `prometheus` feature).
 # Zero-cost when disabled; no code paths are compiled into the wheel.

--- a/crates/dcc-mcp-telemetry/src/error.rs
+++ b/crates/dcc-mcp-telemetry/src/error.rs
@@ -35,8 +35,8 @@ pub enum TelemetryError {
     Internal(String),
 }
 
-impl From<opentelemetry_sdk::trace::TraceError> for TelemetryError {
-    fn from(e: opentelemetry_sdk::trace::TraceError) -> Self {
+impl From<opentelemetry_sdk::error::OTelSdkError> for TelemetryError {
+    fn from(e: opentelemetry_sdk::error::OTelSdkError) -> Self {
         TelemetryError::TracerProviderSetup(e.to_string())
     }
 }
@@ -95,9 +95,10 @@ mod tests {
         use super::*;
 
         #[test]
-        fn from_trace_error() {
-            let trace_err = opentelemetry_sdk::trace::TraceError::Other("test error".into());
-            let tel_err = TelemetryError::from(trace_err);
+        fn from_otel_sdk_error() {
+            let sdk_err =
+                opentelemetry_sdk::error::OTelSdkError::InternalFailure("test error".into());
+            let tel_err = TelemetryError::from(sdk_err);
             assert!(matches!(tel_err, TelemetryError::TracerProviderSetup(_)));
         }
     }

--- a/crates/dcc-mcp-telemetry/src/provider.rs
+++ b/crates/dcc-mcp-telemetry/src/provider.rs
@@ -401,20 +401,22 @@ mod tests {
             assert!(result.is_ok());
         }
 
+        #[cfg(not(feature = "otlp-exporter"))]
         #[test]
         fn otlp_backend_without_feature_returns_error() {
             let cfg = TelemetryConfig::default();
             let resource = Resource::builder_empty().build();
             let result = build_tracer_provider(&cfg, &ExporterBackend::Otlp, resource);
-            // When feature is not enabled, expect OtlpConfig error;
-            // when feature IS enabled, it will attempt to connect (may fail differently).
-            match result {
-                Err(TelemetryError::OtlpConfig(_)) => {}
-                Err(TelemetryError::TracerProviderSetup(_)) => {}
-                // Feature enabled + tonic connected successfully in test env
-                Ok(_) => {}
-                Err(e) => panic!("unexpected error: {e}"),
-            }
+            assert!(matches!(result, Err(TelemetryError::OtlpConfig(_))));
+        }
+
+        #[cfg(feature = "otlp-exporter")]
+        #[tokio::test]
+        async fn otlp_backend_with_feature_builds_inside_runtime() {
+            let cfg = TelemetryConfig::default();
+            let resource = Resource::builder_empty().build();
+            let result = build_tracer_provider(&cfg, &ExporterBackend::Otlp, resource);
+            assert!(result.is_ok());
         }
     }
 

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -53,6 +53,7 @@ rand_chacha = { version = "0.9.0", default-features = false, features = ["std"] 
 rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
+reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls", "stream"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
 serde_json = { version = "1.0.150", features = ["alloc", "preserve_order", "raw_value"] }
@@ -116,6 +117,7 @@ rand_chacha = { version = "0.9.0", default-features = false, features = ["std"] 
 rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
+reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls", "stream"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
 serde_json = { version = "1.0.150", features = ["alloc", "preserve_order", "raw_value"] }

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,13 @@
       "automergeType": "pr"
     },
     {
+      "description": "Keep legacy Python runner labels pinned until Python 3.7 support is dropped.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["ubuntu", "windows"],
+      "matchCurrentValue": "/^(22\\.04|2022)$/",
+      "enabled": false
+    },
+    {
       "matchManagers": ["pep621"],
       "groupName": "python dependencies",
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Summary
- update remaining actions/checkout v4 workflow uses to v6
- upgrade OpenTelemetry-related Rust crates to the 0.32 line and refresh workspace-hack metadata
- keep legacy Python 3.7 runner labels pinned in Renovate so intentional ubuntu-22.04/windows-2022 usage is not reopened

Refs #2

## Validation
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo check -p dcc-mcp-telemetry -p dcc-mcp-gateway --all-features`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo test -p dcc-mcp-telemetry -p dcc-mcp-gateway --all-features --lib`
- `vx node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('renovate.json','utf8')); console.log('renovate.json JSON OK')"`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx just preflight`

Agent skill guidance was checked; no dcc-mcp-creator or dcc-mcp-skills-creator update is needed because this only changes dependency, Renovate, and CI maintenance wiring.