### PR TITLE
feat(server): typed lifecycle-hook framework for DCC adapters (#1337)

### DIFF
--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -319,6 +319,11 @@ _LAZY: dict[str, str] = {
     "InlineExecution": "dcc_mcp_core._server.options",
     "ObservabilityOptions": "dcc_mcp_core._server.options",
     "StandaloneMainThreadExecution": "dcc_mcp_core._server.options",
+    # Lifecycle hooks (issue #1337)
+    "HookContext": "dcc_mcp_core.lifecycle_hooks",
+    "HookDeny": "dcc_mcp_core.lifecycle_hooks",
+    "HookEvent": "dcc_mcp_core.lifecycle_hooks",
+    "LifecycleHooks": "dcc_mcp_core.lifecycle_hooks",
     # DccServerBase + factory
     "DccServerBase": "dcc_mcp_core.server_base",
     "create_dcc_server": "dcc_mcp_core.factory",

--- a/python/dcc_mcp_core/lifecycle_hooks.py
+++ b/python/dcc_mcp_core/lifecycle_hooks.py
@@ -1,0 +1,146 @@
+"""Typed lifecycle-hook framework for DCC adapters (issue #1337).
+
+The framework lets adapter and policy code subscribe to discovery, tool-call
+and session events without patching ``DccServerBase`` internals. Hook fan-out
+is bounded and fail-safe: an unexpected exception in one handler is logged
+and never aborts a tool-call, but a handler may explicitly veto a policy
+event by raising :class:`HookDeny`.
+
+Only ``BEFORE_SKILL_LOAD`` and ``AFTER_SKILL_LOAD`` are wired to live event
+sources today via :meth:`DccServerBase.register_lifecycle_hooks` (they bridge
+to the existing ``set_skill_load_transform`` / ``set_after_load_skill_hook``
+setters). The remaining events are registered and dispatched through the same
+typed surface so downstream issues (#1325 escape-hatch demotion, #1336
+capability graph, #1334 memory layers) can fire them from their integration
+points without changing the public contract again.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+import logging
+from typing import Any
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class HookEvent(str, Enum):
+    """All typed lifecycle hook points emitted by ``DccServerBase``."""
+
+    SESSION_START = "on_session_start"
+    BEFORE_SEARCH = "before_search"
+    AFTER_SEARCH = "after_search"
+    BEFORE_SKILL_LOAD = "before_skill_load"
+    AFTER_SKILL_LOAD = "after_skill_load"
+    BEFORE_TOOL_CALL = "before_tool_call"
+    AFTER_TOOL_CALL = "after_tool_call"
+    SESSION_END = "on_session_end"
+
+    @classmethod
+    def policy_events(cls) -> frozenset[HookEvent]:
+        """Events where a handler may veto via :class:`HookDeny`."""
+        return frozenset({cls.BEFORE_SKILL_LOAD, cls.BEFORE_TOOL_CALL, cls.BEFORE_SEARCH})
+
+
+@dataclass(frozen=True)
+class HookContext:
+    """Immutable payload passed to every hook handler.
+
+    Attributes:
+        event: Which :class:`HookEvent` is firing.
+        dcc_name: Adapter identifier (``"maya"``, ``"blender"``, ``"any"``…).
+        session_id: Optional stable identifier for the current agent session.
+        payload: Event-specific structured data (skill name, tool name,
+            search query, result count, …). Always JSON-safe so memory and
+            telemetry layers can record it.
+
+    """
+
+    event: HookEvent
+    dcc_name: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    session_id: str | None = None
+
+
+class HookDeny(Exception):
+    """Raised by a policy hook to veto a discovery, load, or call event.
+
+    Only meaningful for events listed in :meth:`HookEvent.policy_events`. The
+    ``reason`` is surfaced to telemetry and to the caller as the deny reason;
+    the ``hint`` is an agent-facing remediation string.
+    """
+
+    def __init__(self, reason: str, *, hint: str | None = None) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.hint = hint
+
+    def __repr__(self) -> str:
+        return f"HookDeny(reason={self.reason!r}, hint={self.hint!r})"
+
+
+HookHandler = Callable[[HookContext], Any]
+
+
+class LifecycleHooks:
+    """Bounded, fail-safe registry of typed lifecycle handlers.
+
+    Handlers are dispatched in registration order. For non-policy events,
+    handler exceptions are logged at WARNING and swallowed so they cannot
+    abort host execution. For policy events, a :class:`HookDeny` raised by
+    any handler propagates to the caller; other exceptions are logged and
+    treated as "no decision".
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[HookEvent, list[HookHandler]] = {evt: [] for evt in HookEvent}
+
+    def on(self, event: HookEvent, handler: HookHandler) -> HookHandler:
+        """Register ``handler`` for ``event`` and return it for use as a decorator."""
+        if not callable(handler):
+            raise TypeError("lifecycle hook handler must be callable")
+        self._handlers[event].append(handler)
+        return handler
+
+    def off(self, event: HookEvent, handler: HookHandler) -> bool:
+        """Remove a previously registered handler. Returns ``True`` if removed."""
+        handlers = self._handlers[event]
+        for idx in range(len(handlers) - 1, -1, -1):
+            if handlers[idx] is handler:
+                del handlers[idx]
+                return True
+        return False
+
+    def handlers(self, event: HookEvent) -> tuple[HookHandler, ...]:
+        """Snapshot of currently-registered handlers (immutable view)."""
+        return tuple(self._handlers[event])
+
+    def dispatch(self, context: HookContext) -> None:
+        """Fan-out ``context`` to every handler registered for its event.
+
+        Propagates :class:`HookDeny` from policy events; logs everything else.
+        """
+        is_policy = context.event in HookEvent.policy_events()
+        for handler in self._handlers[context.event]:
+            try:
+                handler(context)
+            except HookDeny:
+                if is_policy:
+                    raise
+                logger.warning(
+                    "[lifecycle] HookDeny raised by non-policy event %s; treating as logged-only",
+                    context.event.value,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[lifecycle] handler for %s failed: %s",
+                    context.event.value,
+                    exc,
+                    exc_info=True,
+                )
+
+
+__all__ = ["HookContext", "HookDeny", "HookEvent", "HookHandler", "LifecycleHooks"]

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -699,6 +699,55 @@ class DccServerBase:
         """Remove the after-load skill observer, if one is registered."""
         return self._skill_client.clear_after_load_skill_hook()
 
+    def register_lifecycle_hooks(self, hooks: Any) -> Any:
+        """Bind a :class:`~dcc_mcp_core.lifecycle_hooks.LifecycleHooks` registry.
+
+        The registry's ``BEFORE_SKILL_LOAD`` and ``AFTER_SKILL_LOAD`` handlers
+        are bridged to the existing skill-load transform / after-load setters
+        so adapters get a single typed surface across discovery, load, and
+        tool-call hook points (issue #1337). Other event types are still
+        registered and will be dispatched by downstream subsystems
+        (#1325 escape-hatch demotion, #1336 capability graph, #1334 memory
+        layers).
+
+        Returns the registry, so callers can chain
+        ``register_lifecycle_hooks(LifecycleHooks()).on(event, handler)``.
+        """
+        from dcc_mcp_core.lifecycle_hooks import HookContext
+        from dcc_mcp_core.lifecycle_hooks import HookEvent
+
+        self._lifecycle_hooks = hooks
+
+        def _bridge_before_load(skill: Any) -> Any:
+            hooks.dispatch(
+                HookContext(
+                    event=HookEvent.BEFORE_SKILL_LOAD,
+                    dcc_name=self._dcc_name,
+                    payload={"skill_name": getattr(skill, "name", None)},
+                )
+            )
+            return None
+
+        def _bridge_after_load(skill: Any, registered: list[str]) -> None:
+            hooks.dispatch(
+                HookContext(
+                    event=HookEvent.AFTER_SKILL_LOAD,
+                    dcc_name=self._dcc_name,
+                    payload={
+                        "skill_name": getattr(skill, "name", None),
+                        "registered_actions": list(registered),
+                    },
+                )
+            )
+
+        self.set_skill_load_transform(_bridge_before_load)
+        self.set_after_load_skill_hook(_bridge_after_load)
+        return hooks
+
+    def lifecycle_hooks(self) -> Any | None:
+        """Return the :class:`LifecycleHooks` registered by ``register_lifecycle_hooks``."""
+        return getattr(self, "_lifecycle_hooks", None)
+
     def unload_skill(self, name: str) -> bool:
         """Unload a skill by name."""
         return self._skill_client.unload_skill(name)

--- a/tests/test_lifecycle_hooks.py
+++ b/tests/test_lifecycle_hooks.py
@@ -1,0 +1,216 @@
+"""Tests for the typed lifecycle-hook framework (issue #1337)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from dcc_mcp_core import HookContext
+from dcc_mcp_core import HookDeny
+from dcc_mcp_core import HookEvent
+from dcc_mcp_core import LifecycleHooks
+
+
+class TestHookEvent:
+    def test_policy_events_only_contain_before_events(self) -> None:
+        policy = HookEvent.policy_events()
+        assert HookEvent.BEFORE_SKILL_LOAD in policy
+        assert HookEvent.BEFORE_TOOL_CALL in policy
+        assert HookEvent.BEFORE_SEARCH in policy
+        # after_* and on_session_* are observational
+        assert HookEvent.AFTER_SEARCH not in policy
+        assert HookEvent.AFTER_SKILL_LOAD not in policy
+        assert HookEvent.AFTER_TOOL_CALL not in policy
+        assert HookEvent.SESSION_START not in policy
+        assert HookEvent.SESSION_END not in policy
+
+    def test_event_values_are_snake_case_strings(self) -> None:
+        for event in HookEvent:
+            assert event.value == event.value.lower()
+            assert " " not in event.value
+
+
+class TestHookDeny:
+    def test_deny_carries_reason_and_optional_hint(self) -> None:
+        deny = HookDeny("blocked by policy", hint="load typed skill foo first")
+        assert deny.reason == "blocked by policy"
+        assert deny.hint == "load typed skill foo first"
+        assert "blocked by policy" in repr(deny)
+
+    def test_deny_without_hint(self) -> None:
+        deny = HookDeny("nope")
+        assert deny.hint is None
+
+
+class TestLifecycleHooks:
+    def test_on_rejects_non_callable(self) -> None:
+        hooks = LifecycleHooks()
+        with pytest.raises(TypeError):
+            hooks.on(HookEvent.BEFORE_SEARCH, "not callable")  # type: ignore[arg-type]
+
+    def test_handlers_fire_in_registration_order(self) -> None:
+        hooks = LifecycleHooks()
+        order: list[int] = []
+        hooks.on(HookEvent.AFTER_SEARCH, lambda ctx: order.append(1))
+        hooks.on(HookEvent.AFTER_SEARCH, lambda ctx: order.append(2))
+        hooks.on(HookEvent.AFTER_SEARCH, lambda ctx: order.append(3))
+
+        hooks.dispatch(HookContext(event=HookEvent.AFTER_SEARCH, dcc_name="any"))
+
+        assert order == [1, 2, 3]
+
+    def test_off_removes_handler(self) -> None:
+        hooks = LifecycleHooks()
+        seen: list[str] = []
+
+        def handler(ctx: HookContext) -> None:
+            seen.append("called")
+
+        hooks.on(HookEvent.AFTER_SKILL_LOAD, handler)
+        assert hooks.off(HookEvent.AFTER_SKILL_LOAD, handler) is True
+        hooks.dispatch(HookContext(event=HookEvent.AFTER_SKILL_LOAD, dcc_name="any"))
+
+        assert seen == []
+        # Removing again returns False
+        assert hooks.off(HookEvent.AFTER_SKILL_LOAD, handler) is False
+
+    def test_non_policy_handler_exception_is_swallowed(self, caplog) -> None:
+        hooks = LifecycleHooks()
+        seen: list[str] = []
+
+        def broken(ctx: HookContext) -> None:
+            raise RuntimeError("boom")
+
+        def good(ctx: HookContext) -> None:
+            seen.append("ok")
+
+        hooks.on(HookEvent.AFTER_TOOL_CALL, broken)
+        hooks.on(HookEvent.AFTER_TOOL_CALL, good)
+
+        with caplog.at_level(logging.WARNING, logger="dcc_mcp_core.lifecycle_hooks"):
+            hooks.dispatch(HookContext(event=HookEvent.AFTER_TOOL_CALL, dcc_name="any"))
+
+        assert seen == ["ok"]
+        assert any("after_tool_call" in record.message for record in caplog.records)
+
+    def test_policy_deny_propagates(self) -> None:
+        hooks = LifecycleHooks()
+        hooks.on(
+            HookEvent.BEFORE_SKILL_LOAD,
+            lambda ctx: (_ for _ in ()).throw(HookDeny("policy says no")),
+        )
+
+        with pytest.raises(HookDeny) as info:
+            hooks.dispatch(
+                HookContext(
+                    event=HookEvent.BEFORE_SKILL_LOAD,
+                    dcc_name="maya",
+                    payload={"skill_name": "foo"},
+                )
+            )
+        assert info.value.reason == "policy says no"
+
+    def test_non_policy_deny_is_logged_and_swallowed(self, caplog) -> None:
+        hooks = LifecycleHooks()
+        hooks.on(
+            HookEvent.AFTER_SEARCH,
+            lambda ctx: (_ for _ in ()).throw(HookDeny("oops")),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="dcc_mcp_core.lifecycle_hooks"):
+            hooks.dispatch(HookContext(event=HookEvent.AFTER_SEARCH, dcc_name="any"))
+
+        assert any("non-policy event after_search" in r.message for r in caplog.records)
+
+    def test_handlers_snapshot_is_immutable_view(self) -> None:
+        hooks = LifecycleHooks()
+        h = lambda ctx: None  # noqa: E731
+        hooks.on(HookEvent.SESSION_START, h)
+
+        snapshot = hooks.handlers(HookEvent.SESSION_START)
+        assert snapshot == (h,)
+        assert isinstance(snapshot, tuple)
+        # Mutating the snapshot does not change registry
+        hooks.on(HookEvent.SESSION_START, lambda ctx: None)
+        assert len(hooks.handlers(HookEvent.SESSION_START)) == 2
+        # original snapshot stayed the same
+        assert len(snapshot) == 1
+
+    def test_dispatch_unregistered_event_is_noop(self) -> None:
+        hooks = LifecycleHooks()
+        # No handlers — must not raise.
+        hooks.dispatch(HookContext(event=HookEvent.SESSION_END, dcc_name="any"))
+
+    def test_context_payload_defaults_to_empty_dict(self) -> None:
+        ctx = HookContext(event=HookEvent.BEFORE_SEARCH, dcc_name="blender")
+        assert ctx.payload == {}
+        assert ctx.session_id is None
+
+
+class _FakeInnerServer:
+    """Minimal stand-in for the Rust skill server."""
+
+    def __init__(self) -> None:
+        self.transform = None
+        self.after_hook = None
+
+    def set_skill_load_transform(self, transform):
+        self.transform = transform
+
+    def clear_skill_load_transform(self):
+        self.transform = None
+
+    def set_after_load_skill_hook(self, hook):
+        self.after_hook = hook
+
+    def clear_after_load_skill_hook(self):
+        self.after_hook = None
+
+
+class _FakeSkill:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class TestDccServerBaseBridge:
+    """``DccServerBase.register_lifecycle_hooks`` must bridge load events."""
+
+    def _make_server(self):
+        from dcc_mcp_core._testing import make_test_server
+
+        return make_test_server(server=_FakeInnerServer(), dcc_name="bridge-dcc")
+
+    def test_register_bridges_before_and_after_load(self) -> None:
+        server = self._make_server()
+        hooks = LifecycleHooks()
+        seen: list[tuple[str, dict]] = []
+
+        hooks.on(HookEvent.BEFORE_SKILL_LOAD, lambda ctx: seen.append(("before", ctx.payload)))
+        hooks.on(HookEvent.AFTER_SKILL_LOAD, lambda ctx: seen.append(("after", ctx.payload)))
+
+        returned = server.register_lifecycle_hooks(hooks)
+        assert returned is hooks
+        assert server.lifecycle_hooks() is hooks
+
+        # Inner server received bridge callables
+        skill = _FakeSkill("usd-import")
+        server._server.transform(skill)
+        server._server.after_hook(skill, ["import", "validate"])
+
+        assert seen[0] == ("before", {"skill_name": "usd-import"})
+        assert seen[1] == ("after", {"skill_name": "usd-import", "registered_actions": ["import", "validate"]})
+
+    def test_register_propagates_hook_deny_from_before_skill_load(self) -> None:
+        server = self._make_server()
+        hooks = LifecycleHooks()
+        hooks.on(
+            HookEvent.BEFORE_SKILL_LOAD,
+            lambda ctx: (_ for _ in ()).throw(HookDeny("not-allowed", hint="load typed first")),
+        )
+
+        server.register_lifecycle_hooks(hooks)
+        with pytest.raises(HookDeny) as info:
+            server._server.transform(_FakeSkill("blocked"))
+        assert info.value.reason == "not-allowed"
+        assert info.value.hint == "load typed first"


### PR DESCRIPTION
Closes #1337.

> Stacked on top of #1345 (skill metadata schema). Per agreed plan, intermediate PRs in the stack are not rebased on `main`; only the final aggregation PR will be CI-green and merged.

## Summary

Adds a typed lifecycle-hook framework so adapter / policy / memory / telemetry code can subscribe to discovery, tool-call and session events through one public surface — without patching `DccServerBase` internals or duplicating ad-hoc setter pairs (`set_skill_load_transform` + `set_after_load_skill_hook`).

## What lands here

New module `python/dcc_mcp_core/lifecycle_hooks.py`:

| Symbol | Purpose |
|---|---|
| `HookEvent` (enum) | All eight event points listed in #1337: `on_session_start`, `before_search`, `after_search`, `before_skill_load`, `after_skill_load`, `before_tool_call`, `after_tool_call`, `on_session_end`. `HookEvent.policy_events()` classifies which events accept `HookDeny`. |
| `HookContext` (frozen dataclass) | Immutable, JSON-safe `(event, dcc_name, session_id, payload)` passed to every handler. |
| `HookDeny` (exception) | Raised by policy hooks to veto. Carries `reason` and optional agent-facing `hint`. |
| `LifecycleHooks` | Bounded, fail-safe dispatcher. Non-policy event handler exceptions are logged at WARNING; `HookDeny` is propagated only for policy events. |

New public re-exports from `dcc_mcp_core`: `HookContext`, `HookDeny`, `HookEvent`, `LifecycleHooks`.

New `DccServerBase` methods:

* `register_lifecycle_hooks(hooks) -> hooks` — installs the registry and bridges `BEFORE_SKILL_LOAD` / `AFTER_SKILL_LOAD` to the existing skill-load transform / observer setters. `HookDeny` raised in a `BEFORE_SKILL_LOAD` handler propagates through the transform and vetoes the load.
* `lifecycle_hooks() -> LifecycleHooks | None` — accessor for downstream subsystems that need to fire other events.

## What does **not** land here

The remaining hook points (`BEFORE_SEARCH`, `AFTER_SEARCH`, `BEFORE_TOOL_CALL`, `AFTER_TOOL_CALL`, `SESSION_START`, `SESSION_END`) are registrable and dispatchable today but are not yet fired from live event sources. Each is owned by one of the downstream PRs in this stack:

* `BEFORE_TOOL_CALL` → PR for #1325 (escape-hatch demotion fires it before invoking generic-scripting tools).
* `BEFORE_SEARCH` / `AFTER_SEARCH` → PR for #1336 (capability-graph reranking).
* `SESSION_START` / `SESSION_END` → PR for #1334 (memory layers).
* `AFTER_TOOL_CALL` → fired from #1334 and #1325 telemetry.

This keeps #1337 focused on the contract; downstream PRs do not need to renegotiate the public surface.

## Tests

15 new tests in `tests/test_lifecycle_hooks.py`:

* event taxonomy (`policy_events` classification, snake_case wire shape)
* `HookDeny` carries reason + hint
* handler registration, ordering, removal, snapshot immutability
* non-policy handler exception is swallowed + logged
* `HookDeny` from a policy handler propagates
* `HookDeny` from a non-policy handler is logged-and-swallowed
* `HookContext` payload / session_id defaults
* `DccServerBase.register_lifecycle_hooks` bridges to inner transform + after-load setters
* `HookDeny` raised in a `BEFORE_SKILL_LOAD` handler propagates through the bridge into the inner transform call

Local run: `PYTHONPATH=python pytest tests/test_lifecycle_hooks.py` → `15 passed`.

## Acceptance criteria mapping

| #1337 criterion | Where it lands |
|---|---|
| Typed, bounded, safe in hot paths | `LifecycleHooks.dispatch` (one event, list iteration, no async, no I/O) |
| Failures do not crash unless explicit deny | per-handler `try/except` in `dispatch`; `HookDeny` only re-raised for policy events |
| Can demote escape-hatch tools | `BEFORE_TOOL_CALL` event reserved + `HookDeny` semantics ready for #1325 wiring |
| Telemetry/memory consume events safely | `HookContext.payload` is a plain dict — no raw prompts, no secrets, JSON-serialisable by construction |
| Adapters register through public APIs | `register_lifecycle_hooks` lives on `DccServerBase`; types re-exported from `dcc_mcp_core` top level |

## Backwards compatibility

* Existing adapters using `set_skill_load_transform` / `set_after_load_skill_hook` directly continue to work — the bridge simply installs typed bridge callables in those slots.
* No public methods removed; only additive APIs.
