### PR TITLE
fix: populate admin client attribution

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -56,6 +56,7 @@ pub mod sqlite_lane;
 pub mod state;
 pub mod stats;
 pub mod trace;
+mod trace_log;
 mod traffic;
 pub mod workers;
 pub mod workflows;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
@@ -450,12 +450,23 @@ fn actor_label(ctx: &AgentContext) -> Option<String> {
 }
 
 fn agent_label(ctx: &AgentContext) -> Option<String> {
-    ctx.agent_name
+    let name = ctx
+        .agent_name
         .clone()
         .or_else(|| ctx.agent_id.clone())
         .or_else(|| ctx.agent_kind.clone())
         .or_else(|| ctx.model.clone())
-        .or_else(|| ctx.model_version.clone())
+        .or_else(|| ctx.model_version.clone())?;
+    if let Some(version) = ctx
+        .agent_version
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(format!("{name}@{version}"))
+    } else {
+        Some(name)
+    }
 }
 
 fn add_attribution_facet(

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -115,6 +115,9 @@ mod admin_tests {
             events_tx: Arc::new(events_tx),
             protocol_version: Arc::new(RwLock::new(None)),
             resource_subscriptions: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            client_attribution: Arc::new(
+                crate::gateway::caller_attribution::ClientAttributionStore::default(),
+            ),
             pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
             subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
             allow_unknown_tools: false,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
@@ -13,9 +13,10 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 
 use axum::http::HeaderMap;
-use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+
+pub use super::trace_log::TraceLog;
 
 // ── Trace Context ────────────────────────────────────────────────────────────
 
@@ -476,6 +477,20 @@ fn set_trust(slot: &mut Option<String>, source: &str) {
     *slot = Some(source.to_string());
 }
 
+fn fill_missing_context_string(
+    slot: &mut Option<String>,
+    trust_slot: &mut Option<String>,
+    fallback: &Option<String>,
+    fallback_trust: &Option<String>,
+) {
+    if slot.is_none()
+        && let Some(value) = fallback
+    {
+        *slot = Some(value.clone());
+        *trust_slot = fallback_trust.clone();
+    }
+}
+
 /// Optional client-supplied context that explains why a request was made.
 ///
 /// This is deliberately a telemetry contract, not an instruction to capture a
@@ -621,6 +636,108 @@ pub struct AgentContext {
 }
 
 impl AgentContext {
+    pub fn from_mcp_client_info(session_id: &str, params: Option<&Value>) -> Option<Self> {
+        let client_info = params
+            .and_then(|value| value.get("clientInfo").or_else(|| value.get("client_info")))?;
+        let Value::Object(info) = client_info else {
+            return None;
+        };
+        let name = info
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let version = info
+            .get("version")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        if name.is_none() && version.is_none() {
+            return None;
+        }
+
+        let mut ctx = AgentContext {
+            agent_name: name.clone(),
+            agent_kind: Some("mcp-client".to_string()),
+            agent_version: version,
+            client_platform: name,
+            session_id: Some(session_id.to_string()),
+            ..AgentContext::default()
+        }
+        .normalise();
+        let snapshot = ctx.clone();
+        ctx.trust.mark_present(&snapshot, TRUST_SELF_REPORTED);
+        Some(ctx)
+    }
+
+    pub fn merge_missing_client_identity_from(&mut self, fallback: &AgentContext) {
+        fill_missing_context_string(
+            &mut self.agent_id,
+            &mut self.trust.agent_id,
+            &fallback.agent_id,
+            &fallback.trust.agent_id,
+        );
+        fill_missing_context_string(
+            &mut self.agent_name,
+            &mut self.trust.agent_name,
+            &fallback.agent_name,
+            &fallback.trust.agent_name,
+        );
+        fill_missing_context_string(
+            &mut self.agent_kind,
+            &mut self.trust.agent_kind,
+            &fallback.agent_kind,
+            &fallback.trust.agent_kind,
+        );
+        fill_missing_context_string(
+            &mut self.agent_version,
+            &mut self.trust.agent_version,
+            &fallback.agent_version,
+            &fallback.trust.agent_version,
+        );
+        fill_missing_context_string(
+            &mut self.model,
+            &mut self.trust.model,
+            &fallback.model,
+            &fallback.trust.model,
+        );
+        fill_missing_context_string(
+            &mut self.model_provider,
+            &mut self.trust.model_provider,
+            &fallback.model_provider,
+            &fallback.trust.model_provider,
+        );
+        fill_missing_context_string(
+            &mut self.model_version,
+            &mut self.trust.model_version,
+            &fallback.model_version,
+            &fallback.trust.model_version,
+        );
+        fill_missing_context_string(
+            &mut self.client_platform,
+            &mut self.trust.client_platform,
+            &fallback.client_platform,
+            &fallback.trust.client_platform,
+        );
+        fill_missing_context_string(
+            &mut self.client_os,
+            &mut self.trust.client_os,
+            &fallback.client_os,
+            &fallback.trust.client_os,
+        );
+        fill_missing_context_string(
+            &mut self.client_host,
+            &mut self.trust.client_host,
+            &fallback.client_host,
+            &fallback.trust.client_host,
+        );
+        if self.session_id.is_none() {
+            self.session_id = fallback.session_id.clone();
+        }
+    }
+
     pub fn from_request_parts(
         headers: &HeaderMap,
         body: Option<&Value>,
@@ -856,11 +973,11 @@ fn merge_header_agent_context(ctx: &mut AgentContext, headers: &HeaderMap) {
         headers,
         "x-dcc-mcp-agent-id",
     );
-    fill_header_trusted_string(
+    fill_header_trusted_string_any(
         &mut ctx.agent_name,
         &mut ctx.trust.agent_name,
         headers,
-        "x-dcc-mcp-agent-name",
+        &["x-dcc-mcp-agent-name", "x-dcc-mcp-agent"],
     );
     fill_header_trusted_string(
         &mut ctx.agent_kind,
@@ -922,6 +1039,12 @@ fn merge_header_agent_context(ctx: &mut AgentContext, headers: &HeaderMap) {
         headers,
         "x-dcc-mcp-client-platform",
     );
+    if ctx.client_platform.is_none()
+        && let Some(value) = client_platform_from_user_agent(headers)
+    {
+        ctx.client_platform = Some(value);
+        set_trust(&mut ctx.trust.client_platform, TRUST_HEADER);
+    }
     fill_header_trusted_string(
         &mut ctx.client_os,
         &mut ctx.trust.client_os,
@@ -1037,6 +1160,23 @@ fn header_str_any(headers: &HeaderMap, names: &[&str]) -> Option<String> {
 
 fn header_u64_any(headers: &HeaderMap, names: &[&str]) -> Option<u64> {
     header_str_any(headers, names).and_then(|value| value.parse::<u64>().ok())
+}
+
+fn client_platform_from_user_agent(headers: &HeaderMap) -> Option<String> {
+    let raw = header_str(headers, "user-agent")?;
+    let product = raw
+        .split_whitespace()
+        .next()
+        .unwrap_or(raw.as_str())
+        .split('/')
+        .next()
+        .unwrap_or(raw.as_str())
+        .trim();
+    if product.is_empty() {
+        None
+    } else {
+        Some(bound_context_string(product.to_string()))
+    }
 }
 
 fn bound_context_string(value: String) -> String {
@@ -1315,69 +1455,6 @@ mod timestamp_serde {
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<SystemTime, D::Error> {
         let ms = u64::deserialize(d)?;
         Ok(UNIX_EPOCH + Duration::from_millis(ms))
-    }
-}
-
-// ── Ring buffer ───────────────────────────────────────────────────────────────
-
-/// Bounded ring buffer of completed traces.
-pub struct TraceLog {
-    buf: Mutex<Vec<DispatchTrace>>,
-    capacity: usize,
-}
-
-impl TraceLog {
-    pub const DEFAULT_CAPACITY: usize = 200;
-
-    pub fn new(capacity: usize) -> Self {
-        Self {
-            buf: Mutex::new(Vec::with_capacity(capacity.min(TraceLog::DEFAULT_CAPACITY))),
-            capacity,
-        }
-    }
-
-    /// Seed the in-memory ring from durable storage.
-    pub fn extend(&self, traces: impl IntoIterator<Item = DispatchTrace>) {
-        for trace in traces {
-            self.push(trace);
-        }
-    }
-
-    /// Append a completed trace, evicting the oldest entry if at capacity.
-    pub fn push(&self, trace: DispatchTrace) {
-        let mut buf = self.buf.lock();
-        buf.push(trace);
-        while self.capacity > 0 && buf.len() > self.capacity {
-            buf.remove(0);
-        }
-    }
-
-    /// Return the last `limit` traces, newest first.
-    pub fn recent(&self, limit: usize) -> Vec<DispatchTrace> {
-        let buf = self.buf.lock();
-        buf.iter().rev().take(limit).cloned().collect()
-    }
-
-    /// Fetch a single trace by `request_id`.
-    pub fn get(&self, request_id: &str) -> Option<DispatchTrace> {
-        self.buf
-            .lock()
-            .iter()
-            .rev()
-            .find(|t| t.request_id == request_id)
-            .cloned()
-    }
-
-    /// Fetch traces by trace id, newest first.
-    pub fn by_trace_id(&self, trace_id: &str, limit: usize) -> Vec<DispatchTrace> {
-        self.buf
-            .lock()
-            .iter()
-            .rev()
-            .filter(|t| t.trace_id == trace_id)
-            .take(limit)
-            .cloned()
-            .collect()
     }
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/admin/trace_log.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/trace_log.rs
@@ -1,0 +1,66 @@
+//! Bounded in-memory dispatch trace storage for admin diagnostics.
+
+use parking_lot::Mutex;
+
+use super::trace::DispatchTrace;
+
+/// Bounded ring buffer of completed traces.
+pub struct TraceLog {
+    buf: Mutex<Vec<DispatchTrace>>,
+    capacity: usize,
+}
+
+impl TraceLog {
+    pub const DEFAULT_CAPACITY: usize = 200;
+
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            buf: Mutex::new(Vec::with_capacity(capacity.min(TraceLog::DEFAULT_CAPACITY))),
+            capacity,
+        }
+    }
+
+    /// Seed the in-memory ring from durable storage.
+    pub fn extend(&self, traces: impl IntoIterator<Item = DispatchTrace>) {
+        for trace in traces {
+            self.push(trace);
+        }
+    }
+
+    /// Append a completed trace, evicting the oldest entry if at capacity.
+    pub fn push(&self, trace: DispatchTrace) {
+        let mut buf = self.buf.lock();
+        buf.push(trace);
+        while self.capacity > 0 && buf.len() > self.capacity {
+            buf.remove(0);
+        }
+    }
+
+    /// Return the last `limit` traces, newest first.
+    pub fn recent(&self, limit: usize) -> Vec<DispatchTrace> {
+        let buf = self.buf.lock();
+        buf.iter().rev().take(limit).cloned().collect()
+    }
+
+    /// Fetch a single trace by `request_id`.
+    pub fn get(&self, request_id: &str) -> Option<DispatchTrace> {
+        self.buf
+            .lock()
+            .iter()
+            .rev()
+            .find(|t| t.request_id == request_id)
+            .cloned()
+    }
+
+    /// Fetch traces by trace id, newest first.
+    pub fn by_trace_id(&self, trace_id: &str, limit: usize) -> Vec<DispatchTrace> {
+        self.buf
+            .lock()
+            .iter()
+            .rev()
+            .filter(|t| t.trace_id == trace_id)
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/trace_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/trace_tests.rs
@@ -127,6 +127,43 @@ fn agent_context_reads_meta_and_headers() {
 }
 
 #[test]
+fn agent_context_reads_mcp_initialize_client_info() {
+    let ctx = AgentContext::from_mcp_client_info(
+        "mcp-session-1",
+        Some(&json!({
+            "protocolVersion": "2025-03-26",
+            "clientInfo": {"name": "Codex Desktop", "version": "1.2.3"}
+        })),
+    )
+    .unwrap();
+
+    assert_eq!(ctx.agent_name.as_deref(), Some("Codex Desktop"));
+    assert_eq!(ctx.agent_kind.as_deref(), Some("mcp-client"));
+    assert_eq!(ctx.agent_version.as_deref(), Some("1.2.3"));
+    assert_eq!(ctx.client_platform.as_deref(), Some("Codex Desktop"));
+    assert_eq!(ctx.session_id.as_deref(), Some("mcp-session-1"));
+    assert_eq!(ctx.trust.agent_name.as_deref(), Some(TRUST_SELF_REPORTED));
+    assert_eq!(
+        ctx.trust.client_platform.as_deref(),
+        Some(TRUST_SELF_REPORTED)
+    );
+}
+
+#[test]
+fn agent_context_reads_agent_alias_and_user_agent_platform() {
+    let mut headers = HeaderMap::new();
+    headers.insert("x-dcc-mcp-agent", "Studio Gateway CLI".parse().unwrap());
+    headers.insert("user-agent", "dcc-mcp-cli/0.17.37 reqwest".parse().unwrap());
+
+    let ctx = AgentContext::from_request_parts(&headers, None, None).unwrap();
+
+    assert_eq!(ctx.agent_name.as_deref(), Some("Studio Gateway CLI"));
+    assert_eq!(ctx.client_platform.as_deref(), Some("dcc-mcp-cli"));
+    assert_eq!(ctx.trust.agent_name.as_deref(), Some(TRUST_HEADER));
+    assert_eq!(ctx.trust.client_platform.as_deref(), Some(TRUST_HEADER));
+}
+
+#[test]
 fn agent_context_accepts_plain_summary() {
     let headers = HeaderMap::new();
     let body = json!({"caller_context": "manual smoke test"});

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -141,6 +141,9 @@ async fn aggregate_tools_list_returns_only_minimal_gateway_surface() {
         resource_subscriptions: std::sync::Arc::new(tokio::sync::RwLock::new(
             std::collections::HashMap::new(),
         )),
+        client_attribution: std::sync::Arc::new(
+            crate::gateway::caller_attribution::ClientAttributionStore::default(),
+        ),
         pending_calls: std::sync::Arc::new(tokio::sync::RwLock::new(
             std::collections::HashMap::new(),
         )),
@@ -305,6 +308,9 @@ async fn make_gateway_state(
         resource_subscriptions: std::sync::Arc::new(tokio::sync::RwLock::new(
             std::collections::HashMap::new(),
         )),
+        client_attribution: std::sync::Arc::new(
+            crate::gateway::caller_attribution::ClientAttributionStore::default(),
+        ),
         pending_calls: std::sync::Arc::new(tokio::sync::RwLock::new(
             std::collections::HashMap::new(),
         )),
@@ -1231,6 +1237,9 @@ async fn gateway_state_with_instances(
         resource_subscriptions: std::sync::Arc::new(tokio::sync::RwLock::new(
             std::collections::HashMap::new(),
         )),
+        client_attribution: std::sync::Arc::new(
+            crate::gateway::caller_attribution::ClientAttributionStore::default(),
+        ),
         pending_calls: std::sync::Arc::new(tokio::sync::RwLock::new(
             std::collections::HashMap::new(),
         )),

--- a/crates/dcc-mcp-gateway/src/gateway/caller_attribution.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/caller_attribution.rs
@@ -1,5 +1,6 @@
 //! Server-derived caller-attribution helpers for gateway ingress.
 
+use std::collections::{HashMap, VecDeque};
 use std::net::{IpAddr, SocketAddr};
 
 use axum::body::Body;
@@ -7,17 +8,70 @@ use axum::extract::ConnectInfo;
 use axum::http::{HeaderMap, HeaderValue, Request};
 use axum::middleware::Next;
 use axum::response::Response;
+use serde_json::Value;
+use tokio::sync::RwLock;
 
 use super::resilience::gateway_limits;
+use crate::gateway::admin::trace::AgentContext;
 
 pub(crate) const INTERNAL_SOURCE_IP_HEADER: &str = "x-dcc-mcp-internal-source-ip";
 pub(crate) const INTERNAL_FORWARDED_FOR_HEADER: &str = "x-dcc-mcp-internal-forwarded-for";
 pub(crate) const INTERNAL_AUTH_SUBJECT_HEADER: &str = "x-dcc-mcp-internal-auth-subject";
+const MAX_MCP_CLIENT_SESSIONS: usize = 512;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ClientNetworkAttribution {
     pub(crate) source_ip: Option<String>,
     pub(crate) forwarded_for: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct ClientAttributionStore {
+    mcp_sessions: RwLock<ClientAttributionSessions>,
+}
+
+#[derive(Debug, Default)]
+struct ClientAttributionSessions {
+    order: VecDeque<String>,
+    sessions: HashMap<String, AgentContext>,
+}
+
+impl ClientAttributionStore {
+    pub(crate) async fn record_mcp_initialize(&self, session_id: &str, params: Option<&Value>) {
+        let Some(context) = AgentContext::from_mcp_client_info(session_id, params) else {
+            return;
+        };
+        let mut sessions = self.mcp_sessions.write().await;
+        if !sessions.sessions.contains_key(session_id) {
+            sessions.order.push_back(session_id.to_string());
+        }
+        sessions.sessions.insert(session_id.to_string(), context);
+        while sessions.sessions.len() > MAX_MCP_CLIENT_SESSIONS {
+            let Some(oldest) = sessions.order.pop_front() else {
+                break;
+            };
+            sessions.sessions.remove(&oldest);
+        }
+    }
+
+    pub(crate) async fn augment_mcp_context(
+        &self,
+        session_id: &str,
+        mut context: Option<AgentContext>,
+    ) -> Option<AgentContext> {
+        let session_context = {
+            let sessions = self.mcp_sessions.read().await;
+            sessions.sessions.get(session_id).cloned()
+        };
+        let Some(session_context) = session_context else {
+            return context;
+        };
+        match context.as_mut() {
+            Some(ctx) => ctx.merge_missing_client_identity_from(&session_context),
+            None => context = Some(session_context),
+        }
+        context
+    }
 }
 
 /// Attach server-derived network attribution for downstream handlers.

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -162,7 +162,7 @@ pub(crate) async fn dispatch_single_request(
     let id_str = serde_json::to_string(&id).unwrap_or_default();
 
     let response = match req.method.as_str() {
-        "initialize" => Some(handle_initialize_with_timeout(gs, id, req).await),
+        "initialize" => Some(handle_initialize_with_timeout(gs, id, req, session_id).await),
         "ping" => Some(json!({"jsonrpc":"2.0","id":id,"result":{}})),
         "notifications/initialized" => Some(json!({"jsonrpc":"2.0","id":id,"result":{}})),
         "tools/list" => Some(handle_tools_list(gs, id, req).await),
@@ -189,10 +189,11 @@ async fn handle_initialize_with_timeout(
     gs: &GatewayState,
     id: Value,
     req: &JsonRpcRequest,
+    session_id: &str,
 ) -> Value {
     match tokio::time::timeout(
         GATEWAY_INITIALIZE_TIMEOUT,
-        handle_initialize(gs, id.clone(), req),
+        handle_initialize(gs, id.clone(), req, session_id),
     )
     .await
     {
@@ -218,13 +219,21 @@ fn gateway_busy_initialize_response(id: Value) -> Value {
     })
 }
 
-async fn handle_initialize(gs: &GatewayState, id: Value, req: &JsonRpcRequest) -> Value {
+async fn handle_initialize(
+    gs: &GatewayState,
+    id: Value,
+    req: &JsonRpcRequest,
+    session_id: &str,
+) -> Value {
     let client_version = req
         .params
         .as_ref()
         .and_then(|params| params.get("protocolVersion"))
         .and_then(|value| value.as_str());
     let negotiated = negotiate_protocol_version(client_version);
+    gs.client_attribution
+        .record_mcp_initialize(session_id, req.params.as_ref())
+        .await;
     match gs.protocol_version.try_write() {
         Ok(mut protocol_version) => {
             *protocol_version = Some(negotiated.to_string());
@@ -507,6 +516,10 @@ async fn handle_tools_call(
             req.params.as_ref(),
             meta.as_ref(),
         );
+    let agent_context = gs
+        .client_attribution
+        .augment_mcp_context(session_id, agent_context)
+        .await;
     let trace_context = crate::gateway::admin::trace::TraceContext::from_headers_with_request_id(
         headers,
         id_str.to_string(),
@@ -866,6 +879,9 @@ mod tests {
             events_tx: Arc::new(events_tx),
             protocol_version: Arc::new(RwLock::new(None)),
             resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
+            client_attribution: Arc::new(
+                crate::gateway::caller_attribution::ClientAttributionStore::default(),
+            ),
             pending_calls: Arc::new(RwLock::new(HashMap::new())),
             subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
             allow_unknown_tools: false,
@@ -1100,6 +1116,70 @@ mod tests {
         assert_eq!(agent.actor_id.as_deref(), Some("artist-1"));
         assert_eq!(agent.client_platform.as_deref(), Some("cursor"));
         assert_eq!(agent.source_ip.as_deref(), Some("192.0.2.44"));
+    }
+
+    #[tokio::test]
+    async fn initialize_client_info_flows_to_mcp_call_admin_stats() {
+        let trace_log = Arc::new(crate::gateway::admin::TraceLog::new(10));
+        let audit_log: Arc<crate::gateway::admin::AuditLog> =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let sink = Arc::new(
+            crate::gateway::admin::AdminAuditSink::new(audit_log, 10)
+                .with_trace_log(trace_log.clone()),
+        );
+        let audit = Arc::new(crate::gateway::middleware::AuditMiddleware::new(sink));
+        let mut gs = test_gateway_state();
+        gs.middleware_chain = Arc::new(
+            crate::gateway::middleware::MiddlewareChain::new()
+                .with_before(audit.clone())
+                .with_after(audit),
+        );
+        let init = request(
+            "initialize",
+            json!("init"),
+            Some(json!({
+                "protocolVersion": "2025-03-26",
+                "clientInfo": {"name": "Codex Desktop", "version": "1.2.3"}
+            })),
+        );
+        let init_response =
+            dispatch_single_request(&gs, &init, "client-session-a", &HeaderMap::new())
+                .await
+                .expect("initialize request has id");
+        assert_eq!(
+            init_response["result"]["serverInfo"]["name"],
+            "test-gateway"
+        );
+
+        let call = request(
+            "tools/call",
+            json!("client-call"),
+            Some(json!({
+                "name": "search",
+                "arguments": {"kind": "tool", "query": "sphere"}
+            })),
+        );
+        let call_response =
+            dispatch_single_request(&gs, &call, "client-session-a", &HeaderMap::new())
+                .await
+                .expect("call request has id");
+        assert_eq!(call_response["result"]["isError"], false);
+
+        let traces = trace_log.recent(10);
+        assert_eq!(traces.len(), 1);
+        let agent = traces[0]
+            .agent_context
+            .as_ref()
+            .expect("MCP call should inherit initialize client attribution");
+        assert_eq!(agent.agent_name.as_deref(), Some("Codex Desktop"));
+        assert_eq!(agent.agent_version.as_deref(), Some("1.2.3"));
+        assert_eq!(agent.agent_kind.as_deref(), Some("mcp-client"));
+        assert_eq!(agent.client_platform.as_deref(), Some("Codex Desktop"));
+
+        let stats = crate::gateway::admin::StatsAggregator::new(trace_log)
+            .compute(crate::gateway::admin::StatsRange::All);
+        assert_eq!(stats.top_agents[0].name, "Codex Desktop@1.2.3");
+        assert_eq!(stats.top_client_platforms[0].name, "Codex Desktop");
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
@@ -276,6 +276,9 @@ mod tests {
             events_tx: Arc::new(events_tx),
             protocol_version: Arc::new(RwLock::new(None)),
             resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
+            client_attribution: Arc::new(
+                crate::gateway::caller_attribution::ClientAttributionStore::default(),
+            ),
             pending_calls: Arc::new(RwLock::new(HashMap::new())),
             subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
             allow_unknown_tools: false,

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -64,6 +64,9 @@ fn test_gateway_state_with_debug_routes(
         events_tx: Arc::new(events_tx),
         protocol_version: Arc::new(RwLock::new(None)),
         resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
+        client_attribution: Arc::new(
+            crate::gateway::caller_attribution::ClientAttributionStore::default(),
+        ),
         pending_calls: Arc::new(RwLock::new(HashMap::new())),
         subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
         allow_unknown_tools: false,

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
@@ -173,6 +173,9 @@ mod tests {
             events_tx: Arc::new(events_tx),
             protocol_version: Arc::new(RwLock::new(None)),
             resource_subscriptions: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            client_attribution: Arc::new(
+                crate::gateway::caller_attribution::ClientAttributionStore::default(),
+            ),
             pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
             subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
             allow_unknown_tools: false,

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -58,6 +58,7 @@ pub mod state;
 pub mod tools;
 pub mod traffic;
 
+pub use caller_attribution::ClientAttributionStore;
 pub use dcc_mcp_gateway_core::policy::{
     GatewayPolicy, GatewayPolicyDenial, GatewayPolicyDenyReason, GatewayPolicyOperation,
 };

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
@@ -23,7 +23,11 @@ and batched `call` requests. The gateway emits `gateway.search`,
 `gateway.call_batch` OTLP spans with bounded `dcc_mcp.*` attributes, including
 selected rank, score, match reasons, policy outcome, and success/failure kind.
 Only explicit bounded `agent_context` fields are exported; do not send hidden
-reasoning, secrets, or raw prompt bodies as telemetry metadata.
+reasoning, secrets, or raw prompt bodies as telemetry metadata. Gateway MCP
+also carries bounded `initialize.params.clientInfo` forward per
+`Mcp-Session-Id` so later `tools/call` rows show client name/version; REST
+clients that omit `client_platform` fall back to the first `User-Agent` product
+token.
 
 If a call is denied, throttled, or unexpectedly redacted, inspect
 `GET /v1/debug/governance` before retrying. It reports the effective read-only

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -185,6 +185,11 @@ pub struct GatewayState {
     /// Key = `Mcp-Session-Id`, value = set of subscribed URIs.
     /// Populated by `resources/subscribe` and pruned by `resources/unsubscribe`.
     pub resource_subscriptions: Arc<RwLock<HashMap<String, HashSet<String>>>>,
+    /// MCP initialize client attribution keyed by `Mcp-Session-Id`.
+    ///
+    /// The store is bounded and only keeps protocol client identity fields, so
+    /// later calls can be attributed without persisting raw request bodies.
+    pub client_attribution: Arc<super::ClientAttributionStore>,
     /// In-flight forwarded tool calls so that `notifications/cancelled` can be
     /// routed to the correct backend.
     ///

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -38,6 +38,9 @@ fn test_gateway_state_with_own_and_unknown(
         events_tx: Arc::new(events_tx),
         protocol_version: Arc::new(RwLock::new(None)),
         resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
+        client_attribution: Arc::new(
+            crate::gateway::caller_attribution::ClientAttributionStore::default(),
+        ),
         pending_calls: Arc::new(RwLock::new(HashMap::new())),
         subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
         allow_unknown_tools,

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -576,6 +576,9 @@ pub(crate) async fn start_gateway_tasks(
         events_tx,
         protocol_version: Arc::new(RwLock::new(None)),
         resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
+        client_attribution: Arc::new(
+            crate::gateway::caller_attribution::ClientAttributionStore::default(),
+        ),
         pending_calls: Arc::new(RwLock::new(HashMap::new())),
         subscriber,
         allow_unknown_tools,

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -227,12 +227,15 @@ user input, or raw agent replies on the default path.
 
 Supported carriers:
 
+- MCP `initialize` `params.clientInfo`; the gateway keeps bounded client
+  identity per `Mcp-Session-Id` and fills missing agent/client fields on later
+  MCP `tools/call` rows.
 - MCP `tools/call` `params._meta.agent_context`
 - REST body `agent_context`, `agentContext`, `caller_context`, or
   `meta.agent_context`
 - Headers such as `x-dcc-mcp-actor-id`, `x-dcc-mcp-actor-name`,
   `x-dcc-mcp-actor-email-hash`, `x-dcc-mcp-agent-id`,
-  `x-dcc-mcp-agent-name`, `x-dcc-mcp-agent-kind`,
+  `x-dcc-mcp-agent-name`, `x-dcc-mcp-agent`, `x-dcc-mcp-agent-kind`,
   `x-dcc-mcp-agent-version`, `x-dcc-mcp-agent-model`,
   `x-dcc-mcp-agent-model-provider`, `x-dcc-mcp-agent-model-version`,
   `x-dcc-mcp-agent-reasoning-effort`, `x-dcc-mcp-client-platform`,
@@ -244,6 +247,8 @@ Supported carriers:
   `x-dcc-mcp-agent-reply-chars`, `x-dcc-mcp-agent-task`,
   `x-dcc-mcp-reasoning-summary`, `x-dcc-mcp-parent-request-id`, and
   `x-dcc-mcp-agent-context` (JSON object)
+- REST `User-Agent`; when no explicit `client_platform` is provided, the first
+  product token is stored as a bounded client-platform fallback.
 
 Caller attribution separates five concepts:
 

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -83,6 +83,9 @@ prompts, raw agent replies, unbounded request bodies, secrets, or arbitrary
 and score to actual tool outcomes. Add `turn_id` and model identity to
 `agent_context` when an evaluation needs to correlate search quality,
 time-to-first-success, and downstream call success back to one agent turn.
+Gateway MCP sessions also use `initialize.params.clientInfo` as bounded client
+identity for later `tools/call` attribution, and REST requests fall back to the
+first `User-Agent` product token when no explicit `client_platform` is present.
 
 ### Trace Context
 
@@ -243,7 +246,10 @@ By default these buffers are in memory only. Set `DCC_MCP_GATEWAY_AUDIT_DIR` to 
 MCP and REST clients can attach optional agent/caller context to correlate an
 operator-visible request with the caller's explicit plan and observations. Use
 `params._meta.agent_context` for MCP, REST `meta.agent_context` or
-`caller_context` fields, or `x-dcc-mcp-*` attribution headers. Fields are
+`caller_context` fields, or `x-dcc-mcp-*` attribution headers. MCP
+`initialize.params.clientInfo` is retained per `Mcp-Session-Id` to fill missing
+client identity on later MCP calls, and REST `User-Agent` supplies a bounded
+`client_platform` fallback when no explicit platform is provided. Fields are
 bounded and intended for concise telemetry such as `actor_id`, `actor_name`,
 `actor_email_hash`, `agent_id`, `agent_name`, `agent_kind`, `agent_version`,
 `client_platform`, `client_os`, `client_host`, `auth_subject`, `model_provider`,

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -433,14 +433,17 @@ telemetry can measure the search-to-action path without storing full prompts.
 
 REST callers may add bounded caller attribution in `meta.agent_context`,
 top-level `agent_context` / `caller_context`, or headers. MCP callers use the
-same shape in `params._meta.agent_context`. This schema is metadata only; do
-not send hidden reasoning, full prompts, raw user messages, secrets, bearer
-tokens, or raw agent replies.
+same shape in `params._meta.agent_context`. Gateway MCP also reads
+`initialize.params.clientInfo` once per `Mcp-Session-Id` and uses it to fill
+missing `agent_name`, `agent_version`, `agent_kind = "mcp-client"`, and
+`client_platform` on later MCP calls. This schema is metadata only; do not send
+hidden reasoning, full prompts, raw user messages, secrets, bearer tokens, or
+raw agent replies.
 
 | Concept | JSON fields | Header fields |
 |---|---|---|
 | Actor | `actor_id`, `actor_name`, `actor_email_hash` | `x-dcc-mcp-actor-id`, `x-dcc-mcp-actor-name`, `x-dcc-mcp-actor-email-hash` |
-| Agent runtime | `agent_id`, `agent_name`, `agent_kind`, `agent_version`, `model`, `model_provider`, `model_version` | `x-dcc-mcp-agent-id`, `x-dcc-mcp-agent-name`, `x-dcc-mcp-agent-kind`, `x-dcc-mcp-agent-version`, `x-dcc-mcp-agent-model`, `x-dcc-mcp-agent-model-provider`, `x-dcc-mcp-agent-model-version` |
+| Agent runtime | `agent_id`, `agent_name`, `agent_kind`, `agent_version`, `model`, `model_provider`, `model_version` | `x-dcc-mcp-agent-id`, `x-dcc-mcp-agent-name`, `x-dcc-mcp-agent`, `x-dcc-mcp-agent-kind`, `x-dcc-mcp-agent-version`, `x-dcc-mcp-agent-model`, `x-dcc-mcp-agent-model-provider`, `x-dcc-mcp-agent-model-version` |
 | Client platform | `client_platform`, `client_os`, `client_host` | `x-dcc-mcp-client-platform`, `x-dcc-mcp-client-os`, `x-dcc-mcp-client-host` |
 | Auth subject | `auth_subject` | `x-dcc-mcp-auth-subject` |
 | Network source | `source_ip`, `forwarded_for` | Server-derived only |
@@ -450,7 +453,9 @@ are reserved for server-derived network data after proxy trust policy has been
 applied; values supplied in REST request bodies, MCP `_meta`, or caller headers
 are ignored. Use `client_platform` values such as `cursor`, `claude-desktop`,
 `openclaw`, `clawhub`, `custom-http`, or `studio-tool` to distinguish surfaces
-without overloading agent identity.
+without overloading agent identity. If a REST request omits `client_platform`,
+the gateway falls back to the first `User-Agent` product token, for example
+`dcc-mcp-cli` from `dcc-mcp-cli/0.17.37`.
 
 The gateway annotates stored context with a server-computed `trust` map and
 Admin rows expose the same map as `attribution_trust`. Values are
@@ -545,6 +550,9 @@ Rules:
 - Optional `meta.agent_context`, top-level `caller_context`, or
   `x-dcc-mcp-*` attribution headers carry bounded actor, agent, client, auth,
   and turn metadata for Admin workflow, search-quality, and OTLP correlation.
+  Gateway MCP calls can also inherit bounded client identity from the session's
+  `initialize.params.clientInfo`; REST requests without explicit
+  `client_platform` use the first `User-Agent` product token as a fallback.
   Send concise summaries, hashes, and character counts only; raw user input and
   raw agent replies are high sensitivity and belong only in an explicit
   redacted traffic-capture flow.

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -50,9 +50,10 @@ skill taxonomy), load `dcc-mcp-skills-creator` instead.
 4. Route host API calls through `HostExecutionBridge`; do not hand-roll a second script executor.
 5. Keep DCC identity data-driven: `dcc_name`, `server_name`, env-var prefix, skill names, and gateway metadata.
 6. Use core helpers for skill discovery, `MinimalModeConfig`, project tools, resources, diagnostics, context snapshots, install lifecycle, and gateway failover before writing adapter-local wrappers.
-7. When the adapter needs a lifecycle hook or metadata transform that core cannot express, open a focused core issue/RFC instead of parsing YAML or mutating private state in the adapter.
-8. Add one executable smoke path: unit tests for construction plus either headless DCC, mock dispatcher MCP calls, or gateway REST replay.
-9. For gateway/admin observability, surface explicit state instead of silent zeroes: traffic panels should report disabled, unavailable, filtered, or genuine no-traffic states and keep admin-facing frames metadata-only unless an operator explicitly configures a private raw sink.
+7. Preserve gateway caller attribution when adding adapter wrappers or admin/debug routes: let MCP `initialize.params.clientInfo`, MCP `_meta.agent_context`, REST `meta.agent_context`, `x-dcc-mcp-*` headers, and safe `User-Agent` fallbacks flow through core rather than logging raw prompts or local machine data.
+8. When the adapter needs a lifecycle hook or metadata transform that core cannot express, open a focused core issue/RFC instead of parsing YAML or mutating private state in the adapter.
+9. Add one executable smoke path: unit tests for construction plus either headless DCC, mock dispatcher MCP calls, or gateway REST replay.
+10. For gateway/admin observability, surface explicit state instead of silent zeroes: traffic panels should report disabled, unavailable, filtered, or genuine no-traffic states and keep admin-facing frames metadata-only unless an operator explicitly configures a private raw sink.
 
 ## Example: New Nuke Adapter
 


### PR DESCRIPTION
## Summary
- Retain MCP `initialize.params.clientInfo` per `Mcp-Session-Id` and use it to fill missing admin call attribution on later MCP `tools/call` rows.
- Add safe REST attribution fallbacks for `User-Agent` and `X-DCC-MCP-Agent`, with version-aware top-agent stats.
- Update admin, REST, observability, gateway workflow, and `dcc-mcp-creator` guidance for the attribution contract.

Fixes #1326

## Validation
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo test -p dcc-mcp-gateway --features admin --lib`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo clippy -p dcc-mcp-gateway --features admin --lib -- -D warnings`
- `vx git diff --check`
- `vx npm ci` in `docs/`
- `vx npm run docs:build` in `docs/`

Note: `vx just docs-check` could not run in this Windows shell because `cygpath` was unavailable; the recipe's docs npm steps passed directly.