### PR TITLE
feat(models): standardize skill metadata for intelligent recall (#1335)

### DIFF
--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -16,10 +16,11 @@ pub use dcc_name::DccName;
 pub use error::DccMcpError;
 pub use registry::{DefaultRegistry, Registry, RegistryEntry, SearchQuery};
 pub use skill_metadata::{
-    ExecutionMode, NextTools, SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup,
-    SkillMetadata, SkillPolicy, SkillRuntimeDescriptor, SkillRuntimeKind, SkillRuntimeReport,
-    SkillRuntimeState, SkillRuntimeSummary, ThreadAffinity, ToolAnnotations, ToolDeclaration,
-    resolve_runtime_reports, summarize_runtime_reports,
+    ExecutionMode, NextTools, Precondition, RecallContext, RiskLevel, SideEffects,
+    SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup, SkillMetadata,
+    SkillPolicy, SkillRuntimeDescriptor, SkillRuntimeKind, SkillRuntimeReport, SkillRuntimeState,
+    SkillRuntimeSummary, SuccessMetrics, ThreadAffinity, ToolAnnotations, ToolDeclaration,
+    ToolRole, resolve_runtime_reports, summarize_runtime_reports,
 };
 pub use skill_scope::SkillScope;
 

--- a/crates/dcc-mcp-models/src/skill_metadata/mod.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/mod.rs
@@ -315,6 +315,61 @@ pub struct SkillMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stage: Option<String>,
 
+    /// One-line statement of what user intent this skill satisfies
+    /// (issue #1335). Powers the search ranker's intent-match boost.
+    ///
+    /// Example: `"Import a USD layer into the active scene."`
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent: Option<String>,
+
+    /// Recall context (`app_type`, `domain`, `workflow_stage`,
+    /// `task_category`) used by the search ranker and capability graph
+    /// (issues #1335, #1336).
+    #[serde(
+        default,
+        rename = "recall_context",
+        alias = "recall-context",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub recall_context: Option<skill_recall::RecallContext>,
+
+    /// Structured preconditions that must hold before this skill can run
+    /// safely — software, plugin, selection, scene state, capability, or
+    /// free-form descriptions (issue #1335).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub preconditions: Vec<skill_recall::Precondition>,
+
+    /// Aggregate side-effect descriptor — what the skill changes in the host
+    /// (issue #1335). Feeds the capability graph and the safety surfaces.
+    #[serde(
+        default,
+        rename = "side_effects",
+        alias = "side-effects",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub side_effects: Option<skill_recall::SideEffects>,
+
+    /// Artefact / object / scene-state tags this skill produces (issue #1335).
+    /// Example: `["file:usd", "scene_node:transform", "render:beauty"]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub produces: Vec<String>,
+
+    /// Required upstream capabilities or skill names that must run before
+    /// this one is meaningful (issue #1335). Complements the load-blocking
+    /// `depends` field.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requires: Vec<String>,
+
+    /// Aggregate runtime success metrics — populated by the ranker / memory
+    /// layer (#1334), never authored by hand in SKILL.md.
+    #[serde(
+        default,
+        rename = "success_metrics",
+        alias = "success-metrics",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub success_metrics: Option<skill_recall::SuccessMetrics>,
+
     /// Sibling-file reference for skill recipes (issue #466).
     ///
     /// Set from `metadata.dcc-mcp.recipes` in SKILL.md frontmatter. The value
@@ -342,6 +397,7 @@ pub struct SkillMetadata {
 mod execution;
 mod skill_dependency;
 mod skill_policy;
+mod skill_recall;
 mod skill_runtime;
 mod tests;
 mod tool_declaration;
@@ -349,5 +405,6 @@ mod tool_declaration;
 pub use execution::*;
 pub use skill_dependency::*;
 pub use skill_policy::*;
+pub use skill_recall::*;
 pub use skill_runtime::*;
 pub use tool_declaration::*;

--- a/crates/dcc-mcp-models/src/skill_metadata/skill_recall.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/skill_recall.rs
@@ -1,0 +1,352 @@
+//! Recall metadata for intelligent skill discovery (issue #1335).
+//!
+//! These types extend `SkillMetadata` and `ToolDeclaration` with structured,
+//! optional fields the ranker, capability graph (#1336), lifecycle hooks
+//! (#1337) and escape-hatch policy (#1325) can consume without changing the
+//! wire shape of skills that do not opt in.
+//!
+//! Design rules:
+//!
+//! * Every field is optional.  Missing values are equivalent to "unknown".
+//! * Types are pure data — no I/O, no validation logic here.  The validator
+//!   in `dcc-mcp-skills` is the only place that turns "missing recommended
+//!   field" into a warning.
+//! * Enums use `#[serde(rename_all = "snake_case")]` so YAML, JSON, and the
+//!   Rust label all agree.
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level recall context for a skill or tool.
+///
+/// Tells discovery where this capability lives in the DCC universe so the
+/// ranker can down-rank obviously-irrelevant candidates without loading full
+/// schemas.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecallContext {
+    /// Target application family — `"maya"`, `"blender"`, `"houdini"`, `"any"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_type: Option<String>,
+
+    /// Domain bucket — `"modeling"`, `"rigging"`, `"rendering"`, `"io"`,
+    /// `"diagnostics"`, …
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+
+    /// Workflow stage — adapter-defined, e.g. Maya uses `"bootstrap"`,
+    /// `"scene"`, `"authoring"`, `"interchange"`, `"pipeline"`.
+    #[serde(
+        default,
+        rename = "workflow_stage",
+        alias = "workflow-stage",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub workflow_stage: Option<String>,
+
+    /// Task category — `"query"`, `"mutate"`, `"export"`, `"import"`,
+    /// `"diagnose"`, …
+    #[serde(
+        default,
+        rename = "task_category",
+        alias = "task-category",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub task_category: Option<String>,
+}
+
+impl RecallContext {
+    /// Returns `true` when every field is unset.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.app_type.is_none()
+            && self.domain.is_none()
+            && self.workflow_stage.is_none()
+            && self.task_category.is_none()
+    }
+}
+
+/// A single precondition that must hold for a skill or tool to run safely.
+///
+/// Open-ended via the `Other` variant so adapters can express studio-specific
+/// requirements without core needing a new variant per DCC.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Precondition {
+    /// Specific application + optional version constraint, e.g. Maya 2024+.
+    Software {
+        name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<String>,
+    },
+    /// Loaded plugin or module the host must have available.
+    Plugin { name: String },
+    /// Required selection state in the host.
+    Selection {
+        kind: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min: Option<u32>,
+    },
+    /// Scene state predicate (`"has_active_camera"`, `"in_object_mode"`, …).
+    SceneState { predicate: String },
+    /// Adapter capability tag (mirrors `ToolDeclaration::required_capabilities`).
+    Capability { tag: String },
+    /// Free-form fallback for conditions the modelled variants cannot express.
+    Other { description: String },
+}
+
+/// Side-effect descriptor — what does this skill or tool change?
+///
+/// The booleans surface as agent-facing safety hints; `targets` is the
+/// machine-readable list of artefact/object tags fed into the capability
+/// graph (#1336) — e.g. `["scene_node", "file:fbx"]`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SideEffects {
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub creates: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub modifies: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub deletes: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub exports: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub imports: bool,
+    #[serde(
+        default,
+        rename = "ui_mutation",
+        alias = "ui-mutation",
+        skip_serializing_if = "is_false"
+    )]
+    pub ui_mutation: bool,
+    #[serde(
+        default,
+        rename = "file_output",
+        alias = "file-output",
+        skip_serializing_if = "is_false"
+    )]
+    pub file_output: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub render: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub targets: Vec<String>,
+}
+
+impl SideEffects {
+    /// Returns `true` when every flag is `false` and `targets` is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        !(self.creates
+            || self.modifies
+            || self.deletes
+            || self.exports
+            || self.imports
+            || self.ui_mutation
+            || self.file_output
+            || self.render)
+            && self.targets.is_empty()
+    }
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+fn is_zero_u64(v: &u64) -> bool {
+    *v == 0
+}
+
+/// Tool semantic role — drives ranking and safety surfaces (issue #1325).
+///
+/// `EscapeHatch` is what generic-scripting tools (`execute_python`, host
+/// script eval, MaxScript-style execution) declare so the gateway can demote
+/// them in search results unless the agent explicitly asks for scripting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolRole {
+    /// Pure read tool — no observable state change.
+    ReadOnly,
+    /// Normal action — mutates state but recoverable through undo / re-run.
+    Action,
+    /// Destructive mutation — undo may not recover.
+    Destructive,
+    /// Generic scripting / shell / eval escape hatch.  Only ranked when no
+    /// typed skill covers the query.
+    EscapeHatch,
+    /// Debug-only tool — hidden from production discovery unless explicitly
+    /// requested.
+    DebugOnly,
+}
+
+impl ToolRole {
+    /// Short label used in JSON, logs, and Python `__str__`.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read_only",
+            Self::Action => "action",
+            Self::Destructive => "destructive",
+            Self::EscapeHatch => "escape_hatch",
+            Self::DebugOnly => "debug_only",
+        }
+    }
+
+    /// Whether this role should be treated as an explicit fallback path
+    /// rather than a normal first-class capability.
+    #[must_use]
+    pub fn is_escape_hatch(self) -> bool {
+        matches!(self, Self::EscapeHatch)
+    }
+}
+
+/// Coarse risk classification surfaced to agents and admins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskLevel {
+    /// Read-only / sandboxed operation.
+    Low,
+    /// Mutates host state but bounded.
+    Medium,
+    /// Destructive or irreversible without explicit acknowledgement.
+    High,
+    /// Host scripting / shell execution — must be paired with
+    /// `ToolRole::EscapeHatch`.
+    HostScriptExecution,
+}
+
+impl RiskLevel {
+    /// Short label used in JSON, logs, and Python `__str__`.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::HostScriptExecution => "host_script_execution",
+        }
+    }
+}
+
+/// Aggregate success metrics for a skill or tool.
+///
+/// Populated at runtime by the ranker / memory layer (#1334) — never written
+/// by hand into SKILL.md.  Stored alongside the static metadata so the same
+/// type round-trips through the public `SkillMetadata` JSON when an admin
+/// surface chooses to expose it.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SuccessMetrics {
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub success_count: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub failure_count: u64,
+    #[serde(
+        default,
+        rename = "last_used_unix_secs",
+        alias = "last-used-unix-secs",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub last_used_unix_secs: Option<i64>,
+    #[serde(
+        default,
+        rename = "recent_failure_kinds",
+        alias = "recent-failure-kinds",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub recent_failure_kinds: Vec<String>,
+    #[serde(
+        default,
+        rename = "mean_selected_rank",
+        alias = "mean-selected-rank",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub mean_selected_rank: Option<f32>,
+}
+
+impl SuccessMetrics {
+    /// Returns `true` when no observations have been recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.success_count == 0
+            && self.failure_count == 0
+            && self.last_used_unix_secs.is_none()
+            && self.recent_failure_kinds.is_empty()
+            && self.mean_selected_rank.is_none()
+    }
+
+    /// Empirical success rate over observed runs, or `None` if no runs yet.
+    #[must_use]
+    pub fn success_rate(&self) -> Option<f32> {
+        let total = self.success_count + self.failure_count;
+        if total == 0 {
+            None
+        } else {
+            Some(self.success_count as f32 / total as f32)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recall_context_serde_omits_unset_fields() {
+        let ctx = RecallContext {
+            app_type: Some("maya".into()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&ctx).unwrap();
+        assert_eq!(json, r#"{"app_type":"maya"}"#);
+        let back: RecallContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ctx);
+    }
+
+    #[test]
+    fn precondition_software_serde_roundtrip() {
+        let p = Precondition::Software {
+            name: "maya".into(),
+            version: Some(">=2024".into()),
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: Precondition = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn side_effects_default_is_empty() {
+        let s = SideEffects::default();
+        assert!(s.is_empty());
+        let json = serde_json::to_string(&s).unwrap();
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn tool_role_serde_snake_case() {
+        let role = ToolRole::EscapeHatch;
+        let json = serde_json::to_string(&role).unwrap();
+        assert_eq!(json, "\"escape_hatch\"");
+        assert_eq!(role.label(), "escape_hatch");
+        assert!(role.is_escape_hatch());
+    }
+
+    #[test]
+    fn risk_level_host_script_label() {
+        assert_eq!(
+            RiskLevel::HostScriptExecution.label(),
+            "host_script_execution"
+        );
+    }
+
+    #[test]
+    fn success_metrics_rate_is_none_when_unused() {
+        assert_eq!(SuccessMetrics::default().success_rate(), None);
+    }
+
+    #[test]
+    fn success_metrics_rate_computes_correctly() {
+        let m = SuccessMetrics {
+            success_count: 3,
+            failure_count: 1,
+            ..Default::default()
+        };
+        assert!((m.success_rate().unwrap() - 0.75).abs() < f32::EPSILON);
+    }
+}

--- a/crates/dcc-mcp-models/src/skill_metadata/tests.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tests.rs
@@ -408,6 +408,13 @@ fn test_skill_metadata_serde_round_trip() {
         stage: Some("authoring".to_string()),
         recipes_file: None,
         introspection_file: None,
+        intent: None,
+        recall_context: None,
+        preconditions: Vec::new(),
+        side_effects: None,
+        produces: Vec::new(),
+        requires: Vec::new(),
+        success_metrics: None,
     };
     let json = serde_json::to_string(&meta).unwrap();
     let back: SkillMetadata = serde_json::from_str(&json).unwrap();

--- a/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
@@ -4,6 +4,7 @@ fn is_default_affinity(affinity: &ThreadAffinity) -> bool {
 
 use serde::{Deserialize, Serialize};
 
+use super::skill_recall::{RiskLevel, SideEffects, ToolRole};
 use super::{ExecutionMode, ThreadAffinity};
 
 #[cfg(feature = "stub-gen")]
@@ -360,6 +361,52 @@ pub struct ToolDeclaration {
         skip_serializing_if = "Vec::is_empty"
     )]
     pub search_aliases: Vec<String>,
+
+    // ── Recall metadata extensions (issue #1335) ──────────────────────────
+    //
+    // All fields are optional; missing values are equivalent to "unknown"
+    // and never block tool loading or dispatch.  See `skill_recall.rs` for
+    // type definitions.
+    /// One-line statement of what user intent this tool satisfies — fuels the
+    /// search ranker's intent-match boost (issue #1335).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent: Option<String>,
+
+    /// Semantic role.  `EscapeHatch` flags this tool as a generic-scripting
+    /// fallback that the gateway should demote in default search ranking
+    /// (issue #1325).
+    #[serde(
+        default,
+        rename = "tool_role",
+        alias = "tool-role",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tool_role: Option<ToolRole>,
+
+    /// Coarse risk classification.  When omitted the gateway infers a level
+    /// from `annotations.read_only_hint` / `destructive_hint`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk: Option<RiskLevel>,
+
+    /// Side-effect descriptor for this tool (issue #1335).  Falls back to the
+    /// skill-level `side_effects` when unset.
+    #[serde(
+        default,
+        rename = "side_effects",
+        alias = "side-effects",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub side_effects: Option<SideEffects>,
+
+    /// Artefact / object / scene-state tags this tool produces (issue #1335).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub produces: Vec<String>,
+
+    /// Required upstream capabilities or tool names that must run before
+    /// this one is meaningful (issue #1335).  Complements
+    /// `required_capabilities`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requires: Vec<String>,
 }
 
 // ── ToolDeclaration custom deserializer (issue #344) ──────────────────────
@@ -469,6 +516,20 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
                 alias = "aliases"
             )]
             search_aliases: Vec<String>,
+
+            // ── Recall metadata (issue #1335) ─────────────────────────────
+            #[serde(default)]
+            intent: Option<String>,
+            #[serde(default, rename = "tool_role", alias = "tool-role")]
+            tool_role: Option<ToolRole>,
+            #[serde(default)]
+            risk: Option<RiskLevel>,
+            #[serde(default, rename = "side_effects", alias = "side-effects")]
+            side_effects: Option<SideEffects>,
+            #[serde(default)]
+            produces: Vec<String>,
+            #[serde(default)]
+            requires: Vec<String>,
         }
 
         let w = Wire::deserialize(deserializer)?;
@@ -519,6 +580,12 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
             annotations,
             required_capabilities: w.required_capabilities,
             search_aliases: w.search_aliases,
+            intent: w.intent,
+            tool_role: w.tool_role,
+            risk: w.risk,
+            side_effects: w.side_effects,
+            produces: w.produces,
+            requires: w.requires,
         })
     }
 }

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -319,6 +319,11 @@ _LAZY: dict[str, str] = {
     "InlineExecution": "dcc_mcp_core._server.options",
     "ObservabilityOptions": "dcc_mcp_core._server.options",
     "StandaloneMainThreadExecution": "dcc_mcp_core._server.options",
+    # Lifecycle hooks (issue #1337)
+    "HookContext": "dcc_mcp_core.lifecycle_hooks",
+    "HookDeny": "dcc_mcp_core.lifecycle_hooks",
+    "HookEvent": "dcc_mcp_core.lifecycle_hooks",
+    "LifecycleHooks": "dcc_mcp_core.lifecycle_hooks",
     # DccServerBase + factory
     "DccServerBase": "dcc_mcp_core.server_base",
     "create_dcc_server": "dcc_mcp_core.factory",

--- a/python/dcc_mcp_core/lifecycle_hooks.py
+++ b/python/dcc_mcp_core/lifecycle_hooks.py
@@ -1,0 +1,146 @@
+"""Typed lifecycle-hook framework for DCC adapters (issue #1337).
+
+The framework lets adapter and policy code subscribe to discovery, tool-call
+and session events without patching ``DccServerBase`` internals. Hook fan-out
+is bounded and fail-safe: an unexpected exception in one handler is logged
+and never aborts a tool-call, but a handler may explicitly veto a policy
+event by raising :class:`HookDeny`.
+
+Only ``BEFORE_SKILL_LOAD`` and ``AFTER_SKILL_LOAD`` are wired to live event
+sources today via :meth:`DccServerBase.register_lifecycle_hooks` (they bridge
+to the existing ``set_skill_load_transform`` / ``set_after_load_skill_hook``
+setters). The remaining events are registered and dispatched through the same
+typed surface so downstream issues (#1325 escape-hatch demotion, #1336
+capability graph, #1334 memory layers) can fire them from their integration
+points without changing the public contract again.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+import logging
+from typing import Any
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class HookEvent(str, Enum):
+    """All typed lifecycle hook points emitted by ``DccServerBase``."""
+
+    SESSION_START = "on_session_start"
+    BEFORE_SEARCH = "before_search"
+    AFTER_SEARCH = "after_search"
+    BEFORE_SKILL_LOAD = "before_skill_load"
+    AFTER_SKILL_LOAD = "after_skill_load"
+    BEFORE_TOOL_CALL = "before_tool_call"
+    AFTER_TOOL_CALL = "after_tool_call"
+    SESSION_END = "on_session_end"
+
+    @classmethod
+    def policy_events(cls) -> frozenset[HookEvent]:
+        """Events where a handler may veto via :class:`HookDeny`."""
+        return frozenset({cls.BEFORE_SKILL_LOAD, cls.BEFORE_TOOL_CALL, cls.BEFORE_SEARCH})
+
+
+@dataclass(frozen=True)
+class HookContext:
+    """Immutable payload passed to every hook handler.
+
+    Attributes:
+        event: Which :class:`HookEvent` is firing.
+        dcc_name: Adapter identifier (``"maya"``, ``"blender"``, ``"any"``…).
+        session_id: Optional stable identifier for the current agent session.
+        payload: Event-specific structured data (skill name, tool name,
+            search query, result count, …). Always JSON-safe so memory and
+            telemetry layers can record it.
+
+    """
+
+    event: HookEvent
+    dcc_name: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    session_id: str | None = None
+
+
+class HookDeny(Exception):
+    """Raised by a policy hook to veto a discovery, load, or call event.
+
+    Only meaningful for events listed in :meth:`HookEvent.policy_events`. The
+    ``reason`` is surfaced to telemetry and to the caller as the deny reason;
+    the ``hint`` is an agent-facing remediation string.
+    """
+
+    def __init__(self, reason: str, *, hint: str | None = None) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.hint = hint
+
+    def __repr__(self) -> str:
+        return f"HookDeny(reason={self.reason!r}, hint={self.hint!r})"
+
+
+HookHandler = Callable[[HookContext], Any]
+
+
+class LifecycleHooks:
+    """Bounded, fail-safe registry of typed lifecycle handlers.
+
+    Handlers are dispatched in registration order. For non-policy events,
+    handler exceptions are logged at WARNING and swallowed so they cannot
+    abort host execution. For policy events, a :class:`HookDeny` raised by
+    any handler propagates to the caller; other exceptions are logged and
+    treated as "no decision".
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[HookEvent, list[HookHandler]] = {evt: [] for evt in HookEvent}
+
+    def on(self, event: HookEvent, handler: HookHandler) -> HookHandler:
+        """Register ``handler`` for ``event`` and return it for use as a decorator."""
+        if not callable(handler):
+            raise TypeError("lifecycle hook handler must be callable")
+        self._handlers[event].append(handler)
+        return handler
+
+    def off(self, event: HookEvent, handler: HookHandler) -> bool:
+        """Remove a previously registered handler. Returns ``True`` if removed."""
+        handlers = self._handlers[event]
+        for idx in range(len(handlers) - 1, -1, -1):
+            if handlers[idx] is handler:
+                del handlers[idx]
+                return True
+        return False
+
+    def handlers(self, event: HookEvent) -> tuple[HookHandler, ...]:
+        """Snapshot of currently-registered handlers (immutable view)."""
+        return tuple(self._handlers[event])
+
+    def dispatch(self, context: HookContext) -> None:
+        """Fan-out ``context`` to every handler registered for its event.
+
+        Propagates :class:`HookDeny` from policy events; logs everything else.
+        """
+        is_policy = context.event in HookEvent.policy_events()
+        for handler in self._handlers[context.event]:
+            try:
+                handler(context)
+            except HookDeny:
+                if is_policy:
+                    raise
+                logger.warning(
+                    "[lifecycle] HookDeny raised by non-policy event %s; treating as logged-only",
+                    context.event.value,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[lifecycle] handler for %s failed: %s",
+                    context.event.value,
+                    exc,
+                    exc_info=True,
+                )
+
+
+__all__ = ["HookContext", "HookDeny", "HookEvent", "HookHandler", "LifecycleHooks"]

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -699,6 +699,55 @@ class DccServerBase:
         """Remove the after-load skill observer, if one is registered."""
         return self._skill_client.clear_after_load_skill_hook()
 
+    def register_lifecycle_hooks(self, hooks: Any) -> Any:
+        """Bind a :class:`~dcc_mcp_core.lifecycle_hooks.LifecycleHooks` registry.
+
+        The registry's ``BEFORE_SKILL_LOAD`` and ``AFTER_SKILL_LOAD`` handlers
+        are bridged to the existing skill-load transform / after-load setters
+        so adapters get a single typed surface across discovery, load, and
+        tool-call hook points (issue #1337). Other event types are still
+        registered and will be dispatched by downstream subsystems
+        (#1325 escape-hatch demotion, #1336 capability graph, #1334 memory
+        layers).
+
+        Returns the registry, so callers can chain
+        ``register_lifecycle_hooks(LifecycleHooks()).on(event, handler)``.
+        """
+        from dcc_mcp_core.lifecycle_hooks import HookContext
+        from dcc_mcp_core.lifecycle_hooks import HookEvent
+
+        self._lifecycle_hooks = hooks
+
+        def _bridge_before_load(skill: Any) -> Any:
+            hooks.dispatch(
+                HookContext(
+                    event=HookEvent.BEFORE_SKILL_LOAD,
+                    dcc_name=self._dcc_name,
+                    payload={"skill_name": getattr(skill, "name", None)},
+                )
+            )
+            return None
+
+        def _bridge_after_load(skill: Any, registered: list[str]) -> None:
+            hooks.dispatch(
+                HookContext(
+                    event=HookEvent.AFTER_SKILL_LOAD,
+                    dcc_name=self._dcc_name,
+                    payload={
+                        "skill_name": getattr(skill, "name", None),
+                        "registered_actions": list(registered),
+                    },
+                )
+            )
+
+        self.set_skill_load_transform(_bridge_before_load)
+        self.set_after_load_skill_hook(_bridge_after_load)
+        return hooks
+
+    def lifecycle_hooks(self) -> Any | None:
+        """Return the :class:`LifecycleHooks` registered by ``register_lifecycle_hooks``."""
+        return getattr(self, "_lifecycle_hooks", None)
+
     def unload_skill(self, name: str) -> bool:
         """Unload a skill by name."""
         return self._skill_client.unload_skill(name)

--- a/tests/test_lifecycle_hooks.py
+++ b/tests/test_lifecycle_hooks.py
@@ -1,0 +1,216 @@
+"""Tests for the typed lifecycle-hook framework (issue #1337)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from dcc_mcp_core import HookContext
+from dcc_mcp_core import HookDeny
+from dcc_mcp_core import HookEvent
+from dcc_mcp_core import LifecycleHooks
+
+
+class TestHookEvent:
+    def test_policy_events_only_contain_before_events(self) -> None:
+        policy = HookEvent.policy_events()
+        assert HookEvent.BEFORE_SKILL_LOAD in policy
+        assert HookEvent.BEFORE_TOOL_CALL in policy
+        assert HookEvent.BEFORE_SEARCH in policy
+        # after_* and on_session_* are observational
+        assert HookEvent.AFTER_SEARCH not in policy
+        assert HookEvent.AFTER_SKILL_LOAD not in policy
+        assert HookEvent.AFTER_TOOL_CALL not in policy
+        assert HookEvent.SESSION_START not in policy
+        assert HookEvent.SESSION_END not in policy
+
+    def test_event_values_are_snake_case_strings(self) -> None:
+        for event in HookEvent:
+            assert event.value == event.value.lower()
+            assert " " not in event.value
+
+
+class TestHookDeny:
+    def test_deny_carries_reason_and_optional_hint(self) -> None:
+        deny = HookDeny("blocked by policy", hint="load typed skill foo first")
+        assert deny.reason == "blocked by policy"
+        assert deny.hint == "load typed skill foo first"
+        assert "blocked by policy" in repr(deny)
+
+    def test_deny_without_hint(self) -> None:
+        deny = HookDeny("nope")
+        assert deny.hint is None
+
+
+class TestLifecycleHooks:
+    def test_on_rejects_non_callable(self) -> None:
+        hooks = LifecycleHooks()
+        with pytest.raises(TypeError):
+            hooks.on(HookEvent.BEFORE_SEARCH, "not callable")  # type: ignore[arg-type]
+
+    def test_handlers_fire_in_registration_order(self) -> None:
+        hooks = LifecycleHooks()
+        order: list[int] = []
+        hooks.on(HookEvent.AFTER_SEARCH, lambda ctx: order.append(1))
+        hooks.on(HookEvent.AFTER_SEARCH, lambda ctx: order.append(2))
+        hooks.on(HookEvent.AFTER_SEARCH, lambda ctx: order.append(3))
+
+        hooks.dispatch(HookContext(event=HookEvent.AFTER_SEARCH, dcc_name="any"))
+
+        assert order == [1, 2, 3]
+
+    def test_off_removes_handler(self) -> None:
+        hooks = LifecycleHooks()
+        seen: list[str] = []
+
+        def handler(ctx: HookContext) -> None:
+            seen.append("called")
+
+        hooks.on(HookEvent.AFTER_SKILL_LOAD, handler)
+        assert hooks.off(HookEvent.AFTER_SKILL_LOAD, handler) is True
+        hooks.dispatch(HookContext(event=HookEvent.AFTER_SKILL_LOAD, dcc_name="any"))
+
+        assert seen == []
+        # Removing again returns False
+        assert hooks.off(HookEvent.AFTER_SKILL_LOAD, handler) is False
+
+    def test_non_policy_handler_exception_is_swallowed(self, caplog) -> None:
+        hooks = LifecycleHooks()
+        seen: list[str] = []
+
+        def broken(ctx: HookContext) -> None:
+            raise RuntimeError("boom")
+
+        def good(ctx: HookContext) -> None:
+            seen.append("ok")
+
+        hooks.on(HookEvent.AFTER_TOOL_CALL, broken)
+        hooks.on(HookEvent.AFTER_TOOL_CALL, good)
+
+        with caplog.at_level(logging.WARNING, logger="dcc_mcp_core.lifecycle_hooks"):
+            hooks.dispatch(HookContext(event=HookEvent.AFTER_TOOL_CALL, dcc_name="any"))
+
+        assert seen == ["ok"]
+        assert any("after_tool_call" in record.message for record in caplog.records)
+
+    def test_policy_deny_propagates(self) -> None:
+        hooks = LifecycleHooks()
+        hooks.on(
+            HookEvent.BEFORE_SKILL_LOAD,
+            lambda ctx: (_ for _ in ()).throw(HookDeny("policy says no")),
+        )
+
+        with pytest.raises(HookDeny) as info:
+            hooks.dispatch(
+                HookContext(
+                    event=HookEvent.BEFORE_SKILL_LOAD,
+                    dcc_name="maya",
+                    payload={"skill_name": "foo"},
+                )
+            )
+        assert info.value.reason == "policy says no"
+
+    def test_non_policy_deny_is_logged_and_swallowed(self, caplog) -> None:
+        hooks = LifecycleHooks()
+        hooks.on(
+            HookEvent.AFTER_SEARCH,
+            lambda ctx: (_ for _ in ()).throw(HookDeny("oops")),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="dcc_mcp_core.lifecycle_hooks"):
+            hooks.dispatch(HookContext(event=HookEvent.AFTER_SEARCH, dcc_name="any"))
+
+        assert any("non-policy event after_search" in r.message for r in caplog.records)
+
+    def test_handlers_snapshot_is_immutable_view(self) -> None:
+        hooks = LifecycleHooks()
+        h = lambda ctx: None  # noqa: E731
+        hooks.on(HookEvent.SESSION_START, h)
+
+        snapshot = hooks.handlers(HookEvent.SESSION_START)
+        assert snapshot == (h,)
+        assert isinstance(snapshot, tuple)
+        # Mutating the snapshot does not change registry
+        hooks.on(HookEvent.SESSION_START, lambda ctx: None)
+        assert len(hooks.handlers(HookEvent.SESSION_START)) == 2
+        # original snapshot stayed the same
+        assert len(snapshot) == 1
+
+    def test_dispatch_unregistered_event_is_noop(self) -> None:
+        hooks = LifecycleHooks()
+        # No handlers — must not raise.
+        hooks.dispatch(HookContext(event=HookEvent.SESSION_END, dcc_name="any"))
+
+    def test_context_payload_defaults_to_empty_dict(self) -> None:
+        ctx = HookContext(event=HookEvent.BEFORE_SEARCH, dcc_name="blender")
+        assert ctx.payload == {}
+        assert ctx.session_id is None
+
+
+class _FakeInnerServer:
+    """Minimal stand-in for the Rust skill server."""
+
+    def __init__(self) -> None:
+        self.transform = None
+        self.after_hook = None
+
+    def set_skill_load_transform(self, transform):
+        self.transform = transform
+
+    def clear_skill_load_transform(self):
+        self.transform = None
+
+    def set_after_load_skill_hook(self, hook):
+        self.after_hook = hook
+
+    def clear_after_load_skill_hook(self):
+        self.after_hook = None
+
+
+class _FakeSkill:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class TestDccServerBaseBridge:
+    """``DccServerBase.register_lifecycle_hooks`` must bridge load events."""
+
+    def _make_server(self):
+        from dcc_mcp_core._testing import make_test_server
+
+        return make_test_server(server=_FakeInnerServer(), dcc_name="bridge-dcc")
+
+    def test_register_bridges_before_and_after_load(self) -> None:
+        server = self._make_server()
+        hooks = LifecycleHooks()
+        seen: list[tuple[str, dict]] = []
+
+        hooks.on(HookEvent.BEFORE_SKILL_LOAD, lambda ctx: seen.append(("before", ctx.payload)))
+        hooks.on(HookEvent.AFTER_SKILL_LOAD, lambda ctx: seen.append(("after", ctx.payload)))
+
+        returned = server.register_lifecycle_hooks(hooks)
+        assert returned is hooks
+        assert server.lifecycle_hooks() is hooks
+
+        # Inner server received bridge callables
+        skill = _FakeSkill("usd-import")
+        server._server.transform(skill)
+        server._server.after_hook(skill, ["import", "validate"])
+
+        assert seen[0] == ("before", {"skill_name": "usd-import"})
+        assert seen[1] == ("after", {"skill_name": "usd-import", "registered_actions": ["import", "validate"]})
+
+    def test_register_propagates_hook_deny_from_before_skill_load(self) -> None:
+        server = self._make_server()
+        hooks = LifecycleHooks()
+        hooks.on(
+            HookEvent.BEFORE_SKILL_LOAD,
+            lambda ctx: (_ for _ in ()).throw(HookDeny("not-allowed", hint="load typed first")),
+        )
+
+        server.register_lifecycle_hooks(hooks)
+        with pytest.raises(HookDeny) as info:
+            server._server.transform(_FakeSkill("blocked"))
+        assert info.value.reason == "not-allowed"
+        assert info.value.hint == "load typed first"


### PR DESCRIPTION
Closes #1335.

## Summary

Adds an opt-in recall-metadata layer to `SkillMetadata` and `ToolDeclaration` so the search ranker, capability graph (#1336), lifecycle hooks (#1337) and escape-hatch demotion (#1325) have a stable contract to consume — without changing the wire shape of skills that do not opt in.

## What lands here

New module `crates/dcc-mcp-models/src/skill_metadata/skill_recall.rs` defines six pure data types (no I/O, no validation logic):

| Type | Purpose |
|------|---------|
| `RecallContext` | `app_type`, `domain`, `workflow_stage`, `task_category` — feeds the ranker and the capability graph (#1336). |
| `Precondition` | Tagged enum: `software` / `plugin` / `selection` / `scene_state` / `capability` / `other`. Open-ended so adapters can express studio-specific requirements. |
| `SideEffects` | Boolean flags (`creates`, `modifies`, `deletes`, `exports`, `imports`, `ui_mutation`, `file_output`, `render`) plus structured `targets` tags. |
| `ToolRole` | `read_only`, `action`, `destructive`, `escape_hatch`, `debug_only`. The `escape_hatch` variant is the contract #1325 will use to demote generic-scripting tools (`execute_python`, host script eval, …) in default search ranking. |
| `RiskLevel` | `low`, `medium`, `high`, `host_script_execution`. |
| `SuccessMetrics` | Runtime-populated counters (`success_count`, `failure_count`, `mean_selected_rank`, `recent_failure_kinds`, `last_used_unix_secs`). Authored by the ranker / memory layer (#1334) — never hand-written in SKILL.md. |

New optional fields on `SkillMetadata`: `intent`, `recall_context`, `preconditions`, `side_effects`, `produces`, `requires`, `success_metrics`.

New optional fields on `ToolDeclaration`: `intent`, `tool_role`, `risk`, `side_effects`, `produces`, `requires`.

All new fields are `Option<T>` or `Vec<T>` and use `serde(default, skip_serializing_if = ...)` so:

* existing SKILL.md files serialize and round-trip unchanged,
* JSON output stays compact for skills that have not opted in,
* the deserializer accepts both `snake_case` and `kebab-case` aliases on the wire.

The custom `Deserialize` for `ToolDeclaration` is extended to thread the new fields through its `Wire` intermediate struct.

## Tests

7 new unit tests in `skill_recall::tests`:

* `recall_context_serde_omits_unset_fields`
* `precondition_software_serde_roundtrip`
* `side_effects_default_is_empty`
* `tool_role_serde_snake_case`
* `risk_level_host_script_label`
* `success_metrics_rate_is_none_when_unused`
* `success_metrics_rate_computes_correctly`

Existing 39 `skill_metadata::tests` still pass.

`cargo check --workspace --no-default-features` is clean across all 41 crates.

## Stacked PR notes

This is PR #1 of a stack against `main`. Per agreed plan, intermediate PRs in the stack do not need to be CI-green or merged in order; only the final aggregation PR will be rebased onto `main` for CI-green merge. Downstream PRs in the stack will consume the types added here (e.g. `ToolRole::EscapeHatch` for #1325, `RecallContext` and `Precondition` for #1336).

## Backwards compatibility

* Existing SKILL.md / `tools.yaml` / `tool.json` payloads still deserialize.
* Existing serialized JSON keeps the same shape (no new keys when fields are unset).
* No public API was removed; new types are additive re-exports from `dcc_mcp_models`.
