### PR TITLE
fix: change default standalone registry DCC type from generic to python

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -131,7 +131,7 @@ pub(crate) async fn skill_mgmt_dispatch(
             if targets.is_empty() {
                 return (
                     "No live DCC instances. Start dcc-mcp-server (or your DCC adapter) so the gateway can fan out skill tools. \
-Standalone `dcc-mcp-server` without `--app` registers as `dcc_type` from DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE (default `generic`); \
+Standalone `dcc-mcp-server` without `--app` registers as `dcc_type` from DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE (default `python`); \
 `unknown` is hidden from fan-out unless gateway `allow_unknown_tools` is enabled."
                         .to_string(),
                     true,

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -79,7 +79,7 @@
 //! | `DCC_MCP_GATEWAY_ADMIN_DB` | Override path for admin SQLite (traces / skill paths) |
 //! | `DCC_MCP_GATEWAY_ADMIN_RETENTION_DAYS` | Admin SQLite retention in days (default 30, max 3650) |
 //! | `DCC_MCP_WEBHOOKS_CONFIG` | YAML event webhook config for forwarding `skill.*`, `tool.*`, and other EventBus envelopes |
-//! | `DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE` | FileRegistry `dcc_type` when `--app` is empty (default `generic`) |
+//! | `DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE` | FileRegistry `dcc_type` when `--app` is empty (default `python`) |
 //! | `DCC_MCP_REGISTRY_DIR`    | Shared FileRegistry directory                      |
 //! | `DCC_MCP_STALE_TIMEOUT`   | Seconds without heartbeat = stale (default 30)     |
 

--- a/crates/dcc-mcp-skills/src/constants.rs
+++ b/crates/dcc-mcp-skills/src/constants.rs
@@ -36,8 +36,8 @@ pub const ENV_TEAM_APP_SKILL_PATHS_TEMPLATE: &str = "DCC_MCP_TEAM_{APP}_SKILL_PA
 /// without enabling `allow_unknown_tools`.
 pub const ENV_STANDALONE_REGISTRY_DCC_TYPE: &str = "DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE";
 
-/// Default registry `dcc_type` for standalone / generic hosts (not `"unknown"`).
-pub const DEFAULT_STANDALONE_REGISTRY_DCC_TYPE: &str = "generic";
+/// Default registry `dcc_type` for standalone / Python-oriented hosts (not `"unknown"`).
+pub const DEFAULT_STANDALONE_REGISTRY_DCC_TYPE: &str = "python";
 
 /// Resolve the `dcc_type` string stored on a [`ServiceEntry`] for MCP registration.
 #[must_use]
@@ -272,5 +272,34 @@ mod tests {
     #[test]
     fn test_resolve_registry_dcc_type_prefers_embedder() {
         assert_eq!(resolve_registry_dcc_type(Some("Maya")), "maya");
+    }
+
+    #[test]
+    fn test_resolve_registry_dcc_type_defaults_to_python() {
+        // Standalone dcc-mcp-server without --app and no env override
+        // should default to "python", not "generic".
+        assert_eq!(resolve_registry_dcc_type(None), "python");
+    }
+
+    #[test]
+    fn test_resolve_registry_dcc_type_env_override() {
+        unsafe {
+            std::env::set_var("DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE", "blender");
+        }
+        assert_eq!(resolve_registry_dcc_type(None), "blender");
+        unsafe {
+            std::env::remove_var("DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE");
+        }
+    }
+
+    #[test]
+    fn test_resolve_registry_dcc_type_embedder_overrides_env() {
+        unsafe {
+            std::env::set_var("DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE", "blender");
+        }
+        assert_eq!(resolve_registry_dcc_type(Some("Maya")), "maya");
+        unsafe {
+            std::env::remove_var("DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1353

Change the default standalone registry DCC type from `generic` to `python` so that the default `dcc-mcp-server` without `--app` registers as `python` instead of `generic`.

## Changes

- **core const**: `DEFAULT_STANDALONE_REGISTRY_DCC_TYPE` changed from `"generic"` to `"python"`
- **docs**: Updated CLI help text in `dcc-mcp-server` and gateway error message
- **tests**: Added tests for default fallback (`python`), env override, and embedder priority

## Verification

```
cargo test -p dcc-mcp-skills resolve_registry
```

All 4 tests pass (prefers embedder, defaults to python, env override, embedder overrides env).

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `dcc-mcp-server` (no `--app`) | `dcc_type = generic` | `dcc_type = python` |
| `dcc-mcp-server --app maya` | `dcc_type = maya` | `dcc_type = maya` (unchanged) |
| `DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE=blender` | `dcc_type = blender` | `dcc_type = blender` (unchanged) |