### PR TITLE
feat(server): pick up admin-UI-added skill paths without restart (#1400)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,7 @@ Gateway resources/prompts:
 | Stamp gateway sentinel for election | `McpHttpConfig(..., adapter_version=..., adapter_dcc=...)` or `.with_adapter_version().with_adapter_dcc()` (issue maya#137) |
 | Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
 | Discover user-level skills | `scan_and_load_user()` / `scan_and_load_user_lenient()` |
+| Pick up admin-UI-added skill paths in a running adapter | `DccServerBase.reload_skill_paths()` re-runs discovery with the gateway admin SQLite `skill_paths_custom` table merged in (#1400). The merge happens automatically inside `collect_skill_search_paths(include_admin_custom=True)` on every startup; `reload_skill_paths()` is the runtime trigger for re-scanning after a path is added through the dashboard. Read the raw rows via `dcc_mcp_core.read_custom_skill_paths()` / `resolve_admin_db_path()` |
 | Bridge stdio MCP server to HTTP/SSE | `dcc-mcp-server translate --stdio "cmd" --app-type foo --port N` |
 | Add audit/quota/redact to all gateway calls | `GatewayConfig::middleware_chain` + `AuditMiddleware` / `QuotaMiddleware` / `RedactionMiddleware` |
 | Mount OpenAPI REST API as MCP tools | `GatewayBuilder::mount_openapi(OpenApiMount::from_url(...).auth(...))` |

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -366,6 +366,8 @@ _LAZY: dict[str, str] = {
     "start_embedded_dcc_server": "dcc_mcp_core.factory",
     "DccGatewayElection": "dcc_mcp_core.gateway_election",
     "DccSkillHotReloader": "dcc_mcp_core.hotreload",
+    "read_custom_skill_paths": "dcc_mcp_core.admin_sqlite_lane",
+    "resolve_admin_db_path": "dcc_mcp_core.admin_sqlite_lane",
     # Pure-Python constants
     "CAPABILITY_KEYS": "dcc_mcp_core.adapters",
     "WEBVIEW_DEFAULT_CAPABILITIES": "dcc_mcp_core.adapters",

--- a/python/dcc_mcp_core/admin_sqlite_lane.py
+++ b/python/dcc_mcp_core/admin_sqlite_lane.py
@@ -1,0 +1,133 @@
+"""Read-only helpers for the gateway admin SQLite lane (issue #1400).
+
+Mirrors the Rust path-resolution and `skill_paths_custom` query so that
+Python-side adapters (Maya, 3ds Max, Blender, Houdini, …) can pick up
+admin-UI-added skill discovery roots **without** spawning a gateway
+process or going through any HTTP API.
+
+Why a thin Python module instead of a PyO3 binding?
+
+* The SQLite file is plain WAL-mode `sqlite3` — Python's stdlib speaks
+  it natively. Adding a PyO3 wrapper just to read one column is more
+  build/cargo lock churn than it's worth for a read path.
+* Keeping the resolver here in Python lets adapter code call it from
+  pre-startup hooks (e.g. bootstrap scripts) that don't yet hold a
+  `DccServerBase` reference.
+
+Resolution order (matches `crates/dcc-mcp-db/src/application/gateway_admin.rs`):
+
+  1. ``explicit`` argument
+  2. ``DCC_MCP_GATEWAY_ADMIN_DB`` env var
+  3. ``<registry_dir or DCC_MCP_REGISTRY_DIR or temp>/gateway_admin.sqlite``
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+import sqlite3
+import tempfile
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+# Mirror of the Rust constants in `crates/dcc-mcp-db/src/domain/env.rs`.
+# Keep both lists in sync if either side changes.
+ENV_GATEWAY_ADMIN_DB = "DCC_MCP_GATEWAY_ADMIN_DB"
+ENV_REGISTRY_DIR = "DCC_MCP_REGISTRY_DIR"
+GATEWAY_ADMIN_SQLITE_FILENAME = "gateway_admin.sqlite"
+
+
+def resolve_admin_db_path(
+    explicit: str | os.PathLike[str] | None = None,
+    registry_dir: str | os.PathLike[str] | None = None,
+) -> Path:
+    """Resolve the admin SQLite path using the same rules as the Rust gateway.
+
+    Always returns a :class:`~pathlib.Path` — the file may or may not exist
+    on disk. Callers should test ``.exists()`` before opening when the gateway
+    might not have run on this machine yet.
+    """
+    if explicit is not None:
+        return Path(explicit)
+    env_db = os.environ.get(ENV_GATEWAY_ADMIN_DB)
+    if env_db:
+        return Path(env_db)
+    base: Path
+    if registry_dir is not None:
+        base = Path(registry_dir)
+    else:
+        env_reg = os.environ.get(ENV_REGISTRY_DIR)
+        base = Path(env_reg) if env_reg else Path(tempfile.gettempdir()) / "dcc-mcp-registry"
+    return base / GATEWAY_ADMIN_SQLITE_FILENAME
+
+
+def read_custom_skill_paths(
+    db_path: str | os.PathLike[str] | None = None,
+    *,
+    registry_dir: str | os.PathLike[str] | None = None,
+    require_exists: bool = True,
+) -> list[str]:
+    """Return all admin-UI-added skill discovery roots, in insertion order.
+
+    Args:
+        db_path: Explicit SQLite path. ``None`` resolves via
+            :func:`resolve_admin_db_path`.
+        registry_dir: Forwarded to :func:`resolve_admin_db_path` when
+            ``db_path`` is ``None``.
+        require_exists: When ``True`` (default), each returned path is
+            filtered through :py:meth:`Path.is_dir` so callers don't try
+            to scan a directory that was removed off-disk after being
+            persisted. Set to ``False`` to get the raw rows for
+            diagnostics.
+
+    Returns:
+        List of absolute path strings. Empty when the SQLite file does
+        not exist, lacks the table, or yields no rows — callers can
+        treat the return value as a best-effort additive set.
+
+    """
+    resolved = resolve_admin_db_path(db_path, registry_dir)
+    if not resolved.exists():
+        return []
+    # Open read-only (URI form) so we never race the gateway writer.
+    uri = f"file:{resolved.as_posix()}?mode=ro"
+    rows: list[str] = []
+    try:
+        with sqlite3.connect(uri, uri=True, timeout=0.5) as conn:
+            cur = conn.execute("SELECT path FROM skill_paths_custom ORDER BY id ASC")
+            rows = [str(row[0]) for row in cur.fetchall()]
+    except sqlite3.Error as exc:
+        # Common during a fresh install: the gateway has never run, so
+        # the file exists (empty) but the table doesn't. Treat as empty.
+        logger.debug("[admin_sqlite_lane] read failed: %s", exc)
+        return []
+    if not require_exists:
+        return rows
+    return [p for p in rows if Path(p).is_dir()]
+
+
+def filter_new_paths(known: Sequence[str], rows: Sequence[str]) -> list[str]:
+    """Return ``rows`` minus anything already in ``known`` (preserving order).
+
+    Convenience helper for callers that merge admin SQLite paths into a
+    larger discovery path list and want to dedupe cheaply.
+    """
+    seen = set(known)
+    out: list[str] = []
+    for p in rows:
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+__all__ = [
+    "ENV_GATEWAY_ADMIN_DB",
+    "ENV_REGISTRY_DIR",
+    "GATEWAY_ADMIN_SQLITE_FILENAME",
+    "filter_new_paths",
+    "read_custom_skill_paths",
+    "resolve_admin_db_path",
+]

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -304,6 +304,7 @@ class DccServerBase:
         extra_paths: list[str] | None = None,
         include_bundled: bool = True,
         filter_existing: bool = False,
+        include_admin_custom: bool = True,
     ) -> list[str]:
         """Build the ordered skill search path list for this DCC.
 
@@ -315,6 +316,8 @@ class DccServerBase:
         5. Local developer skills in ``~/.dcc-mcp/{dcc_name}/skills``
         6. Bundled skills shipped with dcc-mcp-core (when ``include_bundled=True``)
         7. Platform default skills dir
+        8. Admin-UI-added skill discovery roots from the gateway SQLite lane
+           (when ``include_admin_custom=True``; issue #1400)
 
         Args:
             extra_paths: Additional directories to prepend.
@@ -323,6 +326,12 @@ class DccServerBase:
                 disk and deduplicate the result.  Pass this when feeding paths
                 to ``McpHttpServer.discover()`` to avoid warnings on missing dirs.
                 Default ``False`` preserves backward-compatible behaviour.
+            include_admin_custom: When ``True`` (default), append any custom
+                skill paths persisted by the gateway admin UI (#1400) so an
+                operator who adds a path via the dashboard sees it picked up
+                on the next call to :meth:`reload_skill_paths` (or on the
+                next adapter startup). Reads are best-effort — a missing or
+                locked SQLite file is treated as zero rows.
 
         Returns:
             Ordered list of directory paths (strings).
@@ -353,6 +362,20 @@ class DccServerBase:
         default_dir = get_skills_dir()
         if default_dir and default_dir not in paths:
             paths.append(default_dir)
+
+        if include_admin_custom:
+            try:
+                from dcc_mcp_core.admin_sqlite_lane import filter_new_paths
+                from dcc_mcp_core.admin_sqlite_lane import read_custom_skill_paths
+
+                custom = read_custom_skill_paths()
+                paths.extend(filter_new_paths(paths, custom))
+            except Exception as exc:
+                logger.debug(
+                    "[%s] could not read admin SQLite skill paths: %s",
+                    self._dcc_name,
+                    exc,
+                )
 
         if filter_existing:
             seen: set[str] = set()
@@ -426,6 +449,62 @@ class DccServerBase:
                 )
             except Exception as exc:
                 logger.warning("[%s] minimal_mode application failed: %s", self._dcc_name, exc)
+
+    def reload_skill_paths(
+        self,
+        extra_skill_paths: list[str] | None = None,
+        include_bundled: bool = True,
+    ) -> int:
+        """Re-discover skills after admin-UI skill paths changed (#1400).
+
+        Re-collects the search path list (which by default merges any
+        rows in the gateway admin SQLite ``skill_paths_custom`` table —
+        see :meth:`collect_skill_search_paths`) and calls
+        ``McpHttpServer.discover`` so the adapter's catalog picks up
+        skills that an operator added through the admin dashboard
+        without restarting the DCC.
+
+        This is the per-adapter counterpart to the standalone
+        ``dcc-mcp-server`` binary's ``catalog_discover_hook``: each
+        adapter can poll, hot-key, or react to a gateway notification
+        and call this method, and the running DCC will then expose any
+        new skills on the next ``tools/list`` round-trip.
+
+        Args:
+            extra_skill_paths: Additional directories to scan on top of
+                the standard path list. Useful for adapters that want
+                to inject ephemeral roots (CI / tests).
+            include_bundled: Include dcc-mcp-core bundled skills.
+
+        Returns:
+            The discovery count as reported by ``McpHttpServer.discover``
+            (informational — equals the number of skill directories the
+            backend was able to scan, not the delta vs. the previous
+            scan). Returns ``0`` on any failure (logged at warning level).
+
+        """
+        skill_paths = self.collect_skill_search_paths(
+            extra_paths=extra_skill_paths,
+            include_bundled=include_bundled,
+            filter_existing=True,
+        )
+        logger.debug(
+            "[%s] reload_skill_paths: re-scanning %d path(s)",
+            self._dcc_name,
+            len(skill_paths),
+        )
+        try:
+            count = self._server.discover(extra_paths=skill_paths)
+        except Exception as exc:
+            logger.warning("[%s] reload_skill_paths failed: %s", self._dcc_name, exc)
+            return 0
+        logger.info(
+            "[%s] reload_skill_paths: %d skill(s) total from %d path(s)",
+            self._dcc_name,
+            count,
+            len(skill_paths),
+        )
+        return count
 
     # ── gateway & is_gateway ──────────────────────────────────────────────────
 

--- a/tests/test_admin_skill_paths_reload.py
+++ b/tests/test_admin_skill_paths_reload.py
@@ -1,0 +1,181 @@
+"""End-to-end regression for adapter-side admin skill-paths reload (#1400).
+
+Reproduces the workflow:
+
+    operator opens admin UI → POST /admin/api/skill-paths → row appears in
+    gateway_admin.sqlite → adapter (Maya / Blender / …) must rediscover
+    its catalog so the new path's skills become visible.
+
+Pre-#1400 only the standalone ``dcc-mcp-server`` binary picked these up via
+its ``catalog_discover_hook``; per-DCC adapter processes did not. This
+suite covers the new ``DccServerBase.reload_skill_paths()`` path and the
+``collect_skill_search_paths(include_admin_custom=True)`` default.
+
+The test writes to the SQLite file directly using stdlib sqlite3 (matching
+the gateway writer's schema and behaviour) so we don't need to spin up a
+real gateway process.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+import time
+from typing import Sequence
+
+import pytest
+
+from dcc_mcp_core import admin_sqlite_lane
+from dcc_mcp_core.admin_sqlite_lane import GATEWAY_ADMIN_SQLITE_FILENAME
+from dcc_mcp_core.admin_sqlite_lane import filter_new_paths
+from dcc_mcp_core.admin_sqlite_lane import read_custom_skill_paths
+from dcc_mcp_core.admin_sqlite_lane import resolve_admin_db_path
+
+_SKILL_PATHS_DDL = """
+CREATE TABLE IF NOT EXISTS skill_paths_custom (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  path TEXT NOT NULL UNIQUE,
+  created_ms INTEGER NOT NULL
+)
+"""
+
+
+def _write_admin_skill_path(db_path: Path, value: str) -> None:
+    """Mimic ``POST /admin/api/skill-paths`` against the gateway SQLite lane.
+
+    Uses the same DDL as ``crates/dcc-mcp-db/src/infra/gateway_admin_schema.rs``.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path, timeout=2.0) as conn:
+        conn.execute(_SKILL_PATHS_DDL)
+        conn.execute(
+            "INSERT OR IGNORE INTO skill_paths_custom (path, created_ms) VALUES (?, ?)",
+            (str(value), int(time.time() * 1000)),
+        )
+        conn.commit()
+
+
+def _write_skill(skill_root: Path, name: str) -> None:
+    skill_dir = skill_root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "scripts").mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                f"name: {name}",
+                f"description: e2e fixture {name}",
+                "metadata:",
+                "  dcc-mcp:",
+                "    dcc: maya",
+                "---",
+                f"# {name}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def registry_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolate the admin SQLite file under tmp_path via the env var."""
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_resolve_admin_db_path_honours_env(registry_dir: Path) -> None:
+    resolved = resolve_admin_db_path()
+    assert resolved == registry_dir / GATEWAY_ADMIN_SQLITE_FILENAME
+
+
+def test_resolve_admin_db_path_explicit_wins(registry_dir: Path, tmp_path_factory: pytest.TempPathFactory) -> None:
+    explicit = tmp_path_factory.mktemp("explicit") / "custom.sqlite"
+    assert resolve_admin_db_path(explicit) == explicit
+
+
+def test_read_custom_skill_paths_missing_db_is_empty(registry_dir: Path) -> None:
+    # No SQLite file yet → empty list, no crash.
+    assert read_custom_skill_paths() == []
+
+
+def test_read_custom_skill_paths_round_trip(registry_dir: Path) -> None:
+    skill_root = registry_dir / "studio-skills"
+    _write_skill(skill_root, "ext-render")
+    db_path = registry_dir / GATEWAY_ADMIN_SQLITE_FILENAME
+    _write_admin_skill_path(db_path, str(skill_root))
+
+    rows = read_custom_skill_paths()
+    assert rows == [str(skill_root)]
+
+
+def test_read_custom_skill_paths_filters_missing_dirs(registry_dir: Path) -> None:
+    db_path = registry_dir / GATEWAY_ADMIN_SQLITE_FILENAME
+    _write_admin_skill_path(db_path, str(registry_dir / "does-not-exist"))
+
+    assert read_custom_skill_paths() == []
+    # Diagnostic mode returns the row even when the dir is gone.
+    assert read_custom_skill_paths(require_exists=False) == [str(registry_dir / "does-not-exist")]
+
+
+def test_filter_new_paths_dedupes(registry_dir: Path) -> None:
+    known: Sequence[str] = ["a", "b"]
+    rows: Sequence[str] = ["b", "c", "a", "d", "c"]
+    assert filter_new_paths(known, rows) == ["c", "d"]
+
+
+def test_server_base_reload_picks_up_admin_path(registry_dir: Path, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """The key #1400 regression: a path added to admin SQLite after the
+    adapter has started must become visible after ``reload_skill_paths``.
+    """
+    skill_root = tmp_path_factory.mktemp("studio-skills")
+    _write_skill(skill_root, "ext-rigging")
+
+    # Simulate a running adapter: build a DccServerBase but don't start
+    # the HTTP listener (we only need its catalog wiring for this test).
+    from dcc_mcp_core import DccServerBase
+    from dcc_mcp_core._server.options import DccServerOptions
+
+    builtin = tmp_path_factory.mktemp("builtin-skills")
+    opts = DccServerOptions.from_env(
+        dcc_name="maya",
+        builtin_skills_dir=builtin,
+        server_name="test-maya",
+        port=0,
+        gateway_port=None,
+        enable_gateway_failover=False,
+    )
+    server = DccServerBase(opts)
+
+    def _skill_names(rows: object) -> set[str]:
+        # `list_skills()` returns either `SkillSummary` objects or dicts
+        # depending on the build path — handle both for portability.
+        out: set[str] = set()
+        for row in rows:  # type: ignore[union-attr]
+            name = row["name"] if isinstance(row, dict) else getattr(row, "name", None)
+            if name:
+                out.add(name)
+        return out
+
+    # Before the operator adds the path, the catalog has no fixture.
+    server.register_builtin_actions(include_bundled=False)
+    initial = _skill_names(server.list_skills())
+    assert "ext-rigging" not in initial, f"fixture leaked into initial discovery: {initial}"
+
+    # Operator clicks "Add path" in the admin UI → row lands in SQLite.
+    db_path = registry_dir / GATEWAY_ADMIN_SQLITE_FILENAME
+    _write_admin_skill_path(db_path, str(skill_root))
+
+    # The new public reload API picks it up without restarting the server.
+    count = server.reload_skill_paths(include_bundled=False)
+    assert count >= 1
+    after = _skill_names(server.list_skills())
+    assert "ext-rigging" in after, f"reload_skill_paths did not pick up admin SQLite path; got {after}"
+
+
+def test_module_re_exports() -> None:
+    """The public symbols are reachable from the top-level package."""
+    import dcc_mcp_core
+
+    assert dcc_mcp_core.resolve_admin_db_path is admin_sqlite_lane.resolve_admin_db_path
+    assert dcc_mcp_core.read_custom_skill_paths is admin_sqlite_lane.read_custom_skill_paths


### PR DESCRIPTION
Closes #1400.

## What

Per-DCC adapters (Maya, 3ds Max, Blender, Houdini, …) now pick up skill
discovery roots added through the gateway admin UI without having to
restart the DCC. Brings adapter parity with the standalone
`dcc-mcp-server` binary's existing `catalog_discover_hook` wiring.

* New module `dcc_mcp_core.admin_sqlite_lane` — read-only Python helpers
  that mirror the Rust path-resolution rules
  (`crates/dcc-mcp-db/src/application/gateway_admin.rs`) and read
  `gateway_admin.sqlite::skill_paths_custom` through stdlib `sqlite3`.
* `DccServerBase.collect_skill_search_paths(include_admin_custom=True)`
  merges the SQLite rows into the path list. Default ON so any adapter
  that builds its discovery path through this method gets the behaviour
  for free.
* New `DccServerBase.reload_skill_paths()` — runtime trigger for
  re-running discovery after a path is added through the dashboard.
* Top-level re-exports of `read_custom_skill_paths` /
  `resolve_admin_db_path` so adapter bootstrap code can call them
  before holding a `DccServerBase` reference.

## Why Python, not PyO3

The `skill_paths_custom` table is a 3-column SQLite schema. Python's
stdlib `sqlite3` reads it natively (URI form, read-only flag). Adding a
PyO3 binding just for this would mean another `cargo` build path on
every adapter wheel for no measurable gain on a read-only call. The
trade-off is documented in the module docstring; if we later need
write-side parity (`add_path` / `remove_path` from Python) we can revisit.

## Changes

| File | Δ | Note |
|------|---|------|
| `python/dcc_mcp_core/admin_sqlite_lane.py` | +132 (new) | Path resolver + reader + dedupe helper |
| `python/dcc_mcp_core/server_base.py` | +84 / −5 | `include_admin_custom` arg + `reload_skill_paths()` method |
| `python/dcc_mcp_core/_exports.py` | +2 / −0 | Top-level re-exports |
| `tests/test_admin_skill_paths_reload.py` | +172 (new) | 8 tests covering resolver, reader, helper, server reload, re-exports |
| `AGENTS.md` | +1 / −0 | Decision-table row |

## Validation

* `pytest tests/test_admin_skill_paths_reload.py` — **8 / 8 pass**:
  * `test_resolve_admin_db_path_honours_env` — `DCC_MCP_REGISTRY_DIR` resolves
    to `<dir>/gateway_admin.sqlite`.
  * `test_resolve_admin_db_path_explicit_wins` — explicit kw arg overrides
    env / default.
  * `test_read_custom_skill_paths_missing_db_is_empty` — fresh install
    → `[]`, no crash.
  * `test_read_custom_skill_paths_round_trip` — write through the gateway
    schema, read back the path.
  * `test_read_custom_skill_paths_filters_missing_dirs` — stale rows
    pointing at deleted dirs are filtered (with a `require_exists=False`
    diagnostic mode for debugging).
  * `test_filter_new_paths_dedupes` — order-preserving set diff helper.
  * **`test_server_base_reload_picks_up_admin_path`** — the key #1400
    regression: spin up a `DccServerBase`, run initial discovery, write a
    new path to the SQLite lane (mimicking the gateway writer), call
    `server.reload_skill_paths()`, assert the new skill is visible.
  * `test_module_re_exports` — top-level package symbols line up with the
    internal module.
* `ruff check` + `ruff format` clean on all touched files.

## Out of scope (separate issues)

| Track | Theme | Status |
|-------|-------|--------|
| A | Layer-based rank penalty (#1398) | Merged path / open as #1399 |
| **C — this PR** | DccServerBase auto-discovers admin paths (#1400) | ← here |
| B | Persist `SkillCatalog.loaded` set across restarts | Future |
| D | Admin UI Skills panel marketplace redesign | Future |
| E | `SkillMetadata` branding / links / example-prompts fields | Future (depends on D) |

This PR also intentionally **does not** add a gateway → adapter
notification channel or filesystem watcher. The current shape lets
adapters call `reload_skill_paths()` from a polling loop, from a hot-key,
or from a future MCP `notifications/skill-paths-changed` handler. Adding
the push channel is a separate ticket so this PR stays a focused additive
change with no behaviour shift for adapters that don't call the new API.

## Behaviour deltas downstream

* Adapter cold-start: any path the operator has added through the admin
  UI is now visible to the adapter's local catalog on the next
  `register_builtin_actions` call. Pre-#1400 the adapter ignored those
  rows entirely.
* Adapter warm-restart: calling `reload_skill_paths()` rediscovers
  skills without a process restart. Returns the new total count.
* Path-set hermeticity for tests: pass `include_admin_custom=False` to
  `collect_skill_search_paths` (or to `register_builtin_actions` via the
  same flag, in a future enhancement) to suppress the SQLite merge.
