### PR TITLE
feat(skill-rest): surface next-tools at describe-time

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/tests.rs
@@ -188,6 +188,10 @@ async fn skill_rest_metadata_survives_fetch_and_describe() {
                             "execution": "sync",
                             "timeoutHintSecs": 2,
                             "risk": "read-only"
+                        },
+                        "dcc.next_tools": {
+                            "on_success": ["app_ui__inspect"],
+                            "on_failure": ["dcc_diagnostics__screenshot"]
                         }
                     }
                 }))
@@ -256,6 +260,21 @@ async fn skill_rest_metadata_survives_fetch_and_describe() {
             .and_then(|dcc| dcc.get("risk"))
             .and_then(Value::as_str),
         Some("read-only")
+    );
+    // next-tools hints authored in tools.yaml must survive the describe
+    // round-trip so agents can pre-plan failure recovery (issue #1408).
+    let next_tools = described
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.get("dcc.next_tools"))
+        .expect("dcc.next_tools forwarded through describe");
+    assert_eq!(
+        next_tools.get("on_failure").and_then(Value::as_array),
+        Some(&vec![Value::String("dcc_diagnostics__screenshot".into())])
+    );
+    assert_eq!(
+        next_tools.get("on_success").and_then(Value::as_array),
+        Some(&vec![Value::String("app_ui__inspect".into())])
     );
     let _ = stop.send(());
 }

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -25,7 +25,9 @@ use dcc_mcp_actions::dispatcher::{DispatchError, ToolDispatcher, with_thread_aff
 use dcc_mcp_actions::{
     DispatchExecutionContext, current_execution_context, with_execution_context,
 };
-use dcc_mcp_models::{ExecutionMode, SkillRuntimeSummary, ThreadAffinity, ToolAnnotations};
+use dcc_mcp_models::{
+    ExecutionMode, NextTools, SkillRuntimeSummary, ThreadAffinity, ToolAnnotations,
+};
 use dcc_mcp_skills::SkillCatalog;
 
 use super::errors::{ServiceError, ServiceErrorKind};
@@ -319,6 +321,9 @@ pub struct CatalogAction {
     pub enforce_thread_affinity: bool,
     pub available_groups: Vec<SkillGroupState>,
     pub runtime: Option<SkillRuntimeSummary>,
+    /// Suggested follow-up tools (`on-success` / `on-failure`). Surfaced at
+    /// describe-time so agents can pre-plan recovery steps (issue #1408).
+    pub next_tools: NextTools,
 }
 
 /// Anything that can invoke a tool by name and return its output.
@@ -602,6 +607,7 @@ impl SkillCatalogSource for CatalogSource {
                     .cloned()
                     .unwrap_or_default(),
                 runtime,
+                next_tools: meta.next_tools,
             });
         }
 
@@ -654,6 +660,7 @@ impl SkillCatalogSource for CatalogSource {
                         .cloned()
                         .unwrap_or_default(),
                     runtime: detail.runtime.clone(),
+                    next_tools: tool_decl.next_tools.clone(),
                 });
             }
         }
@@ -1029,7 +1036,16 @@ impl SkillRestService {
         let action = self.resolve_slug(&req.tool_slug)?;
         let entry = action_to_entry(action.clone());
         let annotations = describe_annotations(&action);
-        let metadata = action_metadata(&action);
+        let mut metadata = action_metadata(&action);
+        // Surface next-tools hints at describe-time so agents can pre-plan
+        // both the success path and failure recovery before calling the
+        // tool (issue #1408). Mirrors the post-call `_meta["dcc.next_tools"]`
+        // convention, but exposes both branches at once.
+        if let Some(next_tools) = next_tools_meta_value(&action.next_tools)
+            && let Some(obj) = metadata.as_object_mut()
+        {
+            obj.insert("dcc.next_tools".to_string(), next_tools);
+        }
         let mut annotations = annotations.unwrap_or_else(|| serde_json::json!({}));
         annotations["tags"] = serde_json::json!(action.tags);
         annotations["scope"] = serde_json::json!(action.scope);
@@ -1242,6 +1258,32 @@ fn action_to_entry(a: CatalogAction) -> SkillListEntry {
 
 fn describe_annotations(action: &CatalogAction) -> Option<Value> {
     safety_annotations(&action.annotations)
+}
+
+/// Build the `dcc.next_tools` describe-time hint value (issue #1408).
+///
+/// Unlike the post-call `_meta` slot — which carries only the branch that
+/// matched the outcome — describe exposes **both** `on_success` and
+/// `on_failure` so agents can plan recovery before invoking the tool.
+/// Returns `None` when no follow-ups are declared so the key stays absent.
+fn next_tools_meta_value(next_tools: &NextTools) -> Option<Value> {
+    if next_tools.on_success.is_empty() && next_tools.on_failure.is_empty() {
+        return None;
+    }
+    let mut map = serde_json::Map::new();
+    if !next_tools.on_success.is_empty() {
+        map.insert(
+            "on_success".to_string(),
+            serde_json::json!(next_tools.on_success),
+        );
+    }
+    if !next_tools.on_failure.is_empty() {
+        map.insert(
+            "on_failure".to_string(),
+            serde_json::json!(next_tools.on_failure),
+        );
+    }
+    Some(Value::Object(map))
 }
 
 fn safety_annotations(annotations: &ToolAnnotations) -> Option<Value> {

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -106,6 +106,7 @@ fn sphere_action(loaded: bool) -> CatalogAction {
         enforce_thread_affinity: false,
         available_groups: Vec::new(),
         runtime: None,
+        next_tools: Default::default(),
     }
 }
 
@@ -236,6 +237,53 @@ fn search_and_describe_surface_runtime_metadata() {
 }
 
 #[test]
+fn describe_surfaces_next_tools_both_branches() {
+    // Authoring a tool with next-tools must expose BOTH branches at
+    // describe-time so an agent can pre-plan success + failure recovery
+    // (issue #1408). The flat `dcc.next_tools` key mirrors the post-call
+    // `_meta` convention so agents look in the same place.
+    let mut action = sphere_action(true);
+    action.next_tools = dcc_mcp_models::NextTools {
+        on_success: vec!["validate_naming".into(), "inspect_usd".into()],
+        on_failure: vec!["dcc_diagnostics__screenshot".into()],
+    };
+    let (svc, _) = build_service(vec![action]);
+
+    let desc = svc
+        .describe(&DescribeRequest {
+            tool_slug: ToolSlug::build("maya", "spheres", "create_sphere"),
+            include_schema: false,
+        })
+        .expect("describe");
+    let next = &desc.metadata.as_ref().expect("metadata")["dcc.next_tools"];
+    assert_eq!(
+        next["on_success"],
+        serde_json::json!(["validate_naming", "inspect_usd"])
+    );
+    assert_eq!(
+        next["on_failure"],
+        serde_json::json!(["dcc_diagnostics__screenshot"])
+    );
+}
+
+#[test]
+fn describe_omits_next_tools_when_none_declared() {
+    // No follow-ups declared → the `dcc.next_tools` key must be absent so
+    // the describe payload stays lean.
+    let (svc, _) = build_service(vec![sphere_action(true)]);
+
+    let desc = svc
+        .describe(&DescribeRequest {
+            tool_slug: ToolSlug::build("maya", "spheres", "create_sphere"),
+            include_schema: false,
+        })
+        .expect("describe");
+    if let Some(metadata) = desc.metadata.as_ref() {
+        assert!(metadata.get("dcc.next_tools").is_none());
+    }
+}
+
+#[test]
 fn load_skill_then_search_makes_action_callable() {
     let (svc, _) = build_service(vec![sphere_action(false)]);
 
@@ -308,6 +356,7 @@ fn search_matches_aliases_and_schema_tokens_without_schema_expansion() {
         enforce_thread_affinity: false,
         available_groups: Vec::new(),
         runtime: None,
+        next_tools: Default::default(),
     };
 
     let (svc, _) = build_service(vec![maya, photoshop]);


### PR DESCRIPTION
## Summary

Expose on-success/on-failure next-tools hints in the describe output, not just after a call, so agents can pre-plan failure recovery.

- Add `next_tools` to `CatalogAction` and populate from `ToolMeta` (loaded) and `ToolDeclaration` (unloaded) in `list_actions`.
- Inject `next_tools` into the describe metadata under `dcc.next_tools` so it threads through the gateway `mcp_meta_from_rest_metadata` helper into the MCP `_meta` field.
- Add Rust tests for describe-time hints (both branches / omitted when none) and extend the gateway describe round-trip test.

Closes #1408

## Test plan

- [x] All 85 skill-rest tests pass
- [x] Gateway backend_client tests pass
- [x] `cargo fmt --check` clean for touched files