### PR TITLE
feat(skills): de-prioritise infrastructure / example layers in search (#1398)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,17 +273,27 @@ Gateway resources/prompts:
 
 ### Skill layer taxonomy (`metadata.dcc-mcp.layer`)
 
-| Layer | Purpose | `search_skills` rank multiplier |
-|-------|---------|---------------------------------|
-| `thin-harness` | One Python script + minimal SKILL.md — agents wrap a single CLI/API | × 1.00 |
+| Layer | Purpose | `search_skills` rank |
+|-------|---------|----------------------|
 | `domain` | Pipeline-level intent (shot export, render farm) | × 1.00 |
-| `infrastructure` | Safety, diagnostics, introspection — **fallback tier** | × 0.35 |
-| `example` | Authoring reference only | × 0.20 |
+| `infrastructure` | Safety, diagnostics, introspection — fallback tier | × 0.35 |
+| `thin-harness` | One Python script + minimal SKILL.md — raw `python` / `bash` / CLI wrappers | × 0.20 |
+| `example` | Authoring reference only | **excluded from results** |
 
-The rank multiplier (#1398) keeps broad infrastructure skills (e.g. `app-ui`,
-`dcc-adapter`, `dcc-diagnostics`) below domain skills for neutral queries.
-The penalty is bypassed when the caller explicitly filters by a known layer
-name through `tags=` (case-insensitive), e.g. `search_skills(tags=["infrastructure"])`,
+The ranking rules (#1398) keep low-level skills out of the agent's primary
+flow for neutral queries:
+
+- `domain` skills win by default.
+- `infrastructure` skills (e.g. `app-ui`, `dcc-adapter`, `dcc-diagnostics`)
+  stay around as fallbacks but rank below domain.
+- `thin-harness` skills are the lowest tier that still appears — useful as a
+  last-resort wrapper around a raw script.
+- `example` skills are dropped from results entirely; they only surface when
+  the caller explicitly asks for them (see below) or types the exact name.
+
+The penalty and the `example` exclusion are bypassed when the caller filters
+by a known layer name through `tags=` (case-insensitive), e.g.
+`search_skills(tags=["example"])` or `search_skills(tags=["infrastructure"])`,
 so the raw BM25 order is honoured inside the filtered slice.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,12 +273,18 @@ Gateway resources/prompts:
 
 ### Skill layer taxonomy (`metadata.dcc-mcp.layer`)
 
-| Layer | Purpose |
-|-------|---------|
-| `thin-harness` | One Python script + minimal SKILL.md — agents wrap a single CLI/API |
-| `infrastructure` | Safety, diagnostics, introspection |
-| `domain` | Pipeline-level intent (shot export, render farm) |
-| `example` | Authoring reference only |
+| Layer | Purpose | `search_skills` rank multiplier |
+|-------|---------|---------------------------------|
+| `thin-harness` | One Python script + minimal SKILL.md — agents wrap a single CLI/API | × 1.00 |
+| `domain` | Pipeline-level intent (shot export, render farm) | × 1.00 |
+| `infrastructure` | Safety, diagnostics, introspection — **fallback tier** | × 0.35 |
+| `example` | Authoring reference only | × 0.20 |
+
+The rank multiplier (#1398) keeps broad infrastructure skills (e.g. `app-ui`,
+`dcc-adapter`, `dcc-diagnostics`) below domain skills for neutral queries.
+The penalty is bypassed when the caller explicitly filters by a known layer
+name through `tags=` (case-insensitive), e.g. `search_skills(tags=["infrastructure"])`,
+so the raw BM25 order is honoured inside the filtered slice.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-semantic"
-version = "0.17.37"
+version = "0.17.38"
 dependencies = [
  "anyhow",
  "fastembed",

--- a/crates/dcc-mcp-skills/src/catalog/catalog.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog.rs
@@ -68,10 +68,26 @@ impl SkillCatalog {
                 .map(helpers::skill_entry_to_summary)
                 .collect()
         } else {
-            // ── 3. BM25-lite scoring ──
+            // ── 3. BM25-lite scoring (with layer-based rank penalty, #1398) ──
+            //
+            // When the caller filters by a known layer name through `tags`,
+            // they have explicitly asked to browse that layer — bypass the
+            // penalty so the raw BM25 order is honoured inside the filtered
+            // slice. Otherwise apply the penalty so infrastructure / example
+            // skills behave as the documented "fallback" tier.
+            let layer_filter_explicit = tags.iter().any(|t| {
+                let l = t.to_ascii_lowercase();
+                matches!(
+                    l.as_str(),
+                    scoring::LAYER_DOMAIN
+                        | scoring::LAYER_THIN_HARNESS
+                        | scoring::LAYER_INFRASTRUCTURE
+                        | scoring::LAYER_EXAMPLE
+                )
+            });
             let metas: Vec<&SkillMetadata> = prefiltered.iter().map(|e| &e.metadata).collect();
             let scopes: Vec<SkillScope> = prefiltered.iter().map(|e| e.scope).collect();
-            let scored = scoring::score_skills(q_trim, &metas, &scopes);
+            let scored = scoring::score_skills(q_trim, &metas, &scopes, layer_filter_explicit);
             scored
                 .into_iter()
                 .map(|s| helpers::skill_entry_to_summary(&prefiltered[s.index]))

--- a/crates/dcc-mcp-skills/src/catalog/scoring.rs
+++ b/crates/dcc-mcp-skills/src/catalog/scoring.rs
@@ -29,6 +29,28 @@
 //!
 //! Exact-match fast-path: if the query equals the skill name
 //! (case-insensitive, after trimming) that skill sorts first unconditionally.
+//!
+//! # Layer-based rank penalty (issue #1398)
+//!
+//! AI agents naturally rank skills by raw BM25 score alone, which lets broad
+//! infrastructure skills (e.g. `app-ui`, `dcc-adapter`, `dcc-diagnostics`)
+//! that cover dozens of generic tokens outrank domain skills that map a
+//! specific user intent. To make those infrastructure skills behave as the
+//! "fallback" the layering rules say they are, the final score is multiplied
+//! by a coefficient derived from `metadata.dcc-mcp.layer`:
+//!
+//! | Layer            | Multiplier |
+//! |------------------|-----------:|
+//! | `domain`         |       1.00 |
+//! | `thin-harness`   |       1.00 |
+//! | unset (`None`)   |       1.00 |
+//! | `infrastructure` |       0.35 |
+//! | `example`        |       0.20 |
+//!
+//! The penalty is bypassed when the caller explicitly filters by a known
+//! layer name through the `tags` argument (e.g. `tags=["infrastructure"]`).
+//! That case signals deliberate intent to browse low-level skills, so the
+//! ranker honours the raw BM25 order inside that filtered slice.
 
 use dcc_mcp_models::{SkillMetadata, SkillScope};
 
@@ -48,6 +70,37 @@ pub const W_TOOL_NAME: f64 = 2.0;
 pub const W_TOOL_ALIAS: f64 = 2.0;
 pub const W_TOOL_DESCRIPTION: f64 = 1.0;
 pub const W_DCC: f64 = 4.0;
+
+/// Layer multiplier applied to the BM25 total when `apply_layer_penalty`
+/// is true. See module docs for the rationale and table.
+pub const LAYER_MULT_INFRASTRUCTURE: f64 = 0.35;
+pub const LAYER_MULT_EXAMPLE: f64 = 0.20;
+
+/// Known layer names recognised by [`layer_multiplier`] and the
+/// `apply_layer_penalty` detection in [`SkillCatalog::search_skills`].
+/// Match `metadata.dcc-mcp.layer` values declared in `AGENTS.md`.
+pub const LAYER_DOMAIN: &str = "domain";
+pub const LAYER_THIN_HARNESS: &str = "thin-harness";
+pub const LAYER_INFRASTRUCTURE: &str = "infrastructure";
+pub const LAYER_EXAMPLE: &str = "example";
+
+/// Coefficient applied to the BM25 total based on `metadata.dcc-mcp.layer`.
+///
+/// `explicit` is `true` when the caller explicitly filtered by a layer tag
+/// (`tags=["infrastructure"]` etc.) — in that case no penalty is applied
+/// because the caller asked for that layer on purpose.
+pub fn layer_multiplier(layer: Option<&str>, explicit: bool) -> f64 {
+    if explicit {
+        return 1.0;
+    }
+    match layer.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(value) if value.eq_ignore_ascii_case(LAYER_INFRASTRUCTURE) => {
+            LAYER_MULT_INFRASTRUCTURE
+        }
+        Some(value) if value.eq_ignore_ascii_case(LAYER_EXAMPLE) => LAYER_MULT_EXAMPLE,
+        _ => 1.0,
+    }
+}
 
 /// A tiny English stopword list. Intentionally small — this library is used
 /// with short, technical queries ("polygon bevel", "render maya"); we don't
@@ -188,7 +241,18 @@ pub struct Scored {
 /// The `scopes` slice must be the same length as `skills` and provide the
 /// scope for each skill (catalog holds scopes on `SkillEntry`, not on
 /// `SkillMetadata`).
-pub fn score_skills(query: &str, skills: &[&SkillMetadata], scopes: &[SkillScope]) -> Vec<Scored> {
+///
+/// `layer_filter_explicit` should be `true` when the caller already filtered
+/// the input set by a known layer name (e.g. `tags=["infrastructure"]`) —
+/// the layer-based penalty (see module docs, issue #1398) is then skipped so
+/// the user-requested layer is ranked on raw BM25 alone. Pass `false` for
+/// the common case of an unfiltered search.
+pub fn score_skills(
+    query: &str,
+    skills: &[&SkillMetadata],
+    scopes: &[SkillScope],
+    layer_filter_explicit: bool,
+) -> Vec<Scored> {
     assert_eq!(
         skills.len(),
         scopes.len(),
@@ -259,6 +323,11 @@ pub fn score_skills(query: &str, skills: &[&SkillMetadata], scopes: &[SkillScope
                 + W_DCC * field_bm25(count_occurrences(&fields_i.dcc, q), dl, avgdl);
             total += idf_v * contrib;
         }
+
+        // Layer-based rank penalty (issue #1398). Applied after BM25 sum so
+        // the multiplier compounds across all query tokens, not per-token.
+        let mult = layer_multiplier(meta.layer.as_deref(), layer_filter_explicit);
+        total *= mult;
 
         let name_lower = meta.name.to_lowercase();
         let exact_name = name_lower == q_trim_lower && !q_trim_lower.is_empty();
@@ -408,7 +477,7 @@ mod tests {
         let b = mk("sphere");
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("sphere", &skills, &scopes);
+        let out = score_skills("sphere", &skills, &scopes, false);
         assert!(!out.is_empty());
         assert_eq!(out[0].name, "sphere", "exact-name match must rank first");
     }
@@ -419,7 +488,7 @@ mod tests {
         let a = mk_full("polygon-tools", "polygon modelling", "", &[], "maya", &[]);
         let skills = vec![&a];
         let scopes = vec![SkillScope::Repo];
-        let out = score_skills("poly", &skills, &scopes);
+        let out = score_skills("poly", &skills, &scopes, false);
         assert!(
             out.is_empty(),
             "prefix-only queries must not match without stemming"
@@ -432,7 +501,7 @@ mod tests {
         let b = mk_full("beta", "something else entirely", "", &[], "maya", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("rigging", &skills, &scopes);
+        let out = score_skills("rigging", &skills, &scopes, false);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].name, "alpha");
     }
@@ -443,7 +512,7 @@ mod tests {
         let b = mk_full("beta", "handles rendering", "", &[], "maya", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("animation", &skills, &scopes);
+        let out = score_skills("animation", &skills, &scopes, false);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].name, "alpha");
     }
@@ -463,7 +532,7 @@ mod tests {
         let b = mk_full("other", "unrelated stuff", "", &[], "maya", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("turntable", &skills, &scopes);
+        let out = score_skills("turntable", &skills, &scopes, false);
         assert_eq!(out.len(), 1, "sibling tool name must be scorable");
         assert_eq!(out[0].name, "scene-utils");
     }
@@ -476,7 +545,7 @@ mod tests {
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
 
-        let out = score_skills("primitive ball", &skills, &scopes);
+        let out = score_skills("primitive ball", &skills, &scopes, false);
 
         assert_eq!(out.len(), 1, "skill search aliases must be scorable");
         assert_eq!(out[0].name, "geometry-tools");
@@ -497,7 +566,7 @@ mod tests {
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
 
-        let out = score_skills("mesh globe", &skills, &scopes);
+        let out = score_skills("mesh globe", &skills, &scopes, false);
 
         assert_eq!(out.len(), 1, "tool search aliases must be scorable");
         assert_eq!(out[0].name, "scene-utils");
@@ -508,7 +577,7 @@ mod tests {
         let a = mk_full("alpha", "stuff", "", &[], "maya", &[]);
         let skills = vec![&a];
         let scopes = vec![SkillScope::Repo];
-        let out = score_skills("the of and", &skills, &scopes);
+        let out = score_skills("the of and", &skills, &scopes, false);
         assert!(out.is_empty(), "stopword-only queries must yield no hits");
     }
 
@@ -517,7 +586,7 @@ mod tests {
         let a = mk("alpha");
         let skills = vec![&a];
         let scopes = vec![SkillScope::Repo];
-        let out = score_skills("", &skills, &scopes);
+        let out = score_skills("", &skills, &scopes, false);
         assert!(out.is_empty());
     }
 
@@ -542,7 +611,7 @@ mod tests {
         );
         let skills = vec![&one, &both];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("polygon bevel", &skills, &scopes);
+        let out = score_skills("polygon bevel", &skills, &scopes, false);
         assert_eq!(out[0].name, "polygon-bevel");
     }
 
@@ -553,7 +622,7 @@ mod tests {
         let b = mk_full("beta", "renderer thing", "", &[], "maya", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Admin];
-        let out = score_skills("renderer", &skills, &scopes);
+        let out = score_skills("renderer", &skills, &scopes, false);
         assert_eq!(out.len(), 2);
         assert_eq!(
             out[0].name, "beta",
@@ -568,7 +637,7 @@ mod tests {
         let b = mk_full("beta", "renderer thing", "", &[], "blender", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("maya", &skills, &scopes);
+        let out = score_skills("maya", &skills, &scopes, false);
         assert_eq!(out[0].name, "alpha", "dcc token boost must apply");
     }
 
@@ -579,8 +648,129 @@ mod tests {
         let b = mk_full("aaa", "renderer thing", "", &[], "maya", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("renderer", &skills, &scopes);
+        let out = score_skills("renderer", &skills, &scopes, false);
         assert_eq!(out[0].name, "aaa");
         assert_eq!(out[1].name, "zzz");
+    }
+
+    // ── layer-based rank penalty (issue #1398) ──────────────────────────
+
+    fn mk_layered(name: &str, desc: &str, layer: Option<&str>) -> SkillMetadata {
+        let mut m = mk_full(name, desc, "", &[], "maya", &[]);
+        m.layer = layer.map(|s| s.to_string());
+        m
+    }
+
+    #[test]
+    fn test_layer_multiplier_table() {
+        // Sanity table — the constants must produce the documented coefficients.
+        assert_eq!(layer_multiplier(None, false), 1.0);
+        assert_eq!(layer_multiplier(Some("domain"), false), 1.0);
+        assert_eq!(layer_multiplier(Some("thin-harness"), false), 1.0);
+        assert_eq!(layer_multiplier(Some("infrastructure"), false), 0.35);
+        assert_eq!(layer_multiplier(Some("INFRASTRUCTURE"), false), 0.35);
+        assert_eq!(layer_multiplier(Some("example"), false), 0.20);
+        // Explicit filter disables the penalty regardless of layer.
+        assert_eq!(layer_multiplier(Some("infrastructure"), true), 1.0);
+        assert_eq!(layer_multiplier(Some("example"), true), 1.0);
+        // Unknown layer values are treated as "no layer" → no penalty.
+        assert_eq!(layer_multiplier(Some("weird-future-layer"), false), 1.0);
+        // Whitespace-only is treated as None.
+        assert_eq!(layer_multiplier(Some("   "), false), 1.0);
+    }
+
+    #[test]
+    fn test_layer_infrastructure_ranked_below_domain() {
+        // Both skills have the same description — without the penalty BM25
+        // would tie. Layer pushes infrastructure below domain.
+        let infra = mk_layered(
+            "dcc-diagnostics",
+            "render bake helpers",
+            Some("infrastructure"),
+        );
+        let domain = mk_layered("maya-render", "render bake helpers", Some("domain"));
+        let skills = vec![&infra, &domain];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("render bake", &skills, &scopes, false);
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].name, "maya-render",
+            "domain layer must outrank infrastructure"
+        );
+        assert_eq!(out[1].name, "dcc-diagnostics");
+    }
+
+    #[test]
+    fn test_layer_example_ranked_below_infrastructure() {
+        // Both layered — example × 0.20 must lose to infrastructure × 0.35.
+        let example = mk_layered("demo-render", "render bake helpers", Some("example"));
+        let infra = mk_layered(
+            "dcc-diagnostics",
+            "render bake helpers",
+            Some("infrastructure"),
+        );
+        let skills = vec![&example, &infra];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("render bake", &skills, &scopes, false);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].name, "dcc-diagnostics");
+        assert_eq!(out[1].name, "demo-render");
+    }
+
+    #[test]
+    fn test_layer_unset_unaffected() {
+        // Skill with no layer must score identically to a `domain` skill
+        // (multiplier = 1.0 in both cases) — the existing tag/desc tie-break
+        // chain still drives the order.
+        let unset = mk_layered("alpha", "render bake helpers", None);
+        let domain = mk_layered("beta", "render bake helpers", Some("domain"));
+        let skills = vec![&unset, &domain];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("render bake", &skills, &scopes, false);
+        assert_eq!(out.len(), 2);
+        // Identical scores → alphabetical name tie-break.
+        assert_eq!(out[0].name, "alpha");
+        assert_eq!(out[1].name, "beta");
+    }
+
+    #[test]
+    fn test_layer_explicit_filter_disables_penalty() {
+        // When the caller filters by tags=["infrastructure"], the penalty is
+        // off so the raw BM25 order is honoured inside the filtered slice.
+        let infra_strong = mk_layered(
+            "dcc-diagnostics",
+            "render bake render bake",
+            Some("infrastructure"),
+        );
+        let infra_weak = mk_layered("other-infra", "render", Some("infrastructure"));
+        let skills = vec![&infra_weak, &infra_strong];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("render bake", &skills, &scopes, /*explicit=*/ true);
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].name, "dcc-diagnostics",
+            "explicit infrastructure filter must rank by raw BM25"
+        );
+    }
+
+    #[test]
+    fn test_layer_exact_name_fast_path_still_wins() {
+        // Exact-name fast path bypasses score comparison entirely, so a
+        // layer-penalised infrastructure skill still wins when the user
+        // queries its exact name.
+        let infra = mk_layered(
+            "dcc-diagnostics",
+            "diagnostics tool",
+            Some("infrastructure"),
+        );
+        let domain = mk_layered("maya-render", "diagnostics tool", Some("domain"));
+        let skills = vec![&infra, &domain];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("dcc-diagnostics", &skills, &scopes, false);
+        assert!(!out.is_empty());
+        assert_eq!(
+            out[0].name, "dcc-diagnostics",
+            "exact-name match must bypass the layer penalty"
+        );
     }
 }

--- a/crates/dcc-mcp-skills/src/catalog/scoring.rs
+++ b/crates/dcc-mcp-skills/src/catalog/scoring.rs
@@ -35,22 +35,29 @@
 //! AI agents naturally rank skills by raw BM25 score alone, which lets broad
 //! infrastructure skills (e.g. `app-ui`, `dcc-adapter`, `dcc-diagnostics`)
 //! that cover dozens of generic tokens outrank domain skills that map a
-//! specific user intent. To make those infrastructure skills behave as the
+//! specific user intent. To make those low-level skills behave as the
 //! "fallback" the layering rules say they are, the final score is multiplied
 //! by a coefficient derived from `metadata.dcc-mcp.layer`:
 //!
-//! | Layer            | Multiplier |
-//! |------------------|-----------:|
-//! | `domain`         |       1.00 |
-//! | `thin-harness`   |       1.00 |
-//! | unset (`None`)   |       1.00 |
-//! | `infrastructure` |       0.35 |
-//! | `example`        |       0.20 |
+//! | Layer            | Multiplier   |
+//! |------------------|-------------:|
+//! | `domain`         |         1.00 |
+//! | unset (`None`)   |         1.00 |
+//! | `infrastructure` |         0.35 |
+//! | `thin-harness`   |         0.20 |
+//! | `example`        | **excluded** |
 //!
-//! The penalty is bypassed when the caller explicitly filters by a known
-//! layer name through the `tags` argument (e.g. `tags=["infrastructure"]`).
-//! That case signals deliberate intent to browse low-level skills, so the
-//! ranker honours the raw BM25 order inside that filtered slice.
+//! `thin-harness` skills are raw-scripting wrappers (a single Python / bash /
+//! CLI command behind a SKILL.md) and rank below `infrastructure` because the
+//! agent should almost always prefer a higher-level domain action when one is
+//! available. `example` skills are dropped from search results entirely —
+//! they exist as authoring references, not for production agent flows.
+//!
+//! The penalty (and the `example` exclusion) is bypassed when the caller
+//! explicitly filters by a known layer name through the `tags` argument
+//! (e.g. `tags=["infrastructure"]` or `tags=["example"]`). That signals
+//! deliberate intent to browse that layer, so the ranker honours the raw
+//! BM25 order inside the filtered slice.
 
 use dcc_mcp_models::{SkillMetadata, SkillScope};
 
@@ -71,10 +78,10 @@ pub const W_TOOL_ALIAS: f64 = 2.0;
 pub const W_TOOL_DESCRIPTION: f64 = 1.0;
 pub const W_DCC: f64 = 4.0;
 
-/// Layer multiplier applied to the BM25 total when `apply_layer_penalty`
-/// is true. See module docs for the rationale and table.
+/// Layer multipliers applied to the BM25 total. See module docs for the
+/// rationale and table.
 pub const LAYER_MULT_INFRASTRUCTURE: f64 = 0.35;
-pub const LAYER_MULT_EXAMPLE: f64 = 0.20;
+pub const LAYER_MULT_THIN_HARNESS: f64 = 0.20;
 
 /// Known layer names recognised by [`layer_multiplier`] and the
 /// `apply_layer_penalty` detection in [`SkillCatalog::search_skills`].
@@ -86,19 +93,27 @@ pub const LAYER_EXAMPLE: &str = "example";
 
 /// Coefficient applied to the BM25 total based on `metadata.dcc-mcp.layer`.
 ///
+/// Returns:
+/// * `Some(mult)` — multiply the BM25 total by `mult` (1.0 means no change).
+/// * `None` — drop the skill from results entirely (`example` layer).
+///
 /// `explicit` is `true` when the caller explicitly filtered by a layer tag
-/// (`tags=["infrastructure"]` etc.) — in that case no penalty is applied
-/// because the caller asked for that layer on purpose.
-pub fn layer_multiplier(layer: Option<&str>, explicit: bool) -> f64 {
+/// (`tags=["infrastructure"]`, `tags=["example"]`, etc.) — in that case no
+/// penalty is applied and `example` skills are not dropped, because the
+/// caller asked for that layer on purpose.
+pub fn layer_multiplier(layer: Option<&str>, explicit: bool) -> Option<f64> {
     if explicit {
-        return 1.0;
+        return Some(1.0);
     }
     match layer.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(value) if value.eq_ignore_ascii_case(LAYER_EXAMPLE) => None,
         Some(value) if value.eq_ignore_ascii_case(LAYER_INFRASTRUCTURE) => {
-            LAYER_MULT_INFRASTRUCTURE
+            Some(LAYER_MULT_INFRASTRUCTURE)
         }
-        Some(value) if value.eq_ignore_ascii_case(LAYER_EXAMPLE) => LAYER_MULT_EXAMPLE,
-        _ => 1.0,
+        Some(value) if value.eq_ignore_ascii_case(LAYER_THIN_HARNESS) => {
+            Some(LAYER_MULT_THIN_HARNESS)
+        }
+        _ => Some(1.0),
     }
 }
 
@@ -324,14 +339,20 @@ pub fn score_skills(
             total += idf_v * contrib;
         }
 
-        // Layer-based rank penalty (issue #1398). Applied after BM25 sum so
-        // the multiplier compounds across all query tokens, not per-token.
-        let mult = layer_multiplier(meta.layer.as_deref(), layer_filter_explicit);
-        total *= mult;
-
         let name_lower = meta.name.to_lowercase();
         let exact_name = name_lower == q_trim_lower && !q_trim_lower.is_empty();
         let name_substring_hit = !q_raw_lower.is_empty() && name_lower.contains(&q_raw_lower);
+
+        // Layer-based rank penalty (issue #1398). Applied after BM25 sum so
+        // the multiplier compounds across all query tokens, not per-token.
+        // `None` means the layer (currently only `example`) is excluded from
+        // results — keep the entry only if the user typed its exact name, in
+        // which case the existing fast-path still sorts it to the top.
+        match layer_multiplier(meta.layer.as_deref(), layer_filter_explicit) {
+            Some(mult) => total *= mult,
+            None if exact_name => {}
+            None => continue,
+        }
 
         if total == 0.0 && !exact_name {
             continue;
@@ -664,19 +685,26 @@ mod tests {
     #[test]
     fn test_layer_multiplier_table() {
         // Sanity table — the constants must produce the documented coefficients.
-        assert_eq!(layer_multiplier(None, false), 1.0);
-        assert_eq!(layer_multiplier(Some("domain"), false), 1.0);
-        assert_eq!(layer_multiplier(Some("thin-harness"), false), 1.0);
-        assert_eq!(layer_multiplier(Some("infrastructure"), false), 0.35);
-        assert_eq!(layer_multiplier(Some("INFRASTRUCTURE"), false), 0.35);
-        assert_eq!(layer_multiplier(Some("example"), false), 0.20);
-        // Explicit filter disables the penalty regardless of layer.
-        assert_eq!(layer_multiplier(Some("infrastructure"), true), 1.0);
-        assert_eq!(layer_multiplier(Some("example"), true), 1.0);
+        assert_eq!(layer_multiplier(None, false), Some(1.0));
+        assert_eq!(layer_multiplier(Some("domain"), false), Some(1.0));
+        assert_eq!(layer_multiplier(Some("thin-harness"), false), Some(0.20));
+        assert_eq!(layer_multiplier(Some("THIN-HARNESS"), false), Some(0.20));
+        assert_eq!(layer_multiplier(Some("infrastructure"), false), Some(0.35));
+        assert_eq!(layer_multiplier(Some("INFRASTRUCTURE"), false), Some(0.35));
+        // `example` is excluded from results (None), not penalised.
+        assert_eq!(layer_multiplier(Some("example"), false), None);
+        assert_eq!(layer_multiplier(Some("EXAMPLE"), false), None);
+        // Explicit filter disables the penalty AND the exclusion.
+        assert_eq!(layer_multiplier(Some("infrastructure"), true), Some(1.0));
+        assert_eq!(layer_multiplier(Some("thin-harness"), true), Some(1.0));
+        assert_eq!(layer_multiplier(Some("example"), true), Some(1.0));
         // Unknown layer values are treated as "no layer" → no penalty.
-        assert_eq!(layer_multiplier(Some("weird-future-layer"), false), 1.0);
+        assert_eq!(
+            layer_multiplier(Some("weird-future-layer"), false),
+            Some(1.0)
+        );
         // Whitespace-only is treated as None.
-        assert_eq!(layer_multiplier(Some("   "), false), 1.0);
+        assert_eq!(layer_multiplier(Some("   "), false), Some(1.0));
     }
 
     #[test]
@@ -701,20 +729,56 @@ mod tests {
     }
 
     #[test]
-    fn test_layer_example_ranked_below_infrastructure() {
-        // Both layered — example × 0.20 must lose to infrastructure × 0.35.
-        let example = mk_layered("demo-render", "render bake helpers", Some("example"));
-        let infra = mk_layered(
-            "dcc-diagnostics",
-            "render bake helpers",
-            Some("infrastructure"),
-        );
+    fn test_layer_example_excluded_from_results() {
+        // `example` skills are dropped from results entirely (#1398). The
+        // remaining infrastructure skill is the only hit, even though the
+        // example skill's raw BM25 against this query would be higher.
+        let example = mk_layered("demo-render", "render bake render bake", Some("example"));
+        let infra = mk_layered("dcc-diagnostics", "render bake", Some("infrastructure"));
         let skills = vec![&example, &infra];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
         let out = score_skills("render bake", &skills, &scopes, false);
-        assert_eq!(out.len(), 2);
+        assert_eq!(out.len(), 1, "example layer must be excluded from results");
         assert_eq!(out[0].name, "dcc-diagnostics");
-        assert_eq!(out[1].name, "demo-render");
+    }
+
+    #[test]
+    fn test_layer_example_visible_under_explicit_filter() {
+        // Explicit `tags=["example"]` filter at the catalog level passes
+        // `layer_filter_explicit=true`, which both disables the penalty and
+        // suppresses the example-exclusion so the user can still browse them.
+        let example_a = mk_layered("demo-a", "render bake render bake", Some("example"));
+        let example_b = mk_layered("demo-b", "render bake", Some("example"));
+        let skills = vec![&example_b, &example_a];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("render bake", &skills, &scopes, /*explicit=*/ true);
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].name, "demo-a",
+            "explicit example filter must restore raw BM25 order"
+        );
+    }
+
+    #[test]
+    fn test_layer_thin_harness_ranked_below_infrastructure() {
+        // `thin-harness` (raw script / CLI wrappers) must rank below
+        // `infrastructure` — both are fallback tiers, but thin-harness is the
+        // lowest visible one because it offers the least domain context.
+        let thin = mk_layered(
+            "run-python",
+            "render bake render bake",
+            Some("thin-harness"),
+        );
+        let infra = mk_layered("dcc-diagnostics", "render bake", Some("infrastructure"));
+        let skills = vec![&thin, &infra];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("render bake", &skills, &scopes, false);
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].name, "dcc-diagnostics",
+            "infrastructure must outrank thin-harness even when BM25 is higher"
+        );
+        assert_eq!(out[1].name, "run-python");
     }
 
     #[test]
@@ -771,6 +835,23 @@ mod tests {
         assert_eq!(
             out[0].name, "dcc-diagnostics",
             "exact-name match must bypass the layer penalty"
+        );
+    }
+
+    #[test]
+    fn test_layer_example_exact_name_still_returns_match() {
+        // Even an excluded `example` layer surfaces when the user types its
+        // exact name — typing the literal name is the strongest "I want this
+        // specific skill" signal a caller can give.
+        let example = mk_layered("demo-render", "demo turntable", Some("example"));
+        let domain = mk_layered("maya-render", "demo turntable", Some("domain"));
+        let skills = vec![&example, &domain];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("demo-render", &skills, &scopes, false);
+        assert!(!out.is_empty());
+        assert_eq!(
+            out[0].name, "demo-render",
+            "exact-name query must bypass the example-layer exclusion"
         );
     }
 }

--- a/tests/test_search_skills_layer_penalty.py
+++ b/tests/test_search_skills_layer_penalty.py
@@ -76,6 +76,9 @@ def _build_catalog(tmp_path: Path) -> SkillCatalog:
         "demo-render",
         description="render bake helpers tutorial",
         layer="example",
+        # Tag the demo so the explicit-filter test below can prefilter by
+        # `tags=["example"]` and verify the exclusion bypass.
+        tags=("example",),
     )
     catalog = SkillCatalog(ToolRegistry())
     # `discover()` also picks up bundled / env-configured skill paths, so
@@ -105,12 +108,21 @@ def test_domain_ranks_above_infrastructure_for_neutral_query(tmp_path: Path) -> 
         )
 
 
-def test_example_ranks_below_infrastructure(tmp_path: Path) -> None:
+def test_example_excluded_from_unfiltered_results(tmp_path: Path) -> None:
+    # `example` skills are dropped from search results entirely (#1398) —
+    # they exist as authoring references, not for production agent flows.
     catalog = _build_catalog(tmp_path)
     names = [s.name for s in catalog.search_skills(query="render bake")]
-    assert "demo-render" in names
-    last_infra = max(names.index(n) for n in ("dcc-diagnostics", "dcc-adapter") if n in names)
-    assert names.index("demo-render") > last_infra, f"example layer must rank below all infrastructure; order {names}"
+    assert "demo-render" not in names, f"example layer must be excluded from unfiltered results; order {names}"
+
+
+def test_example_visible_under_explicit_filter(tmp_path: Path) -> None:
+    # `tags=["example"]` is the operator opting in to browse example skills;
+    # the exclusion is lifted inside the filtered slice.
+    catalog = _build_catalog(tmp_path)
+    summaries = catalog.search_skills(query="render bake", tags=["example"])
+    names = [s.name for s in summaries]
+    assert "demo-render" in names, f"explicit example filter must restore demo skills; got {names}"
 
 
 def test_explicit_infrastructure_filter_disables_penalty(tmp_path: Path) -> None:

--- a/tests/test_search_skills_layer_penalty.py
+++ b/tests/test_search_skills_layer_penalty.py
@@ -1,0 +1,142 @@
+"""End-to-end regression for the search_skills layer-based rank penalty (#1398).
+
+`infrastructure` and `example` layered skills must rank below `domain` /
+unset layered skills for a neutral query, unless the caller explicitly
+filters by a layer tag (`tags=["infrastructure"]`), in which case the raw
+BM25 order is honoured inside the filtered slice.
+
+Exercises the full Rust catalog → Python binding path; layer detection
+lives in `crates/dcc-mcp-skills/src/catalog/catalog.rs` and the penalty in
+`crates/dcc-mcp-skills/src/catalog/scoring.rs`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+from dcc_mcp_core import SkillCatalog
+from dcc_mcp_core import ToolRegistry
+
+
+def _write_skill(
+    skills_root: Path,
+    name: str,
+    *,
+    description: str,
+    layer: str | None,
+    dcc: str = "maya",
+    tags: Sequence[str] = (),
+) -> None:
+    skill_dir = skills_root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "scripts").mkdir()
+    lines = [
+        "---",
+        f"name: {name}",
+        f"description: {description}",
+        "metadata:",
+        "  dcc-mcp:",
+        f"    dcc: {dcc}",
+    ]
+    if tags:
+        rendered = ", ".join(tags)
+        lines.append(f"    tags: [{rendered}]")
+    if layer:
+        lines.append(f"    layer: {layer}")
+    lines += ["---", f"# {name}", ""]
+    (skill_dir / "SKILL.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _build_catalog(tmp_path: Path) -> SkillCatalog:
+    # Mirrors the screenshot scenario: a domain skill, two infrastructure
+    # skills, and one example. All share the query tokens "render bake" so
+    # raw BM25 would tie them — only the layer multiplier should break the
+    # tie.
+    _write_skill(
+        tmp_path,
+        "maya-render",
+        description="render bake helpers for maya",
+        layer="domain",
+    )
+    _write_skill(
+        tmp_path,
+        "dcc-diagnostics",
+        description="render bake helpers diagnostics",
+        layer="infrastructure",
+    )
+    _write_skill(
+        tmp_path,
+        "dcc-adapter",
+        description="render bake helpers adapter",
+        layer="infrastructure",
+    )
+    _write_skill(
+        tmp_path,
+        "demo-render",
+        description="render bake helpers tutorial",
+        layer="example",
+    )
+    catalog = SkillCatalog(ToolRegistry())
+    # `discover()` also picks up bundled / env-configured skill paths, so
+    # the total count can exceed the four fixtures written above. The
+    # important assertion is that our four are all present.
+    catalog.discover(extra_paths=[str(tmp_path)], dcc_name="maya")
+    discovered_names = {s.name for s in catalog.search_skills()}
+    for expected in ("maya-render", "dcc-diagnostics", "dcc-adapter", "demo-render"):
+        assert expected in discovered_names, (
+            f"fixture skill {expected!r} not discovered; got {sorted(discovered_names)}"
+        )
+    return catalog
+
+
+def test_domain_ranks_above_infrastructure_for_neutral_query(tmp_path: Path) -> None:
+    catalog = _build_catalog(tmp_path)
+    summaries = catalog.search_skills(query="render bake")
+    names = [s.name for s in summaries]
+    assert names, "expected at least one match"
+    assert names[0] == "maya-render", (
+        f"domain skill must outrank infrastructure/example for a neutral query; got order {names}"
+    )
+    domain_idx = names.index("maya-render")
+    for infra_name in ("dcc-diagnostics", "dcc-adapter"):
+        assert names.index(infra_name) > domain_idx, (
+            f"infrastructure skill {infra_name!r} ranked above domain; order was {names}"
+        )
+
+
+def test_example_ranks_below_infrastructure(tmp_path: Path) -> None:
+    catalog = _build_catalog(tmp_path)
+    names = [s.name for s in catalog.search_skills(query="render bake")]
+    assert "demo-render" in names
+    last_infra = max(names.index(n) for n in ("dcc-diagnostics", "dcc-adapter") if n in names)
+    assert names.index("demo-render") > last_infra, f"example layer must rank below all infrastructure; order {names}"
+
+
+def test_explicit_infrastructure_filter_disables_penalty(tmp_path: Path) -> None:
+    # When the agent explicitly asks for infrastructure skills, the
+    # filtered slice is returned in raw BM25 order (no penalty).
+    # The penalty bypass is keyed on the *tag* parameter matching a known
+    # layer name (case-insensitive), so both skills must also carry the
+    # "infrastructure" tag for the prefilter to keep them.
+    _write_skill(
+        tmp_path,
+        "infra-strong",
+        description="render bake render bake helpers diagnostics",
+        layer="infrastructure",
+        tags=("infrastructure",),
+    )
+    _write_skill(
+        tmp_path,
+        "infra-weak",
+        description="render helpers",
+        layer="infrastructure",
+        tags=("infrastructure",),
+    )
+
+    catalog = SkillCatalog(ToolRegistry())
+    catalog.discover(extra_paths=[str(tmp_path)], dcc_name="maya")
+    summaries = catalog.search_skills(query="render bake", tags=["infrastructure"])
+    names = [s.name for s in summaries]
+    assert names, "expected matches inside the explicit-infrastructure filter"
+    assert names[0] == "infra-strong", f"explicit infrastructure filter must rank by raw BM25; got {names}"


### PR DESCRIPTION
Closes #1398.

## What

Multiply the final BM25 score in `search_skills` by a layer-based coefficient so broad infrastructure / raw-script skills stop outranking the domain skills that actually map a user intent, and drop example-layer skills from results entirely.

| Layer                  | Rank                          |
|------------------------|-------------------------------|
| `domain` / unset       | × 1.00                        |
| `infrastructure`       | × 0.35                        |
| `thin-harness`         | × 0.20                        |
| `example`              | **excluded from results**     |

`thin-harness` skills are raw-scripting wrappers (a single `python` / `bash` / CLI command behind a SKILL.md) and rank below `infrastructure` because the agent should almost always prefer a higher-level domain action when one is available. `example` skills are dropped from results entirely — they exist as authoring references, not for production agent flows.

The penalty AND the `example` exclusion are bypassed when the caller filters by a known layer name through `tags=` (case-insensitive), e.g. `search_skills(tags=["infrastructure"])` or `search_skills(tags=["example"])` — that signals deliberate intent to browse the layer, so raw BM25 wins inside the filtered slice. The exact-name fast-path is unaffected (`search_skills("dcc-diagnostics")` still ranks the exact-name match first regardless of layer; `search_skills("demo-render")` still finds the exact example skill).

## Why

Live admin UI screenshots show `app-ui`, `dcc-adapter`, `dcc-diagnostics`, and `core` (the example skill) consistently surfacing at the top of `search_skills` results even for neutral domain queries like *"render bake"*. AI agents then `load_skill` them and burn budget on low-level fallbacks before reaching the domain skill that maps the user intent. See issue #1398 for the full diagnosis.

## Changes

| File | Note |
|------|------|
| `crates/dcc-mcp-skills/src/catalog/scoring.rs` | `layer_multiplier()` returns `Option<f64>` — `Some(mult)` to scale BM25, `None` to drop the skill from results; `score_skills` gains `layer_filter_explicit` arg; 9 unit tests covering domain / infrastructure / thin-harness / example / exact-name bypass / explicit-filter bypass |
| `crates/dcc-mcp-skills/src/catalog/catalog.rs` | `SkillCatalog::search_skills` detects when `tags` contains a known layer name and toggles the bypass |
| `tests/test_search_skills_layer_penalty.py` | End-to-end via Python `SkillCatalog` with real `SKILL.md` fixtures — covers domain-over-infrastructure, example exclusion, and explicit-tag bypass |
| `AGENTS.md` | Skill-layer taxonomy table now shows the new rank rules (incl. `example` exclusion) + bypass rule |

## Validation

- `cargo test -p dcc-mcp-skills --lib catalog::scoring` — **26 / 26 pass** (17 pre-existing + 9 layer-specific covering each layer + bypass paths).
- `pytest tests/test_search_skills_layer_penalty.py` — **4 / 4 pass** (full Rust → Python `SkillCatalog.search_skills` path with real fixtures).
- `cargo fmt --check` + `cargo clippy -p dcc-mcp-skills --all-targets -- -D warnings` clean.
- `cargo hakari` pre-commit hook clean.

Pre-existing flakes in `test_catalog_crud` (2 tests: `test_get_skill_info_includes_skill_markdown` / `test_rediscover_removes_missing_skill_and_registered_tools`) are NOT introduced by this change — verified by running them on the previous commit before this PR's changes were applied. They're unrelated `rediscover` count mismatches and out of scope here.

## Out of scope (separate PRs)

Issue #1398 is part of a 5-PR series triggered by the admin-UI screenshot audit:

| Track | Theme | Status |
|-------|-------|--------|
| **A — this PR** | Layer-based rank penalty | ← here |
| B | Persist `SkillCatalog.loaded` across restarts | Future |
| C | `DccServerBase` auto-registers skill-paths reload hook | #1401 |
| D | Admin UI Skills panel marketplace redesign | Future |
| E | `SkillMetadata` branding / links / example-prompts fields | Future (depends on D) |

A follow-up question on path-source priority (built-in vs env-var/custom-path) is tracked separately — it's an orthogonal ranking signal and intentionally out of scope here.

## Behaviour deltas to expect downstream

- `infrastructure`-layer skills (`app-ui`, `dcc-adapter`, `dcc-diagnostics`, …) drop from the top of `search_skills` results for neutral domain queries; they still beat truly unrelated skills.
- `thin-harness`-layer skills (raw `python` / `bash` / CLI wrappers) rank below `infrastructure` — they remain visible as a last-resort fallback, but a higher-level domain skill will always win when one matches.
- `example`-layer skills (`core`, demo skills) are **excluded from results** entirely for unfiltered queries; they only surface when the caller types their exact name or explicitly opts in via `tags=["example"]`.
- Domain skills with `metadata.dcc-mcp.layer: domain` and skills with no `layer` field score unchanged (× 1.00).
- Existing agent calls that pre-filter `tags=["infrastructure"]` / `tags=["thin-harness"]` / `tags=["example"]` see the raw BM25 order inside the filtered slice — no behaviour change for power-users who explicitly browse those tiers.