### PR TITLE
fix(ci): install openssl-devel in manylinux semantic wheel build

### DIFF
--- a/scripts/release/build_manylinux_semantic_wheel.sh
+++ b/scripts/release/build_manylinux_semantic_wheel.sh
@@ -38,12 +38,13 @@ esac
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo_root"
 
+maturin_args_str="${maturin_args[*]}"
 docker run --rm \
   -v "$PWD:/io" \
   -e CARGO_TARGET_DIR=/io/target-manylinux-semantic \
   -w /io/pkg/dcc-mcp-core-semantic \
   ghcr.io/pyo3/maturin:v1.13.3 \
-  build --release --manylinux 2_28 --out wheels "${maturin_args[@]}"
+  sh -c "dnf install -y openssl-devel && maturin build --release --manylinux 2_28 --out wheels ${maturin_args_str}"
 
 if command -v sudo >/dev/null 2>&1; then
   sudo chown -R "$(id -u):$(id -g)" pkg/dcc-mcp-core-semantic/wheels


### PR DESCRIPTION
## Problem

The `build-semantic-wheels` job in `release.yml` fails on `linux-abi3` with:
```
error: failed to run custom build command for `openssl-sys v0.9.116`
pkg-config exited with status code 1
```

## Root Cause

`fastembed` v5 pulls in `hf-hub` → `native-tls` → `openssl` → `openssl-sys`, but the `ghcr.io/pyo3/maturin:v1.13.3` Docker image (manylinux_2_28) does not include OpenSSL development headers.

## Fix

Install `openssl-devel` via `dnf` before running `maturin build` inside the Docker container.

## Affected CI

- `release.yml` → `build-semantic-wheels` → `linux-abi3`
- `release.yml` → `build-semantic-wheels` → `linux-py37`