### PR TITLE
feat: demote scripting tools to explicit escape hatches (#1325)

### DIFF
--- a/crates/dcc-mcp-gateway-core/src/capability/record.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/record.rs
@@ -178,6 +178,15 @@ pub struct CapabilityMetadata {
     /// Coarse risk label derived from safety annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub risk: Option<String>,
+    /// Tool semantic role (`read_only`, `action`, `destructive`,
+    /// `escape_hatch`, `debug_only`) propagated from
+    /// `ToolDeclaration::tool_role` (issues #1335, #1325).
+    ///
+    /// When equal to `"escape_hatch"`, the gateway search ranker applies
+    /// a fixed demotion so generic-scripting tools rank below typed
+    /// alternatives unless the agent explicitly invoked scripting.
+    #[serde(rename = "toolRole", skip_serializing_if = "Option::is_none")]
+    pub tool_role: Option<String>,
 }
 
 impl CapabilityMetadata {
@@ -189,6 +198,7 @@ impl CapabilityMetadata {
             && self.timeout_hint_secs.is_none()
             && self.enforce_thread_affinity.is_none()
             && self.risk.is_none()
+            && self.tool_role.is_none()
     }
 }
 
@@ -425,6 +435,14 @@ impl dcc_mcp_gateway_search::SearchRecord for CapabilityRecord {
 
     fn loaded(&self) -> bool {
         self.loaded
+    }
+
+    fn tool_role(&self) -> Option<&str> {
+        self.metadata.as_ref().and_then(|m| m.tool_role.as_deref())
+    }
+
+    fn risk(&self) -> Option<&str> {
+        self.metadata.as_ref().and_then(|m| m.risk.as_deref())
     }
 }
 

--- a/crates/dcc-mcp-gateway-search/src/ranking.rs
+++ b/crates/dcc-mcp-gateway-search/src/ranking.rs
@@ -427,6 +427,24 @@ impl Scorer for FuzzyScorer {
                 }
                 add_reason(&mut out.match_reasons, "meta_tool_demoted");
             }
+
+            // Issue #1325: tools tagged as escape-hatch scripting fallbacks
+            // (`execute_python`, host script eval, MaxScript-style execution)
+            // are kept in results but demoted so typed alternatives surface
+            // first when both match the query. A tool that explicitly names
+            // the escape-hatch backend (e.g. q = "execute_python") still
+            // wins via the tool-name boost so debugging workflows are
+            // unaffected.
+            if out.score > 0
+                && r.tool_role().is_some_and(|role| role == "escape_hatch")
+                && !r.backend_tool().to_ascii_lowercase().contains(q)
+            {
+                out.score /= ESCAPE_HATCH_DIVISOR;
+                if out.score == 0 {
+                    out.score = 1;
+                }
+                add_reason(&mut out.match_reasons, "escape_hatch_demoted");
+            }
         }
 
         if let Some(hint) = scene_hint
@@ -474,6 +492,12 @@ fn is_meta_tool(backend_tool: &str) -> bool {
 /// a meta-tool needs 3× the raw relevance of a domain tool to rank
 /// above it.
 const META_TOOL_DIVISOR: u32 = 3;
+
+/// Demotion divisor applied to escape-hatch / generic-scripting tools
+/// (issue #1325). A factor of 4 means a typed alternative with ¼ the
+/// raw relevance still wins, so agents see the typed skill first when
+/// it exists.
+const ESCAPE_HATCH_DIVISOR: u32 = 4;
 
 /// `SubstringScorer` alias from issue #765 acceptance text.
 pub type ExactScorer = SubstringScorer;
@@ -564,6 +588,8 @@ mod tests {
         dcc_type: String,
         instance_id: Uuid,
         loaded: bool,
+        #[serde(default)]
+        tool_role: Option<String>,
     }
 
     impl SearchRecord for TestRow {
@@ -591,6 +617,9 @@ mod tests {
         fn loaded(&self) -> bool {
             self.loaded
         }
+        fn tool_role(&self) -> Option<&str> {
+            self.tool_role.as_deref()
+        }
     }
 
     fn rec(name: &str, summary: &str, skill: Option<&str>, tags: &[&str], loaded: bool) -> TestRow {
@@ -604,7 +633,21 @@ mod tests {
             dcc_type: "maya".to_string(),
             instance_id: iid,
             loaded,
+            tool_role: None,
         }
+    }
+
+    fn rec_with_role(
+        name: &str,
+        summary: &str,
+        skill: Option<&str>,
+        tags: &[&str],
+        loaded: bool,
+        role: &str,
+    ) -> TestRow {
+        let mut r = rec(name, summary, skill, tags, loaded);
+        r.tool_role = Some(role.to_string());
+        r
     }
 
     #[test]
@@ -898,6 +941,74 @@ mod tests {
         assert!(
             score > 0,
             "meta-tool must still surface for exact-name query; got {score}"
+        );
+    }
+
+    // ── Issue #1325: escape-hatch demotion ────────────────────────────────
+
+    #[test]
+    fn fuzzy_scorer_escape_hatch_demoted_below_typed_alternative() {
+        let mut s = FuzzyScorer::new();
+        let typed = rec(
+            "usd_import",
+            "Import a USD layer into the active scene.",
+            Some("interchange"),
+            &["usd", "import"],
+            true,
+        );
+        let escape = rec_with_role(
+            "execute_python",
+            "Execute arbitrary Python in the host. Useful for USD import scripts.",
+            Some("scripting"),
+            &["scripting"],
+            true,
+            "escape_hatch",
+        );
+
+        let typed_score = s.score(&typed, "import usd", None);
+        let escape_breakdown = s.explain(&escape, "import usd", None);
+
+        assert!(typed_score > 0, "typed tool must still match");
+        assert!(
+            typed_score > escape_breakdown.score,
+            "typed ({typed_score}) must outrank escape-hatch ({}) for typed-intent query",
+            escape_breakdown.score
+        );
+        assert!(
+            escape_breakdown
+                .match_reasons
+                .iter()
+                .any(|r| r == "escape_hatch_demoted"),
+            "escape_hatch demotion must surface in match_reasons; got {:?}",
+            escape_breakdown.match_reasons
+        );
+    }
+
+    #[test]
+    fn fuzzy_scorer_escape_hatch_still_wins_for_explicit_query() {
+        let mut s = FuzzyScorer::new();
+        let escape = rec_with_role(
+            "execute_python",
+            "Execute arbitrary Python in the host.",
+            Some("scripting"),
+            &["scripting"],
+            true,
+            "escape_hatch",
+        );
+
+        let breakdown = s.explain(&escape, "execute_python", None);
+        assert!(
+            breakdown.score > 0,
+            "explicit escape-hatch name must still surface; got {}",
+            breakdown.score
+        );
+        assert!(
+            !breakdown
+                .match_reasons
+                .iter()
+                .any(|r| r == "escape_hatch_demoted"),
+            "explicit-name query must not be demoted; got {:?}",
+            breakdown.match_reasons
         );
     }
 }

--- a/crates/dcc-mcp-gateway-search/src/record.rs
+++ b/crates/dcc-mcp-gateway-search/src/record.rs
@@ -28,4 +28,19 @@ pub trait SearchRecord {
     fn instance_id(&self) -> Uuid;
     /// Whether the skill is loaded on the backend.
     fn loaded(&self) -> bool;
+    /// Tool semantic role label propagated from `ToolDeclaration::tool_role`
+    /// (issues #1335, #1325).  Returning `Some("escape_hatch")` lets the
+    /// ranker demote generic-scripting fallbacks below typed alternatives.
+    ///
+    /// Defaults to `None` so existing implementations stay valid.
+    fn tool_role(&self) -> Option<&str> {
+        None
+    }
+    /// Coarse risk label (`low`, `medium`, `high`, `host_script_execution`)
+    /// propagated from `ToolDeclaration::risk`.
+    ///
+    /// Defaults to `None` so existing implementations stay valid.
+    fn risk(&self) -> Option<&str> {
+        None
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -422,6 +422,11 @@ fn extract_metadata(meta: Option<&serde_json::Map<String, Value>>) -> Option<Cap
             .or_else(|| dcc.get("enforce_thread_affinity"))
             .and_then(Value::as_bool),
         risk: dcc.get("risk").and_then(Value::as_str).map(str::to_string),
+        tool_role: dcc
+            .get("toolRole")
+            .or_else(|| dcc.get("tool_role"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
     })
 }
 

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -324,6 +324,9 @@ _LAZY: dict[str, str] = {
     "HookDeny": "dcc_mcp_core.lifecycle_hooks",
     "HookEvent": "dcc_mcp_core.lifecycle_hooks",
     "LifecycleHooks": "dcc_mcp_core.lifecycle_hooks",
+    # Escape-hatch demotion policy (issue #1325)
+    "EscapeHatchInvocation": "dcc_mcp_core.escape_hatch_policy",
+    "EscapeHatchPolicy": "dcc_mcp_core.escape_hatch_policy",
     # DccServerBase + factory
     "DccServerBase": "dcc_mcp_core.server_base",
     "create_dcc_server": "dcc_mcp_core.factory",

--- a/python/dcc_mcp_core/escape_hatch_policy.py
+++ b/python/dcc_mcp_core/escape_hatch_policy.py
@@ -1,0 +1,149 @@
+"""Escape-hatch demotion policy for generic-scripting tools (issue #1325).
+
+When a backend exposes generic scripting tools (``execute_python``, host
+script eval, MaxScript-style execution, …), the gateway search ranker
+already demotes them (see ``ESCAPE_HATCH_DIVISOR`` in
+``crates/dcc-mcp-gateway-search/src/ranking.rs``) so typed alternatives
+surface first. This module adds the matching invocation-time policy:
+
+* invoking a tool whose ``tool_role`` is ``escape_hatch`` requires a
+  structured ``reason`` in the call meta;
+* the policy fires through the :class:`LifecycleHooks`
+  ``BEFORE_TOOL_CALL`` event and raises :class:`HookDeny` when a reason
+  is missing;
+* a bounded telemetry counter records every justified escape-hatch
+  invocation by ``(dcc_name, tool_role, reason_category)``.
+
+External design references:
+
+* Claude Code Bash permissions and ``PreToolUse`` hooks
+  (https://code.claude.com/docs/en/settings, https://code.claude.com/docs/en/hooks).
+* OpenAI Codex shell safety: sandboxing + approvals + audit
+  (https://openai.com/index/running-codex-safely/).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+from typing import Callable
+
+from dcc_mcp_core.lifecycle_hooks import HookContext
+from dcc_mcp_core.lifecycle_hooks import HookDeny
+from dcc_mcp_core.lifecycle_hooks import HookEvent
+from dcc_mcp_core.lifecycle_hooks import LifecycleHooks
+
+logger = logging.getLogger(__name__)
+
+ESCAPE_HATCH_ROLE = "escape_hatch"
+HOST_SCRIPT_RISK = "host_script_execution"
+
+# Keys the policy looks for in the ``before_tool_call`` payload. Adapter code
+# building the HookContext is expected to populate these from the call's MCP
+# meta block (``arguments.meta.escape_hatch_reason`` / similar) and the
+# selected tool's declared metadata.
+REASON_KEY = "escape_hatch_reason"
+ROLE_KEY = "tool_role"
+RISK_KEY = "risk"
+
+
+@dataclass(frozen=True)
+class EscapeHatchInvocation:
+    """One justified escape-hatch invocation observed by the policy."""
+
+    dcc_name: str
+    tool_name: str
+    tool_role: str
+    reason_category: str
+    reason: str
+
+
+class EscapeHatchPolicy:
+    """Enforce the structured-reason requirement for escape-hatch tools.
+
+    Install once per ``DccServerBase`` by binding to a :class:`LifecycleHooks`
+    registry::
+
+        hooks = LifecycleHooks()
+        EscapeHatchPolicy().install(hooks)
+        server.register_lifecycle_hooks(hooks)
+
+    The policy is intentionally pure: it does not store raw prompts, only
+    short ``(dcc_name, tool_name, tool_role, reason_category)`` tuples for
+    audit/telemetry export.
+    """
+
+    def __init__(
+        self,
+        *,
+        telemetry_sink: Callable[[EscapeHatchInvocation], None] | None = None,
+    ) -> None:
+        self._telemetry_sink = telemetry_sink
+        self._observed: list[EscapeHatchInvocation] = []
+
+    def install(self, hooks: LifecycleHooks) -> EscapeHatchPolicy:
+        """Subscribe ``BEFORE_TOOL_CALL`` on ``hooks``; return ``self`` for chaining."""
+        hooks.on(HookEvent.BEFORE_TOOL_CALL, self._on_before_tool_call)
+        return self
+
+    def observed(self) -> tuple[EscapeHatchInvocation, ...]:
+        """Read-only snapshot of justified escape-hatch invocations."""
+        return tuple(self._observed)
+
+    def _on_before_tool_call(self, ctx: HookContext) -> None:
+        payload = ctx.payload or {}
+        role = _str(payload.get(ROLE_KEY))
+        risk = _str(payload.get(RISK_KEY))
+        if role != ESCAPE_HATCH_ROLE and risk != HOST_SCRIPT_RISK:
+            return  # not an escape-hatch invocation
+
+        reason = _str(payload.get(REASON_KEY))
+        if not reason:
+            raise HookDeny(
+                f"tool {payload.get('tool_name')!r} is an escape-hatch "
+                f"(tool_role={role or 'unset'}, risk={risk or 'unset'}); "
+                "callers must supply meta.escape_hatch_reason with the "
+                "missing typed capability or failed search intent",
+                hint="search for a typed skill first, or pass "
+                "meta.escape_hatch_reason='no_typed_skill_found' "
+                "after confirming nothing typed matches the query",
+            )
+
+        invocation = EscapeHatchInvocation(
+            dcc_name=ctx.dcc_name,
+            tool_name=_str(payload.get("tool_name")),
+            tool_role=role or ESCAPE_HATCH_ROLE,
+            reason_category=_categorise_reason(reason),
+            reason=reason,
+        )
+        self._observed.append(invocation)
+        if self._telemetry_sink is not None:
+            try:
+                self._telemetry_sink(invocation)
+            except Exception as exc:
+                logger.warning("[escape-hatch] telemetry sink failed: %s", exc)
+
+
+_KNOWN_REASON_CATEGORIES = {
+    "no_typed_skill_found",
+    "debug",
+    "user_requested_script",
+    "automation",
+}
+
+
+def _categorise_reason(reason: str) -> str:
+    lower = reason.strip().lower()
+    if lower in _KNOWN_REASON_CATEGORIES:
+        return lower
+    return "custom"
+
+
+def _str(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+__all__ = ["ESCAPE_HATCH_ROLE", "HOST_SCRIPT_RISK", "EscapeHatchInvocation", "EscapeHatchPolicy"]

--- a/tests/test_escape_hatch_policy.py
+++ b/tests/test_escape_hatch_policy.py
@@ -1,0 +1,138 @@
+"""Tests for the escape-hatch demotion policy (issue #1325)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dcc_mcp_core import EscapeHatchInvocation
+from dcc_mcp_core import EscapeHatchPolicy
+from dcc_mcp_core import HookContext
+from dcc_mcp_core import HookDeny
+from dcc_mcp_core import HookEvent
+from dcc_mcp_core import LifecycleHooks
+
+
+def _context(**payload) -> HookContext:
+    return HookContext(event=HookEvent.BEFORE_TOOL_CALL, dcc_name="maya", payload=payload)
+
+
+class TestEscapeHatchPolicy:
+    def test_install_returns_self_for_chaining(self) -> None:
+        hooks = LifecycleHooks()
+        policy = EscapeHatchPolicy()
+        assert policy.install(hooks) is policy
+        assert hooks.handlers(HookEvent.BEFORE_TOOL_CALL) != ()
+
+    def test_typed_tool_call_is_allowed_without_reason(self) -> None:
+        hooks = LifecycleHooks()
+        EscapeHatchPolicy().install(hooks)
+        # tool_role: action — no demotion, no reason required
+        hooks.dispatch(_context(tool_name="usd_import", tool_role="action"))
+
+    def test_escape_hatch_without_reason_is_denied(self) -> None:
+        hooks = LifecycleHooks()
+        EscapeHatchPolicy().install(hooks)
+        with pytest.raises(HookDeny) as info:
+            hooks.dispatch(_context(tool_name="execute_python", tool_role="escape_hatch"))
+        assert "escape-hatch" in info.value.reason
+        assert info.value.hint is not None
+
+    def test_escape_hatch_with_known_reason_is_recorded(self) -> None:
+        hooks = LifecycleHooks()
+        policy = EscapeHatchPolicy().install(hooks)
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="no_typed_skill_found",
+            )
+        )
+        assert policy.observed() == (
+            EscapeHatchInvocation(
+                dcc_name="maya",
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                reason_category="no_typed_skill_found",
+                reason="no_typed_skill_found",
+            ),
+        )
+
+    def test_unknown_reason_is_categorised_as_custom(self) -> None:
+        hooks = LifecycleHooks()
+        policy = EscapeHatchPolicy().install(hooks)
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="studio-specific exporter workaround",
+            )
+        )
+        assert policy.observed()[0].reason_category == "custom"
+
+    def test_host_script_risk_alone_triggers_policy(self) -> None:
+        hooks = LifecycleHooks()
+        EscapeHatchPolicy().install(hooks)
+        # tool_role unset, risk = host_script_execution must still require a reason
+        with pytest.raises(HookDeny):
+            hooks.dispatch(_context(tool_name="maxscript_eval", risk="host_script_execution"))
+
+    def test_telemetry_sink_receives_each_invocation(self) -> None:
+        hooks = LifecycleHooks()
+        captured: list[EscapeHatchInvocation] = []
+        policy = EscapeHatchPolicy(telemetry_sink=captured.append).install(hooks)
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="debug",
+            )
+        )
+        assert len(captured) == 1
+        assert captured[0].reason_category == "debug"
+        assert policy.observed() == tuple(captured)
+
+    def test_telemetry_sink_failure_does_not_crash_dispatch(self) -> None:
+        def broken(_inv: EscapeHatchInvocation) -> None:
+            raise RuntimeError("sink down")
+
+        hooks = LifecycleHooks()
+        policy = EscapeHatchPolicy(telemetry_sink=broken).install(hooks)
+        # Must not raise
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="debug",
+            )
+        )
+        assert len(policy.observed()) == 1
+
+    def test_observed_snapshot_is_immutable_tuple(self) -> None:
+        policy = EscapeHatchPolicy()
+        hooks = LifecycleHooks()
+        policy.install(hooks)
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="debug",
+            )
+        )
+        snap = policy.observed()
+        assert isinstance(snap, tuple)
+        # Mutating after snapshot still grows the underlying list
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="debug",
+            )
+        )
+        assert len(snap) == 1
+        assert len(policy.observed()) == 2
+
+    def test_empty_payload_is_allowed(self) -> None:
+        hooks = LifecycleHooks()
+        EscapeHatchPolicy().install(hooks)
+        # No role / risk -> not an escape-hatch, no deny
+        hooks.dispatch(_context(tool_name="other_tool"))


### PR DESCRIPTION
Closes #1325.

> Stacked on top of #1346 (lifecycle hooks) and #1345 (skill metadata schema). Only the final PR in the stack will be rebased on `main` and CI-green merged.

## Summary

Implements the escape-hatch demotion contract from #1325 in two places:

1. **Gateway search ranker** — `FuzzyScorer` divides scores by a fixed `ESCAPE_HATCH_DIVISOR` for tools whose declared `tool_role` is `escape_hatch`, so typed alternatives surface first for typed-intent queries. Explicit-by-name queries (e.g. `execute_python`) bypass the demotion so debugging workflows still work.
2. **Invocation-time policy** — new `EscapeHatchPolicy` plugs into the #1337 `BEFORE_TOOL_CALL` event and raises `HookDeny` unless the call meta carries a structured `escape_hatch_reason`. Reasons are normalised into a bounded vocabulary so admin telemetry stays low-cardinality.

The two pieces compose into the full #1325 acceptance flow: search demotes scripting fallbacks at discovery time, the policy enforces a documented justification at call time, and downstream telemetry / memory layers (#1334) can ingest the structured invocation records.

## Rust changes

| File | Change |
|---|---|
| `crates/dcc-mcp-gateway-search/src/record.rs` | `SearchRecord` gains default `tool_role()` / `risk()` accessors returning `None` so existing impls keep compiling. |
| `crates/dcc-mcp-gateway-core/src/capability/record.rs` | `CapabilityMetadata` gains optional `tool_role` (`serde(rename = "toolRole")`). `CapabilityRecord` implements `tool_role()` / `risk()` by reading its `metadata`. |
| `crates/dcc-mcp-gateway/src/gateway/capability/builder.rs` | `extract_metadata` reads `dcc.toolRole` / `dcc.tool_role` from the wire payload. |
| `crates/dcc-mcp-gateway-search/src/ranking.rs` | New `ESCAPE_HATCH_DIVISOR = 4`. `FuzzyScorer::explain` demotes when `tool_role == escape_hatch` and the backend name does not contain the query, then pushes `escape_hatch_demoted` to `match_reasons`. |

## Python changes

New module `python/dcc_mcp_core/escape_hatch_policy.py`:

* `EscapeHatchPolicy.install(hooks)` — subscribes `BEFORE_TOOL_CALL`, returns `self`.
* Raises `HookDeny(reason, hint=…)` when `payload.tool_role == "escape_hatch"` (or `payload.risk == "host_script_execution"`) and `payload.escape_hatch_reason` is missing.
* Records justified invocations as immutable `EscapeHatchInvocation` records and forwards each to an optional `telemetry_sink`; sink exceptions are logged and never abort dispatch.
* `_categorise_reason` normalises to `no_typed_skill_found` / `debug` / `user_requested_script` / `automation` / `custom` so admin counters stay bounded.

Public re-exports added to `dcc_mcp_core`: `EscapeHatchInvocation`, `EscapeHatchPolicy`.

External design references followed (per the issue body):

* Claude Code permissions + `PreToolUse` hooks for Bash — same allow/deny + structured-reason pattern.
* OpenAI Codex shell safety — bounded vocabulary + audit trail.

## Tests

* **2 Rust ranker tests** — `escape_hatch_demoted_below_typed_alternative` and `escape_hatch_still_wins_for_explicit_query`. The full `dcc-mcp-gateway-search` suite stays at **31 passing**.
* **10 Python tests** covering install chaining, deny semantics for both `tool_role` and `risk` paths, reason categorisation, telemetry sink fan-out, sink-failure safety, immutable snapshots, and empty-payload pass-through.

Local commands used:

```
vx cargo test -p dcc-mcp-gateway-search --no-default-features --lib
PYTHONPATH=python pytest tests/test_escape_hatch_policy.py -x -q
vx cargo check --workspace --no-default-features
```

## Acceptance criteria mapping

| #1325 criterion | Where it lands |
|---|---|
| Typed USD-import skill ranks above generic Python execution for `"import usd into blender"` | `escape_hatch_demoted_below_typed_alternative` test |
| Response clearly says no typed capability was found | `HookDeny.reason` + `hint` strings |
| Admin can see how often agents used scripting fallback and which capability was missing | `EscapeHatchInvocation` + telemetry sink + bounded reason categories |
| Existing script tools remain available for expert/debug workflows | `escape_hatch_still_wins_for_explicit_query` test + `escape_hatch_reason="debug"` path |

## Backwards compatibility

* `SearchRecord::tool_role` / `risk` default to `None` — every existing implementor keeps compiling.
* `CapabilityMetadata.tool_role` is optional with `skip_serializing_if = "Option::is_none"`, so the REST wire shape only grows when the backend opts in.
* Adapters that never enable `EscapeHatchPolicy` see exactly today's behaviour.
