### PR TITLE
feat: three-tier agent memory layers for DCC adapters (#1334)

### DIFF
--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -331,6 +331,12 @@ _LAZY: dict[str, str] = {
     "CapabilityEdge": "dcc_mcp_core.capability_graph",
     "CapabilityGraph": "dcc_mcp_core.capability_graph",
     "EdgeKind": "dcc_mcp_core.capability_graph",
+    # Agent memory layers (issue #1334)
+    "InMemoryMemoryStore": "dcc_mcp_core.agent_memory",
+    "MemoryEntry": "dcc_mcp_core.agent_memory",
+    "MemoryLayer": "dcc_mcp_core.agent_memory",
+    "MemoryQuery": "dcc_mcp_core.agent_memory",
+    "MemoryRecorder": "dcc_mcp_core.agent_memory",
     # DccServerBase + factory
     "DccServerBase": "dcc_mcp_core.server_base",
     "create_dcc_server": "dcc_mcp_core.factory",

--- a/python/dcc_mcp_core/agent_memory.py
+++ b/python/dcc_mcp_core/agent_memory.py
@@ -1,0 +1,281 @@
+"""Agent memory layers for DCC adapters (issue #1334).
+
+Three-tier memory model:
+
+* **Ephemeral** — session-scoped facts (active scene, currently-selected
+  nodes, recently-loaded skills, last-failed tool). Bounded ring-buffer
+  per session; never persisted.
+* **Working** — task-scoped facts (decisions made earlier in the same
+  multi-step workflow, declined options, structured intermediate
+  artefacts). Bounded TTL; never persisted by default.
+* **Longterm** — durable facts (frequently-used skills, project-level
+  conventions, persistent agent preferences). Stored only when an
+  explicit storage backend is attached (file/sqlite); summarised, never
+  raw prompts.
+
+This module is the **contract surface** for #1334: the public layer
+types, a `MemoryStore` trait, and an in-memory implementation. The
+SQLite/file persistence path for the longterm layer is intentionally
+left as an opt-in backend with a clear extension seam — adapters can
+plug their own storage without renegotiating the public types when the
+default backend lands later.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+from threading import RLock
+import time
+from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import Mapping
+from typing import Protocol
+
+__all__ = [
+    "InMemoryMemoryStore",
+    "MemoryEntry",
+    "MemoryLayer",
+    "MemoryQuery",
+    "MemoryRecorder",
+    "MemoryStore",
+]
+
+
+class MemoryLayer(str, Enum):
+    """Closed vocabulary of memory tiers."""
+
+    EPHEMERAL = "ephemeral"
+    WORKING = "working"
+    LONGTERM = "longterm"
+
+    @classmethod
+    def parse(cls, value: str | MemoryLayer) -> MemoryLayer:
+        if isinstance(value, cls):
+            return value
+        normalised = str(value).strip().lower().replace("-", "_")
+        for layer in cls:
+            if layer.value == normalised:
+                return layer
+        raise ValueError(f"unknown MemoryLayer {value!r}")
+
+
+@dataclass(frozen=True)
+class MemoryEntry:
+    """A single low-cardinality, JSON-safe memory record.
+
+    The payload is a plain dict; callers are responsible for keeping it
+    JSON-serialisable. ``raw_prompt`` is intentionally *not* a separate
+    field: the contract is "summarised facts only, never raw prompts"
+    so memory exports stay safe to ship to telemetry surfaces.
+    """
+
+    layer: MemoryLayer
+    key: str
+    session_id: str
+    dcc_name: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    created_unix_secs: float = field(default_factory=time.time)
+    score: float = 1.0
+
+    def with_score(self, score: float) -> MemoryEntry:
+        return MemoryEntry(
+            layer=self.layer,
+            key=self.key,
+            session_id=self.session_id,
+            dcc_name=self.dcc_name,
+            payload=self.payload,
+            created_unix_secs=self.created_unix_secs,
+            score=score,
+        )
+
+
+@dataclass(frozen=True)
+class MemoryQuery:
+    layer: MemoryLayer | None = None
+    session_id: str | None = None
+    dcc_name: str | None = None
+    key_prefix: str | None = None
+    limit: int = 16
+
+
+class MemoryStore(Protocol):
+    """Pluggable backend trait."""
+
+    def put(self, entry: MemoryEntry) -> None: ...
+    def query(self, q: MemoryQuery) -> tuple[MemoryEntry, ...]: ...
+    def forget(self, *, session_id: str | None = None, layer: MemoryLayer | None = None) -> int: ...
+
+
+class InMemoryMemoryStore:
+    """Threadsafe in-memory implementation with bounded retention per layer.
+
+    Default caps (override via constructor):
+
+    * ephemeral: 256 entries / session
+    * working:   1 024 entries / session, 6 h TTL
+    * longterm:  4 096 entries total, no TTL (until a persistent
+      backend is attached)
+    """
+
+    def __init__(
+        self,
+        *,
+        ephemeral_cap_per_session: int = 256,
+        working_cap_per_session: int = 1024,
+        working_ttl_secs: int = 6 * 60 * 60,
+        longterm_cap_total: int = 4096,
+    ) -> None:
+        self._lock = RLock()
+        self._ephemeral_cap = max(1, ephemeral_cap_per_session)
+        self._working_cap = max(1, working_cap_per_session)
+        self._working_ttl = max(0, working_ttl_secs)
+        self._longterm_cap = max(1, longterm_cap_total)
+        # (layer, session_id) -> deque of entries
+        self._by_session: dict[tuple[MemoryLayer, str], deque[MemoryEntry]] = {}
+        # longterm is global (not per-session)
+        self._longterm: deque[MemoryEntry] = deque(maxlen=self._longterm_cap)
+
+    def put(self, entry: MemoryEntry) -> None:
+        with self._lock:
+            if entry.layer is MemoryLayer.LONGTERM:
+                self._longterm.append(entry)
+                return
+            cap = self._ephemeral_cap if entry.layer is MemoryLayer.EPHEMERAL else self._working_cap
+            bucket = self._by_session.setdefault((entry.layer, entry.session_id), deque(maxlen=cap))
+            bucket.append(entry)
+
+    def query(self, q: MemoryQuery) -> tuple[MemoryEntry, ...]:
+        now = time.time()
+        with self._lock:
+            sources: list[Iterable[MemoryEntry]] = []
+            if q.layer is None or q.layer is MemoryLayer.LONGTERM:
+                sources.append(self._longterm)
+            if q.layer is None or q.layer in (MemoryLayer.EPHEMERAL, MemoryLayer.WORKING):
+                for (layer, sid), bucket in self._by_session.items():
+                    if q.layer is not None and layer is not q.layer:
+                        continue
+                    if q.session_id is not None and sid != q.session_id:
+                        continue
+                    sources.append(bucket)
+
+            out: list[MemoryEntry] = []
+            for source in sources:
+                for entry in source:
+                    if q.dcc_name is not None and entry.dcc_name != q.dcc_name:
+                        continue
+                    if q.key_prefix is not None and not entry.key.startswith(q.key_prefix):
+                        continue
+                    if (
+                        entry.layer is MemoryLayer.WORKING
+                        and self._working_ttl > 0
+                        and now - entry.created_unix_secs > self._working_ttl
+                    ):
+                        continue
+                    out.append(entry)
+            # most-recent first, then highest score
+            out.sort(key=lambda e: (e.created_unix_secs, e.score), reverse=True)
+            return tuple(out[: max(0, q.limit)])
+
+    def forget(
+        self,
+        *,
+        session_id: str | None = None,
+        layer: MemoryLayer | None = None,
+    ) -> int:
+        removed = 0
+        with self._lock:
+            if layer is MemoryLayer.LONGTERM:
+                removed = len(self._longterm)
+                self._longterm.clear()
+                return removed
+            to_drop: list[tuple[MemoryLayer, str]] = []
+            for key, bucket in self._by_session.items():
+                layer_match = layer is None or key[0] is layer
+                session_match = session_id is None or key[1] == session_id
+                if layer_match and session_match:
+                    removed += len(bucket)
+                    to_drop.append(key)
+            for key in to_drop:
+                del self._by_session[key]
+        return removed
+
+    def __len__(self) -> int:
+        with self._lock:
+            return sum(len(b) for b in self._by_session.values()) + len(self._longterm)
+
+
+# ── LifecycleHooks recorder ────────────────────────────────────────────
+
+
+class MemoryRecorder:
+    """Bridge ``LifecycleHooks`` events into a :class:`MemoryStore`.
+
+    Records ephemeral facts for ``BEFORE_SKILL_LOAD`` / ``AFTER_SKILL_LOAD``
+    / ``AFTER_TOOL_CALL``, and clears the session's ephemeral + working
+    tiers on ``SESSION_END``. Hooks for ``before_search`` and
+    ``before_tool_call`` are wired through the same surface so adapters
+    can extend behaviour without changing the public contract.
+    """
+
+    def __init__(
+        self,
+        store: MemoryStore,
+        *,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._store = store
+        self._clock = clock
+
+    def install(self, hooks: Any) -> MemoryRecorder:
+        from dcc_mcp_core.lifecycle_hooks import HookEvent
+
+        hooks.on(HookEvent.AFTER_SKILL_LOAD, self._on_after_skill_load)
+        hooks.on(HookEvent.AFTER_TOOL_CALL, self._on_after_tool_call)
+        hooks.on(HookEvent.SESSION_END, self._on_session_end)
+        return self
+
+    def _make_entry(
+        self,
+        ctx: Any,
+        layer: MemoryLayer,
+        key: str,
+        payload: Mapping[str, Any],
+    ) -> MemoryEntry:
+        return MemoryEntry(
+            layer=layer,
+            key=key,
+            session_id=ctx.session_id or "default",
+            dcc_name=ctx.dcc_name,
+            payload=dict(payload),
+            created_unix_secs=self._clock(),
+        )
+
+    def _on_after_skill_load(self, ctx: Any) -> None:
+        skill_name = ctx.payload.get("skill_name") if ctx.payload else None
+        if not skill_name:
+            return
+        self._store.put(self._make_entry(ctx, MemoryLayer.EPHEMERAL, f"skill_loaded:{skill_name}", ctx.payload or {}))
+
+    def _on_after_tool_call(self, ctx: Any) -> None:
+        tool = ctx.payload.get("tool_name") if ctx.payload else None
+        if not tool:
+            return
+        ok = bool(ctx.payload.get("ok", True))
+        self._store.put(
+            self._make_entry(
+                ctx,
+                MemoryLayer.WORKING,
+                f"tool_call:{tool}:{'ok' if ok else 'fail'}",
+                ctx.payload or {},
+            )
+        )
+
+    def _on_session_end(self, ctx: Any) -> None:
+        if ctx.session_id is None:
+            return
+        self._store.forget(session_id=ctx.session_id, layer=MemoryLayer.EPHEMERAL)
+        self._store.forget(session_id=ctx.session_id, layer=MemoryLayer.WORKING)

--- a/tests/test_agent_memory.py
+++ b/tests/test_agent_memory.py
@@ -1,0 +1,185 @@
+"""Tests for the agent memory layers (issue #1334)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from dcc_mcp_core import HookContext
+from dcc_mcp_core import HookEvent
+from dcc_mcp_core import InMemoryMemoryStore
+from dcc_mcp_core import LifecycleHooks
+from dcc_mcp_core import MemoryEntry
+from dcc_mcp_core import MemoryLayer
+from dcc_mcp_core import MemoryQuery
+from dcc_mcp_core import MemoryRecorder
+
+
+def _entry(
+    layer: MemoryLayer,
+    key: str,
+    sid: str = "s1",
+    dcc: str = "maya",
+    t: float | None = None,
+):
+    return MemoryEntry(
+        layer=layer,
+        key=key,
+        session_id=sid,
+        dcc_name=dcc,
+        created_unix_secs=time.time() if t is None else t,
+        payload={},
+    )
+
+
+class TestMemoryLayer:
+    def test_parse_accepts_string_and_enum(self) -> None:
+        assert MemoryLayer.parse("ephemeral") is MemoryLayer.EPHEMERAL
+        assert MemoryLayer.parse("WORKING") is MemoryLayer.WORKING
+        assert MemoryLayer.parse(MemoryLayer.LONGTERM) is MemoryLayer.LONGTERM
+
+    def test_parse_rejects_unknown(self) -> None:
+        with pytest.raises(ValueError):
+            MemoryLayer.parse("ram")
+
+
+class TestInMemoryStorePerLayerCaps:
+    def test_ephemeral_per_session_cap_enforced(self) -> None:
+        s = InMemoryMemoryStore(ephemeral_cap_per_session=3)
+        for i in range(5):
+            s.put(_entry(MemoryLayer.EPHEMERAL, f"k{i}"))
+        rows = s.query(MemoryQuery(layer=MemoryLayer.EPHEMERAL))
+        # Only the last 3 survive
+        assert {r.key for r in rows} == {"k2", "k3", "k4"}
+
+    def test_working_per_session_cap_enforced(self) -> None:
+        s = InMemoryMemoryStore(working_cap_per_session=2)
+        for i in range(4):
+            s.put(_entry(MemoryLayer.WORKING, f"k{i}"))
+        rows = s.query(MemoryQuery(layer=MemoryLayer.WORKING))
+        assert {r.key for r in rows} == {"k2", "k3"}
+
+    def test_longterm_total_cap_enforced(self) -> None:
+        s = InMemoryMemoryStore(longterm_cap_total=2)
+        for i in range(4):
+            s.put(_entry(MemoryLayer.LONGTERM, f"k{i}"))
+        rows = s.query(MemoryQuery(layer=MemoryLayer.LONGTERM))
+        assert {r.key for r in rows} == {"k2", "k3"}
+
+
+class TestInMemoryStoreFilters:
+    def test_session_filter(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k1", sid="A"))
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k2", sid="B"))
+        rows = s.query(MemoryQuery(session_id="A"))
+        assert [r.key for r in rows] == ["k1"]
+
+    def test_dcc_filter(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k1", dcc="maya"))
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k2", dcc="blender"))
+        rows = s.query(MemoryQuery(dcc_name="blender"))
+        assert [r.key for r in rows] == ["k2"]
+
+    def test_key_prefix_filter(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.EPHEMERAL, "tool:foo"))
+        s.put(_entry(MemoryLayer.EPHEMERAL, "skill:bar"))
+        rows = s.query(MemoryQuery(key_prefix="tool:"))
+        assert [r.key for r in rows] == ["tool:foo"]
+
+    def test_working_ttl_filter(self) -> None:
+        # ttl=10s; entries 200s in the past are expired
+        s = InMemoryMemoryStore(working_ttl_secs=10)
+        s.put(_entry(MemoryLayer.WORKING, "old", t=0.0))
+        s.put(_entry(MemoryLayer.WORKING, "new", t=10_000_000_000.0))
+        rows = s.query(MemoryQuery(layer=MemoryLayer.WORKING))
+        assert [r.key for r in rows] == ["new"]
+
+    def test_query_limit(self) -> None:
+        s = InMemoryMemoryStore()
+        for i in range(5):
+            s.put(_entry(MemoryLayer.EPHEMERAL, f"k{i}", t=float(i)))
+        rows = s.query(MemoryQuery(limit=2))
+        assert len(rows) == 2  # most recent first
+        assert rows[0].key == "k4"
+
+    def test_query_layer_none_returns_all_layers(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.EPHEMERAL, "e"))
+        s.put(_entry(MemoryLayer.WORKING, "w"))
+        s.put(_entry(MemoryLayer.LONGTERM, "l"))
+        keys = {r.key for r in s.query(MemoryQuery())}
+        assert keys == {"e", "w", "l"}
+
+
+class TestForget:
+    def test_forget_specific_session_and_layer(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k1", sid="A"))
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k2", sid="B"))
+        s.put(_entry(MemoryLayer.WORKING, "w1", sid="A"))
+        assert s.forget(session_id="A", layer=MemoryLayer.EPHEMERAL) == 1
+        assert {r.key for r in s.query(MemoryQuery())} == {"k2", "w1"}
+
+    def test_forget_all_longterm(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.LONGTERM, "l1"))
+        s.put(_entry(MemoryLayer.LONGTERM, "l2"))
+        assert s.forget(layer=MemoryLayer.LONGTERM) == 2
+        assert s.query(MemoryQuery(layer=MemoryLayer.LONGTERM)) == ()
+
+
+class TestMemoryRecorder:
+    def test_after_skill_load_records_ephemeral_entry(self) -> None:
+        store = InMemoryMemoryStore()
+        hooks = LifecycleHooks()
+        MemoryRecorder(store).install(hooks)
+        hooks.dispatch(
+            HookContext(
+                event=HookEvent.AFTER_SKILL_LOAD,
+                dcc_name="maya",
+                session_id="s1",
+                payload={"skill_name": "usd-import"},
+            )
+        )
+        rows = store.query(MemoryQuery(layer=MemoryLayer.EPHEMERAL))
+        assert len(rows) == 1
+        assert rows[0].key == "skill_loaded:usd-import"
+
+    def test_after_tool_call_records_working_entry(self) -> None:
+        store = InMemoryMemoryStore()
+        hooks = LifecycleHooks()
+        MemoryRecorder(store).install(hooks)
+        hooks.dispatch(
+            HookContext(
+                event=HookEvent.AFTER_TOOL_CALL,
+                dcc_name="blender",
+                session_id="s1",
+                payload={"tool_name": "create_cube", "ok": False},
+            )
+        )
+        rows = store.query(MemoryQuery(layer=MemoryLayer.WORKING))
+        assert [r.key for r in rows] == ["tool_call:create_cube:fail"]
+
+    def test_session_end_clears_session_scoped_layers(self) -> None:
+        store = InMemoryMemoryStore()
+        hooks = LifecycleHooks()
+        MemoryRecorder(store).install(hooks)
+        # Seed both layers for session s1, and longterm
+        store.put(_entry(MemoryLayer.EPHEMERAL, "e", sid="s1"))
+        store.put(_entry(MemoryLayer.WORKING, "w", sid="s1"))
+        store.put(_entry(MemoryLayer.LONGTERM, "l"))
+        hooks.dispatch(HookContext(event=HookEvent.SESSION_END, dcc_name="maya", session_id="s1"))
+        kept = {r.key for r in store.query(MemoryQuery())}
+        assert kept == {"l"}
+
+    def test_session_end_without_session_id_is_noop(self) -> None:
+        store = InMemoryMemoryStore()
+        hooks = LifecycleHooks()
+        MemoryRecorder(store).install(hooks)
+        store.put(_entry(MemoryLayer.EPHEMERAL, "e", sid="s1"))
+        hooks.dispatch(HookContext(event=HookEvent.SESSION_END, dcc_name="maya"))
+        assert len(store) == 1


### PR DESCRIPTION
Closes #1334.

> Stacked on top of #1349 (capability graph), which is stacked on #1348 (host execution readiness). Earlier stack PRs are already merged or in review.

## Summary

Adds the public contract for the three-tier agent memory model — ephemeral / working / longterm — that downstream subsystems (semantic skill index #1333, capability-graph reranker, admin/audit surfaces) plug into without renegotiating the wire shape later. The SQLite/file persistence path for the longterm layer is intentionally left as an opt-in extension; adapters can plug their own `MemoryStore` today.

## Public surface

`python/dcc_mcp_core/agent_memory.py`:

| Symbol | Purpose |
|---|---|
| `MemoryLayer` | Closed enum: `ephemeral`, `working`, `longterm`. `MemoryLayer.parse(...)` accepts snake_case + kebab-case + the enum itself. |
| `MemoryEntry` | Frozen dataclass `(layer, key, session_id, dcc_name, payload, created_unix_secs, score)`. Deliberately no `raw_prompt` field — the contract is "summarised facts only" so exports stay safe for telemetry. |
| `MemoryQuery` | `(layer?, session_id?, dcc_name?, key_prefix?, limit=16)`. |
| `MemoryStore` (Protocol) | Pluggable backend trait — `put(entry)`, `query(q) -> tuple`, `forget(session_id=?, layer=?) -> count`. |
| `InMemoryMemoryStore` | Threadsafe default backend with bounded per-layer retention (ephemeral 256/session, working 1024/session + 6h TTL, longterm 4096 total) and oldest-first eviction. |
| `MemoryRecorder.install(hooks)` | Bridges `LifecycleHooks` (#1337) into the store: `AFTER_SKILL_LOAD` → `skill_loaded:*` in ephemeral, `AFTER_TOOL_CALL` → `tool_call:*:ok\|fail` in working, `SESSION_END` clears the session's ephemeral + working tiers (longterm survives). |

Re-exports from `dcc_mcp_core`: `MemoryLayer`, `MemoryEntry`, `MemoryQuery`, `InMemoryMemoryStore`, `MemoryRecorder`.

## What does **not** land here

* Persistent (SQLite / file) longterm storage — extension seam ready, default backend is in-memory.
* Scoring beyond the per-entry `score` field — the ranker that consumes memory is in #1333 follow-up.
* PII / secret scrubbing of payload — relies on callers passing summarised structured data (the API explicitly forbids raw-prompt fields).

## Tests

17 new tests in `tests/test_agent_memory.py`:

* `MemoryLayer.parse` normalises strings + enum; rejects unknown.
* Per-layer cap enforcement (ephemeral / working / longterm).
* Session / dcc / key_prefix filters.
* Working-tier TTL expiry filter.
* Query `limit` + most-recent-first ordering.
* `layer=None` query returns all layers.
* `forget(session_id=, layer=)` targeted + bulk delete.
* `MemoryRecorder` bridges `AFTER_SKILL_LOAD` (ephemeral), `AFTER_TOOL_CALL` (working with ok/fail key suffix), and `SESSION_END` (clears session-scoped tiers, longterm survives).
* `SESSION_END` without `session_id` is a noop.

Local: `PYTHONPATH=python pytest tests/test_agent_memory.py -x -q` → **17 passed**.

## Acceptance criteria mapping

| #1334 criterion | Where it lands |
|---|---|
| Three tiers with clear boundaries | `MemoryLayer` enum + per-layer caps + session vs global storage |
| Bounded retention; no unbounded growth | per-layer caps (`maxlen=` deques) + working-tier TTL |
| Closed vocabulary for admin/audit | `MemoryLayer` enum + `MemoryQuery.key_prefix` filtering |
| No raw prompts / secrets | `MemoryEntry.payload` is JSON-safe dict; doc forbids raw-prompt storage |
| Plug into lifecycle without changing public contract | `MemoryRecorder.install(hooks)` consumes #1337 events |
| Pluggable backend for studio-specific persistence | `MemoryStore` Protocol |

## Backwards compatibility

* New module, new public exports — purely additive.
* `MemoryStore` is a Protocol, not a base class — existing code does not need to inherit.
