### PR TITLE
feat: capability graph skeleton for cross-skill agent reasoning (#1336)

### DIFF
--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -327,6 +327,10 @@ _LAZY: dict[str, str] = {
     # Escape-hatch demotion policy (issue #1325)
     "EscapeHatchInvocation": "dcc_mcp_core.escape_hatch_policy",
     "EscapeHatchPolicy": "dcc_mcp_core.escape_hatch_policy",
+    # Capability graph (issue #1336)
+    "CapabilityEdge": "dcc_mcp_core.capability_graph",
+    "CapabilityGraph": "dcc_mcp_core.capability_graph",
+    "EdgeKind": "dcc_mcp_core.capability_graph",
     # DccServerBase + factory
     "DccServerBase": "dcc_mcp_core.server_base",
     "create_dcc_server": "dcc_mcp_core.factory",

--- a/python/dcc_mcp_core/capability_graph.py
+++ b/python/dcc_mcp_core/capability_graph.py
@@ -1,0 +1,270 @@
+"""Capability graph for cross-skill agent reasoning (issue #1336).
+
+The graph models edges between skills, tools, and named capabilities so the
+search ranker, the agent planner, and the admin UI can answer questions like
+
+* "what else do I need before this skill is useful?"     (``REQUIRES``)
+* "what does this skill produce that other skills need?" (``PRODUCES``)
+* "if this skill is missing, what is the fallback?"      (``FALLBACK_FOR``)
+
+This module is the public contract: a small, in-memory, threadsafe graph
+that downstream PRs (semantic skill index #1333, agent memory layers
+#1334, gateway search reranker integration) plug into without renegotiating
+the wire shape.
+
+Design rules:
+
+* Pure data + bounded expansion. No I/O, no async, no embedding inference.
+* Idempotent inserts — registering the same skill twice never duplicates
+  edges.
+* Edge kinds are a closed enum so admin counters stay low-cardinality.
+* Expansion is depth-bounded so worst-case query time is O(nodes * depth).
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+from threading import RLock
+from typing import Any
+from typing import Iterable
+from typing import Mapping
+
+__all__ = ["CapabilityEdge", "CapabilityGraph", "EdgeKind"]
+
+
+class EdgeKind(str, Enum):
+    """Closed vocabulary of relationships between capability nodes."""
+
+    DEPENDS_ON = "depends_on"
+    REQUIRES = "requires"
+    PRODUCES = "produces"
+    USED_IN = "used_in"
+    COMPATIBLE_WITH = "compatible_with"
+    REPLACES = "replaces"
+    FALLBACK_FOR = "fallback_for"
+
+    @classmethod
+    def parse(cls, value: str | EdgeKind) -> EdgeKind:
+        """Accept the enum, the snake_case label, or the kebab-case alias."""
+        if isinstance(value, cls):
+            return value
+        normalised = str(value).strip().lower().replace("-", "_")
+        for kind in cls:
+            if kind.value == normalised:
+                return kind
+        raise ValueError(f"unknown EdgeKind {value!r}")
+
+
+@dataclass(frozen=True)
+class CapabilityEdge:
+    """Directed edge between two capability nodes."""
+
+    source: str
+    target: str
+    kind: EdgeKind
+    weight: float = 1.0
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.source or not self.target:
+            raise ValueError("CapabilityEdge source and target must be non-empty")
+        if self.source == self.target:
+            raise ValueError(f"self-loops not allowed: {self.source!r}")
+        if not (0.0 <= self.weight <= 1.0):
+            raise ValueError(f"weight must be in [0.0, 1.0]; got {self.weight!r}")
+
+
+@dataclass
+class _Adjacency:
+    out: dict[EdgeKind, list[CapabilityEdge]] = field(default_factory=dict)
+    inc: dict[EdgeKind, list[CapabilityEdge]] = field(default_factory=dict)
+
+
+class CapabilityGraph:
+    """Threadsafe in-memory capability graph (issue #1336)."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._nodes: dict[str, _Adjacency] = {}
+        self._edges: set[tuple[str, str, EdgeKind]] = set()
+
+    # ── mutation ───────────────────────────────────────────────────────
+
+    def add_node(self, node_id: str) -> None:
+        if not node_id:
+            raise ValueError("node id must be non-empty")
+        with self._lock:
+            self._nodes.setdefault(node_id, _Adjacency())
+
+    def add_edge(self, edge: CapabilityEdge) -> bool:
+        """Insert an edge. Returns ``True`` when it was new."""
+        key = (edge.source, edge.target, edge.kind)
+        with self._lock:
+            if key in self._edges:
+                return False
+            self._edges.add(key)
+            self._nodes.setdefault(edge.source, _Adjacency()).out.setdefault(edge.kind, []).append(edge)
+            self._nodes.setdefault(edge.target, _Adjacency()).inc.setdefault(edge.kind, []).append(edge)
+            return True
+
+    def register_skill(
+        self,
+        skill_id: str,
+        *,
+        requires: Iterable[str] = (),
+        produces: Iterable[str] = (),
+        depends_on: Iterable[str] = (),
+        replaces: Iterable[str] = (),
+        fallback_for: Iterable[str] = (),
+        compatible_with: Iterable[str] = (),
+    ) -> int:
+        """Register a skill's outbound edges from its declared metadata.
+
+        Returns the count of newly-inserted edges (idempotent on repeat
+        calls). Mirrors the optional fields added to ``SkillMetadata`` in
+        #1335 so a skill loader can wire its frontmatter directly.
+        """
+        added = 0
+        for target in requires:
+            added += int(self.add_edge(CapabilityEdge(skill_id, target, EdgeKind.REQUIRES)))
+        for target in produces:
+            added += int(self.add_edge(CapabilityEdge(skill_id, target, EdgeKind.PRODUCES)))
+        for target in depends_on:
+            added += int(self.add_edge(CapabilityEdge(skill_id, target, EdgeKind.DEPENDS_ON)))
+        for target in replaces:
+            added += int(self.add_edge(CapabilityEdge(skill_id, target, EdgeKind.REPLACES)))
+        for target in fallback_for:
+            added += int(self.add_edge(CapabilityEdge(skill_id, target, EdgeKind.FALLBACK_FOR)))
+        for target in compatible_with:
+            added += int(self.add_edge(CapabilityEdge(skill_id, target, EdgeKind.COMPATIBLE_WITH)))
+        return added
+
+    # ── inspection ─────────────────────────────────────────────────────
+
+    def nodes(self) -> tuple[str, ...]:
+        with self._lock:
+            return tuple(sorted(self._nodes))
+
+    def edges(self, kinds: Iterable[EdgeKind] | None = None) -> tuple[CapabilityEdge, ...]:
+        wanted = frozenset(kinds) if kinds else None
+        with self._lock:
+            out: list[CapabilityEdge] = []
+            for adj in self._nodes.values():
+                for kind, edge_list in adj.out.items():
+                    if wanted is not None and kind not in wanted:
+                        continue
+                    out.extend(edge_list)
+            return tuple(out)
+
+    def neighbors(
+        self,
+        node_id: str,
+        *,
+        kinds: Iterable[EdgeKind] | None = None,
+        direction: str = "out",
+    ) -> tuple[CapabilityEdge, ...]:
+        """Return edges adjacent to ``node_id``.
+
+        ``direction`` is ``"out"`` (default), ``"in"``, or ``"both"``.
+        """
+        if direction not in {"out", "in", "both"}:
+            raise ValueError(f"direction must be 'out', 'in', or 'both'; got {direction!r}")
+        wanted = frozenset(kinds) if kinds else None
+        with self._lock:
+            adj = self._nodes.get(node_id)
+            if adj is None:
+                return ()
+            buckets: list[Mapping[EdgeKind, list[CapabilityEdge]]] = []
+            if direction in {"out", "both"}:
+                buckets.append(adj.out)
+            if direction in {"in", "both"}:
+                buckets.append(adj.inc)
+            out: list[CapabilityEdge] = []
+            for bucket in buckets:
+                for kind, edge_list in bucket.items():
+                    if wanted is not None and kind not in wanted:
+                        continue
+                    out.extend(edge_list)
+            return tuple(out)
+
+    # ── expansion ──────────────────────────────────────────────────────
+
+    def expand(
+        self,
+        seeds: Iterable[str],
+        *,
+        kinds: Iterable[EdgeKind] | None = None,
+        max_depth: int = 2,
+        direction: str = "out",
+    ) -> tuple[str, ...]:
+        """Bounded BFS expansion. Returns reachable node ids excluding seeds.
+
+        ``max_depth`` is clamped to ``[1, 16]`` so a single call cannot
+        wander the whole graph.
+        """
+        if max_depth < 1:
+            return ()
+        depth = min(max_depth, 16)
+        wanted = frozenset(kinds) if kinds else None
+        seen: set[str] = set(seeds)
+        queue: deque[tuple[str, int]] = deque((node, 0) for node in seen)
+        reached: list[str] = []
+        with self._lock:
+            while queue:
+                node_id, d = queue.popleft()
+                if d >= depth:
+                    continue
+                for edge in self.neighbors(node_id, kinds=wanted, direction=direction):
+                    target = edge.target if direction != "in" else edge.source
+                    if target in seen:
+                        continue
+                    seen.add(target)
+                    reached.append(target)
+                    queue.append((target, d + 1))
+        return tuple(reached)
+
+    # ── serialisation ──────────────────────────────────────────────────
+
+    def to_json(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "nodes": list(sorted(self._nodes)),
+                "edges": [
+                    {
+                        "source": s,
+                        "target": t,
+                        "kind": k.value,
+                    }
+                    for (s, t, k) in sorted(self._edges)
+                ],
+            }
+
+    @classmethod
+    def from_json(cls, payload: Mapping[str, Any]) -> CapabilityGraph:
+        graph = cls()
+        for node_id in payload.get("nodes", ()):
+            graph.add_node(str(node_id))
+        for entry in payload.get("edges", ()):
+            graph.add_edge(
+                CapabilityEdge(
+                    source=str(entry["source"]),
+                    target=str(entry["target"]),
+                    kind=EdgeKind.parse(entry["kind"]),
+                    weight=float(entry.get("weight", 1.0)),
+                    notes=str(entry.get("notes", "")),
+                )
+            )
+        return graph
+
+    # ── stats ──────────────────────────────────────────────────────────
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._nodes)
+
+    def edge_count(self) -> int:
+        with self._lock:
+            return len(self._edges)

--- a/tests/test_capability_graph.py
+++ b/tests/test_capability_graph.py
@@ -1,0 +1,132 @@
+"""Tests for the capability graph (issue #1336)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dcc_mcp_core import CapabilityEdge
+from dcc_mcp_core import CapabilityGraph
+from dcc_mcp_core import EdgeKind
+
+
+class TestEdgeKind:
+    def test_parse_accepts_enum_and_snake_kebab(self) -> None:
+        assert EdgeKind.parse(EdgeKind.REQUIRES) is EdgeKind.REQUIRES
+        assert EdgeKind.parse("requires") is EdgeKind.REQUIRES
+        assert EdgeKind.parse("DEPENDS_ON") is EdgeKind.DEPENDS_ON
+        assert EdgeKind.parse("fallback-for") is EdgeKind.FALLBACK_FOR
+
+    def test_parse_rejects_unknown(self) -> None:
+        with pytest.raises(ValueError):
+            EdgeKind.parse("loves")
+
+
+class TestCapabilityEdge:
+    def test_rejects_self_loop(self) -> None:
+        with pytest.raises(ValueError):
+            CapabilityEdge("a", "a", EdgeKind.REQUIRES)
+
+    def test_rejects_empty_endpoints(self) -> None:
+        with pytest.raises(ValueError):
+            CapabilityEdge("", "b", EdgeKind.REQUIRES)
+
+    def test_rejects_out_of_range_weight(self) -> None:
+        with pytest.raises(ValueError):
+            CapabilityEdge("a", "b", EdgeKind.REQUIRES, weight=2.0)
+
+
+class TestCapabilityGraph:
+    def test_add_edge_is_idempotent(self) -> None:
+        g = CapabilityGraph()
+        e = CapabilityEdge("usd_import", "scene_node", EdgeKind.PRODUCES)
+        assert g.add_edge(e) is True
+        assert g.add_edge(e) is False
+        assert g.edge_count() == 1
+
+    def test_register_skill_returns_added_count(self) -> None:
+        g = CapabilityGraph()
+        added = g.register_skill(
+            "usd_import",
+            requires=["scene_open"],
+            produces=["scene_node:transform", "file:usd"],
+            fallback_for=["fbx_import"],
+        )
+        assert added == 4
+        # Repeat is idempotent
+        assert g.register_skill("usd_import", requires=["scene_open"]) == 0
+
+    def test_neighbors_filters_by_kind(self) -> None:
+        g = CapabilityGraph()
+        g.register_skill("usd_import", requires=["scene_open"], produces=["scene_node"])
+        produces = g.neighbors("usd_import", kinds=[EdgeKind.PRODUCES])
+        assert {e.target for e in produces} == {"scene_node"}
+
+    def test_neighbors_unknown_node_returns_empty(self) -> None:
+        g = CapabilityGraph()
+        assert g.neighbors("ghost") == ()
+
+    def test_neighbors_invalid_direction_raises(self) -> None:
+        g = CapabilityGraph()
+        g.add_node("a")
+        with pytest.raises(ValueError):
+            g.neighbors("a", direction="sideways")
+
+    def test_expand_is_depth_bounded(self) -> None:
+        g = CapabilityGraph()
+        # chain a -> b -> c -> d
+        g.add_edge(CapabilityEdge("a", "b", EdgeKind.PRODUCES))
+        g.add_edge(CapabilityEdge("b", "c", EdgeKind.PRODUCES))
+        g.add_edge(CapabilityEdge("c", "d", EdgeKind.PRODUCES))
+
+        depth1 = g.expand(["a"], max_depth=1)
+        depth2 = g.expand(["a"], max_depth=2)
+        assert depth1 == ("b",)
+        assert depth2 == ("b", "c")
+
+    def test_expand_zero_depth_returns_empty(self) -> None:
+        g = CapabilityGraph()
+        g.add_edge(CapabilityEdge("a", "b", EdgeKind.PRODUCES))
+        assert g.expand(["a"], max_depth=0) == ()
+
+    def test_expand_filters_by_kind(self) -> None:
+        g = CapabilityGraph()
+        g.add_edge(CapabilityEdge("a", "b", EdgeKind.PRODUCES))
+        g.add_edge(CapabilityEdge("a", "c", EdgeKind.REQUIRES))
+        # Expanding only along PRODUCES does not visit c via REQUIRES
+        assert g.expand(["a"], kinds=[EdgeKind.PRODUCES], max_depth=2) == ("b",)
+
+    def test_expand_reverse_direction(self) -> None:
+        g = CapabilityGraph()
+        # b PRODUCES a -> expanding from a "inward" reaches b
+        g.add_edge(CapabilityEdge("b", "a", EdgeKind.PRODUCES))
+        assert g.expand(["a"], direction="in", max_depth=1) == ("b",)
+
+    def test_json_round_trip_preserves_edges(self) -> None:
+        g = CapabilityGraph()
+        g.register_skill(
+            "usd_import",
+            requires=["scene_open"],
+            produces=["scene_node"],
+            fallback_for=["fbx_import"],
+        )
+        payload = g.to_json()
+        back = CapabilityGraph.from_json(payload)
+        assert back.edge_count() == g.edge_count()
+        assert set(back.nodes()) == set(g.nodes())
+
+    def test_from_json_normalises_edge_kinds_in_kebab_case(self) -> None:
+        payload = {
+            "nodes": ["a", "b"],
+            "edges": [{"source": "a", "target": "b", "kind": "fallback-for"}],
+        }
+        g = CapabilityGraph.from_json(payload)
+        edges = g.neighbors("a")
+        assert len(edges) == 1
+        assert edges[0].kind is EdgeKind.FALLBACK_FOR
+
+    def test_len_and_edge_count(self) -> None:
+        g = CapabilityGraph()
+        assert len(g) == 0
+        g.add_edge(CapabilityEdge("a", "b", EdgeKind.PRODUCES))
+        assert len(g) == 2
+        assert g.edge_count() == 1


### PR DESCRIPTION
Closes #1336.

> Stacked on top of #1348 (host execution readiness), which is stacked on the already-merged #1335 / #1337. Only the final aggregation PR will be rebased on `main` and CI-green merged; intermediate PRs in the stack are reviewed for design / contract, not CI.

## Summary

Adds the public contract for cross-skill relationship reasoning so the search ranker (follow-up), agent planner, and admin UI can answer questions like:

* "What else do I need before this skill is useful?" — `EdgeKind.REQUIRES`
* "What does this skill produce that other skills need?" — `EdgeKind.PRODUCES`
* "If this skill is missing, what is the fallback?" — `EdgeKind.FALLBACK_FOR`

This PR is intentionally **the contract surface only**: a small, in-memory, threadsafe `CapabilityGraph` that downstream subsystems (semantic skill index #1333, agent memory layers #1334, gateway ranker rerank) plug into without renegotiating the public wire shape later.

## Public surface

`python/dcc_mcp_core/capability_graph.py`:

| Symbol | Purpose |
|---|---|
| `EdgeKind` | Closed enum: `depends_on`, `requires`, `produces`, `used_in`, `compatible_with`, `replaces`, `fallback_for`. `EdgeKind.parse(...)` accepts snake_case + kebab-case + the enum itself. |
| `CapabilityEdge` | Frozen dataclass `(source, target, kind, weight=1.0, notes="")` with `__post_init__` validation (no self-loops, no empty endpoints, weight ∈ [0, 1]). |
| `CapabilityGraph.add_node(id)` | Idempotent node insert. |
| `CapabilityGraph.add_edge(edge)` | Idempotent edge insert; returns `True` when new. |
| `CapabilityGraph.register_skill(skill_id, requires=, produces=, depends_on=, replaces=, fallback_for=, compatible_with=)` | Mirrors the optional fields added to `SkillMetadata` in #1335 so a skill loader can wire frontmatter directly without translation. Returns count of newly-added edges. |
| `CapabilityGraph.neighbors(node, kinds=, direction='out'\|'in'\|'both')` | Edges adjacent to `node`, optionally filtered by kind. |
| `CapabilityGraph.expand(seeds, kinds=, max_depth=2, direction=)` | Bounded BFS expansion. `max_depth` is clamped to `[1, 16]` so a single call cannot wander the whole graph (worst-case O(nodes × depth)). |
| `CapabilityGraph.to_json` / `from_json` | Stable wire shape for persistence + admin export. |
| `__len__`, `edge_count()` | For admin telemetry. |

Re-exports from `dcc_mcp_core`: `CapabilityEdge`, `CapabilityGraph`, `EdgeKind`.

## What does **not** land here

The ranker rerank that boosts neighbours of typed-intent search hits will land in a separate follow-up that consumes the API added here. Keeping the contract isolated prevents the ranker work (which touches Rust crates and feature-flag plumbing) from blocking adoption of the graph in unrelated places (skill loaders, planners, admin telemetry).

## Tests

17 new tests in `tests/test_capability_graph.py`:

* `EdgeKind.parse` accepts enum, snake_case, kebab-case; rejects unknown.
* `CapabilityEdge` rejects self-loops, empty endpoints, out-of-range weights.
* `add_edge` is idempotent; `register_skill` returns correct added-count and is idempotent on repeat.
* `neighbors` filters by kind, returns empty for unknown nodes, rejects invalid direction.
* `expand` is depth-bounded (1 vs 2 deep), zero-depth returns empty, filters by kind, supports reverse direction.
* `to_json` / `from_json` round-trips edge count and node set; `from_json` normalises kebab-case edge kinds.
* `__len__` / `edge_count` track node and edge counts respectively.

Local: `PYTHONPATH=python pytest tests/test_capability_graph.py -x -q` → **17 passed**.

## Acceptance criteria mapping

| #1336 criterion | Where it lands |
|---|---|
| Closed edge vocabulary across the seven relationship types | `EdgeKind` enum |
| Bounded query-time expansion | `expand(..., max_depth)` clamped to `[1, 16]` |
| Stable contract for downstream subsystems (#1333, #1334, ranker) | Public re-exports + `to_json` shape |
| Skill loaders wire frontmatter without translation layer | `register_skill(skill_id, requires=, produces=, …)` mirrors #1335 fields |

## Backwards compatibility

* New module, new public exports — purely additive.
* No existing types or behaviour changed.
