### PR TITLE
fix: request JSON for CLI gateway REST calls

### DIFF
--- a/crates/dcc-mcp-cli/src/infra/http.rs
+++ b/crates/dcc-mcp-cli/src/infra/http.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use reqwest::header;
 use serde_json::Value;
 use thiserror::Error;
 
@@ -37,12 +38,23 @@ impl HttpGateway {
     }
 
     pub async fn get_json(&self, url: &str) -> Result<Value, HttpError> {
-        let response = self.client.get(url).send().await?;
+        let response = self
+            .client
+            .get(url)
+            .header(header::ACCEPT, "application/json")
+            .send()
+            .await?;
         Self::json_response(response).await
     }
 
     pub async fn post_json(&self, url: &str, body: &Value) -> Result<Value, HttpError> {
-        let response = self.client.post(url).json(body).send().await?;
+        let response = self
+            .client
+            .post(url)
+            .header(header::ACCEPT, "application/json")
+            .json(body)
+            .send()
+            .await?;
         Self::json_response(response).await
     }
 
@@ -53,6 +65,12 @@ impl HttpGateway {
         headers: &[(&str, &str)],
     ) -> Result<Value, HttpError> {
         let mut request = self.client.post(url).json(body);
+        let has_accept = headers
+            .iter()
+            .any(|(name, _)| name.eq_ignore_ascii_case("accept"));
+        if !has_accept {
+            request = request.header(header::ACCEPT, "application/json");
+        }
         for (name, value) in headers {
             request = request.header(*name, *value);
         }
@@ -68,5 +86,108 @@ impl HttpGateway {
 
         let body = response.text().await.unwrap_or_default();
         Err(HttpError::Status { status, body })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::Router;
+    use axum::extract::Json;
+    use axum::http::{HeaderMap, header};
+    use axum::routing::get;
+    use serde_json::json;
+    use tokio::sync::oneshot;
+
+    struct AcceptFixture {
+        url: String,
+        shutdown: Option<oneshot::Sender<()>>,
+    }
+
+    impl Drop for AcceptFixture {
+        fn drop(&mut self) {
+            if let Some(shutdown) = self.shutdown.take() {
+                let _ = shutdown.send(());
+            }
+        }
+    }
+
+    async fn accept_echo(headers: HeaderMap) -> Json<Value> {
+        let accept = headers
+            .get(header::ACCEPT)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        Json(json!({ "accept": accept }))
+    }
+
+    async fn spawn_accept_fixture() -> AcceptFixture {
+        let app = Router::new().route("/accept", get(accept_echo).post(accept_echo));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        AcceptFixture {
+            url: format!("http://{addr}/accept"),
+            shutdown: Some(shutdown_tx),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_json_requests_json_response() {
+        let fixture = spawn_accept_fixture().await;
+        let gateway = HttpGateway::default();
+
+        let response = gateway.get_json(&fixture.url).await.unwrap();
+
+        assert_eq!(response["accept"], "application/json");
+    }
+
+    #[tokio::test]
+    async fn post_json_requests_json_response() {
+        let fixture = spawn_accept_fixture().await;
+        let gateway = HttpGateway::default();
+
+        let response = gateway.post_json(&fixture.url, &json!({})).await.unwrap();
+
+        assert_eq!(response["accept"], "application/json");
+    }
+
+    #[tokio::test]
+    async fn post_json_with_headers_defaults_to_json_accept() {
+        let fixture = spawn_accept_fixture().await;
+        let gateway = HttpGateway::default();
+
+        let response = gateway
+            .post_json_with_headers(&fixture.url, &json!({}), &[("X-Test", "yes")])
+            .await
+            .unwrap();
+
+        assert_eq!(response["accept"], "application/json");
+    }
+
+    #[tokio::test]
+    async fn post_json_with_headers_preserves_explicit_accept() {
+        let fixture = spawn_accept_fixture().await;
+        let gateway = HttpGateway::default();
+
+        let response = gateway
+            .post_json_with_headers(
+                &fixture.url,
+                &json!({}),
+                &[("Accept", "application/json, text/event-stream")],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response["accept"], "application/json, text/event-stream");
     }
 }

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -3,6 +3,7 @@ use std::process::Command;
 use axum::Router;
 use axum::extract::{Json, Path};
 use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use serde_json::{Value, json};
 use tempfile::{NamedTempFile, TempDir};
@@ -22,6 +23,27 @@ impl Drop for GatewayFixture {
         if let Some(thread) = self.thread.take() {
             let _ = thread.join();
         }
+    }
+}
+
+fn json_or_compact_fixture_response(
+    headers: &HeaderMap,
+    payload: Value,
+    compact_body: &'static str,
+) -> Response {
+    let accept = headers
+        .get(header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    if accept.contains("application/json") {
+        Json(payload).into_response()
+    } else {
+        (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/toon")],
+            compact_body,
+        )
+            .into_response()
     }
 }
 
@@ -165,8 +187,10 @@ fn spawn_gateway_fixture() -> GatewayFixture {
         )
         .route(
             "/v1/search",
-            post(|Json(body): Json<Value>| async move {
-                Json(json!({
+            post(|headers: HeaderMap, Json(body): Json<Value>| async move {
+                json_or_compact_fixture_response(
+                    &headers,
+                    json!({
                     "total": 1,
                     "hits": [{
                         "slug": "maya.abc12345.create_sphere",
@@ -178,7 +202,9 @@ fn spawn_gateway_fixture() -> GatewayFixture {
                         "loaded": true,
                         "scope": "gateway"
                     }]
-                }))
+                    }),
+                    "hits[slug:\"maya.abc12345.create_sphere\"]",
+                )
             }),
         )
         .route(
@@ -192,8 +218,10 @@ fn spawn_gateway_fixture() -> GatewayFixture {
         )
         .route(
             "/v1/load_skill",
-            post(|Json(body): Json<Value>| async move {
-                Json(json!({
+            post(|headers: HeaderMap, Json(body): Json<Value>| async move {
+                json_or_compact_fixture_response(
+                    &headers,
+                    json!({
                     "loaded": true,
                     "skill_name": body["skill_name"],
                     "dcc_type": body.get("dcc_type").cloned().unwrap_or(Value::Null),
@@ -205,7 +233,9 @@ fn spawn_gateway_fixture() -> GatewayFixture {
                         "name": "workflow__run",
                         "inputSchema": {"type": "object"}
                     }]
-                }))
+                    }),
+                    "loaded:true\nskill_name:\"workflow\"",
+                )
             }),
         )
         .route(
@@ -431,6 +461,35 @@ fn list_search_describe_and_call_gateway_rest_surface() {
     assert_eq!(stop["ok"], true);
     assert_eq!(stop["stopping"], true);
     assert_eq!(stop["expected_owner"], "release-smoke-test");
+}
+
+#[test]
+fn search_and_load_skill_decode_json_when_gateway_defaults_to_compact() {
+    let fixture = spawn_gateway_fixture();
+
+    let search = run_json(&[
+        "--base-url",
+        &fixture.base_url,
+        "search",
+        "--query",
+        "sphere",
+        "--dcc-type",
+        "maya",
+    ]);
+    assert_eq!(search["hits"][0]["slug"], "maya.abc12345.create_sphere");
+
+    let loaded = run_json(&[
+        "--base-url",
+        &fixture.base_url,
+        "load-skill",
+        "workflow",
+        "--dcc-type",
+        "maya",
+        "--instance-id",
+        "abc12345",
+    ]);
+    assert_eq!(loaded["loaded"], true);
+    assert_eq!(loaded["registered_tools"][0], "workflow__run");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- request `Accept: application/json` for CLI REST JSON helpers so gateway compact defaults do not break decoding
- preserve explicit MCP `Accept: application/json, text/event-stream` on MCP calls
- strengthen unit and e2e coverage so search/load-skill fail if the CLI forgets to request JSON

Closes #1323

## Validation
- reproduced the failure before the fix with `DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo test -p dcc-mcp-cli --test cli_e2e list_search_describe_and_call_gateway_rest_surface -- --exact --nocapture`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo test -p dcc-mcp-cli`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx just preflight`

Agent skill guidance was checked; no dcc-mcp-creator or dcc-mcp-skills-creator update is needed because this only changes CLI REST content negotiation and tests.