### PR TITLE
refactor(http): gate auto-gateway bootstrap behind cargo feature (#1357)

### DIFF
--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -18,7 +18,11 @@ dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
 dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
 dcc-mcp-job = { path = "../dcc-mcp-job" }
 dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
-dcc-mcp-gateway = { path = "../dcc-mcp-gateway", features = ["admin", "admin-persist-sqlite"] }
+# Optional via the `auto-gateway` feature (default-on). Embedders that
+# only need the per-DCC MCP HTTP server (no first-wins election, no
+# admin UI, no aggregation) can opt out with `default-features = false`
+# and drop the whole gateway code path / dependency tree (issue #1357).
+dcc-mcp-gateway = { path = "../dcc-mcp-gateway", features = ["admin", "admin-persist-sqlite"], optional = true }
 dcc-mcp-models = { path = "../dcc-mcp-models" }
 dcc-mcp-skills = { path = "../dcc-mcp-skills" }
 dcc-mcp-pybridge = { path = "../dcc-mcp-pybridge", optional = true }
@@ -90,14 +94,23 @@ dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
 pyo3 = { workspace = true, features = ["auto-initialize"] }
 
 [features]
-default = []
+default = ["auto-gateway"]
+# Wires the first-wins gateway election + aggregation runtime into
+# `McpHttpServer::start()` so a single embedded server can also act as
+# the LAN gateway (default behavior, issue #1357). Turning this off
+# drops the entire `dcc-mcp-gateway` dep — `gateway_port` becomes a
+# no-op and `cargo tree -p dcc-mcp-http --no-default-features` shows
+# no aggregation tier.
+auto-gateway = ["dep:dcc-mcp-gateway"]
 python-bindings = ["pyo3", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-artefact/python-bindings", "dep:dcc-mcp-pybridge", "dcc-mcp-pybridge/python-bindings", "dcc-mcp-host/python-bindings"]
 # Enable `pyo3-stub-gen` annotations on this crate's PyO3 types.
 stub-gen = ["python-bindings", "dep:pyo3-stub-gen", "dep:pyo3-stub-gen-derive"]
 # Enable the Prometheus `/metrics` endpoint (issue #331). Pulls in the
 # matching `prometheus` feature of dcc-mcp-telemetry. Off by default so
-# zero Prometheus code compiles into the wheel when not requested.
-prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus", "dcc-mcp-gateway/prometheus", "dcc-mcp-http-server/prometheus"]
+# zero Prometheus code compiles into the wheel when not requested. The
+# `dcc-mcp-gateway?/prometheus` form only enables the gateway sub-
+# feature when `auto-gateway` already pulled the dep in.
+prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus", "dcc-mcp-gateway?/prometheus", "dcc-mcp-http-server/prometheus"]
 # Persist tracked Jobs in a SQLite database so they survive a server
 # restart (issue #328). Pulls in the bundled `rusqlite` driver via the
 # extracted `dcc-mcp-job` crate. Off by default — the wheel's default

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -73,6 +73,7 @@ pub mod metrics;
 // Re-exports
 pub use bridge_registry::{BridgeContext, BridgeRegistry};
 pub use config::{McpHttpConfig, ServerSpawnMode};
+#[cfg(feature = "auto-gateway")]
 pub use dcc_mcp_gateway::{GatewayConfig, GatewayHandle, GatewayRunner};
 pub use dcc_mcp_http_types::debug_session::{
     DebugPathMapping, DebugSessionDescriptor, DebugSessionStatus,

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -21,6 +21,7 @@ use dcc_mcp_skill_rest::ReadinessProbe;
 use dcc_mcp_skills::SkillCatalog;
 
 mod background_impl;
+#[cfg(feature = "auto-gateway")]
 mod gateway_impl;
 mod spawn_impl;
 
@@ -65,8 +66,13 @@ pub struct McpServerHandle {
     pub port: u16,
     pub bind_addr: String,
     /// `true` if this process won the gateway port competition.
+    ///
+    /// Always `false` when the crate is built with
+    /// `--no-default-features` (the `auto-gateway` feature is off and
+    /// `gateway_port` becomes a no-op).
     pub is_gateway: bool,
     // Keep the GatewayHandle alive so background tasks keep running.
+    #[cfg(feature = "auto-gateway")]
     _gateway: Option<dcc_mcp_gateway::GatewayHandle>,
 }
 
@@ -79,6 +85,7 @@ impl McpServerHandle {
         // than waiting the full `stale_timeout_secs` (default 30 s). The
         // call is idempotent — the `GatewayHandle::Drop` path is still a
         // correctness safety net for callers who skip `shutdown()`.
+        #[cfg(feature = "auto-gateway")]
         if let Some(gw) = self._gateway.as_mut() {
             gw.deregister_all();
         }
@@ -632,13 +639,22 @@ impl McpHttpServer {
         );
 
         // ── Optional gateway competition ──────────────────────────────────────
+        //
+        // Gated by the `auto-gateway` feature (default-on, issue #1357).
+        // When the feature is off, `gateway_port` is a no-op and this
+        // server runs purely as a per-DCC backend.
+        #[cfg(feature = "auto-gateway")]
         let gateway_handle =
             gateway_impl::start_gateway_runner(&self.config, port, &self.live_meta).await;
 
+        #[cfg(feature = "auto-gateway")]
         let is_gateway = gateway_handle
             .as_ref()
             .map(|h| h.is_gateway)
             .unwrap_or(false);
+
+        #[cfg(not(feature = "auto-gateway"))]
+        let is_gateway = false;
 
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
@@ -670,6 +686,7 @@ impl McpHttpServer {
             port,
             bind_addr: actual_bind,
             is_gateway,
+            #[cfg(feature = "auto-gateway")]
             _gateway: gateway_handle,
         })
     }


### PR DESCRIPTION
Closes #1357. Phase 1 of the server/gateway split epic #1367.

## Why

`dcc-mcp-http` only really depended on `dcc-mcp-gateway` to wire up the
first-wins gateway election + admin runtime inside
`McpHttpServer::start()`. The actual coupling surface was tiny:

* one `pub use dcc_mcp_gateway::{GatewayConfig, GatewayHandle, GatewayRunner}` re-export — **no external consumers** (verified with ripgrep across `crates`, `python`, `tests`),
* one `_gateway: Option<dcc_mcp_gateway::GatewayHandle>` field on `McpServerHandle`,
* the 88-line `server/gateway_impl.rs` bootstrap.

Carving the whole crate out into a new `dcc-mcp-http-core` package
would have touched ~4000 LOC across `prompts/`, `resources/`,
`server/`, `handler/`, and the lib.rs re-export surface — high churn,
high risk, and most of that move is **mechanical**. The
load-bearing piece of #1357 is the dependency edge, not the crate
name. So this PR delivers the actual goal with three targeted edits.

## What changes

Hide auto-gateway behind a default-on cargo feature `auto-gateway`:

* `dcc-mcp-gateway = { ..., optional = true }` in `dcc-mcp-http/Cargo.toml`.
* `default = ["auto-gateway"]`, `auto-gateway = ["dep:dcc-mcp-gateway"]`.
* `prometheus` uses `dcc-mcp-gateway?/prometheus` so the sub-feature
  only activates when `auto-gateway` already pulled the dep in
  (Cargo's optional-dep sub-feature syntax).
* `pub use dcc_mcp_gateway::*`, `mod gateway_impl`, the `_gateway`
  field, the shutdown `deregister_all()` block, and the
  `start_gateway_runner` call site are all `#[cfg(feature = "auto-gateway")]`.
* When the feature is off, `is_gateway` is always `false` and
  `gateway_port` is silently ignored.

Embedders that target only a per-DCC backend now opt out with one flag:

```toml
dcc-mcp-http = { workspace = true, default-features = false }
```

…and drop the entire `dcc-mcp-gateway` dep tree (admin UI, capability
index, election, sqlite admin persist, etc.).

## Acceptance criteria — status

- [x] `cargo build -p dcc-mcp-http` (default) — clean
- [x] `cargo build -p dcc-mcp-http --no-default-features` — clean
- [x] `cargo build -p dcc-mcp-http --features prometheus` — clean
- [x] `cargo build -p dcc-mcp-http --no-default-features --features prometheus` — clean
- [x] `cargo test -p dcc-mcp-http --lib` — **54 passed** with default features
- [x] `cargo test -p dcc-mcp-http --lib --no-default-features` — **54 passed**
- [x] `cargo clippy -p dcc-mcp-http --all-targets` — clean both configs
- [x] `cargo tree -p dcc-mcp-http --no-default-features` — **no `dcc-mcp-gateway`** in the dep graph (only `dcc-mcp-gateway-core` from #1368 remains, which is the pure naming/policy domain)
- [x] `cargo build --workspace --all-targets` — clean

## Validation notes

- Default behavior is **byte-for-byte preserved** for every existing
  embedder: `dcc-mcp-http-py`, the root `dcc-mcp-core` crate, and the
  `dcc-mcp-server` binary all inherit `default-features = true` and
  therefore keep auto-gateway on. No downstream code or wheel
  configuration needs to change.
- Python ImportError stack from `vx just test` (`HookContext`,
  `CapabilityEdge`, `qt_describe_widget`, `LexicalSkillIndex`,
  `EscapeHatchInvocation`) is pre-existing — the installed wheel in
  `site-packages` is stale relative to `main` (`#1352` and friends).
  CI runs a fresh build and will exercise the full Python suite.
- No skill-facing or adapter-facing guidance changes; the public Rust
  and Python API paths are unchanged.
  `skills/dcc-mcp-creator/SKILL.md` and
  `skills/dcc-mcp-skills-creator/SKILL.md` do not need updates.

## Renaming `dcc-mcp-http` → `dcc-mcp-http-core`

Deferred. The original issue framed it as a hard requirement; in
practice the dep boundary is the load-bearing piece and renaming
introduces a wave of import-path churn (every `dcc_mcp_http::*` Rust
caller, every Python re-export, every doc reference) for **zero
behavior change**. If/when the audience for a "core-only" crate name
materializes (e.g. an OSS embedder wanting the package on crates.io
with a non-confusing name), we can do it as a mechanical rename PR.
Tracking this as a non-blocking follow-up in epic #1367.

## Refs

- Epic: #1367
- Unblocks: #1358 (gateway daemon), #1359 (composition binary), #1360 (CLI modes)
