### PR TITLE
refactor(server): add Cargo features for composition binary (#1359)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,17 @@ jobs:
       - name: Rust compile smoke
         if: matrix.rust-validation == 'smoke'
         run: vx cargo check --workspace --all-targets
+      # Verify the composition binary still builds in its slim variants
+      # (issue #1359). Defaults are already exercised by the workspace
+      # check / clippy / test steps above.
+      - name: dcc-mcp-server slim feature matrix
+        if: matrix.rust-validation == 'full'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          vx cargo check -p dcc-mcp-server --no-default-features --features server
+          vx cargo check -p dcc-mcp-server --no-default-features --features gateway-daemon,admin
+          vx cargo check -p dcc-mcp-server --no-default-features --features server,gateway-auto,gateway-daemon,admin
 
   # ── Build ABI3 wheel (one per OS, reused by python-test) ──
   # Intentionally does NOT `needs: [rust-check]` — maturin runs its own compile

--- a/crates/dcc-mcp-server/Cargo.toml
+++ b/crates/dcc-mcp-server/Cargo.toml
@@ -13,7 +13,13 @@ name = "dcc-mcp-server"
 path = "src/main.rs"
 
 [dependencies]
-dcc-mcp-http.workspace = true
+# `dcc-mcp-http` default features include `auto-gateway` which pulls in
+# the full gateway runtime. We forward that explicitly through our own
+# `gateway-auto` feature so this binary can also build slim variants
+# (issue #1359). Use a direct path dep here because the workspace
+# inheritance form (`workspace = true`) cannot override the inherited
+# `default-features` setting.
+dcc-mcp-http = { path = "../dcc-mcp-http", default-features = false }
 dcc-mcp-actions.workspace = true
 dcc-mcp-skills.workspace = true
 dcc-mcp-protocols.workspace = true
@@ -42,10 +48,52 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 clap = { version = "4", features = ["derive", "env"] }
 sysinfo.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
-dcc-mcp-gateway = { version = "0.17.0", path = "../dcc-mcp-gateway", features = ["admin", "admin-persist-sqlite"] }
+# Optional — only linked when either `gateway-auto` (embedded election +
+# admin) or `gateway-daemon` (standalone daemon subcommand) is enabled.
+dcc-mcp-gateway = { version = "0.17.0", path = "../dcc-mcp-gateway", optional = true }
 
 [features]
-default = []
+# Default matches today's binary: per-DCC MCP server with embedded
+# first-wins gateway election and the read-only Admin UI.
+default = ["server", "gateway-auto", "gateway-daemon", "admin"]
+
+# Per-DCC MCP HTTP server (mandatory for the default `dcc-mcp-server`
+# entry point). Currently a marker feature; opting it out leaves only
+# the gateway daemon subcommand available, which is useful for the
+# slim `dcc-mcp-server gateway` deployment topology.
+server = []
+
+# Embedded auto-gateway: first-wins election on the well-known gateway
+# port, admin UI on the elected gateway, sidecar gateway failover,
+# translate-mode gateway registration. Pulls `dcc-mcp-gateway` and
+# turns on the matching `auto-gateway` feature on `dcc-mcp-http`.
+gateway-auto = [
+    "dep:dcc-mcp-gateway",
+    "dcc-mcp-http/auto-gateway",
+]
+
+# Standalone gateway daemon (`dcc-mcp-server gateway` subcommand). Can
+# be enabled together with or independently of `gateway-auto`.
+gateway-daemon = ["dep:dcc-mcp-gateway"]
+
+# Read-only Admin UI on the elected gateway. Forwarded to whichever of
+# `gateway-auto` / `gateway-daemon` happens to be enabled.
+admin = [
+    "dcc-mcp-gateway?/admin",
+    "dcc-mcp-gateway?/admin-persist-sqlite",
+]
+
+# Placeholder for embedding the relay tunnel agent in-process. Wired
+# up by issue #1363; currently a no-op feature gate so downstream
+# build configs can already declare it.
+tunnel-agent = []
+
+# Prometheus `/metrics` endpoint on the MCP server (and admin UI).
+prometheus = [
+    "dcc-mcp-http/prometheus",
+    "dcc-mcp-gateway?/prometheus",
+]
+
 otlp-exporter = ["dcc-mcp-telemetry/otlp-exporter", "dep:dcc-mcp-telemetry"]
 telemetry = ["dep:dcc-mcp-telemetry"]
 

--- a/crates/dcc-mcp-server/src/gateway_daemon.rs
+++ b/crates/dcc-mcp-server/src/gateway_daemon.rs
@@ -1,11 +1,16 @@
 //! Machine-wide standalone gateway daemon and auto-launch helper.
 
+#[cfg(feature = "gateway-auto")]
 use std::ffi::OsString;
+#[cfg(feature = "gateway-auto")]
 use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
+#[cfg(feature = "gateway-auto")]
 use std::process::{Command, Stdio};
+#[cfg(feature = "gateway-auto")]
 use std::time::{Duration, Instant};
 
+#[cfg(feature = "gateway-auto")]
 use anyhow::Context as _;
 use clap::Args;
 use dcc_mcp_gateway::{AdminPersistConfig, GatewayConfig, GatewayRunner};
@@ -50,6 +55,10 @@ pub struct GatewayArgs {
     pub stale_timeout_secs: u64,
 }
 
+/// Helpers for auto-launching the standalone gateway from inside another
+/// process (the per-DCC sidecar / embedded server). Only needed when the
+/// `gateway-auto` feature is on; pure daemon builds skip them entirely.
+#[cfg(feature = "gateway-auto")]
 #[derive(Debug, Clone)]
 pub struct EnsureGatewayOptions {
     pub host: String,
@@ -133,6 +142,7 @@ pub async fn run(args: GatewayArgs) -> anyhow::Result<()> {
 }
 
 /// Ensure the machine-wide gateway is reachable, launching it once if needed.
+#[cfg(feature = "gateway-auto")]
 pub async fn ensure_gateway_running(opts: &EnsureGatewayOptions) -> anyhow::Result<()> {
     if opts.port == 0 || gateway_health_ok(&opts.host, opts.port).await {
         return Ok(());
@@ -160,6 +170,7 @@ pub async fn ensure_gateway_running(opts: &EnsureGatewayOptions) -> anyhow::Resu
     wait_gateway_ready(&opts.host, opts.port, Duration::from_secs(10)).await
 }
 
+#[cfg(feature = "gateway-auto")]
 async fn wait_gateway_ready(host: &str, port: u16, timeout: Duration) -> anyhow::Result<()> {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
@@ -173,6 +184,7 @@ async fn wait_gateway_ready(host: &str, port: u16, timeout: Duration) -> anyhow:
     )
 }
 
+#[cfg(feature = "gateway-auto")]
 async fn gateway_health_ok(host: &str, port: u16) -> bool {
     let url = format!("http://{host}:{port}/health");
     let client = match reqwest::Client::builder()
@@ -189,17 +201,20 @@ async fn gateway_health_ok(host: &str, port: u16) -> bool {
         .is_ok_and(|resp| resp.status().is_success())
 }
 
+#[cfg(feature = "gateway-auto")]
 struct LaunchLock {
     _file: File,
     path: PathBuf,
 }
 
+#[cfg(feature = "gateway-auto")]
 impl Drop for LaunchLock {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.path);
     }
 }
 
+#[cfg(feature = "gateway-auto")]
 fn acquire_launch_lock(path: &std::path::Path) -> std::io::Result<LaunchLock> {
     OpenOptions::new()
         .write(true)
@@ -211,6 +226,7 @@ fn acquire_launch_lock(path: &std::path::Path) -> std::io::Result<LaunchLock> {
         })
 }
 
+#[cfg(feature = "gateway-auto")]
 fn spawn_detached_gateway(opts: &EnsureGatewayOptions) -> anyhow::Result<()> {
     let exe = std::env::current_exe().context("resolving current executable")?;
     let mut cmd = Command::new(exe);
@@ -233,6 +249,7 @@ fn spawn_detached_gateway(opts: &EnsureGatewayOptions) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "gateway-auto")]
 fn gateway_command_args(opts: &EnsureGatewayOptions) -> Vec<OsString> {
     let mut args = vec![
         OsString::from("gateway"),
@@ -263,6 +280,7 @@ fn default_gateway_name() -> String {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "gateway-auto")]
     #[test]
     fn auto_launch_gateway_args_do_not_include_registry_dir_flag() {
         let opts = EnsureGatewayOptions {

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -90,20 +90,26 @@ use std::time::Duration;
 
 use clap::{Parser, Subcommand};
 use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
+#[cfg(feature = "gateway-auto")]
 use dcc_mcp_gateway::{AdminPersistConfig, GatewayConfig, GatewayRunner, SkillPathEntry};
 use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
 use dcc_mcp_logging::file_logging::prune_old_logs;
 use dcc_mcp_skills::SkillCatalog;
-use dcc_mcp_skills::constants::{
-    ENV_SKILL_PATHS, app_skill_paths_env_key, resolve_registry_dcc_type,
-};
+use dcc_mcp_skills::constants::resolve_registry_dcc_type;
+#[cfg(feature = "gateway-auto")]
+use dcc_mcp_skills::constants::{ENV_SKILL_PATHS, app_skill_paths_env_key};
+#[cfg(feature = "gateway-auto")]
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 use sysinfo::{Pid, ProcessesToUpdate, System};
 mod capture;
 mod event_webhooks;
+#[cfg(feature = "gateway-daemon")]
 mod gateway_daemon;
+#[cfg(feature = "gateway-auto")]
 mod sidecar;
+#[cfg(feature = "gateway-auto")]
 mod sidecar_gateway;
+#[cfg(feature = "gateway-auto")]
 mod sidecar_mcp;
 mod translate;
 
@@ -124,8 +130,10 @@ enum SubCmd {
     /// Spawned by a DCC plugin/addon (`dcc-mcp-maya`, `dcc-mcp-blender`, …)
     /// and supervised via `--watch-pid`.  Exits cleanly when its parent
     /// DCC dies so we never leak stale workers.
+    #[cfg(feature = "gateway-auto")]
     Sidecar(sidecar::SidecarArgs),
     /// Machine-wide gateway daemon. Per-DCC sidecars auto-launch this when needed.
+    #[cfg(feature = "gateway-daemon")]
     Gateway(gateway_daemon::GatewayArgs),
     /// Replay or diff gateway traffic capture files.
     Capture {
@@ -558,6 +566,10 @@ pub(crate) async fn select_shutdown_signal() -> anyhow::Result<&'static str> {
 // ── main ──────────────────────────────────────────────────────────────────────
 
 #[tokio::main]
+// Without the `server` feature, the early `return Err(...)` in the
+// no-subcommand arm makes the rest of `main` provably unreachable. That
+// is intentional, not a bug — silence the lint only for that build.
+#[cfg_attr(not(feature = "server"), allow(unreachable_code, unused_variables))]
 async fn main() -> anyhow::Result<()> {
     // Install the shared subscriber (stderr fmt-layer + reload slot for the
     // optional file-logging layer). Safe to call multiple times.
@@ -597,10 +609,26 @@ async fn main() -> anyhow::Result<()> {
     match args.command {
         Some(SubCmd::Translate(translate_args)) => return translate::run(translate_args).await,
         Some(SubCmd::Catalog { action }) => return run_catalog_cmd(&action),
+        #[cfg(feature = "gateway-auto")]
         Some(SubCmd::Sidecar(sidecar_args)) => return sidecar::run(sidecar_args).await,
+        #[cfg(feature = "gateway-daemon")]
         Some(SubCmd::Gateway(gateway_args)) => return gateway_daemon::run(gateway_args).await,
         Some(SubCmd::Capture { action }) => return capture::run(action).await,
         None => {}
+    }
+
+    // When this binary is built without the `server` feature, the default
+    // (no-subcommand) path has nothing useful to do — print help and exit
+    // cleanly so callers get a clear signal instead of opening a port.
+    #[cfg(not(feature = "server"))]
+    {
+        use clap::CommandFactory as _;
+        let mut cmd = Args::command();
+        cmd.print_long_help().ok();
+        return Err(anyhow::anyhow!(
+            "this build was compiled without the `server` feature; \
+             use a subcommand such as `gateway` to invoke the binary"
+        ));
     }
 
     if let (Some(path), Some(pid)) = (args.pid_cleanup_watch.clone(), args.watch_pid) {
@@ -681,7 +709,12 @@ async fn main() -> anyhow::Result<()> {
 
     let registry_dir_path: Option<PathBuf> = args.registry_dir.as_deref().map(PathBuf::from);
 
+    // `skill_paths_snapshot` is fed straight into the gateway admin UI's
+    // `AdminPersistConfig`. Slim builds without `gateway-auto` drop the
+    // entire admin pipeline, so we skip building the snapshot too.
+    #[cfg(feature = "gateway-auto")]
     let mut skill_paths_snapshot: Vec<SkillPathEntry> = Vec::new();
+    #[cfg(feature = "gateway-auto")]
     for p in &args.skill_paths {
         skill_paths_snapshot.push(SkillPathEntry {
             path: p.display().to_string(),
@@ -693,22 +726,25 @@ async fn main() -> anyhow::Result<()> {
     skill_paths.extend(
         dcc_mcp_skills::paths::get_skill_paths_from_env()
             .into_iter()
-            .inspect(|s| {
+            .inspect(|_s| {
+                #[cfg(feature = "gateway-auto")]
                 skill_paths_snapshot.push(SkillPathEntry {
-                    path: s.clone(),
+                    path: _s.clone(),
                     source: format!("env:{ENV_SKILL_PATHS}"),
                 });
             })
             .map(PathBuf::from),
     );
     if !args.app.is_empty() {
+        #[cfg(feature = "gateway-auto")]
         let env_key = app_skill_paths_env_key(&args.app);
         skill_paths.extend(
             dcc_mcp_skills::paths::get_app_skill_paths_from_env(&args.app)
                 .into_iter()
-                .inspect(|s| {
+                .inspect(|_s| {
+                    #[cfg(feature = "gateway-auto")]
                     skill_paths_snapshot.push(SkillPathEntry {
-                        path: s.clone(),
+                        path: _s.clone(),
                         source: format!("env:{env_key}"),
                     });
                 })
@@ -718,6 +754,7 @@ async fn main() -> anyhow::Result<()> {
             match std::fs::create_dir_all(&local_default) {
                 Ok(()) => {
                     let p = PathBuf::from(&local_default);
+                    #[cfg(feature = "gateway-auto")]
                     skill_paths_snapshot.push(SkillPathEntry {
                         path: local_default.clone(),
                         source: "local_default".into(),
@@ -739,6 +776,7 @@ async fn main() -> anyhow::Result<()> {
     if let Ok(bundled) = dcc_mcp_skills::paths::get_skills_dir(None) {
         let p = PathBuf::from(&bundled);
         if p.exists() {
+            #[cfg(feature = "gateway-auto")]
             skill_paths_snapshot.push(SkillPathEntry {
                 path: bundled.clone(),
                 source: "bundled".into(),
@@ -747,10 +785,13 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
+    #[cfg(feature = "gateway-auto")]
     let skill_paths_for_catalog_reload = skill_paths.clone();
 
+    #[cfg(feature = "gateway-auto")]
     let admin_db =
         dcc_mcp_gateway::gateway::admin::resolve_admin_db_path(None, registry_dir_path.as_ref());
+    #[cfg(feature = "gateway-auto")]
     for p in
         dcc_mcp_gateway::gateway::admin::sqlite_lane::read_custom_skill_paths_for_startup(&admin_db)
     {
@@ -796,6 +837,7 @@ async fn main() -> anyhow::Result<()> {
     let n = catalog.discover(extra_dirs.as_deref(), app_hint);
     tracing::info!("Discovered {} skill(s) in catalog", n);
 
+    #[cfg(feature = "gateway-auto")]
     let catalog_discover_hook: Arc<dyn Fn() + Send + Sync> = {
         let catalog = catalog.clone();
         let base_dirs = skill_paths_for_catalog_reload.clone();
@@ -855,67 +897,73 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Register + gateway competition (via library) ──────────────────────
 
-    let admin_retention = std::env::var("DCC_MCP_GATEWAY_ADMIN_RETENTION_DAYS")
-        .ok()
-        .and_then(|s| s.parse::<u32>().ok())
-        .unwrap_or(30)
-        .clamp(1, 3650);
+    #[cfg(feature = "gateway-auto")]
+    let gw_handle = {
+        let admin_retention = std::env::var("DCC_MCP_GATEWAY_ADMIN_RETENTION_DAYS")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(30)
+            .clamp(1, 3650);
 
-    let gateway_host = args
-        .gateway_host
-        .clone()
-        .unwrap_or_else(|| args.host.clone());
+        let gateway_host = args
+            .gateway_host
+            .clone()
+            .unwrap_or_else(|| args.host.clone());
 
-    let gateway_cfg = GatewayConfig {
-        host: gateway_host,
-        gateway_port: args.gateway_port,
-        remote_host: Some(args.gateway_remote_host.clone()),
-        remote_gateway_port: args.gateway_remote_port,
-        stale_timeout_secs: args.stale_timeout_secs,
-        heartbeat_secs: args.heartbeat_secs,
-        server_name: args.server_name.clone(),
-        gateway_name: args.gateway_name.clone(),
-        server_version: env!("CARGO_PKG_VERSION").to_string(),
-        registry_dir: registry_dir_path,
-        // Issue maya#137: standalone server has no adapter package, so the
-        // election treats it as the lowest tier and yields to any real
-        // DCC adapter at equal crate version.
-        adapter_dcc: if args.app.is_empty() {
-            None
-        } else {
-            Some(args.app.clone())
-        },
-        admin_enabled: !args.no_admin,
-        admin_path: args.admin_path.clone(),
-        admin_persist: AdminPersistConfig {
-            sqlite_path: std::env::var_os("DCC_MCP_GATEWAY_ADMIN_DB").map(PathBuf::from),
-            sqlite_retention_days: admin_retention,
-            skill_paths_snapshot,
-            skill_paths_reload: Some(catalog_discover_hook),
-        },
-        ..GatewayConfig::default()
+        let gateway_cfg = GatewayConfig {
+            host: gateway_host,
+            gateway_port: args.gateway_port,
+            remote_host: Some(args.gateway_remote_host.clone()),
+            remote_gateway_port: args.gateway_remote_port,
+            stale_timeout_secs: args.stale_timeout_secs,
+            heartbeat_secs: args.heartbeat_secs,
+            server_name: args.server_name.clone(),
+            gateway_name: args.gateway_name.clone(),
+            server_version: env!("CARGO_PKG_VERSION").to_string(),
+            registry_dir: registry_dir_path,
+            // Issue maya#137: standalone server has no adapter package, so
+            // the election treats it as the lowest tier and yields to any
+            // real DCC adapter at equal crate version.
+            adapter_dcc: if args.app.is_empty() {
+                None
+            } else {
+                Some(args.app.clone())
+            },
+            admin_enabled: !args.no_admin,
+            admin_path: args.admin_path.clone(),
+            admin_persist: AdminPersistConfig {
+                sqlite_path: std::env::var_os("DCC_MCP_GATEWAY_ADMIN_DB").map(PathBuf::from),
+                sqlite_retention_days: admin_retention,
+                skill_paths_snapshot,
+                skill_paths_reload: Some(catalog_discover_hook),
+            },
+            ..GatewayConfig::default()
+        };
+
+        let runner = GatewayRunner::new(gateway_cfg)
+            .map_err(|e| anyhow::anyhow!("Failed to create GatewayRunner: {e}"))?;
+
+        let mut entry = ServiceEntry::new(registry_dcc.as_str(), &args.host, handle.port);
+        entry.version = args.app_version.clone();
+        entry.scene = args.scene.clone();
+        entry
+            .metadata
+            .insert("server_name".to_string(), args.server_name.clone());
+        entry.metadata.insert(
+            "mcp_url".to_string(),
+            format!("http://{}:{}/mcp", args.host, handle.port),
+        );
+
+        // Standalone binary: scene is fixed at launch; no live provider needed.
+        runner
+            .start(entry, None)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to start gateway: {e}"))?
     };
-
-    let runner = GatewayRunner::new(gateway_cfg)
-        .map_err(|e| anyhow::anyhow!("Failed to create GatewayRunner: {e}"))?;
-
-    let mut entry = ServiceEntry::new(registry_dcc.as_str(), &args.host, handle.port);
-    entry.version = args.app_version.clone();
-    entry.scene = args.scene.clone();
-    entry
-        .metadata
-        .insert("server_name".to_string(), args.server_name.clone());
-    entry.metadata.insert(
-        "mcp_url".to_string(),
-        format!("http://{}:{}/mcp", args.host, handle.port),
-    );
-
-    // Standalone binary: scene is fixed at launch; no live provider needed.
-    let gw_handle = runner
-        .start(entry, None)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to start gateway: {e}"))?;
+    #[cfg(feature = "gateway-auto")]
     let is_gateway = gw_handle.is_gateway;
+    #[cfg(not(feature = "gateway-auto"))]
+    let _ = (&registry_dir_path, &registry_dcc);
 
     // ── Start WebSocket bridge (optional) ─────────────────────────────────
 
@@ -931,11 +979,14 @@ async fn main() -> anyhow::Result<()> {
     let shutdown_reason = select_shutdown_signal().await?;
     tracing::info!(shutdown_reason, "Shutdown signal received");
 
-    if is_gateway {
-        tracing::info!("Gateway port released");
+    #[cfg(feature = "gateway-auto")]
+    {
+        if is_gateway {
+            tracing::info!("Gateway port released");
+        }
+        // gw_handle dropped here — aborts heartbeat, cleanup, and gateway tasks automatically
+        drop(gw_handle);
     }
-    // gw_handle dropped here — aborts heartbeat, cleanup, and gateway tasks automatically
-    drop(gw_handle);
 
     let deadline = Duration::from_secs(args.shutdown_timeout_secs);
     match tokio::time::timeout(deadline, handle.shutdown()).await {

--- a/crates/dcc-mcp-server/src/translate.rs
+++ b/crates/dcc-mcp-server/src/translate.rs
@@ -54,6 +54,7 @@ use axum::response::Response;
 use axum::routing::{get, post};
 use clap::Args;
 use dcc_mcp_jsonrpc::{JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
+#[cfg(feature = "gateway-auto")]
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -540,6 +541,9 @@ fn build_router(state: BridgeState) -> Router {
 
 /// Run the translate bridge. Does not return until a shutdown signal is received.
 pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
+    // `server_name` is forwarded into the gateway registration entry,
+    // so slim builds without `gateway-auto` never read it.
+    #[cfg(feature = "gateway-auto")]
     let server_name = args
         .server_name
         .clone()
@@ -586,6 +590,7 @@ pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
     }
 
     // ── Gateway registration ──────────────────────────────────────────────
+    #[cfg(feature = "gateway-auto")]
     let gw_handle_opt = if !args.no_register {
         use dcc_mcp_gateway::{GatewayConfig, GatewayRunner};
 
@@ -653,6 +658,21 @@ pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
         info!("--no-register: skipping gateway registration");
         None
     };
+    // Slim builds without `gateway-auto` always behave as `--no-register`:
+    // there is no GatewayRunner compiled in. The local HTTP/SSE/Streamable
+    // bridge still works; only registration with a gateway is dropped.
+    #[cfg(not(feature = "gateway-auto"))]
+    let gw_handle_opt: Option<()> = {
+        if !args.no_register {
+            info!(
+                "translate compiled without the `gateway-auto` feature; \
+                 skipping gateway registration (--no-register behaviour)"
+            );
+        } else {
+            info!("--no-register: skipping gateway registration");
+        }
+        None
+    };
 
     // ── PID file ──────────────────────────────────────────────────────────
     let _pid_guard = args
@@ -684,8 +704,10 @@ pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
         "Shutdown signal received; stopping translate bridge"
     );
 
-    // Drop gateway handle (stops heartbeat)
-    drop(gw_handle_opt);
+    // Drop gateway handle (stops heartbeat). In slim builds this is
+    // `Option<()>` and the drop is a no-op; `let _ =` keeps the variable
+    // alive until this point without tripping `dropping_copy_types`.
+    let _ = gw_handle_opt;
 
     // Signal HTTP server to stop
     let _ = shutdown_tx.send(true);


### PR DESCRIPTION
Closes #1359. Phase 1 of the server/gateway split epic #1367.

## Why

`dcc-mcp-server` currently hard-links the entire gateway crate
(`dcc-mcp-gateway`) into every build. There is no way to ship a slim
per-DCC server binary without the admin UI / election runtime, nor a
pure gateway-daemon binary without the per-DCC bootstrap. PRs #1370
(http ↔ gateway decoupling) and #1371 (standalone daemon) opened the
door; this PR makes the binary a composition crate whose capabilities
are picked by Cargo features.

## Features

| Feature | Default | Purpose |
|---|---|---|
| `server` | ✅ | Per-DCC MCP HTTP server bootstrap in the no-subcommand path |
| `gateway-auto` | ✅ | First-wins election + admin UI + sidecar gateway failover + translate-mode gateway registration |
| `gateway-daemon` | ✅ | `dcc-mcp-server gateway` standalone daemon subcommand |
| `admin` | ✅ | Read-only Admin UI on the elected gateway (forwarded to `dcc-mcp-gateway`) |
| `tunnel-agent` | — | Placeholder for embedding the relay tunnel agent (issue #1363) |
| `prometheus` | — | `/metrics` endpoint (forwarded to `dcc-mcp-http` + `dcc-mcp-gateway`) |
| `telemetry` / `otlp-exporter` | — | Unchanged, kept for backwards compat |

`dcc-mcp-gateway` is now `optional = true` and only pulled by
`gateway-auto` or `gateway-daemon`. `dcc-mcp-http` is consumed with
`default-features = false` (via a path dep — workspace inheritance can't
override `default-features`) so disabling our `gateway-auto` also drops
the http crate's matching `auto-gateway` feature (issue #1357 / PR #1370).

## Per-source feature gating

| Source | Gate |
|---|---|
| `gateway_daemon` module + `Gateway` subcommand | `gateway-daemon` |
| `sidecar*` modules + `Sidecar` subcommand | `gateway-auto` |
| `translate` gateway registration block | `gateway-auto` (slim build behaves as `--no-register`) |
| Auto-launch helpers in `gateway_daemon` (`ensure_gateway_running`, etc.) | `gateway-auto` (only sidecars need to spawn the daemon out-of-process) |
| Default-mode `GatewayRunner` / `AdminPersistConfig` / `skill_paths_snapshot` blocks in `main` | `gateway-auto` |

## Acceptance criteria — status

- [x] `cargo build -p dcc-mcp-server --no-default-features --features server` produces an MCP-server binary with no gateway code linked in.
- [x] `cargo build -p dcc-mcp-server --no-default-features --features gateway-daemon,admin` produces a gateway-only binary.
- [x] Default `cargo build -p dcc-mcp-server` matches today's binary (server + auto-gateway + daemon + admin).
- [x] CI matrix exercises three combos: defaults (existing), server-only, gateway-daemon+admin, full (added as one new step on the full-validation Linux Rust job).
- [x] Binary size delta reported in the PR description.

## Validation

* `cargo build -p dcc-mcp-server` (default) — clean
* `cargo build -p dcc-mcp-server --no-default-features --features server` — clean
* `cargo build -p dcc-mcp-server --no-default-features --features gateway-daemon,admin` — clean
* `cargo build -p dcc-mcp-server --no-default-features --features server,gateway-auto,gateway-daemon,admin` — clean
* `cargo clippy -p dcc-mcp-server --all-targets -- -D warnings` across all three combos — clean
* `cargo test -p dcc-mcp-server` across all three combos — **30 / 9 / 10 lib tests + 3 integration each, all pass**
* `cargo tree -p dcc-mcp-server --no-default-features --features server` — no `dcc-mcp-gateway` runtime in the tree (only the pure `dcc-mcp-gateway-core` types crate that `dcc-mcp-http-server` depends on)
* `cargo tree -p dcc-mcp-server --no-default-features --features gateway-daemon,admin` — no `dcc-mcp-http/auto-gateway` activation
* `cargo check --workspace --all-targets` — clean (no downstream breakage)
* `cargo hakari verify` — workspace-hack already correct, no changes needed

## Release binary sizes (Windows `dcc-mcp-server.exe`)

| Variant | Size | Δ from default |
|---|---|---|
| default (`server` + `gateway-auto` + `gateway-daemon` + `admin`) | **30.11 MB** | — |
| `--no-default-features --features server` | **18.86 MB** | **−37%** |
| `--no-default-features --features gateway-daemon,admin` | **20.35 MB** | **−32%** |

## CI matrix

Added a single `dcc-mcp-server slim feature matrix` step to the
`Rust (ubuntu-latest)` job (gated on `rust-validation == 'full'`)
running three `cargo check` invocations:

```bash
cargo check -p dcc-mcp-server --no-default-features --features server
cargo check -p dcc-mcp-server --no-default-features --features gateway-daemon,admin
cargo check -p dcc-mcp-server --no-default-features --features server,gateway-auto,gateway-daemon,admin
```

Defaults are already exercised by the existing `cargo check` / `clippy`
/ `nextest` steps. Smoke runners (Windows/macOS) are unchanged so we
don't pay the extra build minutes on every PR.

## Non-goals (deferred / out of scope)

- CLI subcommand harmonisation (`auto` / `serve` / `gateway`) — issue #1360.
- Embedding the relay tunnel agent — issue #1363; `tunnel-agent` is a
  no-op feature gate today so downstream Cargo configs can already
  declare it.
- Slimming `dcc-mcp-gateway` admin warnings under `gateway-daemon` only
  (the gateway crate currently emits ~110 dead-code warnings when admin
  is off because its admin source is not internally `#[cfg]`-gated) —
  pre-existing concern, out of scope for this PR.

## Refs

- Epic: #1367
- Builds on: #1370 (#1357), #1371 (#1358)
- Unblocks: #1360 (CLI), #1361 (HTTP registration), #1363 (tunnel)
