### PR TITLE
feat(gateway): surface host execution readiness in admin and selection (#1331)

### DIFF
--- a/crates/dcc-mcp-gateway-core/src/capability/record.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/record.rs
@@ -178,6 +178,15 @@ pub struct CapabilityMetadata {
     /// Coarse risk label derived from safety annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub risk: Option<String>,
+    /// Tool semantic role (`read_only`, `action`, `destructive`,
+    /// `escape_hatch`, `debug_only`) propagated from
+    /// `ToolDeclaration::tool_role` (issues #1335, #1325).
+    ///
+    /// When equal to `"escape_hatch"`, the gateway search ranker applies
+    /// a fixed demotion so generic-scripting tools rank below typed
+    /// alternatives unless the agent explicitly invoked scripting.
+    #[serde(rename = "toolRole", skip_serializing_if = "Option::is_none")]
+    pub tool_role: Option<String>,
 }
 
 impl CapabilityMetadata {
@@ -189,6 +198,7 @@ impl CapabilityMetadata {
             && self.timeout_hint_secs.is_none()
             && self.enforce_thread_affinity.is_none()
             && self.risk.is_none()
+            && self.tool_role.is_none()
     }
 }
 
@@ -425,6 +435,14 @@ impl dcc_mcp_gateway_search::SearchRecord for CapabilityRecord {
 
     fn loaded(&self) -> bool {
         self.loaded
+    }
+
+    fn tool_role(&self) -> Option<&str> {
+        self.metadata.as_ref().and_then(|m| m.tool_role.as_deref())
+    }
+
+    fn risk(&self) -> Option<&str> {
+        self.metadata.as_ref().and_then(|m| m.risk.as_deref())
     }
 }
 

--- a/crates/dcc-mcp-gateway-search/src/ranking.rs
+++ b/crates/dcc-mcp-gateway-search/src/ranking.rs
@@ -427,6 +427,24 @@ impl Scorer for FuzzyScorer {
                 }
                 add_reason(&mut out.match_reasons, "meta_tool_demoted");
             }
+
+            // Issue #1325: tools tagged as escape-hatch scripting fallbacks
+            // (`execute_python`, host script eval, MaxScript-style execution)
+            // are kept in results but demoted so typed alternatives surface
+            // first when both match the query. A tool that explicitly names
+            // the escape-hatch backend (e.g. q = "execute_python") still
+            // wins via the tool-name boost so debugging workflows are
+            // unaffected.
+            if out.score > 0
+                && r.tool_role().is_some_and(|role| role == "escape_hatch")
+                && !r.backend_tool().to_ascii_lowercase().contains(q)
+            {
+                out.score /= ESCAPE_HATCH_DIVISOR;
+                if out.score == 0 {
+                    out.score = 1;
+                }
+                add_reason(&mut out.match_reasons, "escape_hatch_demoted");
+            }
         }
 
         if let Some(hint) = scene_hint
@@ -474,6 +492,12 @@ fn is_meta_tool(backend_tool: &str) -> bool {
 /// a meta-tool needs 3× the raw relevance of a domain tool to rank
 /// above it.
 const META_TOOL_DIVISOR: u32 = 3;
+
+/// Demotion divisor applied to escape-hatch / generic-scripting tools
+/// (issue #1325). A factor of 4 means a typed alternative with ¼ the
+/// raw relevance still wins, so agents see the typed skill first when
+/// it exists.
+const ESCAPE_HATCH_DIVISOR: u32 = 4;
 
 /// `SubstringScorer` alias from issue #765 acceptance text.
 pub type ExactScorer = SubstringScorer;
@@ -564,6 +588,8 @@ mod tests {
         dcc_type: String,
         instance_id: Uuid,
         loaded: bool,
+        #[serde(default)]
+        tool_role: Option<String>,
     }
 
     impl SearchRecord for TestRow {
@@ -591,6 +617,9 @@ mod tests {
         fn loaded(&self) -> bool {
             self.loaded
         }
+        fn tool_role(&self) -> Option<&str> {
+            self.tool_role.as_deref()
+        }
     }
 
     fn rec(name: &str, summary: &str, skill: Option<&str>, tags: &[&str], loaded: bool) -> TestRow {
@@ -604,7 +633,21 @@ mod tests {
             dcc_type: "maya".to_string(),
             instance_id: iid,
             loaded,
+            tool_role: None,
         }
+    }
+
+    fn rec_with_role(
+        name: &str,
+        summary: &str,
+        skill: Option<&str>,
+        tags: &[&str],
+        loaded: bool,
+        role: &str,
+    ) -> TestRow {
+        let mut r = rec(name, summary, skill, tags, loaded);
+        r.tool_role = Some(role.to_string());
+        r
     }
 
     #[test]
@@ -898,6 +941,74 @@ mod tests {
         assert!(
             score > 0,
             "meta-tool must still surface for exact-name query; got {score}"
+        );
+    }
+
+    // ── Issue #1325: escape-hatch demotion ────────────────────────────────
+
+    #[test]
+    fn fuzzy_scorer_escape_hatch_demoted_below_typed_alternative() {
+        let mut s = FuzzyScorer::new();
+        let typed = rec(
+            "usd_import",
+            "Import a USD layer into the active scene.",
+            Some("interchange"),
+            &["usd", "import"],
+            true,
+        );
+        let escape = rec_with_role(
+            "execute_python",
+            "Execute arbitrary Python in the host. Useful for USD import scripts.",
+            Some("scripting"),
+            &["scripting"],
+            true,
+            "escape_hatch",
+        );
+
+        let typed_score = s.score(&typed, "import usd", None);
+        let escape_breakdown = s.explain(&escape, "import usd", None);
+
+        assert!(typed_score > 0, "typed tool must still match");
+        assert!(
+            typed_score > escape_breakdown.score,
+            "typed ({typed_score}) must outrank escape-hatch ({}) for typed-intent query",
+            escape_breakdown.score
+        );
+        assert!(
+            escape_breakdown
+                .match_reasons
+                .iter()
+                .any(|r| r == "escape_hatch_demoted"),
+            "escape_hatch demotion must surface in match_reasons; got {:?}",
+            escape_breakdown.match_reasons
+        );
+    }
+
+    #[test]
+    fn fuzzy_scorer_escape_hatch_still_wins_for_explicit_query() {
+        let mut s = FuzzyScorer::new();
+        let escape = rec_with_role(
+            "execute_python",
+            "Execute arbitrary Python in the host.",
+            Some("scripting"),
+            &["scripting"],
+            true,
+            "escape_hatch",
+        );
+
+        let breakdown = s.explain(&escape, "execute_python", None);
+        assert!(
+            breakdown.score > 0,
+            "explicit escape-hatch name must still surface; got {}",
+            breakdown.score
+        );
+        assert!(
+            !breakdown
+                .match_reasons
+                .iter()
+                .any(|r| r == "escape_hatch_demoted"),
+            "explicit-name query must not be demoted; got {:?}",
+            breakdown.match_reasons
         );
     }
 }

--- a/crates/dcc-mcp-gateway-search/src/record.rs
+++ b/crates/dcc-mcp-gateway-search/src/record.rs
@@ -28,4 +28,19 @@ pub trait SearchRecord {
     fn instance_id(&self) -> Uuid;
     /// Whether the skill is loaded on the backend.
     fn loaded(&self) -> bool;
+    /// Tool semantic role label propagated from `ToolDeclaration::tool_role`
+    /// (issues #1335, #1325).  Returning `Some("escape_hatch")` lets the
+    /// ranker demote generic-scripting fallbacks below typed alternatives.
+    ///
+    /// Defaults to `None` so existing implementations stay valid.
+    fn tool_role(&self) -> Option<&str> {
+        None
+    }
+    /// Coarse risk label (`low`, `medium`, `high`, `host_script_execution`)
+    /// propagated from `ToolDeclaration::risk`.
+    ///
+    /// Defaults to `None` so existing implementations stay valid.
+    fn risk(&self) -> Option<&str> {
+        None
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -422,6 +422,11 @@ fn extract_metadata(meta: Option<&serde_json::Map<String, Value>>) -> Option<Cap
             .or_else(|| dcc.get("enforce_thread_affinity"))
             .and_then(Value::as_bool),
         risk: dcc.get("risk").and_then(Value::as_str).map(str::to_string),
+        tool_role: dcc
+            .get("toolRole")
+            .or_else(|| dcc.get("tool_role"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
     })
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/instance_diagnostics.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/instance_diagnostics.rs
@@ -82,6 +82,77 @@ impl InstanceDiagnosticsStore {
     }
 }
 
+/// Host-execution readiness summary (issue #1331).
+///
+/// `ready` when every bit required to dispatch a host-thread action is green
+/// (`dispatcher`, `dcc`, `host_execution_bridge`, `main_thread_executor`);
+/// `not_ready` when at least one of those bits is red but readiness was
+/// probed; `unknown` when no readiness probe data has been observed yet
+/// (e.g. a pre-#660 backend that only exposes `GET /health`).
+///
+/// Lifted to the top level of the instance JSON so admin / agent surfaces
+/// can distinguish "online but execution bridge not attached" from
+/// "fully ready" without parsing the nested `diagnostics.readiness` block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostExecutionStatus {
+    Ready,
+    NotReady,
+    Unknown,
+}
+
+impl HostExecutionStatus {
+    /// Stable label used in JSON, logs, and admin counters.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::NotReady => "not_ready",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Derive the summary from a cached [`InstanceDiagnostics`] entry.
+    #[must_use]
+    pub fn from_diagnostics(diag: Option<&InstanceDiagnostics>) -> Self {
+        let Some(report) = diag.and_then(|d| d.readiness.as_ref()) else {
+            return Self::Unknown;
+        };
+        if report.dispatcher
+            && report.dcc
+            && report.host_execution_bridge
+            && report.main_thread_executor
+        {
+            Self::Ready
+        } else {
+            Self::NotReady
+        }
+    }
+
+    /// Bounded list of readiness bits that are currently red, for the
+    /// admin/debug remediation hint. Empty when status is `Ready` or
+    /// `Unknown`.
+    #[must_use]
+    pub fn missing_bits(diag: Option<&InstanceDiagnostics>) -> Vec<&'static str> {
+        let Some(report) = diag.and_then(|d| d.readiness.as_ref()) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        if !report.dispatcher {
+            out.push("dispatcher");
+        }
+        if !report.dcc {
+            out.push("dcc");
+        }
+        if !report.host_execution_bridge {
+            out.push("host_execution_bridge");
+        }
+        if !report.main_thread_executor {
+            out.push("main_thread_executor");
+        }
+        out
+    }
+}
+
 /// Build the `backend` object attached to gateway call errors.
 #[must_use]
 pub fn backend_error_attachment(
@@ -162,6 +233,79 @@ mod tests {
         assert_eq!(
             diag.last_error.as_ref().unwrap().kind,
             "thread-affinity-violation"
+        );
+    }
+
+    // ── HostExecutionStatus (issue #1331) ─────────────────────────────────
+
+    fn diag_with(report: ReadinessReport) -> InstanceDiagnostics {
+        InstanceDiagnostics {
+            readiness: Some(report),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn host_execution_status_unknown_without_probe() {
+        assert_eq!(
+            HostExecutionStatus::from_diagnostics(None),
+            HostExecutionStatus::Unknown
+        );
+        assert_eq!(HostExecutionStatus::Unknown.label(), "unknown");
+        assert!(HostExecutionStatus::missing_bits(None).is_empty());
+    }
+
+    #[test]
+    fn host_execution_status_ready_when_all_bits_green() {
+        let diag = diag_with(ReadinessReport {
+            process: true,
+            dcc: true,
+            skill_catalog: true,
+            dispatcher: true,
+            host_execution_bridge: true,
+            main_thread_executor: true,
+        });
+        assert_eq!(
+            HostExecutionStatus::from_diagnostics(Some(&diag)),
+            HostExecutionStatus::Ready
+        );
+        assert_eq!(HostExecutionStatus::Ready.label(), "ready");
+        assert!(HostExecutionStatus::missing_bits(Some(&diag)).is_empty());
+    }
+
+    #[test]
+    fn host_execution_status_not_ready_lists_missing_bits() {
+        let diag = diag_with(ReadinessReport {
+            process: true,
+            dcc: false,
+            skill_catalog: true,
+            dispatcher: true,
+            host_execution_bridge: false,
+            main_thread_executor: true,
+        });
+        assert_eq!(
+            HostExecutionStatus::from_diagnostics(Some(&diag)),
+            HostExecutionStatus::NotReady
+        );
+        assert_eq!(HostExecutionStatus::NotReady.label(), "not_ready");
+        let missing = HostExecutionStatus::missing_bits(Some(&diag));
+        assert_eq!(missing, vec!["dcc", "host_execution_bridge"]);
+    }
+
+    #[test]
+    fn host_execution_status_skill_catalog_red_does_not_block_ready() {
+        // skill_catalog red is irrelevant for host execution; it gates discovery.
+        let diag = diag_with(ReadinessReport {
+            process: true,
+            dcc: true,
+            skill_catalog: false,
+            dispatcher: true,
+            host_execution_bridge: true,
+            main_thread_executor: true,
+        });
+        assert_eq!(
+            HostExecutionStatus::from_diagnostics(Some(&diag)),
+            HostExecutionStatus::Ready
         );
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -677,6 +677,17 @@ pub fn entry_to_json(
         },
         "stale":           stale,
     });
+    // ── host execution readiness (issue #1331) ────────────────────────────
+    //
+    // Always include this summary so admin/agent surfaces can branch on a
+    // single string without parsing the nested `diagnostics.readiness`
+    // block. Status is `unknown` when no readiness probe has reported yet.
+    let host_exec = super::instance_diagnostics::HostExecutionStatus::from_diagnostics(diagnostics);
+    let missing_bits = super::instance_diagnostics::HostExecutionStatus::missing_bits(diagnostics);
+    row["host_execution"] = json!({
+        "status": host_exec.label(),
+        "missing_bits": missing_bits,
+    });
     if let Some(diag) = diagnostics.filter(|d| {
         d.readiness.is_some() || d.last_error.is_some() || d.probed_at_unix_secs.is_some()
     }) {

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -545,6 +545,70 @@ fn test_entry_to_json_includes_pool_state() {
     assert!(json["pool"]["lease_expires_at"].as_u64().is_some());
 }
 
+// ── host_execution summary (issue #1331) ──────────────────────────────
+
+#[test]
+fn test_entry_to_json_host_execution_unknown_without_diagnostics() {
+    let e = ServiceEntry::new("maya", "127.0.0.1", 18813);
+    let json = entry_to_json(&e, Duration::from_secs(30), None);
+    assert_eq!(json["host_execution"]["status"].as_str(), Some("unknown"));
+    assert_eq!(
+        json["host_execution"]["missing_bits"]
+            .as_array()
+            .map(Vec::len),
+        Some(0)
+    );
+}
+
+#[test]
+fn test_entry_to_json_host_execution_ready_when_probe_green() {
+    use crate::gateway::instance_diagnostics::InstanceDiagnostics;
+    use dcc_mcp_skill_rest::ReadinessReport;
+
+    let e = ServiceEntry::new("maya", "127.0.0.1", 18814);
+    let diag = InstanceDiagnostics {
+        readiness: Some(ReadinessReport {
+            process: true,
+            dcc: true,
+            skill_catalog: true,
+            dispatcher: true,
+            host_execution_bridge: true,
+            main_thread_executor: true,
+        }),
+        ..Default::default()
+    };
+    let json = entry_to_json(&e, Duration::from_secs(30), Some(&diag));
+    assert_eq!(json["host_execution"]["status"].as_str(), Some("ready"));
+}
+
+#[test]
+fn test_entry_to_json_host_execution_not_ready_lists_missing_bits() {
+    use crate::gateway::instance_diagnostics::InstanceDiagnostics;
+    use dcc_mcp_skill_rest::ReadinessReport;
+
+    let e = ServiceEntry::new("maya", "127.0.0.1", 18815);
+    let diag = InstanceDiagnostics {
+        readiness: Some(ReadinessReport {
+            process: true,
+            dcc: false,
+            skill_catalog: true,
+            dispatcher: true,
+            host_execution_bridge: false,
+            main_thread_executor: true,
+        }),
+        ..Default::default()
+    };
+    let json = entry_to_json(&e, Duration::from_secs(30), Some(&diag));
+    assert_eq!(json["host_execution"]["status"].as_str(), Some("not_ready"));
+    let missing: Vec<&str> = json["host_execution"]["missing_bits"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(missing, vec!["dcc", "host_execution_bridge"]);
+}
+
 // ── display_id (RFC #998 Addendum B) ───────────────────────────────────
 
 /// `gateway://instances` carries the derived `{dcc}@{version}-{short8}`

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -324,6 +324,9 @@ _LAZY: dict[str, str] = {
     "HookDeny": "dcc_mcp_core.lifecycle_hooks",
     "HookEvent": "dcc_mcp_core.lifecycle_hooks",
     "LifecycleHooks": "dcc_mcp_core.lifecycle_hooks",
+    # Escape-hatch demotion policy (issue #1325)
+    "EscapeHatchInvocation": "dcc_mcp_core.escape_hatch_policy",
+    "EscapeHatchPolicy": "dcc_mcp_core.escape_hatch_policy",
     # DccServerBase + factory
     "DccServerBase": "dcc_mcp_core.server_base",
     "create_dcc_server": "dcc_mcp_core.factory",

--- a/python/dcc_mcp_core/escape_hatch_policy.py
+++ b/python/dcc_mcp_core/escape_hatch_policy.py
@@ -1,0 +1,149 @@
+"""Escape-hatch demotion policy for generic-scripting tools (issue #1325).
+
+When a backend exposes generic scripting tools (``execute_python``, host
+script eval, MaxScript-style execution, …), the gateway search ranker
+already demotes them (see ``ESCAPE_HATCH_DIVISOR`` in
+``crates/dcc-mcp-gateway-search/src/ranking.rs``) so typed alternatives
+surface first. This module adds the matching invocation-time policy:
+
+* invoking a tool whose ``tool_role`` is ``escape_hatch`` requires a
+  structured ``reason`` in the call meta;
+* the policy fires through the :class:`LifecycleHooks`
+  ``BEFORE_TOOL_CALL`` event and raises :class:`HookDeny` when a reason
+  is missing;
+* a bounded telemetry counter records every justified escape-hatch
+  invocation by ``(dcc_name, tool_role, reason_category)``.
+
+External design references:
+
+* Claude Code Bash permissions and ``PreToolUse`` hooks
+  (https://code.claude.com/docs/en/settings, https://code.claude.com/docs/en/hooks).
+* OpenAI Codex shell safety: sandboxing + approvals + audit
+  (https://openai.com/index/running-codex-safely/).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+from typing import Callable
+
+from dcc_mcp_core.lifecycle_hooks import HookContext
+from dcc_mcp_core.lifecycle_hooks import HookDeny
+from dcc_mcp_core.lifecycle_hooks import HookEvent
+from dcc_mcp_core.lifecycle_hooks import LifecycleHooks
+
+logger = logging.getLogger(__name__)
+
+ESCAPE_HATCH_ROLE = "escape_hatch"
+HOST_SCRIPT_RISK = "host_script_execution"
+
+# Keys the policy looks for in the ``before_tool_call`` payload. Adapter code
+# building the HookContext is expected to populate these from the call's MCP
+# meta block (``arguments.meta.escape_hatch_reason`` / similar) and the
+# selected tool's declared metadata.
+REASON_KEY = "escape_hatch_reason"
+ROLE_KEY = "tool_role"
+RISK_KEY = "risk"
+
+
+@dataclass(frozen=True)
+class EscapeHatchInvocation:
+    """One justified escape-hatch invocation observed by the policy."""
+
+    dcc_name: str
+    tool_name: str
+    tool_role: str
+    reason_category: str
+    reason: str
+
+
+class EscapeHatchPolicy:
+    """Enforce the structured-reason requirement for escape-hatch tools.
+
+    Install once per ``DccServerBase`` by binding to a :class:`LifecycleHooks`
+    registry::
+
+        hooks = LifecycleHooks()
+        EscapeHatchPolicy().install(hooks)
+        server.register_lifecycle_hooks(hooks)
+
+    The policy is intentionally pure: it does not store raw prompts, only
+    short ``(dcc_name, tool_name, tool_role, reason_category)`` tuples for
+    audit/telemetry export.
+    """
+
+    def __init__(
+        self,
+        *,
+        telemetry_sink: Callable[[EscapeHatchInvocation], None] | None = None,
+    ) -> None:
+        self._telemetry_sink = telemetry_sink
+        self._observed: list[EscapeHatchInvocation] = []
+
+    def install(self, hooks: LifecycleHooks) -> EscapeHatchPolicy:
+        """Subscribe ``BEFORE_TOOL_CALL`` on ``hooks``; return ``self`` for chaining."""
+        hooks.on(HookEvent.BEFORE_TOOL_CALL, self._on_before_tool_call)
+        return self
+
+    def observed(self) -> tuple[EscapeHatchInvocation, ...]:
+        """Read-only snapshot of justified escape-hatch invocations."""
+        return tuple(self._observed)
+
+    def _on_before_tool_call(self, ctx: HookContext) -> None:
+        payload = ctx.payload or {}
+        role = _str(payload.get(ROLE_KEY))
+        risk = _str(payload.get(RISK_KEY))
+        if role != ESCAPE_HATCH_ROLE and risk != HOST_SCRIPT_RISK:
+            return  # not an escape-hatch invocation
+
+        reason = _str(payload.get(REASON_KEY))
+        if not reason:
+            raise HookDeny(
+                f"tool {payload.get('tool_name')!r} is an escape-hatch "
+                f"(tool_role={role or 'unset'}, risk={risk or 'unset'}); "
+                "callers must supply meta.escape_hatch_reason with the "
+                "missing typed capability or failed search intent",
+                hint="search for a typed skill first, or pass "
+                "meta.escape_hatch_reason='no_typed_skill_found' "
+                "after confirming nothing typed matches the query",
+            )
+
+        invocation = EscapeHatchInvocation(
+            dcc_name=ctx.dcc_name,
+            tool_name=_str(payload.get("tool_name")),
+            tool_role=role or ESCAPE_HATCH_ROLE,
+            reason_category=_categorise_reason(reason),
+            reason=reason,
+        )
+        self._observed.append(invocation)
+        if self._telemetry_sink is not None:
+            try:
+                self._telemetry_sink(invocation)
+            except Exception as exc:
+                logger.warning("[escape-hatch] telemetry sink failed: %s", exc)
+
+
+_KNOWN_REASON_CATEGORIES = {
+    "no_typed_skill_found",
+    "debug",
+    "user_requested_script",
+    "automation",
+}
+
+
+def _categorise_reason(reason: str) -> str:
+    lower = reason.strip().lower()
+    if lower in _KNOWN_REASON_CATEGORIES:
+        return lower
+    return "custom"
+
+
+def _str(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+__all__ = ["ESCAPE_HATCH_ROLE", "HOST_SCRIPT_RISK", "EscapeHatchInvocation", "EscapeHatchPolicy"]

--- a/tests/test_escape_hatch_policy.py
+++ b/tests/test_escape_hatch_policy.py
@@ -1,0 +1,138 @@
+"""Tests for the escape-hatch demotion policy (issue #1325)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dcc_mcp_core import EscapeHatchInvocation
+from dcc_mcp_core import EscapeHatchPolicy
+from dcc_mcp_core import HookContext
+from dcc_mcp_core import HookDeny
+from dcc_mcp_core import HookEvent
+from dcc_mcp_core import LifecycleHooks
+
+
+def _context(**payload) -> HookContext:
+    return HookContext(event=HookEvent.BEFORE_TOOL_CALL, dcc_name="maya", payload=payload)
+
+
+class TestEscapeHatchPolicy:
+    def test_install_returns_self_for_chaining(self) -> None:
+        hooks = LifecycleHooks()
+        policy = EscapeHatchPolicy()
+        assert policy.install(hooks) is policy
+        assert hooks.handlers(HookEvent.BEFORE_TOOL_CALL) != ()
+
+    def test_typed_tool_call_is_allowed_without_reason(self) -> None:
+        hooks = LifecycleHooks()
+        EscapeHatchPolicy().install(hooks)
+        # tool_role: action — no demotion, no reason required
+        hooks.dispatch(_context(tool_name="usd_import", tool_role="action"))
+
+    def test_escape_hatch_without_reason_is_denied(self) -> None:
+        hooks = LifecycleHooks()
+        EscapeHatchPolicy().install(hooks)
+        with pytest.raises(HookDeny) as info:
+            hooks.dispatch(_context(tool_name="execute_python", tool_role="escape_hatch"))
+        assert "escape-hatch" in info.value.reason
+        assert info.value.hint is not None
+
+    def test_escape_hatch_with_known_reason_is_recorded(self) -> None:
+        hooks = LifecycleHooks()
+        policy = EscapeHatchPolicy().install(hooks)
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="no_typed_skill_found",
+            )
+        )
+        assert policy.observed() == (
+            EscapeHatchInvocation(
+                dcc_name="maya",
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                reason_category="no_typed_skill_found",
+                reason="no_typed_skill_found",
+            ),
+        )
+
+    def test_unknown_reason_is_categorised_as_custom(self) -> None:
+        hooks = LifecycleHooks()
+        policy = EscapeHatchPolicy().install(hooks)
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="studio-specific exporter workaround",
+            )
+        )
+        assert policy.observed()[0].reason_category == "custom"
+
+    def test_host_script_risk_alone_triggers_policy(self) -> None:
+        hooks = LifecycleHooks()
+        EscapeHatchPolicy().install(hooks)
+        # tool_role unset, risk = host_script_execution must still require a reason
+        with pytest.raises(HookDeny):
+            hooks.dispatch(_context(tool_name="maxscript_eval", risk="host_script_execution"))
+
+    def test_telemetry_sink_receives_each_invocation(self) -> None:
+        hooks = LifecycleHooks()
+        captured: list[EscapeHatchInvocation] = []
+        policy = EscapeHatchPolicy(telemetry_sink=captured.append).install(hooks)
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="debug",
+            )
+        )
+        assert len(captured) == 1
+        assert captured[0].reason_category == "debug"
+        assert policy.observed() == tuple(captured)
+
+    def test_telemetry_sink_failure_does_not_crash_dispatch(self) -> None:
+        def broken(_inv: EscapeHatchInvocation) -> None:
+            raise RuntimeError("sink down")
+
+        hooks = LifecycleHooks()
+        policy = EscapeHatchPolicy(telemetry_sink=broken).install(hooks)
+        # Must not raise
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="debug",
+            )
+        )
+        assert len(policy.observed()) == 1
+
+    def test_observed_snapshot_is_immutable_tuple(self) -> None:
+        policy = EscapeHatchPolicy()
+        hooks = LifecycleHooks()
+        policy.install(hooks)
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="debug",
+            )
+        )
+        snap = policy.observed()
+        assert isinstance(snap, tuple)
+        # Mutating after snapshot still grows the underlying list
+        hooks.dispatch(
+            _context(
+                tool_name="execute_python",
+                tool_role="escape_hatch",
+                escape_hatch_reason="debug",
+            )
+        )
+        assert len(snap) == 1
+        assert len(policy.observed()) == 2
+
+    def test_empty_payload_is_allowed(self) -> None:
+        hooks = LifecycleHooks()
+        EscapeHatchPolicy().install(hooks)
+        # No role / risk -> not an escape-hatch, no deny
+        hooks.dispatch(_context(tool_name="other_tool"))


### PR DESCRIPTION
Closes #1331.

## Summary

Lifts a derived `host_execution` summary from the cached `ReadinessReport` to the **top level** of every instance JSON row produced by `entry_to_json`. Admin / agent / selection surfaces can now branch on a single string without parsing the nested `diagnostics.readiness` block.

```json
{
  "instance_id": "…",
  "status": "available",
  "host_execution": {
    "status": "not_ready",
    "missing_bits": ["dcc", "host_execution_bridge"]
  },
  "diagnostics": { "readiness": { … } }
}
```

`host_execution.status` is one of:

| Value | Meaning |
|---|---|
| `ready` | `dispatcher` + `dcc` + `host_execution_bridge` + `main_thread_executor` are all green |
| `not_ready` | readiness was probed but at least one of those bits is red; `missing_bits` lists which |
| `unknown` | no readiness probe data observed yet (e.g. a pre-#660 backend that only exposes `GET /health`) |

`skill_catalog` red is intentionally **not** part of the host-execution rollup — it gates discovery, not execution, so a fully-loaded host with a slow catalog still reads `ready` (regression test included).

## Changes

| File | Change |
|---|---|
| `crates/dcc-mcp-gateway/src/gateway/instance_diagnostics.rs` | New `HostExecutionStatus` enum + `from_diagnostics` / `missing_bits` derivation, with stable label strings for JSON, logs, and admin counters. |
| `crates/dcc-mcp-gateway/src/gateway/state.rs` | `entry_to_json` always emits `host_execution` even when diagnostics are absent, so admin UI does not need to special-case missing keys. |
| `crates/dcc-mcp-gateway/src/gateway/state/tests.rs` | 3 new integration tests cover all three derived states. |

## Tests

7 new tests pass alongside the existing gateway state + diagnostics suite:

* `HostExecutionStatus::from_diagnostics` for: no probe (`unknown`), all-green (`ready`), partially-red with two missing bits (`not_ready`), and skill_catalog-red-only (still `ready`).
* `entry_to_json` for: unknown without diagnostics, ready when probe is green, not_ready listing missing bits in stable order.

Local run:

```
vx cargo test -p dcc-mcp-gateway --no-default-features --lib instance_diagnostics
vx cargo test -p dcc-mcp-gateway --no-default-features --lib host_execution
```

## Acceptance criteria mapping

| #1331 criterion | Where it lands |
|---|---|
| Admin distinguishes "online but not execution-ready" from "ready" | `host_execution.status == "not_ready"` vs `"ready"`; bare `status` field unchanged |
| Client / tool selection can avoid routing host actions to a non-ready instance | Selection code can filter on `host_execution.status != "ready"` (bounded vocabulary, stable wire shape) |
| Workflow failures caused by readiness gaps are visible as state problems | `missing_bits` exposes which bridge bit is red, so admin/audit can attribute failures correctly |

## Backwards compatibility

* `host_execution` is a brand-new top-level key; existing fields untouched.
* The legacy nested `diagnostics.readiness` block is still emitted when populated, so any client already keying off it keeps working.
* No public Rust API changes outside the new `HostExecutionStatus` type in `instance_diagnostics`.
