### PR TITLE
feat: semantic skill index with BM25 + RRF fusion (#1333)

### DIFF
--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -337,6 +337,11 @@ _LAZY: dict[str, str] = {
     "MemoryLayer": "dcc_mcp_core.agent_memory",
     "MemoryQuery": "dcc_mcp_core.agent_memory",
     "MemoryRecorder": "dcc_mcp_core.agent_memory",
+    # Semantic skill index (issue #1333)
+    "LexicalSkillIndex": "dcc_mcp_core.semantic_skill_index",
+    "RrfFusionIndex": "dcc_mcp_core.semantic_skill_index",
+    "SkillDocument": "dcc_mcp_core.semantic_skill_index",
+    "SkillSearchHit": "dcc_mcp_core.semantic_skill_index",
     # DccServerBase + factory
     "DccServerBase": "dcc_mcp_core.server_base",
     "create_dcc_server": "dcc_mcp_core.factory",

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -331,6 +331,12 @@ _LAZY: dict[str, str] = {
     "CapabilityEdge": "dcc_mcp_core.capability_graph",
     "CapabilityGraph": "dcc_mcp_core.capability_graph",
     "EdgeKind": "dcc_mcp_core.capability_graph",
+    # Agent memory layers (issue #1334)
+    "InMemoryMemoryStore": "dcc_mcp_core.agent_memory",
+    "MemoryEntry": "dcc_mcp_core.agent_memory",
+    "MemoryLayer": "dcc_mcp_core.agent_memory",
+    "MemoryQuery": "dcc_mcp_core.agent_memory",
+    "MemoryRecorder": "dcc_mcp_core.agent_memory",
     # DccServerBase + factory
     "DccServerBase": "dcc_mcp_core.server_base",
     "create_dcc_server": "dcc_mcp_core.factory",

--- a/python/dcc_mcp_core/agent_memory.py
+++ b/python/dcc_mcp_core/agent_memory.py
@@ -1,0 +1,281 @@
+"""Agent memory layers for DCC adapters (issue #1334).
+
+Three-tier memory model:
+
+* **Ephemeral** — session-scoped facts (active scene, currently-selected
+  nodes, recently-loaded skills, last-failed tool). Bounded ring-buffer
+  per session; never persisted.
+* **Working** — task-scoped facts (decisions made earlier in the same
+  multi-step workflow, declined options, structured intermediate
+  artefacts). Bounded TTL; never persisted by default.
+* **Longterm** — durable facts (frequently-used skills, project-level
+  conventions, persistent agent preferences). Stored only when an
+  explicit storage backend is attached (file/sqlite); summarised, never
+  raw prompts.
+
+This module is the **contract surface** for #1334: the public layer
+types, a `MemoryStore` trait, and an in-memory implementation. The
+SQLite/file persistence path for the longterm layer is intentionally
+left as an opt-in backend with a clear extension seam — adapters can
+plug their own storage without renegotiating the public types when the
+default backend lands later.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+from threading import RLock
+import time
+from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import Mapping
+from typing import Protocol
+
+__all__ = [
+    "InMemoryMemoryStore",
+    "MemoryEntry",
+    "MemoryLayer",
+    "MemoryQuery",
+    "MemoryRecorder",
+    "MemoryStore",
+]
+
+
+class MemoryLayer(str, Enum):
+    """Closed vocabulary of memory tiers."""
+
+    EPHEMERAL = "ephemeral"
+    WORKING = "working"
+    LONGTERM = "longterm"
+
+    @classmethod
+    def parse(cls, value: str | MemoryLayer) -> MemoryLayer:
+        if isinstance(value, cls):
+            return value
+        normalised = str(value).strip().lower().replace("-", "_")
+        for layer in cls:
+            if layer.value == normalised:
+                return layer
+        raise ValueError(f"unknown MemoryLayer {value!r}")
+
+
+@dataclass(frozen=True)
+class MemoryEntry:
+    """A single low-cardinality, JSON-safe memory record.
+
+    The payload is a plain dict; callers are responsible for keeping it
+    JSON-serialisable. ``raw_prompt`` is intentionally *not* a separate
+    field: the contract is "summarised facts only, never raw prompts"
+    so memory exports stay safe to ship to telemetry surfaces.
+    """
+
+    layer: MemoryLayer
+    key: str
+    session_id: str
+    dcc_name: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    created_unix_secs: float = field(default_factory=time.time)
+    score: float = 1.0
+
+    def with_score(self, score: float) -> MemoryEntry:
+        return MemoryEntry(
+            layer=self.layer,
+            key=self.key,
+            session_id=self.session_id,
+            dcc_name=self.dcc_name,
+            payload=self.payload,
+            created_unix_secs=self.created_unix_secs,
+            score=score,
+        )
+
+
+@dataclass(frozen=True)
+class MemoryQuery:
+    layer: MemoryLayer | None = None
+    session_id: str | None = None
+    dcc_name: str | None = None
+    key_prefix: str | None = None
+    limit: int = 16
+
+
+class MemoryStore(Protocol):
+    """Pluggable backend trait."""
+
+    def put(self, entry: MemoryEntry) -> None: ...
+    def query(self, q: MemoryQuery) -> tuple[MemoryEntry, ...]: ...
+    def forget(self, *, session_id: str | None = None, layer: MemoryLayer | None = None) -> int: ...
+
+
+class InMemoryMemoryStore:
+    """Threadsafe in-memory implementation with bounded retention per layer.
+
+    Default caps (override via constructor):
+
+    * ephemeral: 256 entries / session
+    * working:   1 024 entries / session, 6 h TTL
+    * longterm:  4 096 entries total, no TTL (until a persistent
+      backend is attached)
+    """
+
+    def __init__(
+        self,
+        *,
+        ephemeral_cap_per_session: int = 256,
+        working_cap_per_session: int = 1024,
+        working_ttl_secs: int = 6 * 60 * 60,
+        longterm_cap_total: int = 4096,
+    ) -> None:
+        self._lock = RLock()
+        self._ephemeral_cap = max(1, ephemeral_cap_per_session)
+        self._working_cap = max(1, working_cap_per_session)
+        self._working_ttl = max(0, working_ttl_secs)
+        self._longterm_cap = max(1, longterm_cap_total)
+        # (layer, session_id) -> deque of entries
+        self._by_session: dict[tuple[MemoryLayer, str], deque[MemoryEntry]] = {}
+        # longterm is global (not per-session)
+        self._longterm: deque[MemoryEntry] = deque(maxlen=self._longterm_cap)
+
+    def put(self, entry: MemoryEntry) -> None:
+        with self._lock:
+            if entry.layer is MemoryLayer.LONGTERM:
+                self._longterm.append(entry)
+                return
+            cap = self._ephemeral_cap if entry.layer is MemoryLayer.EPHEMERAL else self._working_cap
+            bucket = self._by_session.setdefault((entry.layer, entry.session_id), deque(maxlen=cap))
+            bucket.append(entry)
+
+    def query(self, q: MemoryQuery) -> tuple[MemoryEntry, ...]:
+        now = time.time()
+        with self._lock:
+            sources: list[Iterable[MemoryEntry]] = []
+            if q.layer is None or q.layer is MemoryLayer.LONGTERM:
+                sources.append(self._longterm)
+            if q.layer is None or q.layer in (MemoryLayer.EPHEMERAL, MemoryLayer.WORKING):
+                for (layer, sid), bucket in self._by_session.items():
+                    if q.layer is not None and layer is not q.layer:
+                        continue
+                    if q.session_id is not None and sid != q.session_id:
+                        continue
+                    sources.append(bucket)
+
+            out: list[MemoryEntry] = []
+            for source in sources:
+                for entry in source:
+                    if q.dcc_name is not None and entry.dcc_name != q.dcc_name:
+                        continue
+                    if q.key_prefix is not None and not entry.key.startswith(q.key_prefix):
+                        continue
+                    if (
+                        entry.layer is MemoryLayer.WORKING
+                        and self._working_ttl > 0
+                        and now - entry.created_unix_secs > self._working_ttl
+                    ):
+                        continue
+                    out.append(entry)
+            # most-recent first, then highest score
+            out.sort(key=lambda e: (e.created_unix_secs, e.score), reverse=True)
+            return tuple(out[: max(0, q.limit)])
+
+    def forget(
+        self,
+        *,
+        session_id: str | None = None,
+        layer: MemoryLayer | None = None,
+    ) -> int:
+        removed = 0
+        with self._lock:
+            if layer is MemoryLayer.LONGTERM:
+                removed = len(self._longterm)
+                self._longterm.clear()
+                return removed
+            to_drop: list[tuple[MemoryLayer, str]] = []
+            for key, bucket in self._by_session.items():
+                layer_match = layer is None or key[0] is layer
+                session_match = session_id is None or key[1] == session_id
+                if layer_match and session_match:
+                    removed += len(bucket)
+                    to_drop.append(key)
+            for key in to_drop:
+                del self._by_session[key]
+        return removed
+
+    def __len__(self) -> int:
+        with self._lock:
+            return sum(len(b) for b in self._by_session.values()) + len(self._longterm)
+
+
+# ── LifecycleHooks recorder ────────────────────────────────────────────
+
+
+class MemoryRecorder:
+    """Bridge ``LifecycleHooks`` events into a :class:`MemoryStore`.
+
+    Records ephemeral facts for ``BEFORE_SKILL_LOAD`` / ``AFTER_SKILL_LOAD``
+    / ``AFTER_TOOL_CALL``, and clears the session's ephemeral + working
+    tiers on ``SESSION_END``. Hooks for ``before_search`` and
+    ``before_tool_call`` are wired through the same surface so adapters
+    can extend behaviour without changing the public contract.
+    """
+
+    def __init__(
+        self,
+        store: MemoryStore,
+        *,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._store = store
+        self._clock = clock
+
+    def install(self, hooks: Any) -> MemoryRecorder:
+        from dcc_mcp_core.lifecycle_hooks import HookEvent
+
+        hooks.on(HookEvent.AFTER_SKILL_LOAD, self._on_after_skill_load)
+        hooks.on(HookEvent.AFTER_TOOL_CALL, self._on_after_tool_call)
+        hooks.on(HookEvent.SESSION_END, self._on_session_end)
+        return self
+
+    def _make_entry(
+        self,
+        ctx: Any,
+        layer: MemoryLayer,
+        key: str,
+        payload: Mapping[str, Any],
+    ) -> MemoryEntry:
+        return MemoryEntry(
+            layer=layer,
+            key=key,
+            session_id=ctx.session_id or "default",
+            dcc_name=ctx.dcc_name,
+            payload=dict(payload),
+            created_unix_secs=self._clock(),
+        )
+
+    def _on_after_skill_load(self, ctx: Any) -> None:
+        skill_name = ctx.payload.get("skill_name") if ctx.payload else None
+        if not skill_name:
+            return
+        self._store.put(self._make_entry(ctx, MemoryLayer.EPHEMERAL, f"skill_loaded:{skill_name}", ctx.payload or {}))
+
+    def _on_after_tool_call(self, ctx: Any) -> None:
+        tool = ctx.payload.get("tool_name") if ctx.payload else None
+        if not tool:
+            return
+        ok = bool(ctx.payload.get("ok", True))
+        self._store.put(
+            self._make_entry(
+                ctx,
+                MemoryLayer.WORKING,
+                f"tool_call:{tool}:{'ok' if ok else 'fail'}",
+                ctx.payload or {},
+            )
+        )
+
+    def _on_session_end(self, ctx: Any) -> None:
+        if ctx.session_id is None:
+            return
+        self._store.forget(session_id=ctx.session_id, layer=MemoryLayer.EPHEMERAL)
+        self._store.forget(session_id=ctx.session_id, layer=MemoryLayer.WORKING)

--- a/python/dcc_mcp_core/semantic_skill_index.py
+++ b/python/dcc_mcp_core/semantic_skill_index.py
@@ -1,0 +1,260 @@
+"""Semantic skill index for DCC adapters (issue #1333).
+
+Design goal: typed-intent search across thousands of skills with predictable
+recall even when the agent's wording differs from the SKILL.md author's.
+
+This module is the **public contract** for #1333:
+
+* `SemanticSkillIndex` Protocol — pluggable backend trait.
+* `SkillDocument` / `SkillSearchHit` — wire types shared by every backend.
+* `LexicalSkillIndex` — default in-memory BM25-style lexical backend.
+* `RrfFusionIndex` — Reciprocal Rank Fusion combiner that takes two or
+  more indexes (e.g. lexical + vector) and merges their rankings.
+
+The vector backend is intentionally **not** included in this PR. It needs a
+heavy dependency (ONNX runtime / sqlite-vec / FAISS) that the core crate
+must not require by default. Adapters that want vector recall today can
+implement the Protocol and pass their backend into `RrfFusionIndex`
+without renegotiating the wire shape when the default vector backend
+lands later.
+
+External design references:
+
+* Robertson & Zaragoza, *The Probabilistic Relevance Framework: BM25
+  and Beyond* (Found. Trends Inf. Retr., 2009).
+* Cormack et al., *Reciprocal Rank Fusion outperforms Condorcet and
+  individual rank learning methods* (SIGIR 2009).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from math import log
+import re
+from threading import RLock
+from typing import Iterable, Mapping, Protocol
+
+__all__ = [
+    "LexicalSkillIndex",
+    "RrfFusionIndex",
+    "SemanticSkillIndex",
+    "SkillDocument",
+    "SkillSearchHit",
+]
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+
+
+def _tokenise(text: str) -> list[str]:
+    return [tok.lower() for tok in _TOKEN_RE.findall(text)]
+
+
+@dataclass(frozen=True)
+class SkillDocument:
+    """Stable wire shape for an indexable skill or tool record."""
+
+    skill_id: str
+    name: str
+    summary: str = ""
+    intent: str = ""
+    tags: tuple[str, ...] = ()
+    search_aliases: tuple[str, ...] = ()
+    dcc_name: str = ""
+
+    def corpus(self) -> str:
+        return " ".join(
+            (
+                self.name,
+                self.intent,
+                self.summary,
+                " ".join(self.tags),
+                " ".join(self.search_aliases),
+            )
+        )
+
+
+@dataclass(frozen=True)
+class SkillSearchHit:
+    skill_id: str
+    score: float
+    rank: int
+    match_reasons: tuple[str, ...] = ()
+
+
+class SemanticSkillIndex(Protocol):
+    """Pluggable semantic search backend."""
+
+    def index(self, documents: Iterable[SkillDocument]) -> int: ...
+    def search(self, query: str, *, k: int = 8) -> tuple[SkillSearchHit, ...]: ...
+    def clear(self) -> None: ...
+
+
+# ── Lexical (BM25-style) ───────────────────────────────────────────────
+
+
+@dataclass
+class _LexEntry:
+    doc: SkillDocument
+    term_counts: dict[str, int]
+    length: int
+
+
+class LexicalSkillIndex:
+    """In-memory BM25-style lexical index. Threadsafe."""
+
+    def __init__(self, *, k1: float = 1.5, b: float = 0.75) -> None:
+        if k1 <= 0 or not (0.0 <= b <= 1.0):
+            raise ValueError("k1 must be > 0 and b must be in [0.0, 1.0]")
+        self._k1 = k1
+        self._b = b
+        self._lock = RLock()
+        self._docs: dict[str, _LexEntry] = {}
+        self._df: dict[str, int] = defaultdict(int)
+        self._total_length = 0
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._docs)
+
+    def index(self, documents: Iterable[SkillDocument]) -> int:
+        """Add or replace documents. Returns the count actually written."""
+        added = 0
+        with self._lock:
+            for doc in documents:
+                self._remove_unlocked(doc.skill_id)
+                tokens = _tokenise(doc.corpus())
+                counts: dict[str, int] = defaultdict(int)
+                for tok in tokens:
+                    counts[tok] += 1
+                self._docs[doc.skill_id] = _LexEntry(doc, dict(counts), len(tokens))
+                for tok in counts:
+                    self._df[tok] += 1
+                self._total_length += len(tokens)
+                added += 1
+        return added
+
+    def clear(self) -> None:
+        with self._lock:
+            self._docs.clear()
+            self._df.clear()
+            self._total_length = 0
+
+    def _remove_unlocked(self, skill_id: str) -> None:
+        prev = self._docs.pop(skill_id, None)
+        if prev is None:
+            return
+        self._total_length -= prev.length
+        for tok in prev.term_counts:
+            self._df[tok] -= 1
+            if self._df[tok] <= 0:
+                del self._df[tok]
+
+    def remove(self, skill_id: str) -> bool:
+        with self._lock:
+            before = skill_id in self._docs
+            self._remove_unlocked(skill_id)
+            return before
+
+    def search(self, query: str, *, k: int = 8) -> tuple[SkillSearchHit, ...]:
+        if k <= 0:
+            return ()
+        with self._lock:
+            terms = _tokenise(query)
+            if not terms or not self._docs:
+                return ()
+            avg_len = self._total_length / max(1, len(self._docs))
+            scored: list[tuple[str, float, list[str]]] = []
+            for skill_id, entry in self._docs.items():
+                score = 0.0
+                matched: list[str] = []
+                for term in terms:
+                    tf = entry.term_counts.get(term, 0)
+                    if tf == 0:
+                        continue
+                    df = self._df.get(term, 1)
+                    n = len(self._docs)
+                    idf = log(1.0 + (n - df + 0.5) / (df + 0.5))
+                    denom = tf + self._k1 * (
+                        1.0 - self._b + self._b * (entry.length / max(1.0, avg_len))
+                    )
+                    score += idf * (tf * (self._k1 + 1.0) / max(1e-9, denom))
+                    matched.append(term)
+                if score > 0:
+                    scored.append((skill_id, score, matched))
+            scored.sort(key=lambda x: x[1], reverse=True)
+            return tuple(
+                SkillSearchHit(
+                    skill_id=sid,
+                    score=score,
+                    rank=rank,
+                    match_reasons=tuple(f"lex:{tok}" for tok in matched),
+                )
+                for rank, (sid, score, matched) in enumerate(scored[:k])
+            )
+
+
+# ── Reciprocal Rank Fusion ─────────────────────────────────────────────
+
+
+@dataclass
+class _BackendSpec:
+    name: str
+    index: SemanticSkillIndex
+    weight: float = 1.0
+
+
+class RrfFusionIndex:
+    """Combine multiple :class:`SemanticSkillIndex` backends via RRF.
+
+    Cormack et al. 2009 — score per doc is
+    ``Σ weight_i / (rrf_k + rank_i)``. Default ``rrf_k = 60`` matches the
+    original paper.
+    """
+
+    def __init__(self, *, rrf_k: int = 60) -> None:
+        if rrf_k <= 0:
+            raise ValueError("rrf_k must be > 0")
+        self._rrf_k = rrf_k
+        self._backends: list[_BackendSpec] = []
+
+    def register(self, name: str, index: SemanticSkillIndex, *, weight: float = 1.0) -> RrfFusionIndex:
+        if not name:
+            raise ValueError("backend name must be non-empty")
+        if weight <= 0:
+            raise ValueError("backend weight must be > 0")
+        self._backends.append(_BackendSpec(name=name, index=index, weight=weight))
+        return self
+
+    def index(self, documents: Iterable[SkillDocument]) -> int:
+        docs = list(documents)
+        for spec in self._backends:
+            spec.index.index(docs)
+        return len(docs)
+
+    def clear(self) -> None:
+        for spec in self._backends:
+            spec.index.clear()
+
+    def search(self, query: str, *, k: int = 8) -> tuple[SkillSearchHit, ...]:
+        if k <= 0 or not self._backends:
+            return ()
+        # per-doc fused score and contributing match reasons
+        fused: dict[str, float] = defaultdict(float)
+        reasons: dict[str, list[str]] = defaultdict(list)
+        for spec in self._backends:
+            hits = spec.index.search(query, k=max(k, 16))
+            for hit in hits:
+                fused[hit.skill_id] += spec.weight / (self._rrf_k + hit.rank + 1)
+                reasons[hit.skill_id].append(f"{spec.name}:{hit.rank}")
+        ordered = sorted(fused.items(), key=lambda x: x[1], reverse=True)
+        return tuple(
+            SkillSearchHit(
+                skill_id=sid,
+                score=score,
+                rank=rank,
+                match_reasons=tuple(reasons[sid]),
+            )
+            for rank, (sid, score) in enumerate(ordered[:k])
+        )

--- a/tests/test_agent_memory.py
+++ b/tests/test_agent_memory.py
@@ -1,0 +1,185 @@
+"""Tests for the agent memory layers (issue #1334)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from dcc_mcp_core import HookContext
+from dcc_mcp_core import HookEvent
+from dcc_mcp_core import InMemoryMemoryStore
+from dcc_mcp_core import LifecycleHooks
+from dcc_mcp_core import MemoryEntry
+from dcc_mcp_core import MemoryLayer
+from dcc_mcp_core import MemoryQuery
+from dcc_mcp_core import MemoryRecorder
+
+
+def _entry(
+    layer: MemoryLayer,
+    key: str,
+    sid: str = "s1",
+    dcc: str = "maya",
+    t: float | None = None,
+):
+    return MemoryEntry(
+        layer=layer,
+        key=key,
+        session_id=sid,
+        dcc_name=dcc,
+        created_unix_secs=time.time() if t is None else t,
+        payload={},
+    )
+
+
+class TestMemoryLayer:
+    def test_parse_accepts_string_and_enum(self) -> None:
+        assert MemoryLayer.parse("ephemeral") is MemoryLayer.EPHEMERAL
+        assert MemoryLayer.parse("WORKING") is MemoryLayer.WORKING
+        assert MemoryLayer.parse(MemoryLayer.LONGTERM) is MemoryLayer.LONGTERM
+
+    def test_parse_rejects_unknown(self) -> None:
+        with pytest.raises(ValueError):
+            MemoryLayer.parse("ram")
+
+
+class TestInMemoryStorePerLayerCaps:
+    def test_ephemeral_per_session_cap_enforced(self) -> None:
+        s = InMemoryMemoryStore(ephemeral_cap_per_session=3)
+        for i in range(5):
+            s.put(_entry(MemoryLayer.EPHEMERAL, f"k{i}"))
+        rows = s.query(MemoryQuery(layer=MemoryLayer.EPHEMERAL))
+        # Only the last 3 survive
+        assert {r.key for r in rows} == {"k2", "k3", "k4"}
+
+    def test_working_per_session_cap_enforced(self) -> None:
+        s = InMemoryMemoryStore(working_cap_per_session=2)
+        for i in range(4):
+            s.put(_entry(MemoryLayer.WORKING, f"k{i}"))
+        rows = s.query(MemoryQuery(layer=MemoryLayer.WORKING))
+        assert {r.key for r in rows} == {"k2", "k3"}
+
+    def test_longterm_total_cap_enforced(self) -> None:
+        s = InMemoryMemoryStore(longterm_cap_total=2)
+        for i in range(4):
+            s.put(_entry(MemoryLayer.LONGTERM, f"k{i}"))
+        rows = s.query(MemoryQuery(layer=MemoryLayer.LONGTERM))
+        assert {r.key for r in rows} == {"k2", "k3"}
+
+
+class TestInMemoryStoreFilters:
+    def test_session_filter(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k1", sid="A"))
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k2", sid="B"))
+        rows = s.query(MemoryQuery(session_id="A"))
+        assert [r.key for r in rows] == ["k1"]
+
+    def test_dcc_filter(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k1", dcc="maya"))
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k2", dcc="blender"))
+        rows = s.query(MemoryQuery(dcc_name="blender"))
+        assert [r.key for r in rows] == ["k2"]
+
+    def test_key_prefix_filter(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.EPHEMERAL, "tool:foo"))
+        s.put(_entry(MemoryLayer.EPHEMERAL, "skill:bar"))
+        rows = s.query(MemoryQuery(key_prefix="tool:"))
+        assert [r.key for r in rows] == ["tool:foo"]
+
+    def test_working_ttl_filter(self) -> None:
+        # ttl=10s; entries 200s in the past are expired
+        s = InMemoryMemoryStore(working_ttl_secs=10)
+        s.put(_entry(MemoryLayer.WORKING, "old", t=0.0))
+        s.put(_entry(MemoryLayer.WORKING, "new", t=10_000_000_000.0))
+        rows = s.query(MemoryQuery(layer=MemoryLayer.WORKING))
+        assert [r.key for r in rows] == ["new"]
+
+    def test_query_limit(self) -> None:
+        s = InMemoryMemoryStore()
+        for i in range(5):
+            s.put(_entry(MemoryLayer.EPHEMERAL, f"k{i}", t=float(i)))
+        rows = s.query(MemoryQuery(limit=2))
+        assert len(rows) == 2  # most recent first
+        assert rows[0].key == "k4"
+
+    def test_query_layer_none_returns_all_layers(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.EPHEMERAL, "e"))
+        s.put(_entry(MemoryLayer.WORKING, "w"))
+        s.put(_entry(MemoryLayer.LONGTERM, "l"))
+        keys = {r.key for r in s.query(MemoryQuery())}
+        assert keys == {"e", "w", "l"}
+
+
+class TestForget:
+    def test_forget_specific_session_and_layer(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k1", sid="A"))
+        s.put(_entry(MemoryLayer.EPHEMERAL, "k2", sid="B"))
+        s.put(_entry(MemoryLayer.WORKING, "w1", sid="A"))
+        assert s.forget(session_id="A", layer=MemoryLayer.EPHEMERAL) == 1
+        assert {r.key for r in s.query(MemoryQuery())} == {"k2", "w1"}
+
+    def test_forget_all_longterm(self) -> None:
+        s = InMemoryMemoryStore()
+        s.put(_entry(MemoryLayer.LONGTERM, "l1"))
+        s.put(_entry(MemoryLayer.LONGTERM, "l2"))
+        assert s.forget(layer=MemoryLayer.LONGTERM) == 2
+        assert s.query(MemoryQuery(layer=MemoryLayer.LONGTERM)) == ()
+
+
+class TestMemoryRecorder:
+    def test_after_skill_load_records_ephemeral_entry(self) -> None:
+        store = InMemoryMemoryStore()
+        hooks = LifecycleHooks()
+        MemoryRecorder(store).install(hooks)
+        hooks.dispatch(
+            HookContext(
+                event=HookEvent.AFTER_SKILL_LOAD,
+                dcc_name="maya",
+                session_id="s1",
+                payload={"skill_name": "usd-import"},
+            )
+        )
+        rows = store.query(MemoryQuery(layer=MemoryLayer.EPHEMERAL))
+        assert len(rows) == 1
+        assert rows[0].key == "skill_loaded:usd-import"
+
+    def test_after_tool_call_records_working_entry(self) -> None:
+        store = InMemoryMemoryStore()
+        hooks = LifecycleHooks()
+        MemoryRecorder(store).install(hooks)
+        hooks.dispatch(
+            HookContext(
+                event=HookEvent.AFTER_TOOL_CALL,
+                dcc_name="blender",
+                session_id="s1",
+                payload={"tool_name": "create_cube", "ok": False},
+            )
+        )
+        rows = store.query(MemoryQuery(layer=MemoryLayer.WORKING))
+        assert [r.key for r in rows] == ["tool_call:create_cube:fail"]
+
+    def test_session_end_clears_session_scoped_layers(self) -> None:
+        store = InMemoryMemoryStore()
+        hooks = LifecycleHooks()
+        MemoryRecorder(store).install(hooks)
+        # Seed both layers for session s1, and longterm
+        store.put(_entry(MemoryLayer.EPHEMERAL, "e", sid="s1"))
+        store.put(_entry(MemoryLayer.WORKING, "w", sid="s1"))
+        store.put(_entry(MemoryLayer.LONGTERM, "l"))
+        hooks.dispatch(HookContext(event=HookEvent.SESSION_END, dcc_name="maya", session_id="s1"))
+        kept = {r.key for r in store.query(MemoryQuery())}
+        assert kept == {"l"}
+
+    def test_session_end_without_session_id_is_noop(self) -> None:
+        store = InMemoryMemoryStore()
+        hooks = LifecycleHooks()
+        MemoryRecorder(store).install(hooks)
+        store.put(_entry(MemoryLayer.EPHEMERAL, "e", sid="s1"))
+        hooks.dispatch(HookContext(event=HookEvent.SESSION_END, dcc_name="maya"))
+        assert len(store) == 1

--- a/tests/test_semantic_skill_index.py
+++ b/tests/test_semantic_skill_index.py
@@ -1,0 +1,154 @@
+"""Tests for the semantic skill index (issue #1333)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dcc_mcp_core import LexicalSkillIndex, RrfFusionIndex, SkillDocument, SkillSearchHit
+
+
+def _doc(skill_id: str, name: str, *, intent: str = "", summary: str = "", tags=(), aliases=()):
+    return SkillDocument(
+        skill_id=skill_id,
+        name=name,
+        intent=intent,
+        summary=summary,
+        tags=tuple(tags),
+        search_aliases=tuple(aliases),
+    )
+
+
+class TestLexicalSkillIndex:
+    def test_rejects_invalid_hyperparameters(self) -> None:
+        with pytest.raises(ValueError):
+            LexicalSkillIndex(k1=0)
+        with pytest.raises(ValueError):
+            LexicalSkillIndex(b=1.5)
+
+    def test_indexes_and_searches_returns_typed_hit(self) -> None:
+        idx = LexicalSkillIndex()
+        idx.index(
+            [
+                _doc("usd-import", "usd_import", intent="import a USD layer"),
+                _doc("fbx-import", "fbx_import", intent="import an FBX file"),
+            ]
+        )
+        hits = idx.search("import usd", k=2)
+        assert len(hits) >= 1
+        assert isinstance(hits[0], SkillSearchHit)
+        assert hits[0].skill_id == "usd-import"
+        assert any(r.startswith("lex:") for r in hits[0].match_reasons)
+
+    def test_search_returns_empty_for_unknown_terms(self) -> None:
+        idx = LexicalSkillIndex()
+        idx.index([_doc("a", "alpha")])
+        assert idx.search("zzz", k=5) == ()
+
+    def test_search_empty_index_returns_empty(self) -> None:
+        idx = LexicalSkillIndex()
+        assert idx.search("anything") == ()
+
+    def test_zero_k_returns_empty(self) -> None:
+        idx = LexicalSkillIndex()
+        idx.index([_doc("a", "alpha")])
+        assert idx.search("alpha", k=0) == ()
+
+    def test_reindex_replaces_existing_document(self) -> None:
+        idx = LexicalSkillIndex()
+        idx.index([_doc("usd", "usd_import", intent="import")])
+        idx.index([_doc("usd", "usd_export", intent="export")])
+        # Old intent must not match
+        hits = idx.search("import", k=5)
+        assert hits == ()
+        hits2 = idx.search("export", k=5)
+        assert hits2[0].skill_id == "usd"
+
+    def test_remove_drops_document(self) -> None:
+        idx = LexicalSkillIndex()
+        idx.index([_doc("a", "alpha"), _doc("b", "beta")])
+        assert idx.remove("a") is True
+        assert idx.remove("a") is False
+        hits = idx.search("alpha", k=5)
+        assert hits == ()
+
+    def test_clear_resets_index(self) -> None:
+        idx = LexicalSkillIndex()
+        idx.index([_doc("a", "alpha")])
+        idx.clear()
+        assert len(idx) == 0
+        assert idx.search("alpha") == ()
+
+    def test_aliases_and_tags_contribute_to_recall(self) -> None:
+        idx = LexicalSkillIndex()
+        idx.index([_doc("io", "io_module", tags=("interchange",), aliases=("fbx",))])
+        hits = idx.search("interchange", k=3)
+        assert hits and hits[0].skill_id == "io"
+        hits = idx.search("fbx", k=3)
+        assert hits and hits[0].skill_id == "io"
+
+    def test_idf_demotes_extremely_common_terms(self) -> None:
+        idx = LexicalSkillIndex()
+        idx.index(
+            [
+                _doc("a", "import_one", intent="import shared"),
+                _doc("b", "import_two", intent="import shared"),
+                _doc("c", "load_one", intent="load shared"),
+            ]
+        )
+        # "import" matches a + b; "shared" matches all three.
+        # BM25 IDF should favour the discriminating term.
+        hits = idx.search("import shared", k=3)
+        assert hits[0].skill_id in {"a", "b"}
+
+
+class TestRrfFusionIndex:
+    def test_rejects_invalid_rrf_k(self) -> None:
+        with pytest.raises(ValueError):
+            RrfFusionIndex(rrf_k=0)
+
+    def test_register_rejects_empty_name(self) -> None:
+        f = RrfFusionIndex()
+        with pytest.raises(ValueError):
+            f.register("", LexicalSkillIndex())
+
+    def test_register_rejects_non_positive_weight(self) -> None:
+        f = RrfFusionIndex()
+        with pytest.raises(ValueError):
+            f.register("lex", LexicalSkillIndex(), weight=0.0)
+
+    def test_search_with_no_backends_returns_empty(self) -> None:
+        f = RrfFusionIndex()
+        f.index([_doc("a", "alpha")])
+        assert f.search("alpha") == ()
+
+    def test_index_fans_out_to_backends(self) -> None:
+        lex_a = LexicalSkillIndex()
+        lex_b = LexicalSkillIndex()
+        f = RrfFusionIndex().register("a", lex_a).register("b", lex_b)
+        added = f.index([_doc("x", "alpha"), _doc("y", "beta")])
+        assert added == 2
+        assert len(lex_a) == 2
+        assert len(lex_b) == 2
+
+    def test_fusion_promotes_doc_ranked_high_by_multiple_backends(self) -> None:
+        lex_a = LexicalSkillIndex()
+        lex_b = LexicalSkillIndex()
+        docs = [
+            _doc("usd", "usd_import", intent="import a usd layer"),
+            _doc("fbx", "fbx_import", intent="import an fbx file"),
+        ]
+        lex_a.index(docs)
+        lex_b.index(docs)
+        f = RrfFusionIndex().register("a", lex_a).register("b", lex_b)
+        hits = f.search("import usd", k=2)
+        assert hits[0].skill_id == "usd"
+        # Match reasons must carry both backend tags
+        names = {r.split(":")[0] for r in hits[0].match_reasons}
+        assert names == {"a", "b"}
+
+    def test_clear_fans_out_to_backends(self) -> None:
+        lex_a = LexicalSkillIndex()
+        lex_a.index([_doc("a", "alpha")])
+        f = RrfFusionIndex().register("a", lex_a)
+        f.clear()
+        assert len(lex_a) == 0


### PR DESCRIPTION
Closes #1333.

> Stacked on top of #1350 (agent memory layers).

## Summary

Adds the public contract for typed-intent semantic search across thousands of skills, so adapters / gateway rerankers can answer queries that paraphrase the SKILL.md author's wording.

Two backends ship in this PR:

* **`LexicalSkillIndex`** — threadsafe in-memory BM25-style index (Robertson & Zaragoza 2009) with configurable `k1` / `b` hyperparameters, reindex-replaces-existing semantics, and `remove` / `clear`.
* **`RrfFusionIndex`** — Reciprocal Rank Fusion combiner (Cormack et al. 2009) that takes any number of `SemanticSkillIndex` backends and merges their rankings, tagging each hit's `match_reasons` with the contributing backend name + rank for admin attribution.

The vector backend is intentionally **not** in this PR: it needs a heavy dependency (ONNX runtime / sqlite-vec / FAISS) the core library must not require by default. Adapters that want vector recall today implement the `SemanticSkillIndex` Protocol and pass their backend into `RrfFusionIndex` — no wire-shape renegotiation when a default vector backend lands later.

## Public surface

`python/dcc_mcp_core/semantic_skill_index.py`:

| Symbol | Purpose |
|---|---|
| `SemanticSkillIndex` (Protocol) | Pluggable backend trait: `index(documents) -> int`, `search(query, k) -> tuple`, `clear()`. |
| `SkillDocument` | Frozen dataclass `(skill_id, name, summary, intent, tags, search_aliases, dcc_name)`; `corpus()` returns the concatenated text indexed by lexical backends. |
| `SkillSearchHit` | Frozen dataclass `(skill_id, score, rank, match_reasons)`. |
| `LexicalSkillIndex(k1=1.5, b=0.75)` | BM25 in-memory backend; surfaces matched-term reasons as `lex:<token>`. |
| `RrfFusionIndex(rrf_k=60).register(name, index, weight=1.0)` | RRF combiner. `weight` is multiplicative on the standard `1 / (rrf_k + rank + 1)`. |

Re-exports from `dcc_mcp_core`: `SkillDocument`, `SkillSearchHit`, `LexicalSkillIndex`, `RrfFusionIndex`.

## External design references

* Robertson & Zaragoza, *The Probabilistic Relevance Framework: BM25 and Beyond* (Found. Trends Inf. Retr., 2009).
* Cormack et al., *Reciprocal Rank Fusion outperforms Condorcet and individual rank learning methods* (SIGIR 2009).

## Tests

17 new tests in `tests/test_semantic_skill_index.py`:

* `LexicalSkillIndex`: hyperparameter validation, typed-hit search, empty/zero-k/unknown-term/empty-index queries, reindex replaces existing, `remove` path, `clear`, tag/alias recall contribution, IDF discrimination (rarer term wins).
* `RrfFusionIndex`: `rrf_k` validation, `register` validation (empty name, non-positive weight), no-backends → empty result, `index` fans out to backends, multi-backend agreement promotes the consensus hit and surfaces both backend tags in `match_reasons`, `clear` fans out.

Local: `PYTHONPATH=python pytest tests/test_semantic_skill_index.py -x -q` → **17 passed**.

## Acceptance criteria mapping

| #1333 criterion | Where it lands |
|---|---|
| Typed semantic search across thousands of skills | `LexicalSkillIndex` + `RrfFusionIndex` Protocol seam for vector backend |
| Stable contract for downstream rerankers | `SkillDocument` / `SkillSearchHit` frozen dataclasses |
| Match attribution / debuggability | `SkillSearchHit.match_reasons` carries `lex:<token>` and `<backend>:<rank>` tags |
| Pluggable lexical + vector + fusion architecture | `SemanticSkillIndex` Protocol; RRF k=60 default per the SIGIR 2009 paper |

## Backwards compatibility

* New module, new public exports — purely additive.
* No external dependencies added (everything is stdlib).
