### PR TITLE
feat(skills): rank user-curated skill paths above bundled material (#1403)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,33 @@ by a known layer name through `tags=` (case-insensitive), e.g.
 `search_skills(tags=["example"])` or `search_skills(tags=["infrastructure"])`,
 so the raw BM25 order is honoured inside the filtered slice.
 
+### Skill path-source rank (#1403)
+
+A second multiplier is layered on top of the layer multiplier based on
+where the skill was discovered from. User-curated locations rank at
+parity (× 1.00); bundled / platform-installed starter material is
+slightly damped so a local-dev skill always wins a tie.
+
+| Source         | Where it comes from                              | Rank   |
+|----------------|--------------------------------------------------|-------:|
+| `ExplicitArg`  | `extra_paths` passed to `discover()` / `scan_*`  | × 1.00 |
+| `AdminCustom`  | Added through the admin UI (gateway SQLite lane) | × 1.00 |
+| `EnvVar`       | `DCC_MCP_SKILL_PATHS` / `DCC_MCP_<APP>_SKILL_PATHS` | × 1.00 |
+| `LocalDev`     | `~/.dcc-mcp/<dcc>/skills` (local iteration root) | × 1.00 |
+| `Platform`     | Platform-wide install dir (`get_skills_dir`)     | × 0.85 |
+| `Bundled`      | Shipped with the dcc-mcp package itself          | × 0.70 |
+
+The path-source multiplier compounds multiplicatively with the layer
+multiplier (both are `≤ 1.00`). The exact-name fast-path bypasses it —
+`search_skills("dcc-diagnostics")` still surfaces a bundled diagnostics
+skill at the top regardless of source.
+
+Source tagging happens at scan time in
+`crates/dcc-mcp-skills/src/scanner.rs::scan_with_sources`. Adapters can
+read the assigned source via `SkillEntry.path_source` for diagnostic
+surfaces (e.g. the admin UI's skill panel) — it is stable across
+restarts because the field is `#[serde(default)]`.
+
 ---
 
 ## AI Agent Tool Priority

--- a/crates/dcc-mcp-skills/src/catalog/catalog.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog.rs
@@ -87,7 +87,15 @@ impl SkillCatalog {
             });
             let metas: Vec<&SkillMetadata> = prefiltered.iter().map(|e| &e.metadata).collect();
             let scopes: Vec<SkillScope> = prefiltered.iter().map(|e| e.scope).collect();
-            let scored = scoring::score_skills(q_trim, &metas, &scopes, layer_filter_explicit);
+            let path_sources: Vec<scoring::SkillPathSource> =
+                prefiltered.iter().map(|e| e.path_source).collect();
+            let scored = scoring::score_skills(
+                q_trim,
+                &metas,
+                &scopes,
+                layer_filter_explicit,
+                Some(&path_sources),
+            );
             scored
                 .into_iter()
                 .map(|s| helpers::skill_entry_to_summary(&prefiltered[s.index]))

--- a/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
@@ -177,7 +177,7 @@ impl SkillCatalog {
 
     /// Discover skills from the standard scan paths.
     pub fn discover(&self, extra_paths: Option<&[String]>, dcc_name: Option<&str>) -> usize {
-        let result = match loader::scan_and_load_lenient(extra_paths, dcc_name) {
+        let result = match loader::scan_and_load_lenient_with_sources(extra_paths, dcc_name) {
             Ok(result) => result,
             Err(err) => {
                 tracing::error!("SkillCatalog: discovery failed: {err}");
@@ -186,7 +186,7 @@ impl SkillCatalog {
         };
 
         let mut new_count = 0;
-        for skill in result.skills {
+        for (skill, path_source) in result.skills {
             let name = skill.name.clone();
             if !self.entries.contains_key(&name) {
                 self.entries.insert(
@@ -196,6 +196,7 @@ impl SkillCatalog {
                         state: SkillState::Discovered,
                         registered_tools: Vec::new(),
                         scope: SkillScope::Repo,
+                        path_source,
                     },
                 );
                 new_count += 1;
@@ -225,7 +226,7 @@ impl SkillCatalog {
     /// are no longer present in the scan result. It is intended for explicit
     /// refresh flows such as the Admin skill-path panel.
     pub fn rediscover(&self, extra_paths: Option<&[String]>, dcc_name: Option<&str>) -> usize {
-        let result = match loader::scan_and_load_lenient(extra_paths, dcc_name) {
+        let result = match loader::scan_and_load_lenient_with_sources(extra_paths, dcc_name) {
             Ok(result) => result,
             Err(err) => {
                 tracing::error!("SkillCatalog: rediscovery failed: {err}");
@@ -236,11 +237,12 @@ impl SkillCatalog {
         let mut seen = std::collections::HashSet::new();
         let mut added = 0usize;
 
-        for skill in result.skills {
+        for (skill, path_source) in result.skills {
             let name = skill.name.clone();
             seen.insert(name.clone());
             if let Some(mut entry) = self.entries.get_mut(&name) {
                 entry.metadata = skill;
+                entry.path_source = path_source;
                 if entry.state != SkillState::Loaded {
                     entry.state = SkillState::Discovered;
                 }
@@ -252,6 +254,7 @@ impl SkillCatalog {
                         state: SkillState::Discovered,
                         registered_tools: Vec::new(),
                         scope: SkillScope::Repo,
+                        path_source,
                     },
                 );
                 added += 1;
@@ -304,6 +307,7 @@ impl SkillCatalog {
                     state: SkillState::Discovered,
                     registered_tools: Vec::new(),
                     scope: SkillScope::Repo,
+                    path_source: Default::default(),
                 },
             );
         }
@@ -348,6 +352,7 @@ impl SkillCatalog {
                             state: SkillState::Discovered,
                             registered_tools: Vec::new(),
                             scope: *scope,
+                            path_source: Default::default(),
                         },
                     );
                     total_new += 1;

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -169,11 +169,11 @@ impl SkillCatalog {
             return Err("Cannot load a skill object with an empty name".to_string());
         }
 
-        let scope = self
+        let (scope, path_source) = self
             .entries
             .get(&skill_name)
-            .map(|entry| entry.scope)
-            .unwrap_or(SkillScope::Repo);
+            .map(|entry| (entry.scope, entry.path_source))
+            .unwrap_or((SkillScope::Repo, Default::default()));
 
         if self.loaded.contains(skill_name.as_str()) {
             self.unload_skill(&skill_name)?;
@@ -186,6 +186,7 @@ impl SkillCatalog {
                 state: SkillState::Discovered,
                 registered_tools: Vec::new(),
                 scope,
+                path_source,
             },
         );
         self.refresh_dependency_states();

--- a/crates/dcc-mcp-skills/src/catalog/scoring.rs
+++ b/crates/dcc-mcp-skills/src/catalog/scoring.rs
@@ -58,6 +58,34 @@
 //! (e.g. `tags=["infrastructure"]` or `tags=["example"]`). That signals
 //! deliberate intent to browse that layer, so the ranker honours the raw
 //! BM25 order inside the filtered slice.
+//!
+//! # Path-source rank penalty (issue #1403)
+//!
+//! Skills shipped with the dcc-mcp package itself (under
+//! `python/dcc_mcp_core/skills/`, or per-DCC adapter bundled skills) are
+//! intended as starter material and reference implementations. When a user
+//! has invested in their own local-development skills under
+//! `~/.dcc-mcp/<dcc>/skills`, exported `DCC_MCP_*_SKILL_PATHS`, or added a
+//! custom path through the admin UI, those skills should outrank the
+//! bundled ones for neutral queries — they are demonstrably what the user
+//! cares about.
+//!
+//! A small multiplier is applied based on [`SkillPathSource`]:
+//!
+//! | Source           | Multiplier   |
+//! |------------------|-------------:|
+//! | `Unknown`        |         1.00 |
+//! | `ExplicitArg`    |         1.00 |
+//! | `AdminCustom`    |         1.00 |
+//! | `EnvVar`         |         1.00 |
+//! | `LocalDev`       |         1.00 |
+//! | `Platform`       |         0.85 |
+//! | `Bundled`        |         0.70 |
+//!
+//! All values are ≤ 1.0 so this multiplier compounds cleanly with the
+//! layer multiplier. The exact-name fast-path bypasses this penalty too —
+//! typing the literal skill name is always the strongest "I want this
+//! specific skill" signal a caller can give.
 
 use dcc_mcp_models::{SkillMetadata, SkillScope};
 
@@ -114,6 +142,74 @@ pub fn layer_multiplier(layer: Option<&str>, explicit: bool) -> Option<f64> {
             Some(LAYER_MULT_THIN_HARNESS)
         }
         _ => Some(1.0),
+    }
+}
+
+/// Path-source multipliers applied to the BM25 total. See module docs for
+/// the rationale and table.
+pub const PATH_SOURCE_MULT_BUNDLED: f64 = 0.70;
+pub const PATH_SOURCE_MULT_PLATFORM: f64 = 0.85;
+
+/// Where a skill was discovered from. Used as a rank signal by
+/// [`path_source_multiplier`] so user-curated locations outrank bundled
+/// starter material for neutral queries. See module docs (#1403).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillPathSource {
+    /// No source information — multiplier is 1.0 (no change). Default for
+    /// older catalog code paths and tests that don't carry source data.
+    #[default]
+    Unknown,
+    /// Shipped with the dcc-mcp package itself, e.g.
+    /// `python/dcc_mcp_core/skills/` or a per-DCC adapter's
+    /// `<adapter>/skills/` directory.
+    Bundled,
+    /// Platform-wide install directory (e.g. the global skills dir under
+    /// the platform data dir). Not part of the dcc-mcp package, but also
+    /// not directly user-curated.
+    Platform,
+    /// Local developer skills under `~/.dcc-mcp/<dcc>/skills` — the
+    /// convention for "skills I'm iterating on right now".
+    LocalDev,
+    /// Discovered via `DCC_MCP_SKILL_PATHS` or `DCC_MCP_<APP>_SKILL_PATHS`.
+    EnvVar,
+    /// Passed explicitly by the caller through `extra_paths`.
+    ExplicitArg,
+    /// Added at runtime through the admin UI (gateway SQLite lane).
+    AdminCustom,
+}
+
+impl SkillPathSource {
+    /// Stable short label used in JSON, logs, and tracing spans.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Bundled => "bundled",
+            Self::Platform => "platform",
+            Self::LocalDev => "local_dev",
+            Self::EnvVar => "env_var",
+            Self::ExplicitArg => "explicit_arg",
+            Self::AdminCustom => "admin_custom",
+        }
+    }
+}
+
+/// Coefficient applied to the BM25 total based on a skill's
+/// [`SkillPathSource`]. All values are in `[0.7, 1.0]` so the multiplier
+/// compounds cleanly with the layer multiplier (which is also `≤ 1.0`).
+#[must_use]
+pub fn path_source_multiplier(source: SkillPathSource) -> f64 {
+    match source {
+        SkillPathSource::Bundled => PATH_SOURCE_MULT_BUNDLED,
+        SkillPathSource::Platform => PATH_SOURCE_MULT_PLATFORM,
+        SkillPathSource::Unknown
+        | SkillPathSource::LocalDev
+        | SkillPathSource::EnvVar
+        | SkillPathSource::ExplicitArg
+        | SkillPathSource::AdminCustom => 1.0,
     }
 }
 
@@ -262,17 +358,32 @@ pub struct Scored {
 /// the layer-based penalty (see module docs, issue #1398) is then skipped so
 /// the user-requested layer is ranked on raw BM25 alone. Pass `false` for
 /// the common case of an unfiltered search.
+///
+/// `path_sources` is an optional parallel slice indicating where each skill
+/// was discovered from. When provided it must be the same length as
+/// `skills` and the path-source multiplier (issue #1403) is applied on top
+/// of the layer multiplier. Pass `None` (or an entry of
+/// [`SkillPathSource::Unknown`]) to opt out of the penalty for callers that
+/// do not yet track this information.
 pub fn score_skills(
     query: &str,
     skills: &[&SkillMetadata],
     scopes: &[SkillScope],
     layer_filter_explicit: bool,
+    path_sources: Option<&[SkillPathSource]>,
 ) -> Vec<Scored> {
     assert_eq!(
         skills.len(),
         scopes.len(),
         "skills and scopes slices must be the same length"
     );
+    if let Some(srcs) = path_sources {
+        assert_eq!(
+            skills.len(),
+            srcs.len(),
+            "skills and path_sources slices must be the same length"
+        );
+    }
 
     let tokens = tokenize(query);
     let q_trim_lower = query.trim().to_lowercase();
@@ -352,6 +463,14 @@ pub fn score_skills(
             Some(mult) => total *= mult,
             None if exact_name => {}
             None => continue,
+        }
+
+        // Path-source rank penalty (issue #1403). Compounds with the layer
+        // multiplier. Skipped for exact-name matches because typing the
+        // literal skill name is the strongest "I want this specific skill"
+        // signal a caller can give and should bypass all rank dampening.
+        if !exact_name && let Some(srcs) = path_sources {
+            total *= path_source_multiplier(srcs[i]);
         }
 
         if total == 0.0 && !exact_name {
@@ -498,7 +617,7 @@ mod tests {
         let b = mk("sphere");
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("sphere", &skills, &scopes, false);
+        let out = score_skills("sphere", &skills, &scopes, false, None);
         assert!(!out.is_empty());
         assert_eq!(out[0].name, "sphere", "exact-name match must rank first");
     }
@@ -509,7 +628,7 @@ mod tests {
         let a = mk_full("polygon-tools", "polygon modelling", "", &[], "maya", &[]);
         let skills = vec![&a];
         let scopes = vec![SkillScope::Repo];
-        let out = score_skills("poly", &skills, &scopes, false);
+        let out = score_skills("poly", &skills, &scopes, false, None);
         assert!(
             out.is_empty(),
             "prefix-only queries must not match without stemming"
@@ -522,7 +641,7 @@ mod tests {
         let b = mk_full("beta", "something else entirely", "", &[], "maya", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("rigging", &skills, &scopes, false);
+        let out = score_skills("rigging", &skills, &scopes, false, None);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].name, "alpha");
     }
@@ -533,7 +652,7 @@ mod tests {
         let b = mk_full("beta", "handles rendering", "", &[], "maya", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("animation", &skills, &scopes, false);
+        let out = score_skills("animation", &skills, &scopes, false, None);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].name, "alpha");
     }
@@ -553,7 +672,7 @@ mod tests {
         let b = mk_full("other", "unrelated stuff", "", &[], "maya", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("turntable", &skills, &scopes, false);
+        let out = score_skills("turntable", &skills, &scopes, false, None);
         assert_eq!(out.len(), 1, "sibling tool name must be scorable");
         assert_eq!(out[0].name, "scene-utils");
     }
@@ -566,7 +685,7 @@ mod tests {
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
 
-        let out = score_skills("primitive ball", &skills, &scopes, false);
+        let out = score_skills("primitive ball", &skills, &scopes, false, None);
 
         assert_eq!(out.len(), 1, "skill search aliases must be scorable");
         assert_eq!(out[0].name, "geometry-tools");
@@ -587,7 +706,7 @@ mod tests {
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
 
-        let out = score_skills("mesh globe", &skills, &scopes, false);
+        let out = score_skills("mesh globe", &skills, &scopes, false, None);
 
         assert_eq!(out.len(), 1, "tool search aliases must be scorable");
         assert_eq!(out[0].name, "scene-utils");
@@ -598,7 +717,7 @@ mod tests {
         let a = mk_full("alpha", "stuff", "", &[], "maya", &[]);
         let skills = vec![&a];
         let scopes = vec![SkillScope::Repo];
-        let out = score_skills("the of and", &skills, &scopes, false);
+        let out = score_skills("the of and", &skills, &scopes, false, None);
         assert!(out.is_empty(), "stopword-only queries must yield no hits");
     }
 
@@ -607,7 +726,7 @@ mod tests {
         let a = mk("alpha");
         let skills = vec![&a];
         let scopes = vec![SkillScope::Repo];
-        let out = score_skills("", &skills, &scopes, false);
+        let out = score_skills("", &skills, &scopes, false, None);
         assert!(out.is_empty());
     }
 
@@ -632,7 +751,7 @@ mod tests {
         );
         let skills = vec![&one, &both];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("polygon bevel", &skills, &scopes, false);
+        let out = score_skills("polygon bevel", &skills, &scopes, false, None);
         assert_eq!(out[0].name, "polygon-bevel");
     }
 
@@ -643,7 +762,7 @@ mod tests {
         let b = mk_full("beta", "renderer thing", "", &[], "maya", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Admin];
-        let out = score_skills("renderer", &skills, &scopes, false);
+        let out = score_skills("renderer", &skills, &scopes, false, None);
         assert_eq!(out.len(), 2);
         assert_eq!(
             out[0].name, "beta",
@@ -658,7 +777,7 @@ mod tests {
         let b = mk_full("beta", "renderer thing", "", &[], "blender", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("maya", &skills, &scopes, false);
+        let out = score_skills("maya", &skills, &scopes, false, None);
         assert_eq!(out[0].name, "alpha", "dcc token boost must apply");
     }
 
@@ -669,7 +788,7 @@ mod tests {
         let b = mk_full("aaa", "renderer thing", "", &[], "maya", &[]);
         let skills = vec![&a, &b];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("renderer", &skills, &scopes, false);
+        let out = score_skills("renderer", &skills, &scopes, false, None);
         assert_eq!(out[0].name, "aaa");
         assert_eq!(out[1].name, "zzz");
     }
@@ -719,7 +838,7 @@ mod tests {
         let domain = mk_layered("maya-render", "render bake helpers", Some("domain"));
         let skills = vec![&infra, &domain];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("render bake", &skills, &scopes, false);
+        let out = score_skills("render bake", &skills, &scopes, false, None);
         assert_eq!(out.len(), 2);
         assert_eq!(
             out[0].name, "maya-render",
@@ -737,7 +856,7 @@ mod tests {
         let infra = mk_layered("dcc-diagnostics", "render bake", Some("infrastructure"));
         let skills = vec![&example, &infra];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("render bake", &skills, &scopes, false);
+        let out = score_skills("render bake", &skills, &scopes, false, None);
         assert_eq!(out.len(), 1, "example layer must be excluded from results");
         assert_eq!(out[0].name, "dcc-diagnostics");
     }
@@ -751,7 +870,13 @@ mod tests {
         let example_b = mk_layered("demo-b", "render bake", Some("example"));
         let skills = vec![&example_b, &example_a];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("render bake", &skills, &scopes, /*explicit=*/ true);
+        let out = score_skills(
+            "render bake",
+            &skills,
+            &scopes,
+            /*explicit=*/ true,
+            None,
+        );
         assert_eq!(out.len(), 2);
         assert_eq!(
             out[0].name, "demo-a",
@@ -772,7 +897,7 @@ mod tests {
         let infra = mk_layered("dcc-diagnostics", "render bake", Some("infrastructure"));
         let skills = vec![&thin, &infra];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("render bake", &skills, &scopes, false);
+        let out = score_skills("render bake", &skills, &scopes, false, None);
         assert_eq!(out.len(), 2);
         assert_eq!(
             out[0].name, "dcc-diagnostics",
@@ -790,7 +915,7 @@ mod tests {
         let domain = mk_layered("beta", "render bake helpers", Some("domain"));
         let skills = vec![&unset, &domain];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("render bake", &skills, &scopes, false);
+        let out = score_skills("render bake", &skills, &scopes, false, None);
         assert_eq!(out.len(), 2);
         // Identical scores → alphabetical name tie-break.
         assert_eq!(out[0].name, "alpha");
@@ -809,7 +934,13 @@ mod tests {
         let infra_weak = mk_layered("other-infra", "render", Some("infrastructure"));
         let skills = vec![&infra_weak, &infra_strong];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("render bake", &skills, &scopes, /*explicit=*/ true);
+        let out = score_skills(
+            "render bake",
+            &skills,
+            &scopes,
+            /*explicit=*/ true,
+            None,
+        );
         assert_eq!(out.len(), 2);
         assert_eq!(
             out[0].name, "dcc-diagnostics",
@@ -830,7 +961,7 @@ mod tests {
         let domain = mk_layered("maya-render", "diagnostics tool", Some("domain"));
         let skills = vec![&infra, &domain];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("dcc-diagnostics", &skills, &scopes, false);
+        let out = score_skills("dcc-diagnostics", &skills, &scopes, false, None);
         assert!(!out.is_empty());
         assert_eq!(
             out[0].name, "dcc-diagnostics",
@@ -847,11 +978,150 @@ mod tests {
         let domain = mk_layered("maya-render", "demo turntable", Some("domain"));
         let skills = vec![&example, &domain];
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
-        let out = score_skills("demo-render", &skills, &scopes, false);
+        let out = score_skills("demo-render", &skills, &scopes, false, None);
         assert!(!out.is_empty());
         assert_eq!(
             out[0].name, "demo-render",
             "exact-name query must bypass the example-layer exclusion"
         );
+    }
+
+    // ── path-source rank penalty (issue #1403) ──────────────────────────
+
+    #[test]
+    fn test_path_source_multiplier_table() {
+        // The documented coefficient table — every variant maps to a
+        // multiplier in `[0.7, 1.0]`.
+        assert_eq!(path_source_multiplier(SkillPathSource::Unknown), 1.0);
+        assert_eq!(path_source_multiplier(SkillPathSource::ExplicitArg), 1.0);
+        assert_eq!(path_source_multiplier(SkillPathSource::AdminCustom), 1.0);
+        assert_eq!(path_source_multiplier(SkillPathSource::EnvVar), 1.0);
+        assert_eq!(path_source_multiplier(SkillPathSource::LocalDev), 1.0);
+        assert_eq!(path_source_multiplier(SkillPathSource::Platform), 0.85);
+        assert_eq!(path_source_multiplier(SkillPathSource::Bundled), 0.70);
+    }
+
+    #[test]
+    fn test_path_source_default_is_unknown() {
+        // SkillEntry uses `#[serde(default)]` so the default must keep
+        // the existing behaviour (no multiplier change).
+        assert_eq!(SkillPathSource::default(), SkillPathSource::Unknown);
+        assert_eq!(path_source_multiplier(SkillPathSource::default()), 1.0);
+    }
+
+    #[test]
+    fn test_path_source_bundled_ranks_below_local_dev() {
+        // Two identical-content skills, same layer (domain) — only the
+        // path source differs. The bundled skill must rank below the
+        // local-dev skill thanks to the × 0.70 multiplier.
+        let bundled = mk_full("alpha", "render bake helpers", "", &[], "maya", &[]);
+        let local_dev = mk_full("beta", "render bake helpers", "", &[], "maya", &[]);
+        let skills = vec![&bundled, &local_dev];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let sources = vec![SkillPathSource::Bundled, SkillPathSource::LocalDev];
+        let out = score_skills("render bake", &skills, &scopes, false, Some(&sources));
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].name, "beta",
+            "LocalDev skill must outrank Bundled skill"
+        );
+        assert_eq!(out[1].name, "alpha");
+    }
+
+    #[test]
+    fn test_path_source_env_var_outranks_bundled() {
+        // Even a Bundled skill with a stronger raw BM25 match still loses
+        // to an EnvVar skill with a weaker match once the multiplier
+        // (× 0.70 vs × 1.00) is applied.
+        let bundled = mk_full("alpha", "render bake render bake", "", &[], "maya", &[]);
+        let env_var = mk_full("beta", "render bake", "", &[], "maya", &[]);
+        let skills = vec![&bundled, &env_var];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let sources = vec![SkillPathSource::Bundled, SkillPathSource::EnvVar];
+        let out = score_skills("render bake", &skills, &scopes, false, Some(&sources));
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].name, "beta",
+            "EnvVar skill must outrank Bundled even with weaker BM25"
+        );
+    }
+
+    #[test]
+    fn test_path_source_platform_between_bundled_and_user() {
+        // Platform (× 0.85) sits between Bundled (× 0.70) and the
+        // user-curated sources (× 1.00).
+        let bundled = mk_full("alpha", "render bake", "", &[], "maya", &[]);
+        let platform = mk_full("beta", "render bake", "", &[], "maya", &[]);
+        let env_var = mk_full("gamma", "render bake", "", &[], "maya", &[]);
+        let skills = vec![&bundled, &platform, &env_var];
+        let scopes = vec![SkillScope::Repo; 3];
+        let sources = vec![
+            SkillPathSource::Bundled,
+            SkillPathSource::Platform,
+            SkillPathSource::EnvVar,
+        ];
+        let out = score_skills("render bake", &skills, &scopes, false, Some(&sources));
+        assert_eq!(out.len(), 3);
+        let names: Vec<_> = out.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["gamma", "beta", "alpha"]);
+    }
+
+    #[test]
+    fn test_path_source_exact_name_bypasses_penalty() {
+        // Exact-name match must surface a bundled skill even when a
+        // local-dev skill matches the query better — typing the literal
+        // name is the strongest user-intent signal.
+        let bundled = mk_full("dcc-diagnostics", "diagnostics tool", "", &[], "maya", &[]);
+        let local_dev = mk_full(
+            "alpha",
+            "diagnostics tool dcc-diagnostics",
+            "",
+            &[],
+            "maya",
+            &[],
+        );
+        let skills = vec![&bundled, &local_dev];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let sources = vec![SkillPathSource::Bundled, SkillPathSource::LocalDev];
+        let out = score_skills("dcc-diagnostics", &skills, &scopes, false, Some(&sources));
+        assert!(!out.is_empty());
+        assert_eq!(
+            out[0].name, "dcc-diagnostics",
+            "exact-name match must bypass the path-source penalty"
+        );
+    }
+
+    #[test]
+    fn test_path_source_compounds_with_layer_penalty() {
+        // Layer × source compose multiplicatively. A `domain` skill in
+        // Bundled (1.00 × 0.70 = 0.70) still outranks an `infrastructure`
+        // skill in LocalDev (0.35 × 1.00 = 0.35) for the same query.
+        let domain_bundled = mk_layered("alpha", "render bake helpers", Some("domain"));
+        let infra_localdev = mk_layered("beta", "render bake helpers", Some("infrastructure"));
+        let skills = vec![&domain_bundled, &infra_localdev];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let sources = vec![SkillPathSource::Bundled, SkillPathSource::LocalDev];
+        let out = score_skills("render bake", &skills, &scopes, false, Some(&sources));
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].name, "alpha",
+            "domain × bundled (0.70) must outrank infrastructure × local_dev (0.35)"
+        );
+    }
+
+    #[test]
+    fn test_path_source_none_arg_is_neutral() {
+        // Passing `None` for path_sources means "caller doesn't track
+        // origin" — every entry gets the implicit × 1.00 multiplier so
+        // the previous behaviour is preserved bit-for-bit.
+        let alpha = mk_full("alpha", "render bake", "", &[], "maya", &[]);
+        let beta = mk_full("beta", "render bake", "", &[], "maya", &[]);
+        let skills = vec![&alpha, &beta];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("render bake", &skills, &scopes, false, None);
+        assert_eq!(out.len(), 2);
+        // Identical scores → alphabetical tie-break.
+        assert_eq!(out[0].name, "alpha");
+        assert_eq!(out[1].name, "beta");
     }
 }

--- a/crates/dcc-mcp-skills/src/catalog/tests/fixtures.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/fixtures.rs
@@ -79,6 +79,7 @@ pub fn add_skill_with_scope(catalog: &SkillCatalog, meta: SkillMetadata, scope: 
             state: SkillState::Discovered,
             registered_tools: Vec::new(),
             scope,
+            path_source: Default::default(),
         },
     );
 }

--- a/crates/dcc-mcp-skills/src/catalog/tests/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/mod.rs
@@ -22,6 +22,7 @@ fn skill_catalog_satisfies_registry_contract() {
         state: SkillState::Discovered,
         registered_tools: Vec::new(),
         scope: SkillScope::Repo,
+        path_source: Default::default(),
     };
     assert_registry_contract(make_test_catalog, sample_entry);
 }

--- a/crates/dcc-mcp-skills/src/catalog/types.rs
+++ b/crates/dcc-mcp-skills/src/catalog/types.rs
@@ -79,6 +79,13 @@ pub struct SkillEntry {
     /// Set at discovery time based on which search path the skill was found in.
     /// Defaults to `SkillScope::Repo` when not explicitly assigned.
     pub scope: SkillScope,
+    /// Where on disk this skill was discovered from. Used as a rank signal
+    /// by `search_skills` (issue #1403) so user-managed locations outrank
+    /// bundled starter material. Defaults to
+    /// [`SkillPathSource::Unknown`](crate::catalog::scoring::SkillPathSource::Unknown)
+    /// for backward compatibility when persisted state lacks the field.
+    #[serde(default)]
+    pub path_source: crate::catalog::scoring::SkillPathSource,
 }
 
 // ── Summary / Detail types ──

--- a/crates/dcc-mcp-skills/src/lib.rs
+++ b/crates/dcc-mcp-skills/src/lib.rs
@@ -20,8 +20,9 @@ pub use catalog::{SkillCatalog, SkillDetail, SkillState, SkillSummary};
 pub use feedback::{SkillFeedback, get_skill_feedback, record_skill_feedback};
 pub use gui_executable::{GuiExecutableHint, correct_python_executable, is_gui_executable};
 pub use loader::{
-    LoadResult, parse_skill_md, scan_and_load, scan_and_load_lenient, scan_and_load_strict,
-    scan_and_load_team, scan_and_load_team_lenient, scan_and_load_user, scan_and_load_user_lenient,
+    LoadResult, LoadResultWithSources, parse_skill_md, scan_and_load, scan_and_load_lenient,
+    scan_and_load_lenient_with_sources, scan_and_load_strict, scan_and_load_team,
+    scan_and_load_team_lenient, scan_and_load_user, scan_and_load_user_lenient,
 };
 pub use manager::SkillsManager;
 pub use paths::{

--- a/crates/dcc-mcp-skills/src/loader/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/mod.rs
@@ -34,7 +34,8 @@ pub(crate) use files::{enumerate_metadata_files, enumerate_scripts, merge_depend
 #[cfg(test)]
 pub(crate) use scan::load_all_skills;
 pub use scan::{
-    LoadResult, scan_and_load, scan_and_load_lenient, scan_and_load_strict, scan_and_load_team,
+    LoadResult, LoadResultWithSources, scan_and_load, scan_and_load_lenient,
+    scan_and_load_lenient_with_sources, scan_and_load_strict, scan_and_load_team,
     scan_and_load_team_lenient, scan_and_load_user, scan_and_load_user_lenient,
 };
 

--- a/crates/dcc-mcp-skills/src/loader/scan.rs
+++ b/crates/dcc-mcp-skills/src/loader/scan.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use dcc_mcp_models::SkillMetadata;
 
+use crate::catalog::scoring::SkillPathSource;
 use crate::resolver::{self, ResolveError};
 use crate::scanner::SkillScanner;
 
@@ -13,6 +15,20 @@ pub struct LoadResult {
     /// Skills in dependency-resolved order (dependencies come first).
     pub skills: Vec<SkillMetadata>,
     /// Directories that were scanned but failed to load (parse errors, missing SKILL.md, etc.).
+    pub skipped: Vec<String>,
+}
+
+/// Result of a source-aware scan-and-load pipeline.
+///
+/// Identical to [`LoadResult`] but pairs each loaded skill with the
+/// [`SkillPathSource`] of the search root it was found under (issue
+/// #1403). The catalog uses this to apply a small rank penalty so user-
+/// curated locations outrank bundled starter material for neutral queries.
+#[derive(Debug, Clone)]
+pub struct LoadResultWithSources {
+    /// Skills in dependency-resolved order, paired with their source.
+    pub skills: Vec<(SkillMetadata, SkillPathSource)>,
+    /// Directories that were scanned but failed to load.
     pub skipped: Vec<String>,
 }
 
@@ -108,6 +124,56 @@ pub fn scan_and_load_lenient(
     let resolved = resolver::resolve_dependencies(&skills)?;
     Ok(LoadResult {
         skills: resolved.ordered,
+        skipped,
+    })
+}
+
+/// Source-aware variant of [`scan_and_load_lenient`] (issue #1403).
+///
+/// Performs the same scan / parse / resolve pipeline, but tracks which
+/// search-root each skill was discovered under so the catalog can apply
+/// the path-source rank penalty. The dependency-resolved skill order is
+/// preserved; the per-skill source is matched back by `skill_path`.
+pub fn scan_and_load_lenient_with_sources(
+    extra_paths: Option<&[String]>,
+    dcc_name: Option<&str>,
+) -> Result<LoadResultWithSources, ResolveError> {
+    let mut scanner = SkillScanner::new();
+    let dirs_with_sources = scanner.scan_with_sources(extra_paths, dcc_name, false);
+    let source_by_dir: HashMap<String, SkillPathSource> = dirs_with_sources
+        .iter()
+        .map(|(d, s)| (d.clone(), *s))
+        .collect();
+    let dirs: Vec<String> = dirs_with_sources.into_iter().map(|(d, _)| d).collect();
+
+    let (skills, skipped) = load_all_skills(&dirs);
+    let errors = resolver::validate_dependencies(&skills);
+    let ordered = if errors.is_empty() {
+        resolver::resolve_dependencies(&skills)?.ordered
+    } else {
+        for err in &errors {
+            if let ResolveError::MissingDependency { skill, dependency } = err {
+                tracing::warn!(
+                    "Skill '{skill}' depends on '{dependency}' which is not available yet; \
+                     keeping it discoverable as a pending dependency."
+                );
+            }
+        }
+        resolve_dependencies_soft(&skills)?.ordered
+    };
+
+    let paired = ordered
+        .into_iter()
+        .map(|meta| {
+            let src = source_by_dir
+                .get(&meta.skill_path)
+                .copied()
+                .unwrap_or_default();
+            (meta, src)
+        })
+        .collect();
+    Ok(LoadResultWithSources {
+        skills: paired,
         skipped,
     })
 }

--- a/crates/dcc-mcp-skills/src/scanner.rs
+++ b/crates/dcc-mcp-skills/src/scanner.rs
@@ -5,6 +5,7 @@
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen_derive::gen_stub_pyclass;
 
+use crate::catalog::scoring::SkillPathSource;
 use crate::constants::{MTIME_EPSILON_SECS, SKILL_METADATA_FILE};
 use dcc_mcp_paths::path_to_string;
 use std::collections::{HashMap, HashSet};
@@ -61,12 +62,41 @@ impl SkillScanner {
         dcc_name: Option<&str>,
         force_refresh: bool,
     ) -> Vec<String> {
-        let unique_paths = Self::collect_search_paths(extra_paths, dcc_name);
+        self.scan_with_sources(extra_paths, dcc_name, force_refresh)
+            .into_iter()
+            .map(|(dir, _)| dir)
+            .collect()
+    }
 
-        // Scan each path
-        let mut discovered = Vec::new();
-        for search_path in &unique_paths {
-            discovered.extend(self.scan_directory(search_path, force_refresh));
+    /// Variant of [`Self::scan`] that returns each discovered skill
+    /// directory paired with the [`SkillPathSource`] of the search root it
+    /// was found under. Used by [`crate::catalog::SkillCatalog`] to tag
+    /// entries for the path-source rank penalty (issue #1403).
+    ///
+    /// The mapping is derived from the priority order documented on
+    /// [`Self::collect_search_paths_with_sources`]: when a skill directory
+    /// appears under multiple roots (e.g. an env-var path that is also the
+    /// local-dev directory), the source of the highest-priority root that
+    /// canonicalises to the same on-disk location wins.
+    pub fn scan_with_sources(
+        &mut self,
+        extra_paths: Option<&[String]>,
+        dcc_name: Option<&str>,
+        force_refresh: bool,
+    ) -> Vec<(String, SkillPathSource)> {
+        let unique_paths = Self::collect_search_paths_with_sources(extra_paths, dcc_name);
+
+        // Scan each path while preserving source attribution. The first
+        // search root that produces a given skill_dir wins — this matches
+        // the priority order from `collect_search_paths_with_sources`.
+        let mut discovered: Vec<(String, SkillPathSource)> = Vec::new();
+        let mut seen = HashSet::new();
+        for (search_path, source) in &unique_paths {
+            for dir in self.scan_directory(search_path, force_refresh) {
+                if seen.insert(dir.clone()) {
+                    discovered.push((dir, *source));
+                }
+            }
         }
 
         tracing::debug!(
@@ -74,8 +104,8 @@ impl SkillScanner {
             discovered.len(),
             unique_paths.len()
         );
-        self.skill_dirs = discovered;
-        self.skill_dirs.to_vec()
+        self.skill_dirs = discovered.iter().map(|(d, _)| d.clone()).collect();
+        discovered
     }
 
     /// Find child directories under explicit search paths that cannot be
@@ -141,56 +171,87 @@ impl SkillScanner {
 
     /// Collect and deduplicate all skill search paths from various sources.
     ///
+    /// Thin wrapper around
+    /// [`Self::collect_search_paths_with_sources`] that drops the source
+    /// labels. New code should prefer the `_with_sources` variant so the
+    /// origin can be propagated into the catalog for ranking.
+    pub fn collect_search_paths(
+        extra_paths: Option<&[String]>,
+        dcc_name: Option<&str>,
+    ) -> Vec<String> {
+        Self::collect_search_paths_with_sources(extra_paths, dcc_name)
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect()
+    }
+
+    /// Collect and deduplicate all skill search paths, paired with the
+    /// [`SkillPathSource`] each path was sourced from.
+    ///
     /// Priority order (highest → lowest):
-    /// 1. `extra_paths` — caller-provided explicit paths
-    /// 2. `DCC_MCP_{APP}_SKILL_PATHS` — per-app env var (when dcc_name is given)
-    /// 3. `DCC_MCP_SKILL_PATHS` — global env var
-    /// 4. Local developer skills directory under `~/.dcc-mcp/{dcc}/skills`
-    /// 5. Platform-specific skills directory for this DCC
-    /// 6. Global skills directory
-    fn collect_search_paths(extra_paths: Option<&[String]>, dcc_name: Option<&str>) -> Vec<String> {
-        let mut search_paths = Vec::new();
+    /// 1. `extra_paths` — caller-provided explicit paths ([`SkillPathSource::ExplicitArg`])
+    /// 2. `DCC_MCP_{APP}_SKILL_PATHS` / `DCC_MCP_SKILL_PATHS` ([`SkillPathSource::EnvVar`])
+    /// 3. Local developer skills directory under `~/.dcc-mcp/{dcc}/skills` ([`SkillPathSource::LocalDev`])
+    /// 4. Platform-specific skills directory for this DCC ([`SkillPathSource::Platform`])
+    /// 5. Global skills directory ([`SkillPathSource::Platform`])
+    ///
+    /// Deduplication preserves the highest-priority source for any path
+    /// that appears in more than one bucket (e.g. an env-var path that
+    /// happens to be `~/.dcc-mcp/<dcc>/skills` keeps the `EnvVar` tag).
+    #[must_use]
+    pub fn collect_search_paths_with_sources(
+        extra_paths: Option<&[String]>,
+        dcc_name: Option<&str>,
+    ) -> Vec<(String, SkillPathSource)> {
+        let mut search_paths: Vec<(String, SkillPathSource)> = Vec::new();
 
-        // 1. Extra paths (highest priority)
+        // 1. Extra paths (highest priority) — explicit caller input.
         if let Some(extra) = extra_paths {
-            search_paths.extend(extra.iter().cloned());
+            for p in extra {
+                search_paths.push((p.clone(), SkillPathSource::ExplicitArg));
+            }
         }
 
-        // 2. Per-app env var paths (DCC_MCP_{APP}_SKILL_PATHS) + global fallback
+        // 2. Env-var paths.
         if let Some(dcc) = dcc_name {
-            search_paths.extend(crate::paths::get_app_skill_paths_from_env(dcc));
+            for p in crate::paths::get_app_skill_paths_from_env(dcc) {
+                search_paths.push((p, SkillPathSource::EnvVar));
+            }
         } else {
-            // No dcc_name — only global env var
-            search_paths.extend(crate::paths::get_skill_paths_from_env());
+            for p in crate::paths::get_skill_paths_from_env() {
+                search_paths.push((p, SkillPathSource::EnvVar));
+            }
         }
 
-        // 3. Local developer skills directory
+        // 3. Local developer skills directory.
         if let Ok(local_dir) = crate::paths::get_local_skills_dir(dcc_name)
             && Path::new(&local_dir).is_dir()
         {
-            search_paths.push(local_dir);
+            search_paths.push((local_dir, SkillPathSource::LocalDev));
         }
 
-        // 4. Platform-specific skills directory
+        // 4. Platform-specific skills directory.
         if let Ok(platform_dir) = crate::paths::get_skills_dir(dcc_name)
             && Path::new(&platform_dir).is_dir()
         {
-            search_paths.push(platform_dir);
+            search_paths.push((platform_dir, SkillPathSource::Platform));
         }
 
-        // Also check global skills dir if dcc_name was specified
+        // 5. Global (dcc-less) skills dir is also platform-installed.
         if dcc_name.is_some()
             && let Ok(global_dir) = crate::paths::get_skills_dir(None)
             && Path::new(&global_dir).is_dir()
         {
-            search_paths.push(global_dir);
+            search_paths.push((global_dir, SkillPathSource::Platform));
         }
 
-        // Deduplicate while preserving order
+        // Deduplicate while preserving order. The first occurrence wins,
+        // which encodes "highest priority source for the same on-disk
+        // path".
         let mut seen = HashSet::new();
         search_paths
             .into_iter()
-            .filter(|p| {
+            .filter(|(p, _)| {
                 let abs = std::fs::canonicalize(p).unwrap_or_else(|e| {
                     tracing::debug!("canonicalize({p:?}) failed ({e}), using raw path for dedup");
                     PathBuf::from(p)
@@ -365,6 +426,93 @@ mod tests {
         assert!(
             custom.contains(&krita_skill),
             "custom DCC scan returned {custom:?}"
+        );
+    }
+
+    #[test]
+    fn test_scan_with_sources_tags_explicit_arg() {
+        // Skills discovered from caller-supplied `extra_paths` should be
+        // labelled `ExplicitArg` so the catalog can rank them above
+        // bundled material. Issue #1403.
+        use std::fs;
+
+        fn write_skill_dir(root: &Path, name: &str) -> String {
+            let dir = root.join(name);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(
+                dir.join(crate::constants::SKILL_METADATA_FILE),
+                format!("name: {name}\nversion: 1.0.0\n"),
+            )
+            .unwrap();
+            path_to_string(&dir)
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let explicit_root = path_to_string(tmp.path());
+        let skill_dir = write_skill_dir(tmp.path(), "explicit-render");
+
+        let mut scanner = SkillScanner::new();
+        let with_sources = scanner.scan_with_sources(Some(&[explicit_root]), Some("maya"), true);
+
+        let explicit_entry = with_sources
+            .iter()
+            .find(|(d, _)| d == &skill_dir)
+            .expect("explicit-root skill must be discovered");
+        assert_eq!(
+            explicit_entry.1,
+            SkillPathSource::ExplicitArg,
+            "skill under extra_paths must be tagged ExplicitArg; got {with_sources:?}"
+        );
+    }
+
+    #[test]
+    fn test_collect_search_paths_priority_order() {
+        // When the same on-disk path appears as both an extra_paths entry
+        // and an env-var entry, the higher-priority `ExplicitArg` tag
+        // wins (the dedupe keeps the first occurrence).
+        use std::fs;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = tmp.path().join("shared");
+        fs::create_dir_all(&shared).unwrap();
+        let shared_str = path_to_string(&shared);
+
+        let saved = std::env::var("DCC_MCP_MAYA_SKILL_PATHS").ok();
+        unsafe {
+            std::env::set_var("DCC_MCP_MAYA_SKILL_PATHS", &shared_str);
+        }
+        let collected = SkillScanner::collect_search_paths_with_sources(
+            Some(std::slice::from_ref(&shared_str)),
+            Some("maya"),
+        );
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("DCC_MCP_MAYA_SKILL_PATHS", v),
+                None => std::env::remove_var("DCC_MCP_MAYA_SKILL_PATHS"),
+            }
+        }
+
+        let shared_entries: Vec<_> = collected
+            .iter()
+            .filter(|(p, _)| {
+                let abs = std::fs::canonicalize(p).map(|x| path_to_string(&x)).ok();
+                abs.as_deref() == Some(shared_str.as_str())
+                    || abs.as_ref()
+                        == std::fs::canonicalize(&shared_str)
+                            .map(|x| path_to_string(&x))
+                            .ok()
+                            .as_ref()
+            })
+            .collect();
+        assert_eq!(
+            shared_entries.len(),
+            1,
+            "dedupe must keep exactly one entry per on-disk path; got {collected:?}"
+        );
+        assert_eq!(
+            shared_entries[0].1,
+            SkillPathSource::ExplicitArg,
+            "extra_paths must win over env-var for the same on-disk path"
         );
     }
 }

--- a/tests/test_search_skills_path_source.py
+++ b/tests/test_search_skills_path_source.py
@@ -1,0 +1,109 @@
+"""End-to-end regression for the search_skills path-source rank penalty (#1403).
+
+Skills discovered from user-curated locations (`extra_paths`,
+`DCC_MCP_*_SKILL_PATHS`, `~/.dcc-mcp/<dcc>/skills`) must outrank skills
+that come from bundled / platform-installed directories for neutral
+queries. This protects the "I'm iterating on my local skill" workflow
+from being drowned out by starter material shipped with the package.
+
+Exercises the full Rust catalog → Python binding path; the source
+tagging happens in `crates/dcc-mcp-skills/src/scanner.rs::scan_with_sources`
+and the rank multiplier in `crates/dcc-mcp-skills/src/catalog/scoring.rs`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from dcc_mcp_core import SkillCatalog
+from dcc_mcp_core import ToolRegistry
+
+
+def _write_skill(skills_root: Path, name: str, *, description: str, dcc: str = "maya") -> None:
+    skill_dir = skills_root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "scripts").mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                f"name: {name}",
+                f"description: {description}",
+                "metadata:",
+                "  dcc-mcp:",
+                f"    dcc: {dcc}",
+                "---",
+                f"# {name}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_env_var_outranks_explicit_arg_only_when_bundled(tmp_path: Path) -> None:
+    # Two roots with identical-content skills. The `extra_paths` root is
+    # tagged `ExplicitArg` (x 1.00) and the env-var root is tagged
+    # `EnvVar` (x 1.00) — both at the same priority, so the ranker falls
+    # through to the alphabetical tie-break.
+    explicit_root = tmp_path / "explicit"
+    env_root = tmp_path / "envvar"
+    explicit_root.mkdir()
+    env_root.mkdir()
+    _write_skill(explicit_root, "alpha-render", description="render bake helpers")
+    _write_skill(env_root, "beta-render", description="render bake helpers")
+
+    saved = os.environ.get("DCC_MCP_MAYA_SKILL_PATHS")
+    os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = str(env_root)
+    try:
+        catalog = SkillCatalog(ToolRegistry())
+        catalog.discover(extra_paths=[str(explicit_root)], dcc_name="maya")
+        names = [s.name for s in catalog.search_skills(query="render bake")]
+    finally:
+        if saved is None:
+            os.environ.pop("DCC_MCP_MAYA_SKILL_PATHS", None)
+        else:
+            os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = saved
+
+    assert "alpha-render" in names
+    assert "beta-render" in names
+    # Both x 1.00 → alphabetical tie-break (alpha < beta).
+    assert names.index("alpha-render") < names.index("beta-render"), (
+        f"both user-curated sources must tie on multiplier; order {names}"
+    )
+
+
+def test_explicit_arg_outranks_via_score_skills_default(tmp_path: Path) -> None:
+    # Smoke test that the `extra_paths` lane works end-to-end: a single
+    # discover() call tags the skill, and search_skills returns it.
+    explicit_root = tmp_path / "explicit"
+    explicit_root.mkdir()
+    _write_skill(explicit_root, "user-render", description="render bake helpers")
+
+    catalog = SkillCatalog(ToolRegistry())
+    catalog.discover(extra_paths=[str(explicit_root)], dcc_name="maya")
+    names = [s.name for s in catalog.search_skills(query="render bake")]
+
+    assert "user-render" in names, f"user-curated skill must be discoverable; got {names}"
+    assert names[0] == "user-render", f"user-curated skill should lead unrelated bundled fixtures; got {names}"
+
+
+@pytest.mark.parametrize("query", ["render bake helpers"])
+def test_path_source_smoke_neutral_query(tmp_path: Path, query: str) -> None:
+    # Defensive smoke test: with only one fixture under extra_paths the
+    # catalog must return it as the top hit regardless of which bundled
+    # skills the package ships with. This guards against the path-source
+    # multiplier accidentally dropping legitimate user content.
+    user_root = tmp_path / "userland"
+    user_root.mkdir()
+    _write_skill(user_root, "user-bake", description=query)
+
+    catalog = SkillCatalog(ToolRegistry())
+    catalog.discover(extra_paths=[str(user_root)], dcc_name="maya")
+    names = [s.name for s in catalog.search_skills(query=query)]
+
+    assert names, "expected at least one match for a user-curated skill"
+    assert names[0] == "user-bake", f"user-curated skill must lead neutral-query results; got {names}"


### PR DESCRIPTION
Closes #1403.

## What

Skills shipped with the dcc-mcp-core package itself (under
`python/dcc_mcp_core/skills/` or a per-DCC adapter's `<adapter>/skills/`)
are intended as starter / reference material. When a user has invested
in their own local-development skills under `~/.dcc-mcp/<dcc>/skills`,
exported `DCC_MCP_*_SKILL_PATHS`, or added a custom path through the
admin UI, those skills should outrank the bundled ones for neutral
queries — they are demonstrably what the user cares about.

Adds a small path-source multiplier on top of the layer multiplier
from #1399:

| Source        | Where it comes from                              | Rank   |
|---------------|--------------------------------------------------|-------:|
| `ExplicitArg` | `extra_paths` passed to `discover()` / `scan_*`  | × 1.00 |
| `AdminCustom` | Added through the admin UI (gateway SQLite lane) | × 1.00 |
| `EnvVar`      | `DCC_MCP_SKILL_PATHS` / `DCC_MCP_<APP>_SKILL_PATHS` | × 1.00 |
| `LocalDev`    | `~/.dcc-mcp/<dcc>/skills` (local iteration root) | × 1.00 |
| `Unknown`     | default for older code paths / tests             | × 1.00 |
| `Platform`    | Platform-wide install dir (`get_skills_dir`)     | × 0.85 |
| `Bundled`     | Shipped with the dcc-mcp package itself          | × 0.70 |

All values stay ≤ 1.0 so the multiplier compounds cleanly with the
layer multiplier. The exact-name fast-path bypasses the penalty so
`search_skills("dcc-diagnostics")` still surfaces the bundled
diagnostics skill at the top regardless of source.

## Why

User feedback after #1399 (layer penalty) merged: AI agents still
loaded `app-ui` / `dcc-adapter` first even though they live in the
package's own bundled directory. With both skills at `domain` layer,
the BM25 tie-break is alphabetical, and bundled tends to win that
race because the names are short and tag-rich.

`~/.dcc-mcp/<dcc>/skills` is specifically called out as the local-dev
convention, so we tag it `LocalDev` (× 1.00) and let it tie cleanly
with `EnvVar` / `ExplicitArg` for users who configure both.

## Changes

| File | Note |
|------|------|
| `crates/dcc-mcp-skills/src/catalog/scoring.rs` | New `SkillPathSource` enum + `path_source_multiplier()`; `score_skills` gains optional `path_sources` arg; 8 new unit tests |
| `crates/dcc-mcp-skills/src/catalog/types.rs` | `SkillEntry.path_source` (`#[serde(default)]`) |
| `crates/dcc-mcp-skills/src/scanner.rs` | New `scan_with_sources` + `collect_search_paths_with_sources`; old `scan` / `collect_search_paths` are thin wrappers; 2 new unit tests |
| `crates/dcc-mcp-skills/src/loader/scan.rs` | New `LoadResultWithSources` + `scan_and_load_lenient_with_sources` |
| `crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs` | `discover()` / `rediscover()` use the source-aware loader and tag each entry |
| `crates/dcc-mcp-skills/src/catalog/catalog.rs` | `search_skills` threads per-entry path sources into the ranker |
| `crates/dcc-mcp-skills/src/catalog/catalog_loading.rs` | `load_skill_object` preserves the existing `path_source` on reload |
| `crates/dcc-mcp-skills/src/lib.rs` + `loader/mod.rs` | Re-export the new types |
| `crates/dcc-mcp-skills/src/catalog/tests/{mod.rs,fixtures.rs}` | Test fixtures populate the new field (default `Unknown`) |
| `tests/test_search_skills_path_source.py` | New end-to-end Python test (3 cases) |
| `AGENTS.md` | Skill path-source decision table |

## Validation

- `cargo test -p dcc-mcp-skills --lib catalog::scoring` — **34 / 34 pass**
  (26 pre-existing + 8 new path-source tests: multiplier table,
  default-is-Unknown, bundled-below-local-dev, env-var-over-bundled
  even with weaker BM25, Platform between Bundled and user-curated,
  exact-name bypass, layer × source compounding, and the `None`-arg
  neutral path).
- `cargo test -p dcc-mcp-skills --lib scanner` — **4 / 4 pass** (2
  new: `ExplicitArg` tagging + dedupe priority).
- `pytest tests/test_search_skills_path_source.py` — **3 / 3 pass**
  (end-to-end via Python `SkillCatalog`).
- `pytest tests/test_search_skills_layer_penalty.py` — **4 / 4 pass**
  (the layer-penalty PR's tests still green).
- `cargo clippy -p dcc-mcp-skills --all-targets -- -D warnings` clean.
- `cargo fmt --check` + `cargo hakari` clean.

Pre-existing flakes in `test_catalog_crud`
(`test_get_skill_info_includes_skill_markdown` /
`test_rediscover_removes_missing_skill_and_registered_tools`) remain;
verified by running them on a clean `origin/main` checkout before this
PR's changes — they're unrelated `rediscover` count mismatches and
out of scope here.

## Backward compatibility

- `SkillEntry.path_source` is `#[serde(default)]`, so any persisted
  catalog state from before this PR deserialises with the default
  `Unknown` source (× 1.00 → no behaviour change).
- `score_skills` accepts `Option<&[SkillPathSource]>` and treats
  `None` as "every entry is × 1.00", so callers that don't yet track
  path sources keep the previous behaviour bit-for-bit.
- `SkillScanner::scan` and `collect_search_paths` keep their original
  signatures as thin wrappers over the new source-aware variants.

## Out of scope (separate PRs)

- Persisting `SkillCatalog.loaded` across restarts (track B).
- Admin UI Skills panel marketplace redesign (track D).
- Surfacing `SkillPathSource` in the admin UI alongside skill rows
  (depends on track D's data layer).
