### PR TITLE
refactor(server): add explicit run modes (#1360)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,7 @@ Gateway resources/prompts:
 | IPC | `IpcChannelAdapter` / `SocketServerAdapter` + `DccLinkFrame` |
 | Hand off files between tools | `FileRef` + `artefact_put_file()` / `artefact_get_bytes()` |
 | Multi-DCC gateway | `McpHttpConfig(gateway_port=9765)` |
+| Choose `dcc-mcp-server` run mode | No subcommand or `auto` = per-DCC server + first-wins auto-gateway; `serve --no-auto-gateway` = per-DCC server only; `gateway` = machine-wide gateway daemon with no inline DCC execution |
 | Discover gateway DCC instances / direct MCP URLs | `resources/read uri="gateway://instances"` or `gateway://instances/{id}`; entries carry `mcp_url` and replace the removed `list_dcc_instances` / `get_dcc_instance` / `connect_to_dcc` tools |
 | Gateway dynamic capabilities | MCP `search` → `describe` for read-only discovery, then REST `/v1/call` / `POST /v1/call_batch` for execution |
 | Gateway resources/prompts | `resources/list` / `resources/read` with exact gateway-returned URIs; `prompts/list` / `prompts/get` for aggregated backend prompt templates |

--- a/crates/dcc-mcp-server/src/cli.rs
+++ b/crates/dcc-mcp-server/src/cli.rs
@@ -1,0 +1,316 @@
+use std::path::PathBuf;
+
+use clap::{Args as ClapArgs, Parser, Subcommand};
+
+use crate::{capture, translate};
+
+/// DCC-MCP subcommands.
+#[derive(Debug, Subcommand)]
+pub(crate) enum SubCmd {
+    /// Run the default per-DCC server with first-wins auto-gateway.
+    Auto(ServerArgs),
+    /// Run a per-DCC server, optionally without participating in auto-gateway.
+    Serve(ServeArgs),
+    /// Bridge any stdio MCP server to HTTP/SSE/Streamable-HTTP.
+    Translate(translate::TranslateArgs),
+    /// Catalog commands (search or describe DCC-MCP adapters).
+    Catalog {
+        #[command(subcommand)]
+        action: CatalogAction,
+    },
+    /// Out-of-process worker for crash-isolated DCC actions (RFC #998).
+    ///
+    /// Spawned by a DCC plugin/addon (`dcc-mcp-maya`, `dcc-mcp-blender`, ...)
+    /// and supervised via `--watch-pid`. Exits cleanly when its parent
+    /// DCC dies so we never leak stale workers.
+    #[cfg(feature = "gateway-auto")]
+    Sidecar(crate::sidecar::SidecarArgs),
+    /// Machine-wide gateway daemon. Per-DCC sidecars auto-launch this when needed.
+    #[cfg(feature = "gateway-daemon")]
+    Gateway(crate::gateway_daemon::GatewayArgs),
+    /// Replay or diff gateway traffic capture files.
+    Capture {
+        #[command(subcommand)]
+        action: capture::CaptureAction,
+    },
+}
+
+/// DCC-MCP server CLI.
+#[derive(Debug, Parser)]
+#[command(
+    name = "dcc-mcp-server",
+    about,
+    version,
+    args_conflicts_with_subcommands = true
+)]
+pub(crate) struct Args {
+    /// Optional subcommand. If omitted, runs as `auto` for backwards compatibility.
+    #[command(subcommand)]
+    pub(crate) command: Option<SubCmd>,
+
+    #[command(flatten)]
+    pub(crate) server: ServerArgs,
+}
+
+/// Shared per-DCC server flags for the implicit root mode and `auto` / `serve`.
+#[derive(Debug, Clone, ClapArgs)]
+pub(crate) struct ServerArgs {
+    /// MCP Streamable HTTP server port. Default 0 = OS-assigned.
+    #[arg(long, env = "DCC_MCP_MCP_PORT", default_value = "0")]
+    pub(crate) mcp_port: u16,
+
+    /// WebSocket bridge server port (for non-Python DCC plugins).
+    #[arg(long, env = "DCC_MCP_WS_PORT", default_value = "9001")]
+    pub(crate) ws_port: u16,
+
+    /// Application type (e.g. "maya", "photoshop", "blender").
+    #[arg(long, env = "DCC_MCP_APP", default_value = "")]
+    pub(crate) app: String,
+
+    /// Additional skill search paths (repeatable).
+    #[arg(long, value_name = "PATH", num_args = 1..)]
+    pub(crate) skill_paths: Vec<PathBuf>,
+
+    /// Server name advertised to MCP clients.
+    #[arg(long, env = "DCC_MCP_SERVER_NAME", default_value = "dcc-mcp-server")]
+    pub(crate) server_name: String,
+
+    /// Disable the WebSocket bridge server (MCP HTTP only).
+    #[arg(long, default_value = "false")]
+    pub(crate) no_bridge: bool,
+
+    /// MCP server host to bind to.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub(crate) host: String,
+
+    /// Write the server process ID to this file while running.
+    #[arg(long, value_name = "PATH")]
+    pub(crate) pid_file: Option<PathBuf>,
+
+    /// Overwrite an existing PID file even if it points at a live process.
+    #[arg(long, default_value = "false")]
+    pub(crate) force: bool,
+
+    /// Seconds to wait for graceful shutdown before exiting.
+    #[arg(long, env = "DCC_MCP_SHUTDOWN_TIMEOUT_SECS", default_value = "10")]
+    pub(crate) shutdown_timeout_secs: u64,
+
+    /// Gateway port to compete for. First instance to bind wins the gateway.
+    /// 0 = gateway disabled entirely (and therefore disables admin too).
+    #[arg(long, env = "DCC_MCP_GATEWAY_PORT", default_value = "9765")]
+    pub(crate) gateway_port: u16,
+
+    /// Gateway host/interface to bind. Defaults to the MCP `--host`.
+    #[arg(long, env = "DCC_MCP_GATEWAY_HOST")]
+    pub(crate) gateway_host: Option<String>,
+
+    /// Human-readable gateway candidate name written to the `__gateway__`
+    /// sentinel when this process wins or challenges the gateway role.
+    #[arg(long, env = "DCC_MCP_GATEWAY_NAME")]
+    pub(crate) gateway_name: Option<String>,
+
+    /// Remote/LAN gateway host/interface to bind.
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_HOST", default_value = "0.0.0.0")]
+    pub(crate) gateway_remote_host: String,
+
+    /// Remote/LAN gateway port. 0 disables the remote listener.
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "59765")]
+    pub(crate) gateway_remote_port: u16,
+
+    /// Disable the read-only Admin UI on the elected gateway.
+    #[arg(long, env = "DCC_MCP_NO_ADMIN", default_value = "false")]
+    pub(crate) no_admin: bool,
+
+    /// URL prefix for the read-only Admin UI.
+    #[arg(long, env = "DCC_MCP_ADMIN_PATH", default_value = "/admin")]
+    pub(crate) admin_path: String,
+
+    /// Directory for the shared FileRegistry (auto-created if missing).
+    #[arg(long, env = "DCC_MCP_REGISTRY_DIR")]
+    pub(crate) registry_dir: Option<String>,
+
+    /// Seconds without a heartbeat before an instance is considered stale.
+    #[arg(long, env = "DCC_MCP_STALE_TIMEOUT", default_value = "30")]
+    pub(crate) stale_timeout_secs: u64,
+
+    /// Application version (reported in registry, e.g. "2024.2").
+    #[arg(long, env = "DCC_MCP_APP_VERSION")]
+    pub(crate) app_version: Option<String>,
+
+    /// Currently open scene file (reported in registry, improves routing).
+    #[arg(long, env = "DCC_MCP_SCENE")]
+    pub(crate) scene: Option<String>,
+
+    /// Heartbeat interval in seconds for the registry. 0 = disabled.
+    #[arg(long, env = "DCC_MCP_HEARTBEAT_INTERVAL", default_value = "5")]
+    pub(crate) heartbeat_secs: u64,
+
+    /// Reserved compatibility flag for older sidecar supervisors.
+    #[arg(long, default_value = "30")]
+    pub(crate) reconnect_timeout_secs: u64,
+
+    /// Internal helper: watch a PID and remove its PID file after exit.
+    #[arg(long, hide = true)]
+    pub(crate) pid_cleanup_watch: Option<PathBuf>,
+
+    /// Internal helper: PID to watch for `--pid-cleanup-watch`.
+    #[arg(long, hide = true)]
+    pub(crate) watch_pid: Option<u32>,
+
+    /// Disable logging to rotating files. By default file logging is enabled
+    /// unless this flag is passed.
+    #[arg(long, env = "DCC_MCP_NO_LOG_FILE", default_value = "false")]
+    pub(crate) no_log_file: bool,
+
+    /// Directory for rotated log files. Defaults to the platform log dir
+    /// (`dcc_mcp_paths::get_log_dir()`).
+    #[arg(long, env = "DCC_MCP_LOG_DIR", value_name = "PATH")]
+    pub(crate) log_dir: Option<PathBuf>,
+
+    /// Maximum bytes per log file before a size-triggered rotation.
+    #[arg(long, env = "DCC_MCP_LOG_MAX_SIZE", value_name = "BYTES")]
+    pub(crate) log_max_size: Option<u64>,
+
+    /// Number of **rolled** files to retain (current file excluded).
+    #[arg(long, env = "DCC_MCP_LOG_MAX_FILES", value_name = "N")]
+    pub(crate) log_max_files: Option<usize>,
+
+    /// Rotation policy: `size`, `daily`, or `both`.
+    #[arg(long, env = "DCC_MCP_LOG_ROTATION", value_name = "POLICY")]
+    pub(crate) log_rotation: Option<String>,
+
+    /// File-name prefix (full file is `<prefix>.<pid>.<YYYYMMDD>.log`).
+    #[arg(long, env = "DCC_MCP_LOG_FILE_PREFIX", value_name = "PREFIX")]
+    pub(crate) log_file_prefix: Option<String>,
+
+    /// Log retention in days (0 = disable age pruning). Default: 7.
+    #[arg(
+        long,
+        env = "DCC_MCP_LOG_RETENTION_DAYS",
+        value_name = "DAYS",
+        default_value = "7"
+    )]
+    pub(crate) log_retention_days: Option<u32>,
+
+    /// Maximum total log directory size in MiB (0 = disable size pruning). Default: 100.
+    #[arg(long, env = "DCC_MCP_LOG_MAX_TOTAL_SIZE_MB", value_name = "MB")]
+    pub(crate) log_max_total_size_mb: Option<u32>,
+}
+
+/// Explicit per-DCC server mode.
+#[derive(Debug, ClapArgs)]
+pub(crate) struct ServeArgs {
+    #[command(flatten)]
+    pub(crate) server: ServerArgs,
+
+    /// Run only the per-DCC MCP server and never compete for the gateway port.
+    #[arg(long)]
+    pub(crate) no_auto_gateway: bool,
+}
+
+impl ServeArgs {
+    pub(crate) fn into_server_args(mut self) -> ServerArgs {
+        if self.no_auto_gateway {
+            self.server.gateway_port = 0;
+        }
+        self.server
+    }
+}
+
+/// Catalog subcommand: query the public DCC-MCP catalog.
+#[derive(Debug, Subcommand)]
+pub(crate) enum CatalogAction {
+    /// Search the catalog by keyword (name, description, DCC type, tags).
+    Search {
+        /// Keyword to search for. Omit to list all entries.
+        #[arg(long, default_value = "")]
+        query: String,
+    },
+    /// Show full details for a single catalog entry by exact name.
+    Describe {
+        /// Exact catalog entry name (e.g. dcc-mcp-maya-skills).
+        #[arg(long)]
+        name: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{Parser as _, error::ErrorKind};
+
+    use super::{Args, SubCmd};
+
+    #[test]
+    fn no_subcommand_keeps_backwards_compatible_server_flags() {
+        let parsed = Args::try_parse_from(["dcc-mcp-server", "--app", "maya"]).unwrap();
+
+        assert!(parsed.command.is_none());
+        assert_eq!(parsed.server.app, "maya");
+        assert_eq!(parsed.server.gateway_port, 9765);
+    }
+
+    #[test]
+    fn explicit_auto_uses_the_same_server_flag_surface() {
+        let parsed = Args::try_parse_from(["dcc-mcp-server", "auto", "--app", "blender"]).unwrap();
+
+        let Some(SubCmd::Auto(server)) = parsed.command else {
+            panic!("expected auto subcommand");
+        };
+        assert_eq!(server.app, "blender");
+        assert_eq!(server.gateway_port, 9765);
+    }
+
+    #[test]
+    fn serve_no_auto_gateway_forces_gateway_port_to_zero() {
+        let parsed = Args::try_parse_from([
+            "dcc-mcp-server",
+            "serve",
+            "--no-auto-gateway",
+            "--app",
+            "maya",
+        ])
+        .unwrap();
+
+        let Some(SubCmd::Serve(serve)) = parsed.command else {
+            panic!("expected serve subcommand");
+        };
+        let server = serve.into_server_args();
+        assert_eq!(server.app, "maya");
+        assert_eq!(server.gateway_port, 0);
+    }
+
+    #[test]
+    fn serve_no_auto_gateway_overrides_gateway_port() {
+        let parsed = Args::try_parse_from([
+            "dcc-mcp-server",
+            "serve",
+            "--no-auto-gateway",
+            "--gateway-port",
+            "1234",
+        ])
+        .unwrap();
+
+        let Some(SubCmd::Serve(serve)) = parsed.command else {
+            panic!("expected serve subcommand");
+        };
+        let server = serve.into_server_args();
+        assert_eq!(server.gateway_port, 0);
+    }
+
+    #[test]
+    fn root_server_flags_conflict_with_non_server_subcommands() {
+        let error =
+            Args::try_parse_from(["dcc-mcp-server", "--app", "maya", "gateway"]).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    #[cfg(feature = "gateway-daemon")]
+    fn gateway_subcommand_does_not_accept_server_only_flags() {
+        let error =
+            Args::try_parse_from(["dcc-mcp-server", "gateway", "--app", "maya"]).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+    }
+}

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -88,7 +88,8 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 
-use clap::{Parser, Subcommand};
+use clap::Parser;
+use cli::{Args, CatalogAction, ServerArgs, SubCmd};
 use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
 #[cfg(feature = "gateway-auto")]
 use dcc_mcp_gateway::{AdminPersistConfig, GatewayConfig, GatewayRunner, SkillPathEntry};
@@ -102,6 +103,7 @@ use dcc_mcp_skills::constants::{ENV_SKILL_PATHS, app_skill_paths_env_key};
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 use sysinfo::{Pid, ProcessesToUpdate, System};
 mod capture;
+mod cli;
 mod event_webhooks;
 #[cfg(feature = "gateway-daemon")]
 mod gateway_daemon;
@@ -112,205 +114,6 @@ mod sidecar_gateway;
 #[cfg(feature = "gateway-auto")]
 mod sidecar_mcp;
 mod translate;
-
-// ── CLI ───────────────────────────────────────────────────────────────────────
-
-/// DCC-MCP subcommands.
-#[derive(Debug, Subcommand)]
-enum SubCmd {
-    /// Bridge any stdio MCP server to HTTP/SSE/Streamable-HTTP.
-    Translate(translate::TranslateArgs),
-    /// Catalog commands (search or describe DCC-MCP adapters).
-    Catalog {
-        #[command(subcommand)]
-        action: CatalogAction,
-    },
-    /// Out-of-process worker for crash-isolated DCC actions (RFC #998).
-    ///
-    /// Spawned by a DCC plugin/addon (`dcc-mcp-maya`, `dcc-mcp-blender`, …)
-    /// and supervised via `--watch-pid`.  Exits cleanly when its parent
-    /// DCC dies so we never leak stale workers.
-    #[cfg(feature = "gateway-auto")]
-    Sidecar(sidecar::SidecarArgs),
-    /// Machine-wide gateway daemon. Per-DCC sidecars auto-launch this when needed.
-    #[cfg(feature = "gateway-daemon")]
-    Gateway(gateway_daemon::GatewayArgs),
-    /// Replay or diff gateway traffic capture files.
-    Capture {
-        #[command(subcommand)]
-        action: capture::CaptureAction,
-    },
-}
-
-/// DCC-MCP server with integrated auto-gateway.
-#[derive(Debug, Parser)]
-#[command(name = "dcc-mcp-server", about, version)]
-struct Args {
-    /// Optional subcommand. If omitted, runs as a DCC MCP server.
-    #[command(subcommand)]
-    command: Option<SubCmd>,
-    /// MCP Streamable HTTP server port. Default 0 = OS-assigned.
-    #[arg(long, env = "DCC_MCP_MCP_PORT", default_value = "0")]
-    mcp_port: u16,
-
-    /// WebSocket bridge server port (for non-Python DCC plugins).
-    #[arg(long, env = "DCC_MCP_WS_PORT", default_value = "9001")]
-    ws_port: u16,
-
-    /// Application type (e.g. "maya", "photoshop", "blender").
-    #[arg(long, env = "DCC_MCP_APP", default_value = "")]
-    app: String,
-
-    /// Additional skill search paths (repeatable).
-    #[arg(long, value_name = "PATH", num_args = 1..)]
-    skill_paths: Vec<PathBuf>,
-
-    /// Server name advertised to MCP clients.
-    #[arg(long, env = "DCC_MCP_SERVER_NAME", default_value = "dcc-mcp-server")]
-    server_name: String,
-
-    /// Disable the WebSocket bridge server (MCP HTTP only).
-    #[arg(long, default_value = "false")]
-    no_bridge: bool,
-
-    /// MCP server host to bind to.
-    #[arg(long, default_value = "127.0.0.1")]
-    host: String,
-
-    /// Write the server process ID to this file while running.
-    #[arg(long, value_name = "PATH")]
-    pid_file: Option<PathBuf>,
-
-    /// Overwrite an existing PID file even if it points at a live process.
-    #[arg(long, default_value = "false")]
-    force: bool,
-
-    /// Seconds to wait for graceful shutdown before exiting.
-    #[arg(long, env = "DCC_MCP_SHUTDOWN_TIMEOUT_SECS", default_value = "10")]
-    shutdown_timeout_secs: u64,
-
-    // ── Gateway ──
-    /// Gateway port to compete for. First instance to bind wins the gateway.
-    /// 0 = gateway disabled entirely (and therefore disables admin too).
-    #[arg(long, env = "DCC_MCP_GATEWAY_PORT", default_value = "9765")]
-    gateway_port: u16,
-
-    /// Gateway host/interface to bind. Defaults to the MCP `--host`.
-    #[arg(long, env = "DCC_MCP_GATEWAY_HOST")]
-    gateway_host: Option<String>,
-
-    /// Human-readable gateway candidate name written to the `__gateway__`
-    /// sentinel when this process wins or challenges the gateway role.
-    #[arg(long, env = "DCC_MCP_GATEWAY_NAME")]
-    gateway_name: Option<String>,
-
-    /// Remote/LAN gateway host/interface to bind.
-    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_HOST", default_value = "0.0.0.0")]
-    gateway_remote_host: String,
-
-    /// Remote/LAN gateway port. 0 disables the remote listener.
-    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "59765")]
-    gateway_remote_port: u16,
-
-    /// Disable the read-only Admin UI on the elected gateway.
-    #[arg(long, env = "DCC_MCP_NO_ADMIN", default_value = "false")]
-    no_admin: bool,
-
-    /// URL prefix for the read-only Admin UI.
-    #[arg(long, env = "DCC_MCP_ADMIN_PATH", default_value = "/admin")]
-    admin_path: String,
-
-    /// Directory for the shared FileRegistry (auto-created if missing).
-    #[arg(long, env = "DCC_MCP_REGISTRY_DIR")]
-    registry_dir: Option<String>,
-
-    /// Seconds without a heartbeat before an instance is considered stale.
-    #[arg(long, env = "DCC_MCP_STALE_TIMEOUT", default_value = "30")]
-    stale_timeout_secs: u64,
-
-    /// Application version (reported in registry, e.g. "2024.2").
-    #[arg(long, env = "DCC_MCP_APP_VERSION")]
-    app_version: Option<String>,
-
-    /// Currently open scene file (reported in registry, improves routing).
-    #[arg(long, env = "DCC_MCP_SCENE")]
-    scene: Option<String>,
-
-    /// Heartbeat interval in seconds for the registry. 0 = disabled.
-    #[arg(long, env = "DCC_MCP_HEARTBEAT_INTERVAL", default_value = "5")]
-    heartbeat_secs: u64,
-
-    /// Reserved compatibility flag for older sidecar supervisors.
-    #[arg(long, default_value = "30")]
-    reconnect_timeout_secs: u64,
-
-    /// Internal helper: watch a PID and remove its PID file after exit.
-    #[arg(long, hide = true)]
-    pid_cleanup_watch: Option<PathBuf>,
-
-    /// Internal helper: PID to watch for `--pid-cleanup-watch`.
-    #[arg(long, hide = true)]
-    watch_pid: Option<u32>,
-
-    // ── File logging ──
-    /// Disable logging to rotating files. By default file logging is enabled
-    /// unless this flag is passed.
-    #[arg(long, env = "DCC_MCP_NO_LOG_FILE", default_value = "false")]
-    no_log_file: bool,
-
-    /// Directory for rotated log files. Defaults to the platform log dir
-    /// (`dcc_mcp_paths::get_log_dir()`).
-    #[arg(long, env = "DCC_MCP_LOG_DIR", value_name = "PATH")]
-    log_dir: Option<PathBuf>,
-
-    /// Maximum bytes per log file before a size-triggered rotation.
-    #[arg(long, env = "DCC_MCP_LOG_MAX_SIZE", value_name = "BYTES")]
-    log_max_size: Option<u64>,
-
-    /// Number of **rolled** files to retain (current file excluded).
-    #[arg(long, env = "DCC_MCP_LOG_MAX_FILES", value_name = "N")]
-    log_max_files: Option<usize>,
-
-    /// Rotation policy: `size`, `daily`, or `both`.
-    #[arg(long, env = "DCC_MCP_LOG_ROTATION", value_name = "POLICY")]
-    log_rotation: Option<String>,
-
-    /// File-name prefix (full file is `<prefix>.<pid>.<YYYYMMDD>.log`).
-    #[arg(long, env = "DCC_MCP_LOG_FILE_PREFIX", value_name = "PREFIX")]
-    log_file_prefix: Option<String>,
-
-    /// Log retention in days (0 = disable age pruning). Default: 7.
-    #[arg(
-        long,
-        env = "DCC_MCP_LOG_RETENTION_DAYS",
-        value_name = "DAYS",
-        default_value = "7"
-    )]
-    log_retention_days: Option<u32>,
-
-    /// Maximum total log directory size in MiB (0 = disable size pruning). Default: 100.
-    #[arg(long, env = "DCC_MCP_LOG_MAX_TOTAL_SIZE_MB", value_name = "MB")]
-    log_max_total_size_mb: Option<u32>,
-}
-
-// ── Catalog subcommands ───────────────────────────────────────────────────────
-
-/// Catalog subcommand: query the public DCC-MCP catalog.
-#[derive(Debug, Subcommand)]
-enum CatalogAction {
-    /// Search the catalog by keyword (name, description, DCC type, tags).
-    Search {
-        /// Keyword to search for. Omit to list all entries.
-        #[arg(long, default_value = "")]
-        query: String,
-    },
-    /// Show full details for a single catalog entry by exact name.
-    Describe {
-        /// Exact catalog entry name (e.g. dcc-mcp-maya-skills).
-        #[arg(long)]
-        name: String,
-    },
-}
 
 fn run_catalog_cmd(action: &CatalogAction) -> anyhow::Result<()> {
     let catalog_path = if let Ok(p) = std::env::var("DCC_MCP_CATALOG_PATH") {
@@ -566,10 +369,6 @@ pub(crate) async fn select_shutdown_signal() -> anyhow::Result<&'static str> {
 // ── main ──────────────────────────────────────────────────────────────────────
 
 #[tokio::main]
-// Without the `server` feature, the early `return Err(...)` in the
-// no-subcommand arm makes the rest of `main` provably unreachable. That
-// is intentional, not a bug — silence the lint only for that build.
-#[cfg_attr(not(feature = "server"), allow(unreachable_code, unused_variables))]
 async fn main() -> anyhow::Result<()> {
     // Install the shared subscriber (stderr fmt-layer + reload slot for the
     // optional file-logging layer). Safe to call multiple times.
@@ -607,6 +406,8 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Dispatch to subcommands ───────────────────────────────────────────
     match args.command {
+        Some(SubCmd::Auto(server_args)) => return run_server(server_args).await,
+        Some(SubCmd::Serve(serve_args)) => return run_server(serve_args.into_server_args()).await,
         Some(SubCmd::Translate(translate_args)) => return translate::run(translate_args).await,
         Some(SubCmd::Catalog { action }) => return run_catalog_cmd(&action),
         #[cfg(feature = "gateway-auto")]
@@ -614,9 +415,15 @@ async fn main() -> anyhow::Result<()> {
         #[cfg(feature = "gateway-daemon")]
         Some(SubCmd::Gateway(gateway_args)) => return gateway_daemon::run(gateway_args).await,
         Some(SubCmd::Capture { action }) => return capture::run(action).await,
-        None => {}
+        None => return run_server(args.server).await,
     }
+}
 
+// Without the `server` feature, the early `return Err(...)` below makes the
+// rest of the function provably unreachable. That is intentional for
+// gateway-only builds, so silence the lint only for that feature combination.
+#[cfg_attr(not(feature = "server"), allow(unreachable_code, unused_variables))]
+async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
     // When this binary is built without the `server` feature, the default
     // (no-subcommand) path has nothing useful to do — print help and exit
     // cleanly so callers get a clear signal instead of opening a port.

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -440,7 +440,7 @@ dcc-mcp-app-ui (independent pure app_ui observation/action/wait/policy/audit con
 
 ### dcc-mcp-server
 
-**Purpose**: Binary entry point (`dcc-mcp-server` CLI) that assembles and runs the full MCP server with gateway support.
+**Purpose**: Binary composition entry point (`dcc-mcp-server` CLI). The implicit root mode and explicit `auto` mode run a per-DCC MCP server with first-wins auto-gateway support, `serve --no-auto-gateway` runs a per-DCC server without binding the shared gateway port, and `gateway` runs the machine-wide gateway daemon without inline DCC execution.
 
 ### dcc-mcp-cli
 

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -97,10 +97,22 @@ Default install locations are `~/.local/bin` on Linux/macOS and
 
 ## `dcc-mcp-server`
 
-Standalone server that runs one per-DCC MCP + REST server **and** competes
-for the shared gateway port. The first process to bind the gateway port
-wins the role; later arrivals still register themselves as regular DCC
-instances that the winner aggregates.
+Standalone server runner with explicit run modes for per-DCC MCP servers and
+the machine-wide gateway daemon. Invoking `dcc-mcp-server` with no subcommand
+is still backwards compatible: it behaves exactly like `dcc-mcp-server auto`.
+
+### Run modes
+
+| Command | Role | Gateway behavior |
+|---|---|---|
+| `dcc-mcp-server` | Backwards-compatible implicit `auto`. | Starts a per-DCC MCP server and participates in first-wins gateway election. |
+| `dcc-mcp-server auto` | Explicit form of the default behavior. | Same as the no-subcommand path. |
+| `dcc-mcp-server serve` | Per-DCC MCP server. | Participates in first-wins gateway election unless told otherwise. |
+| `dcc-mcp-server serve --no-auto-gateway` | Per-DCC MCP server only. | Registers/serves tools but never tries to bind the gateway port. |
+| `dcc-mcp-server gateway` | Machine-wide gateway daemon. | Hosts discovery, routing, resources/prompts, admin, and audit without running DCC tools inline. |
+
+`auto` and `serve` share the server flags below. `gateway` has its own smaller
+flag surface and rejects server-only flags such as `--app`.
 
 ### Core flags
 
@@ -117,7 +129,7 @@ instances that the winner aggregates.
 | `--force` | — | `false` | Overwrite an existing PID file even if it points at a live process. |
 | `--shutdown-timeout-secs` | `DCC_MCP_SHUTDOWN_TIMEOUT_SECS` | `10` | Graceful shutdown deadline. |
 
-### Gateway flags
+### Auto-gateway flags (`auto` / `serve`)
 
 | Flag | Env | Default | Meaning |
 |---|---|---|---|
@@ -194,20 +206,21 @@ recording can be replayed against the current live instance.
 ### Typical invocations
 
 ```bash
-# 1) Single standalone server on an OS-assigned MCP port, no gateway.
-dcc-mcp-server --app maya --gateway-port 0
+# 1) Backwards-compatible auto mode (same as: dcc-mcp-server auto --app maya).
+dcc-mcp-server --app maya
 
-# 2) Gateway-winner on a workstation with multiple DCCs.
+# 2) Per-DCC server only, never competing for the shared gateway port.
+dcc-mcp-server serve --no-auto-gateway --app maya
+
+# 3) Gateway-winner on a workstation with multiple DCCs.
 #    First terminal wins the gateway port, subsequent ones register as plain instances.
-dcc-mcp-server --app maya --server-name maya-shotgun-alpha \
+dcc-mcp-server auto --app maya --server-name maya-shotgun-alpha \
                --scene /shots/ep101/sh0200/shot.ma \
                --log-dir /var/log/dcc-mcp
 
-# 3) Workstation-wide gateway listening on 0.0.0.0 (careful: auth is
-#    localhost-only by default; install BearerTokenGate before exposing).
-dcc-mcp-server --app generic --host 0.0.0.0 \
-               --mcp-port 9765 \
-               --registry-dir /var/lib/dcc-mcp
+# 4) Workstation-wide gateway daemon.
+dcc-mcp-server gateway --host 127.0.0.1 --port 9765 \
+                       --registry-dir /var/lib/dcc-mcp
 ```
 
 ---

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -28,6 +28,19 @@ directory so three DCCs starting at once still spawn at most one gateway.
 Use `dcc-mcp-server sidecar --no-ensure-gateway` to disable auto-launch, or
 `--legacy-gateway-election` to restore the old per-DCC first-wins election.
 
+For the standalone `dcc-mcp-server` binary, the run mode is explicit:
+
+```bash
+dcc-mcp-server                  # implicit auto mode, backwards compatible
+dcc-mcp-server auto --app maya  # explicit auto-gateway participation
+dcc-mcp-server serve --app maya # per-DCC server, still auto-gateway capable
+dcc-mcp-server serve --no-auto-gateway --app maya
+dcc-mcp-server gateway --port 9765
+```
+
+Use `serve --no-auto-gateway` when an external daemon owns the shared gateway
+port and this process should never try to bind it.
+
 ## Standalone gateway daemon (#1358)
 
 The `dcc-mcp-server gateway` subcommand runs the gateway **as its own
@@ -94,8 +107,9 @@ standalone). At runtime it satisfies the following:
 
 | Scenario | Recommended mode |
 |----------|------------------|
-| Single artist machine, one DCC | Default auto-gateway in the per-DCC server |
-| Workstation hosting multiple DCCs | Either; auto-gateway elects the first DCC to launch |
+| Single artist machine, one DCC | `dcc-mcp-server` or `dcc-mcp-server auto --app <dcc>` |
+| Workstation hosting multiple DCCs | `auto` / `serve`; auto-gateway elects the first DCC to launch |
+| Workstation with a separate gateway owner | `dcc-mcp-server serve --no-auto-gateway --app <dcc>` plus `dcc-mcp-server gateway` |
 | Studio render node / shared host / CI | `dcc-mcp-server gateway` daemon, sidecars launch DCCs |
 | Headless agent without any DCC installed | `dcc-mcp-server gateway` daemon — DCCs are reached via `FileRegistry` / HTTP registration |
 

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -91,9 +91,22 @@ dcc-mcp-cli lint path/to/skills
 
 ## `dcc-mcp-server`
 
-独立服务器，跑一个 per-DCC MCP + REST 服务**同时**竞争共享的网关端口。
-首个绑定网关端口的进程赢得网关角色；后来者注册成普通 DCC 实例，被赢家
-汇聚。
+独立服务器入口，显式区分 per-DCC MCP server 与整机 gateway daemon。
+不带子命令调用 `dcc-mcp-server` 仍保持向后兼容：行为等同于
+`dcc-mcp-server auto`。
+
+### 运行模式
+
+| 命令 | 角色 | 网关行为 |
+|---|---|---|
+| `dcc-mcp-server` | 向后兼容的隐式 `auto`。 | 启动 per-DCC MCP server，并参与 first-wins 网关选举。 |
+| `dcc-mcp-server auto` | 默认行为的显式写法。 | 与无子命令路径相同。 |
+| `dcc-mcp-server serve` | per-DCC MCP server。 | 默认仍参与 first-wins 网关选举。 |
+| `dcc-mcp-server serve --no-auto-gateway` | 仅运行 per-DCC MCP server。 | 提供 MCP 工具，但绝不尝试绑定 gateway port。 |
+| `dcc-mcp-server gateway` | 整机 gateway daemon。 | 只托管 discovery、routing、resources/prompts、admin 与 audit，不内联执行 DCC tool。 |
+
+`auto` 与 `serve` 共享下面的 server 旗标。`gateway` 有更小的独立旗标面，
+会拒绝 `--app` 这类 server-only 旗标。
 
 ### 核心旗标
 
@@ -110,7 +123,7 @@ dcc-mcp-cli lint path/to/skills
 | `--force` | — | `false` | 覆盖指向活进程的 PID 文件。 |
 | `--shutdown-timeout-secs` | `DCC_MCP_SHUTDOWN_TIMEOUT_SECS` | `10` | 优雅关闭时限。 |
 
-### 网关旗标
+### 自动网关旗标（`auto` / `serve`）
 
 | 旗标 | 环境变量 | 默认值 | 说明 |
 |---|---|---|---|
@@ -186,20 +199,21 @@ slug（例如 `maya.old.tool`）以及 `instance_id` 字段，方便把旧记录
 ### 典型调用
 
 ```bash
-# 1) 单机服务，OS 分配 MCP 端口，不开网关。
-dcc-mcp-server --app maya --gateway-port 0
+# 1) 向后兼容的 auto 模式（等同于：dcc-mcp-server auto --app maya）。
+dcc-mcp-server --app maya
 
-# 2) 工作站上多 DCC 的网关赢家。
+# 2) 仅 per-DCC server，不竞争共享 gateway port。
+dcc-mcp-server serve --no-auto-gateway --app maya
+
+# 3) 工作站上多 DCC 的网关赢家。
 #    第一个终端赢网关端口，后续的注册成普通实例。
-dcc-mcp-server --app maya --server-name maya-shotgun-alpha \
+dcc-mcp-server auto --app maya --server-name maya-shotgun-alpha \
                --scene /shots/ep101/sh0200/shot.ma \
                --log-dir /var/log/dcc-mcp
 
-# 3) 整台工作站的网关，监听 0.0.0.0（注意：默认仅本机鉴权；
-#    对外暴露前先装 BearerTokenGate）。
-dcc-mcp-server --app generic --host 0.0.0.0 \
-               --mcp-port 9765 \
-               --registry-dir /var/lib/dcc-mcp
+# 4) 整台工作站的 gateway daemon。
+dcc-mcp-server gateway --host 127.0.0.1 --port 9765 \
+                       --registry-dir /var/lib/dcc-mcp
 ```
 
 ---

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -50,12 +50,13 @@ skill taxonomy), load `dcc-mcp-skills-creator` instead.
 4. Route host API calls through `HostExecutionBridge`; do not hand-roll a second script executor.
 5. Keep DCC identity data-driven: `dcc_name`, `server_name`, env-var prefix, skill names, and gateway metadata.
 6. Use core helpers for skill discovery, `MinimalModeConfig`, project tools, resources, diagnostics, context snapshots, install lifecycle, and gateway failover before writing adapter-local wrappers.
-7. Preserve gateway caller attribution when adding adapter wrappers or admin/debug routes: let MCP `initialize.params.clientInfo`, MCP `_meta.agent_context`, REST `meta.agent_context`, `x-dcc-mcp-*` headers, and safe `User-Agent` fallbacks flow through core rather than logging raw prompts or local machine data.
-8. When the adapter needs a lifecycle hook or metadata transform that core cannot express, open a focused core issue/RFC instead of parsing YAML or mutating private state in the adapter.
-9. Add one executable smoke path: unit tests for construction plus either headless DCC, mock dispatcher MCP calls, or gateway REST replay.
-10. For gateway/admin observability, surface explicit state instead of silent zeroes: traffic panels should report disabled, unavailable, filtered, or genuine no-traffic states; skill panels should distinguish discovered, loaded, searched, selected, called, failed, and low-adoption skills; and admin-facing frames/paths should stay metadata-only or aliased unless an operator explicitly configures a private raw sink.
-11. Preserve workflow observability: adapter calls should carry request, parent, trace, session, DCC, transport, and artifact/validation metadata so the Admin workflow graph can show Intent → Discovery → Skill Load → Tool Calls → Fallbacks → Artifacts → Validation → Report without raw log reading.
-12. Preserve bounded `agent_context` task/session/turn metadata and artifact/validation-friendly tool names so Admin task outcomes can group workflows, calls, deliverables, and checks without reading raw payloads or local paths.
+7. Choose the `dcc-mcp-server` run mode deliberately: no subcommand or `auto` for backwards-compatible first-wins auto-gateway, `serve --no-auto-gateway` when a separate daemon owns the gateway port, and `gateway` for a machine-wide daemon with no inline DCC execution.
+8. Preserve gateway caller attribution when adding adapter wrappers or admin/debug routes: let MCP `initialize.params.clientInfo`, MCP `_meta.agent_context`, REST `meta.agent_context`, `x-dcc-mcp-*` headers, and safe `User-Agent` fallbacks flow through core rather than logging raw prompts or local machine data.
+9. When the adapter needs a lifecycle hook or metadata transform that core cannot express, open a focused core issue/RFC instead of parsing YAML or mutating private state in the adapter.
+10. Add one executable smoke path: unit tests for construction plus either headless DCC, mock dispatcher MCP calls, or gateway REST replay.
+11. For gateway/admin observability, surface explicit state instead of silent zeroes: traffic panels should report disabled, unavailable, filtered, or genuine no-traffic states; skill panels should distinguish discovered, loaded, searched, selected, called, failed, and low-adoption skills; and admin-facing frames/paths should stay metadata-only or aliased unless an operator explicitly configures a private raw sink.
+12. Preserve workflow observability: adapter calls should carry request, parent, trace, session, DCC, transport, and artifact/validation metadata so the Admin workflow graph can show Intent → Discovery → Skill Load → Tool Calls → Fallbacks → Artifacts → Validation → Report without raw log reading.
+13. Preserve bounded `agent_context` task/session/turn metadata and artifact/validation-friendly tool names so Admin task outcomes can group workflows, calls, deliverables, and checks without reading raw payloads or local paths.
 
 ## Example: New Nuke Adapter
 

--- a/tests/vrs/README.md
+++ b/tests/vrs/README.md
@@ -74,6 +74,7 @@ python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tes
 | File | Needs live DCC? | Purpose |
 |------|-----------------|--------|
 | `traces/gateway-smoke.jsonl` | No | `GET /v1/healthz` + browse `POST /v1/search`. |
+| `traces/core-1360-gateway-daemon-mode.jsonl` | No | `dcc-mcp-server gateway` daemon exposes gateway REST without a live DCC backend. |
 | `traces/gateway-search-no-matches.jsonl` | No | Search with improbable token → `total: 0`, empty `hits`. |
 | `traces/gateway-rest-describe-bad-request-missing-tool-slug.jsonl` | No | `POST /v1/describe` with `{}` → `400`, `error.kind` = `bad-request`. |
 | `traces/gateway-rest-describe-unknown-slug.jsonl` | No | Well-formed unknown slug → `404`, `error.kind` = `unknown-slug`. |

--- a/tests/vrs/traces/core-1360-gateway-daemon-mode.jsonl
+++ b/tests/vrs/traces/core-1360-gateway-daemon-mode.jsonl
@@ -1,0 +1,3 @@
+{"_vrs": {"version": 1}, "trace_id": "core-1360-gateway-daemon-mode", "title": "dcc-mcp-server gateway daemon exposes gateway REST without DCC backend"}
+{"id": "healthz", "http": {"method": "GET", "path": "/v1/healthz"}, "expect": {"status": 200, "json_subset": {"ok": true}}}
+{"id": "search_empty_gateway", "http": {"method": "POST", "path": "/v1/search", "json": {"query": "", "limit": 5}}, "expect": {"status": 200, "body_contains": "\"hits\""}}


### PR DESCRIPTION
Closes #1360. Builds on #1372 / #1359.

## Why

The server composition feature split added the build-time gates for server, auto-gateway, and gateway-daemon. Operators still needed an explicit runtime CLI contract so the default auto-gateway path, server-only mode, and daemon mode are easy to select without breaking existing invocations.

## What changed

- Moved `dcc-mcp-server` CLI parsing into `cli.rs` and added explicit `auto` and `serve` subcommands.
- Kept no-subcommand startup backwards compatible with `auto`.
- Added `serve --no-auto-gateway`, which forces the server path to run with `gateway_port = 0`, including when a gateway port is supplied by env or CLI.
- Kept `gateway` on a separate flag surface that rejects server-only flags such as `--app`.
- Added a VRS trace for gateway daemon REST health/search and updated English/Chinese docs plus agent-facing guidance.

## Validation

- `vx cargo test -p dcc-mcp-server`
- `vx cargo test -p dcc-mcp-server --bin dcc-mcp-server cli::tests`
- `vx cargo test -p dcc-mcp-server --no-default-features --features server --bin dcc-mcp-server cli::tests`
- `vx cargo clippy -p dcc-mcp-server --all-targets -- -D warnings`
- `vx cargo check -p dcc-mcp-server --no-default-features --features server`
- `vx cargo check -p dcc-mcp-server --no-default-features --features gateway-daemon,admin`
- `vx cargo check -p dcc-mcp-server --no-default-features --features server,gateway-auto,gateway-daemon,admin`
- `vx cargo fmt --check`
- `vx git diff --check`
- `vx python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tests/vrs/traces/core-1360-gateway-daemon-mode.jsonl`
- Live `dcc-mcp-server gateway` on a random local port + `scripts/vrs_replay.py` against `core-1360-gateway-daemon-mode.jsonl`
- `vx npm ci` and `vx npm run docs:build` in `docs/`

Note: `vx just docs-check` could not run in this Windows shell because just could not find `cygpath` for the bash shebang. The equivalent docs commands above passed.