### PR TITLE
chore(compat): drop dead deprecation, flag legacy SKILL.md key, fix stale comment

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -20,7 +20,8 @@
 //!
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let registry = Arc::new(ToolRegistry::new());
-//! let config = McpHttpConfig::new(0)
+//! let config = McpHttpConfig::default()
+//!     .with_port(0)
 //!     .with_name("maya")
 //!     .with_dcc_type("maya")
 //!     .with_gateway(9765);

--- a/crates/dcc-mcp-http-types/src/config/aggregate.rs
+++ b/crates/dcc-mcp-http-types/src/config/aggregate.rs
@@ -420,19 +420,6 @@ impl McpHttpConfig {
 
 #[allow(missing_docs, clippy::must_use_candidate)]
 impl McpHttpConfig {
-    /// Create a config with the given port and sensible defaults.
-    ///
-    /// # Deprecated
-    ///
-    /// Use [`McpHttpConfig::default()`] or the builder pattern instead.
-    /// This method will be removed in a future minor release.
-    #[deprecated(note = "use McpHttpConfig::default() or the builder pattern")]
-    pub fn new(port: u16) -> Self {
-        let mut cfg = Self::default();
-        cfg.server.port = port;
-        cfg
-    }
-
     pub fn with_port(mut self, port: u16) -> Self {
         self.server.port = port;
         self

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let registry = Arc::new(ToolRegistry::new());
-//! let config = McpHttpConfig::new(8765);
+//! let config = McpHttpConfig::default().with_port(8765);
 //!
 //! let server = McpHttpServer::new(registry, config);
 //! let handle = server.start().await?;

--- a/python/dcc_mcp_core/_server/host_ui_dispatcher.py
+++ b/python/dcc_mcp_core/_server/host_ui_dispatcher.py
@@ -91,7 +91,12 @@ def host_ui_outcome(
     return payload
 
 
-# Back-compat alias for adapters that already import ``current_host_ui_job``.
+#: Public ``ContextVar`` pointing at the running :class:`HostUiJobEntry`.
+#:
+#: Skill scripts and host dispatcher subclasses read this to obtain the
+#: current job's progress token / cancellation flag / request id without
+#: threading them through every call.  The variable is set by
+#: :meth:`HostUiJobEntry.execute` for the duration of one job.
 current_host_ui_job: contextvars.ContextVar[Optional[HostUiJobEntry]] = contextvars.ContextVar(
     "dcc_mcp_core_current_host_ui_job",
     default=None,

--- a/python/dcc_mcp_core/skill_reference_docs.py
+++ b/python/dcc_mcp_core/skill_reference_docs.py
@@ -1,9 +1,13 @@
 """Skill reference documentation — list/read arbitrary sibling text files (#616+).
 
 Agents need Markdown or notes beside ``scripts/`` without hard-coding one
-filename. Skills may declare explicit globs under ``metadata.dcc-mcp``;
-otherwise we fall back to scanning ``references/`` for common text types,
-and still surface the legacy ``introspection`` sibling path when set.
+filename. Skills declare explicit globs under
+``metadata.dcc-mcp.skill-reference-docs``; otherwise we fall back to
+scanning ``references/`` for common text types.
+
+The legacy ``metadata.dcc-mcp.introspection`` single-file key is still
+surfaced for backwards-compatibility with skills authored before #616,
+with a ``DeprecationWarning`` to nudge authors onto the new key.
 
 Public entry point: :func:`register_skill_reference_docs_tools`.
 """
@@ -13,6 +17,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import Any
+import warnings
 
 from dcc_mcp_core import json_loads
 from dcc_mcp_core._tool_registration import ToolSpec
@@ -94,6 +99,20 @@ def _skill_reference_doc_globs(metadata: Any) -> list[str]:
 
     legacy = getattr(metadata, "introspection_file", None)
     if isinstance(legacy, str) and legacy.strip():
+        # Pre-#616 skills used ``metadata.dcc-mcp.introspection: <path>``;
+        # surface that path through ``skill_refs__*`` one more release so
+        # existing studio skills keep working, but flag the rename so
+        # authors migrate to ``skill-reference-docs: [<path>]``.
+        skill_name = getattr(metadata, "name", None) or getattr(metadata, "skill_path", "<unknown>")
+        warnings.warn(
+            (
+                f"Skill {skill_name!r} declares deprecated 'metadata.dcc-mcp.introspection'; "
+                "rename it to 'metadata.dcc-mcp.skill-reference-docs: [<path>]'. "
+                "The legacy key will stop being honoured in a future minor release."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         globs.append(legacy.strip().replace("\\", "/"))
 
     if globs:

--- a/skills/templates/thin-harness/SKILL.md
+++ b/skills/templates/thin-harness/SKILL.md
@@ -12,8 +12,9 @@ metadata:
     layer: thin-harness
     tools: tools.yaml
     recipes: references/RECIPES.md
-    introspection: references/INTROSPECTION.md
-    # Optional: explicit globs for skill_refs__list/read (defaults also merge introspection + references/*.md)
+    # Reference docs (Markdown / .txt / .rst) under the skill root that
+    # agents can surface via ``skill_refs__list`` / ``skill_refs__read``.
+    # Defaults also pick up ``references/**/*.md`` when this key is absent.
     skill-reference-docs:
       - "references/*.md"
 ---

--- a/tests/test_skill_reference_docs.py
+++ b/tests/test_skill_reference_docs.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+import warnings
+
+import pytest
 
 from dcc_mcp_core.constants import METADATA_SKILL_REFERENCE_DOCS_KEY
 from dcc_mcp_core.skill_reference_docs import _handle_list
@@ -71,6 +74,71 @@ def test_read_roundtrip(tmp_path: Path) -> None:
     out = _handle_read({"s2": md}, {"skill": "s2", "path": "references/ok.md"})
     assert out["success"] is True
     assert out["context"]["content"] == "body"
+
+
+def test_legacy_introspection_file_warns_and_still_surfaces(tmp_path: Path) -> None:
+    """``metadata.dcc-mcp.introspection`` (pre-#616) must still expose the
+    declared file via ``skill_refs__list`` but emit a ``DeprecationWarning``
+    so authors migrate to ``skill-reference-docs``.
+
+    Regression: deprecation must remain non-breaking for one release window;
+    once removed, this test flips to assert the file is *not* listed.
+    """
+    skill_dir = tmp_path / "legacy"
+    skill_dir.mkdir()
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references" / "INTROSPECTION.md").write_text("legacy body", encoding="utf-8")
+
+    md = _Meta(
+        "legacy",
+        str(skill_dir),
+        introspection_file="references/INTROSPECTION.md",
+    )
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", DeprecationWarning)
+        out = _handle_list({"legacy": md}, {"skill": "legacy"})
+
+    deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+    assert deprecations, "Expected DeprecationWarning for the legacy introspection key"
+    assert "introspection" in str(deprecations[0].message)
+    assert "skill-reference-docs" in str(deprecations[0].message)
+
+    assert out["success"] is True
+    paths = {f["path"] for f in out["context"]["files"]}
+    assert "references/INTROSPECTION.md" in paths
+
+
+def test_modern_skill_reference_docs_key_does_not_emit_deprecation(tmp_path: Path) -> None:
+    """Skills using the supported ``skill-reference-docs`` key must never
+    trigger the legacy ``DeprecationWarning``.
+    """
+    skill_dir = tmp_path / "modern"
+    skill_dir.mkdir()
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references" / "NOTE.md").write_text("modern body", encoding="utf-8")
+
+    md = _Meta(
+        "modern",
+        str(skill_dir),
+        metadata={METADATA_SKILL_REFERENCE_DOCS_KEY: ["references/*.md"]},
+    )
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", DeprecationWarning)
+        out = _handle_list({"modern": md}, {"skill": "modern"})
+
+    deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+    assert not deprecations, "skill-reference-docs callers must not see DeprecationWarning; got: " + ", ".join(
+        str(w.message) for w in deprecations
+    )
+    assert out["success"] is True
+
+
+# Silence pytest-on-warning so other tests do not flake on the legacy path.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Skill.*deprecated 'metadata.dcc-mcp.introspection':DeprecationWarning",
+)
 
 
 def test_register_tools_smoke() -> None:


### PR DESCRIPTION
## Summary

Follow-up sweep after dcc-mcp-core#1391 (Maya `hot_reload` import drift, fixed in [dcc-mcp-maya#309](https://github.com/loonghao/dcc-mcp-maya/pull/309)). I audited the Python + Rust surface for back-compat / legacy / deprecated artefacts and acted on three items that have **no downstream consumer left**, deferring two that still do.

## What this PR changes

### 1. Delete `McpHttpConfig::new(port)` (Rust)

`crates/dcc-mcp-http-types/src/config/aggregate.rs` carried `#[deprecated(note = "use McpHttpConfig::default() or the builder pattern")]` with an explicit promise of removal "in a future minor release". GitHub code-search across `org:loonghao` returns **zero call sites** — only two doc-comment examples remain inside this repo. Drop the function and migrate the doc examples to `McpHttpConfig::default().with_port(...)`.

### 2. Fix stale `current_host_ui_job` comment (Python)

`python/dcc_mcp_core/_server/host_ui_dispatcher.py:94` had:

```python
# Back-compat alias for adapters that already import ``current_host_ui_job``.
current_host_ui_job: contextvars.ContextVar[...] = ...
```

The comment dates from a long-past rename; `current_host_ui_job` is the canonical public `ContextVar` — `HostUiJobEntry.execute` sets/resets it directly. Replaced with an accurate `#:`-style Sphinx docstring describing the contract.

### 3. Deprecate `metadata.dcc-mcp.introspection` SKILL.md key (Python + template)

Two coupled changes:

- `skills/templates/thin-harness/SKILL.md` was double-declaring both `introspection: references/INTROSPECTION.md` (legacy, pre-#616) and `skill-reference-docs: [...]` (modern). The template **actively taught new skill authors the deprecated shape**. Drop the legacy line.
- `python/dcc_mcp_core/skill_reference_docs.py` still silently resolves `metadata.introspection_file` so studio skills built before #616 keep showing their docs. Keep the fallback for one more release **but** raise `DeprecationWarning` with the exact migration string (`skill-reference-docs: [<path>]`).

This is the minimum-blast-radius cleanup: existing skills using `introspection:` keep working, the warning surfaces in tests and CI so authors migrate, and the dead removal date can be scheduled once the warning is everywhere.

## Tests

```text
.venv/Scripts/python.exe -m pytest tests/test_skill_reference_docs.py -v
=> 7 / 7 pass
  - test_legacy_introspection_file_warns_and_still_surfaces     ✓  (new)
  - test_modern_skill_reference_docs_key_does_not_emit_deprecation ✓ (new)

vx cargo build --workspace --all-targets                      ✓ clean
vx cargo test -p dcc-mcp-http-types -p dcc-mcp-http -p dcc-mcp-gateway --lib
  - dcc-mcp-http-types : 81 / 81  ✓
  - dcc-mcp-http       : 54 / 54  ✓
  - dcc-mcp-gateway    : 483 / 483 ✓
```

## Deliberately NOT in this PR — tracked cross-repo

Two more compat items were found but cannot be removed unilaterally from core because they have **real** downstream consumers. Cross-repo coordination issues filed separately:

| Item | Where | Downstream consumer | Coordination issue |
|------|-------|---------------------|--------------------|
| `script_path` deprecated tool-arg alias | `python/dcc_mcp_core/dcc_api_executor.py` schema | `dcc-mcp-maya/.../execute_python.py` accepts both `file_path` and `script_path`. External agents may still send `script_path`. | dcc-mcp-maya issue: stop accepting `script_path` once core removes the schema alias |
| `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` legacy env var | `python/dcc_mcp_core/_server/tools_list_policy.py:_LEGACY_MAYA_ENV` | `dcc-mcp-maya/AGENTS.md` documents this env var as canonical | dcc-mcp-maya issue: migrate documentation + operators onto the generic `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST` |

Once those land, follow-up core PRs can delete the corresponding compat surface here.

## Scope

5 files changed, +95 / −20 lines. No public Python API change. The Rust `McpHttpConfig::new` removal is a minor SemVer-breaking change but the function was already marked `#[deprecated]` and has zero org-wide call sites.
