### PR TITLE
build(stub-gen): emit release-please marker so _core.pyi tracks Cargo version

### DIFF
--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -9,7 +9,7 @@ import typing
 
 # ── Module metadata ──
 
-__version__: builtins.str = "0.17.37"
+__version__: builtins.str = "0.17.37"  # x-release-please-version
 __author__: builtins.str = "Hal Long <hal.long@outlook.com>"
 
 # ── Constants (registered via m.add() in src/lib.rs::register_constants) ──

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,6 +31,10 @@
           "path": "pkg/dcc-mcp-server-bin/python/dcc_mcp_server/__init__.py"
         },
         {
+          "type": "generic",
+          "path": "python/dcc_mcp_core/_core.pyi"
+        },
+        {
           "type": "json",
           "path": "admin-ui/package.json",
           "jsonpath": "$.version"

--- a/src/bin/stub_gen.rs
+++ b/src/bin/stub_gen.rs
@@ -106,7 +106,7 @@ import typing
 
 # ── Module metadata ──
 
-__version__: builtins.str = {version:?}
+__version__: builtins.str = {version:?}  # x-release-please-version
 __author__: builtins.str = {author:?}
 
 # ── Constants (registered via m.add() in src/lib.rs::register_constants) ──


### PR DESCRIPTION
## Summary

The release-please PR for 0.17.38 (#1344) failed CI on the `Stub generation
check` step because release-please updates `Cargo.toml` (and other
release-please-tracked files) to the new version but cannot touch the
auto-generated `python/dcc_mcp_core/_core.pyi`. On the next build the stub
generator embeds the bumped `CARGO_PKG_VERSION`, the regenerated content
diverges from the committed file, and `stubgen-check` exits non-zero.

This change closes the gap so release-please can keep `_core.pyi` in sync
with `Cargo.toml`:

- `src/bin/stub_gen.rs` now emits an `# x-release-please-version` annotation
  on the `__version__` line so release-please's `generic` extra-file
  substitution can find and update it.
- `release-please-config.json` registers `python/dcc_mcp_core/_core.pyi`
  as a `generic` extra-file, alongside the other version-bearing files.
- The committed `_core.pyi` was regenerated via `just stubgen` so the
  annotation is present on `main` before the next release-please run.

After this lands, release-please will reopen / refresh #1344 with both
`Cargo.toml` and `_core.pyi` at 0.17.38 in lockstep, and the CI
`stubgen-check` will pass.

## Validation

- `vx cargo run --bin stub_gen --features stub-gen` — regenerated stub,
  only the marker line changed.
- `vx cargo run --bin stub_gen --features stub-gen -- --check` — reports
  `Stub drift check: OK`.
- `vx git diff --stat` — three files touched, six lines added.

## Notes

- The change is mechanically scoped to the stub header and the
  release-please config; no Rust API or Python surface is affected.
- Existing CI workflows continue to call `vx cargo run --bin stub_gen
  --features stub-gen -- --check` unchanged.
