### PR TITLE
ci(semantic): publish dcc-mcp-core-semantic wheels on release (#1395)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,133 @@ jobs:
             ${{ matrix.cli_artifact_name }}
             pkg/dcc-mcp-server-bin/wheels/*.whl
 
+  # ── Build dcc-mcp-core-semantic companion wheels (issue #1395) ──
+  #
+  # Native Rust semantic embeddings (fastembed-rs + ONNX Runtime) shipped as
+  # an opt-in PyPI package. Users only pay this wheel's cost when they
+  # explicitly `pip install 'dcc-mcp-core[semantic]'`. The matrix mirrors
+  # `build-wheels.yml` so the opt-in surface covers the same OS / Python set
+  # as the main wheel, minus macOS Python 3.7 (impossible on hosted runners:
+  # macOS-13 retired Sept 2025, macOS-15 ARM64 has no 3.7 build).
+  #
+  # IMPORTANT: ort 2.x (pulled in transitively by fastembed-rs) requires
+  # glibc >= 2.27, so Linux wheels target manylinux_2_28 — NOT manylinux2014
+  # like `pkg/dcc-mcp-server-bin/`. See
+  # `scripts/release/build_manylinux_semantic_wheel.sh` for the docker
+  # invocation.
+  build-semantic-wheels:
+    needs: [release-please]
+    if: needs.release-please.outputs.release_created == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: semantic-wheel-linux-abi3
+            target: linux-abi3
+          - os: ubuntu-22.04
+            artifact_name: semantic-wheel-linux-py37
+            target: linux-py37
+          - os: windows-latest
+            artifact_name: semantic-wheel-windows-abi3
+            target: windows-abi3
+          - os: windows-2022
+            artifact_name: semantic-wheel-windows-py37
+            target: windows-py37
+          - os: macos-latest
+            artifact_name: semantic-wheel-macos-abi3
+            target: macos-abi3
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      # Rust toolchain is only needed for non-Linux builds; the Linux
+      # builds run inside the pyo3/maturin docker image which bundles its
+      # own pinned toolchain.
+      - name: Setup Rust
+        if: matrix.target != 'linux-abi3' && matrix.target != 'linux-py37'
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: '1.95.0'
+          targets: ${{ matrix.target == 'macos-abi3' && 'aarch64-apple-darwin' || '' }}
+
+      - name: Setup Python (abi3 build)
+        if: endsWith(matrix.target, '-abi3') && !startsWith(matrix.target, 'linux-')
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Setup Python (py37 build)
+        if: matrix.target == 'windows-py37'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.7'
+
+      - name: Install maturin
+        if: matrix.target != 'linux-abi3' && matrix.target != 'linux-py37'
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "maturin>=1.5,<2.0"
+
+      # ── Linux: docker (manylinux_2_28, ort glibc 2.27 baseline) ──
+      - name: Build wheel (Linux abi3)
+        if: matrix.target == 'linux-abi3'
+        shell: bash
+        run: scripts/release/build_manylinux_semantic_wheel.sh abi3
+
+      - name: Build wheel (Linux py37)
+        if: matrix.target == 'linux-py37'
+        shell: bash
+        run: scripts/release/build_manylinux_semantic_wheel.sh py37
+
+      # ── macOS universal2 (abi3) ──
+      - name: Build wheel (macOS universal2 abi3)
+        if: matrix.target == 'macos-abi3'
+        shell: bash
+        working-directory: pkg/dcc-mcp-core-semantic
+        run: |
+          maturin build --release \
+            --target universal2-apple-darwin \
+            --features python-bindings,ext-module,abi3-py38 \
+            --out wheels
+
+      # ── Windows (abi3 / py37) ──
+      - name: Build wheel (Windows abi3)
+        if: matrix.target == 'windows-abi3'
+        shell: bash
+        working-directory: pkg/dcc-mcp-core-semantic
+        run: |
+          maturin build --release \
+            --features python-bindings,ext-module,abi3-py38 \
+            --out wheels
+
+      - name: Build wheel (Windows py37 non-abi3)
+        if: matrix.target == 'windows-py37'
+        shell: bash
+        working-directory: pkg/dcc-mcp-core-semantic
+        run: |
+          maturin build --release \
+            --features python-bindings,ext-module \
+            -i python3.7 \
+            --out wheels
+
+      - name: Upload semantic wheel artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: pkg/dcc-mcp-core-semantic/wheels/*.whl
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          files: pkg/dcc-mcp-core-semantic/wheels/*.whl
+
   # ── Build wheels only when release-please creates a release ──
   build-wheels:
     needs: [release-please]
@@ -331,11 +458,12 @@ jobs:
 
   # ── Publish to PyPI ──
   publish:
-    needs: [release-please, build-wheels, build-binaries]
+    needs: [release-please, build-wheels, build-binaries, build-semantic-wheels]
     if: |
       needs.release-please.outputs.release_created == 'true' &&
       needs.build-wheels.result == 'success' &&
-      needs.build-binaries.result == 'success'
+      needs.build-binaries.result == 'success' &&
+      needs.build-semantic-wheels.result == 'success'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -401,12 +529,21 @@ jobs:
           path: dist-server
           merge-multiple: true
 
+      - name: Download dcc-mcp-core-semantic wheel artefacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: semantic-wheel-*
+          path: dist-semantic
+          merge-multiple: true
+
       - name: List artefacts
         run: |
           echo "── dcc-mcp-core wheels ──"
           ls -la dist/
           echo "── dcc-mcp-server wheels ──"
           ls -la dist-server/ 2>/dev/null || echo "(no server wheels — check build-binaries job)"
+          echo "── dcc-mcp-core-semantic wheels ──"
+          ls -la dist-semantic/ 2>/dev/null || echo "(no semantic wheels — check build-semantic-wheels job)"
 
       # ── PyPI: dcc-mcp-core (existing trusted publisher) ──
       # continue-on-error so that a PyPI failure (e.g. file already exists from
@@ -440,11 +577,31 @@ jobs:
           print-hash: true
           skip-existing: true
 
+      # ── PyPI: dcc-mcp-core-semantic (companion wheel, issue #1395) ──
+      # Trusted publisher setup (one-time, identical pattern to dcc-mcp-server):
+      #   1. https://pypi.org/manage/account/publishing/
+      #   2. Add a new "pending publisher" with:
+      #      Owner = loonghao, Repo = dcc-mcp-core,
+      #      Workflow = release.yml, Environment = pypi,
+      #      Project = dcc-mcp-core-semantic
+      # Until that's configured this step degrades gracefully — the
+      # wheels are still published to GitHub Release below by the safety net.
+      - name: Upload dcc-mcp-core-semantic to PyPI
+        id: pypi-semantic
+        if: hashFiles('dist-semantic/*.whl') != ''
+        continue-on-error: true
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist-semantic
+          verbose: true
+          print-hash: true
+          skip-existing: true
+
       # Always attempt the GitHub Release upload, even if PyPI failed; this is
       # the user-visible artefact set and must be complete per release tag.
-      # Note: build-binaries already uploads each per-platform raw binary +
-      # wheel directly to the Release. This step is the safety net for the
-      # (unlikely) case where the per-platform upload was skipped.
+      # Note: build-binaries / build-semantic-wheels already upload each
+      # per-platform wheel directly to the Release. This step is the safety
+      # net for the (unlikely) case where the per-platform upload was skipped.
       - name: Upload wheels to GitHub Release (safety net)
         if: always()
         uses: softprops/action-gh-release@v3
@@ -453,9 +610,10 @@ jobs:
           files: |
             dist/*
             dist-server/*
+            dist-semantic/*
 
       - name: Fail job if PyPI upload failed
-        if: steps.pypi-core.outcome == 'failure' || steps.pypi-server.outcome == 'failure'
+        if: steps.pypi-core.outcome == 'failure' || steps.pypi-server.outcome == 'failure' || steps.pypi-semantic.outcome == 'failure'
         run: |
-          echo "::error::PyPI upload failed (core=${{ steps.pypi-core.outcome }} server=${{ steps.pypi-server.outcome }}); GitHub Release artefacts were still uploaded above."
+          echo "::error::PyPI upload failed (core=${{ steps.pypi-core.outcome }} server=${{ steps.pypi-server.outcome }} semantic=${{ steps.pypi-semantic.outcome }}); GitHub Release artefacts were still uploaded above."
           exit 1

--- a/scripts/release/build_manylinux_semantic_wheel.sh
+++ b/scripts/release/build_manylinux_semantic_wheel.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Build the `dcc-mcp-core-semantic` companion wheel inside the pyo3/maturin
+# docker image. Two build modes:
+#
+#   abi3  → single wheel for CPython 3.8-3.13 (features without `abi3-py38`
+#           omitted; this script forces it back on so the abi3 ABI tag is
+#           emitted regardless of the host interpreter).
+#   py37  → cp37-cp37m wheel for embedded DCC hosts (Maya 2022, 3ds Max 2022)
+#           that still ship Python 3.7. Built with `-i python3.7`.
+#
+# NOTE on manylinux tag: fastembed-rs pulls `ort` (ONNX Runtime), which
+# requires glibc >= 2.27. That rules out manylinux2014 (CentOS 7, glibc 2.17)
+# used by `pkg/dcc-mcp-server-bin/`; semantic wheels MUST target
+# manylinux_2_28 (CentOS 8 / RHEL 8). The pyke.io CDN ships matching
+# prebuilt ORT binaries for this baseline.
+#
+# The wheel build runs under an isolated CARGO_TARGET_DIR so it never
+# collides with the host's `target/` directory (host build scripts may
+# have been compiled against a newer glibc and would fail to execute
+# inside the container).
+set -euo pipefail
+
+mode="${1:-abi3}"
+
+case "$mode" in
+  abi3)
+    maturin_args=(--features python-bindings,ext-module,abi3-py38)
+    ;;
+  py37)
+    maturin_args=(--features python-bindings,ext-module -i python3.7)
+    ;;
+  *)
+    echo "::error::unknown mode '$mode' (expected abi3|py37)" >&2
+    exit 1
+    ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+docker run --rm \
+  -v "$PWD:/io" \
+  -e CARGO_TARGET_DIR=/io/target-manylinux-semantic \
+  -w /io/pkg/dcc-mcp-core-semantic \
+  ghcr.io/pyo3/maturin:v1.13.3 \
+  build --release --manylinux 2_28 --out wheels "${maturin_args[@]}"
+
+if command -v sudo >/dev/null 2>&1; then
+  sudo chown -R "$(id -u):$(id -g)" pkg/dcc-mcp-core-semantic/wheels
+fi


### PR DESCRIPTION
Follow-up to #1396 (already merged as `v0.17.38`). That PR shipped the
`dcc-mcp-core-semantic` companion package source + Rust crate + Python
3-tier fallback wiring, but did **not** wire the release pipeline. As a
result the trusted publisher configured on PyPI for
`dcc-mcp-core-semantic` is still waiting for its first upload.

This PR completes the missing half.

## What this PR adds

1. **New job `build-semantic-wheels` in `.github/workflows/release.yml`**

   Mirrors the existing `build-wheels.yml` matrix so the opt-in surface
   covers the same OS / Python set as the main wheel:

   | OS | Python | abi3 | tag |
   |---|---|---|---|
   | ubuntu-latest | 3.8-3.13 | yes | `cp38-abi3-manylinux_2_28_x86_64` |
   | ubuntu-22.04 | 3.7 | no | `cp37-cp37m-manylinux_2_28_x86_64` |
   | windows-latest | 3.8-3.13 | yes | `cp38-abi3-win_amd64` |
   | windows-2022 | 3.7 | no | `cp37-cp37m-win_amd64` |
   | macos-latest | 3.8-3.13 | yes | `cp38-abi3-macosx_..._universal2` |

   macOS Python 3.7 is intentionally not built — matches main
   `build-wheels.yml` (macOS-13 retired Sept 2025, macOS-15 ARM has no
   cp37 build). Users on that combination can install from sdist or
   stay on the Python `fastembed` extra fallback.

2. **`scripts/release/build_manylinux_semantic_wheel.sh`**

   Builds the Linux wheel inside `ghcr.io/pyo3/maturin:v1.13.3` with
   `--manylinux 2_28`. Takes `abi3` or `py37` to switch maturin features
   and the Python interpreter.

   **Why manylinux_2_28 and not manylinux2014:** ort 2.x (pulled in
   transitively by fastembed-rs) requires glibc >= 2.27. manylinux2014
   ships glibc 2.17 (CentOS 7) and the pyke.io CDN does not have ORT
   binaries for that baseline.

3. **`publish` job updates**

   - Adds `build-semantic-wheels` to `needs:`
   - Downloads `semantic-wheel-*` artefacts to `dist-semantic/`
   - Uploads via `pypa/gh-action-pypi-publish@release/v1` to the
     `dcc-mcp-core-semantic` trusted publisher
   - Adds `dist-semantic/*` to the GitHub Release safety-net upload
   - Fails the job if any of core / server / semantic PyPI upload fails

## Why this is intentionally a separate PR

#1396 was already merged and a release was cut from it (`v0.17.38`) by
release-please. Adding the CI matrix in-place would have grown that PR
past the 1500-line file budget and put two surfaces (library + release
pipeline) under one review. Splitting keeps each PR scoped.

## What this PR does NOT do

- **No GPU EP build matrix** — CPU-only ORT is already overkill for
  ≤10k skills. CUDA / CoreML / DirectML are follow-ups behind a
  separate Cargo feature.
- **No `[tool.maturin] features` reshuffle** — `pkg/dcc-mcp-core-semantic/pyproject.toml`
  keeps `["python-bindings", "ext-module", "abi3-py38"]` as before;
  the CI passes explicit `--features` flags to override on the cp37
  path, matching the pattern already in `justfile` `WHEEL_FEATURES_PY37`.
- **No backfill for v0.17.38** — that release already shipped without a
  semantic wheel; the next release (`v0.17.39`+) will pick this up
  automatically.

## Validation

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
  parses cleanly; topology shows `build-semantic-wheels` as a dependency
  of `publish` and all 5 matrix targets present.
- Script is syntactically valid bash (`bash -n` passes).
- Pre-commit: `actionlint` passed on the modified workflow.

## Risks / unknowns

1. **First Linux CI run will probably need a fixup** — fastembed-rs +
   ort downloads ONNX Runtime binaries from `cdn.pyke.io` during build.
   If the CDN rate-limits or the maturin docker image is missing a
   pinned `tokenizers` C dep, the first run will surface that. The
   plan is to land this draft, watch the first matrix run, and fix
   whatever breaks.
2. **Trusted publisher project name** — the PyPI pending publisher
   must match `dcc-mcp-core-semantic` exactly (already configured per
   user screenshot).
3. **release-please version sync** — `pkg/dcc-mcp-core-semantic/pyproject.toml`
   on `main` is still at `0.17.37` even though `v0.17.38` was released.
   That's tracked separately; this PR does not touch the version
   marker. The wheel build picks up whatever version is in pyproject
   at release time.
