### PR TITLE
fix(skills): pass skills to register_recipes_tools in builtin registration

### DIFF
--- a/python/dcc_mcp_core/skills/builtin.py
+++ b/python/dcc_mcp_core/skills/builtin.py
@@ -29,6 +29,7 @@ def register_all_builtin_skills(
     dcc_window_handle: int | None = None,
     dcc_window_title: str | None = None,
     gateway_failover_resolver: Callable[[], dict[str, Any]] | None = None,
+    skills: list[Any] | None = None,
 ) -> None:
     """Register all standard built-in tools on *server*.
 
@@ -42,6 +43,13 @@ def register_all_builtin_skills(
 
     The call is idempotent; re-registering the same tools on the same
     server is safe.
+
+    ``skills`` is an optional list of ``SkillMetadata`` objects forwarded to
+    :func:`register_recipes_tools`. When ``None`` (the common case at
+    base-server init time, before any skills are scanned) an empty list is
+    used so the ``recipes__*`` tools are still registered; adapters that have
+    already scanned skills can pass them here and later re-register with the
+    populated set (registration is idempotent).
     """
     logger.debug("[%s] Registering all built-in skills", dcc_name)
 
@@ -61,8 +69,9 @@ def register_all_builtin_skills(
     # 3. Agent feedback
     register_feedback_tool(server, dcc_name=dcc_name)
 
-    # 4. Recipes
-    register_recipes_tools(server, dcc_name=dcc_name)
+    # 4. Recipes (skills default to empty at base init; adapters re-register
+    #    with the scanned skill set later — registration is idempotent).
+    register_recipes_tools(server, skills=skills or [], dcc_name=dcc_name)
 
     # 5. Qt UI inspector (opt-in default capability)
     register_qt_ui_inspector(server, dcc_name=dcc_name)

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -1,0 +1,85 @@
+"""Regression tests for :mod:`dcc_mcp_core.skills.builtin`.
+
+Guards the bug where ``register_all_builtin_skills`` called
+``register_recipes_tools`` without the now-required keyword-only ``skills``
+argument. That raised ``TypeError`` mid-way through registration, aborting the
+later steps (Qt UI inspector + script materialization) and surfacing only as a
+swallowed warning at the ``DccServerBase`` level.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from dcc_mcp_core.skills import builtin
+
+
+def _make_server() -> MagicMock:
+    server = MagicMock()
+    server.registry = MagicMock()
+    handlers: dict = {}
+    server.register_handler.side_effect = lambda name, fn: handlers.__setitem__(name, fn)
+    return server
+
+
+def test_register_all_builtin_skills_runs_every_step(monkeypatch):
+    """All six built-in steps must run; recipes must receive ``skills``."""
+    calls: list[str] = []
+    recipes_kwargs: dict = {}
+
+    def _recorder(name):
+        def _inner(*_args, **_kwargs):
+            calls.append(name)
+
+        return _inner
+
+    def _recipes(*_args, **kwargs):
+        calls.append("recipes")
+        recipes_kwargs.update(kwargs)
+
+    monkeypatch.setattr(builtin, "register_diagnostic_mcp_tools", _recorder("diagnostics"))
+    monkeypatch.setattr(builtin, "register_introspect_tools", _recorder("introspect"))
+    monkeypatch.setattr(builtin, "register_feedback_tool", _recorder("feedback"))
+    monkeypatch.setattr(builtin, "register_recipes_tools", _recipes)
+    monkeypatch.setattr(builtin, "register_qt_ui_inspector", _recorder("qt"))
+    monkeypatch.setattr(builtin, "register_script_materialization_tools", _recorder("materialize"))
+
+    builtin.register_all_builtin_skills(_make_server(), dcc_name="maya")
+
+    # Every step, including the two that previously got skipped after the
+    # TypeError, must have executed in order.
+    assert calls == ["diagnostics", "introspect", "feedback", "recipes", "qt", "materialize"]
+    # recipes must be invoked with an (empty) skills list, never omitted.
+    assert "skills" in recipes_kwargs
+    assert recipes_kwargs["skills"] == []
+
+
+def test_register_all_builtin_skills_forwards_skills(monkeypatch):
+    """When the caller supplies skills they reach ``register_recipes_tools``."""
+    seen: dict = {}
+
+    monkeypatch.setattr(builtin, "register_diagnostic_mcp_tools", lambda *a, **k: None)
+    monkeypatch.setattr(builtin, "register_introspect_tools", lambda *a, **k: None)
+    monkeypatch.setattr(builtin, "register_feedback_tool", lambda *a, **k: None)
+    monkeypatch.setattr(builtin, "register_qt_ui_inspector", lambda *a, **k: None)
+    monkeypatch.setattr(builtin, "register_script_materialization_tools", lambda *a, **k: None)
+    monkeypatch.setattr(
+        builtin,
+        "register_recipes_tools",
+        lambda *a, **k: seen.update(k),
+    )
+
+    sentinel = [MagicMock(name="skill-a"), MagicMock(name="skill-b")]
+    builtin.register_all_builtin_skills(_make_server(), dcc_name="blender", skills=sentinel)
+
+    assert seen["skills"] is sentinel
+
+
+def test_register_all_builtin_skills_with_real_recipes_does_not_raise():
+    """End-to-end: the real recipes registration must not raise on empty skills."""
+    server = _make_server()
+    # Should complete without TypeError even though no skills are scanned yet.
+    builtin.register_all_builtin_skills(server, dcc_name="houdini")
+    registered = [c.kwargs.get("name") for c in server.registry.register.call_args_list]
+    assert "recipes__list" in registered
+    assert "recipes__get" in registered


### PR DESCRIPTION
## Summary

- `register_recipes_tools()` requires a keyword-only `skills` argument, but `register_all_builtin_skills()` called it without one.
- This raised a `TypeError` at step 4 of built-in registration, which **aborted the remaining steps** (step 5 Qt UI inspector + step 6 script materialization). It surfaced only as a swallowed warning at the `DccServerBase` level, so adapters silently lost those built-in tools.
- Fix: thread an optional `skills` list through `register_all_builtin_skills` and forward it (defaulting to `[]`) so the `recipes__*` tools are always registered and the later steps run. Registration stays idempotent, so adapters that re-register with their scanned skills still override the empty set.

## Test plan

- [x] New `tests/test_builtin_skills.py` — verifies the full 6-step sequence runs, that `skills` is forwarded, and that the real recipes registration path does not raise on empty skills.
- [x] `pytest tests/test_builtin_skills.py tests/test_recipes.py tests/test_dcc_adapter_base.py` → 121 passed.
- [x] pre-commit (ruff / ruff format) clean.
