### PR TITLE
fix(ci): override maturin docker entrypoint + bump vx to 0.9.11

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -68,9 +68,9 @@ runs:
         components: clippy rustfmt
 
     - name: Install vx
-      uses: loonghao/vx@v0.9.7
+      uses: loonghao/vx@v0.9.11
       with:
-        version: "0.9.7"
+        version: "0.9.11"
         cache-key-prefix: "vx-tools-v0.9.7"
         cache: "false"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
       - name: Build admin UI bundle
         shell: bash
@@ -148,9 +148,9 @@ jobs:
           echo "CARGO=${CARGO_BIN}" >> "$GITHUB_ENV"
           echo "RUSTC=$(rustup which rustc)" >> "$GITHUB_ENV"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
       - name: Prepare admin UI dependencies
         shell: bash
@@ -302,9 +302,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
       - name: Download wheel
         uses: actions/download-artifact@v8
@@ -390,9 +390,9 @@ jobs:
         with:
           python-version: "3.14"
 
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
 
       - name: Install dev deps
@@ -435,9 +435,9 @@ jobs:
         with:
           python-version: "3.14"
 
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache: "false"
 
       - name: Download wheel

--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -53,9 +53,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
       - name: Cache Cargo
         uses: actions/cache@v5

--- a/.github/workflows/python-matrix-full.yml
+++ b/.github/workflows/python-matrix-full.yml
@@ -39,9 +39,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
       - uses: dtolnay/rust-toolchain@stable
       - name: Build wheel

--- a/.github/workflows/release-please-lock-sync.yml
+++ b/.github/workflows/release-please-lock-sync.yml
@@ -38,9 +38,9 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
 
       - uses: taiki-e/install-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,9 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
 
       - name: Build admin UI bundle
@@ -186,9 +186,9 @@ jobs:
           toolchain: '1.95.0'
           targets: aarch64-apple-darwin  # needed for macOS universal2 lipo
 
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -25,9 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust-matrix-full.yml
+++ b/.github/workflows/rust-matrix-full.yml
@@ -40,9 +40,9 @@ jobs:
           echo "CARGO=${CARGO_BIN}" >> "$GITHUB_ENV"
           echo "RUSTC=$(rustup which rustc)" >> "$GITHUB_ENV"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: loonghao/vx@v0.9.7
+      - uses: loonghao/vx@v0.9.11
         with:
-          version: "0.9.7"
+          version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
       - name: Prepare admin UI dependencies
         shell: bash

--- a/README.md
+++ b/README.md
@@ -251,13 +251,13 @@ By default, the installers download the latest GitHub Release asset:
 Pin a release or install somewhere custom:
 
 ```bash
-export DCC_MCP_VERSION=v0.17.17
+export DCC_MCP_VERSION=v0.17.44
 export DCC_MCP_INSTALL_DIR="$HOME/bin"
 curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
 ```
 
 ```powershell
-$env:DCC_MCP_VERSION = "v0.17.17"
+$env:DCC_MCP_VERSION = "v0.17.44"
 $env:DCC_MCP_INSTALL_DIR = "$env:USERPROFILE\bin"
 irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -190,13 +190,13 @@ powershell -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/
 也可以固定版本或自定义安装目录：
 
 ```bash
-export DCC_MCP_VERSION=v0.17.17
+export DCC_MCP_VERSION=v0.17.44
 export DCC_MCP_INSTALL_DIR="$HOME/bin"
 curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
 ```
 
 ```powershell
-$env:DCC_MCP_VERSION = "v0.17.17"
+$env:DCC_MCP_VERSION = "v0.17.44"
 $env:DCC_MCP_INSTALL_DIR = "$env:USERPROFILE\bin"
 irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex
 ```

--- a/scripts/release/build_manylinux_semantic_wheel.sh
+++ b/scripts/release/build_manylinux_semantic_wheel.sh
@@ -39,12 +39,19 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo_root"
 
 maturin_args_str="${maturin_args[*]}"
+# The `ghcr.io/pyo3/maturin` image declares `maturin` as its ENTRYPOINT, so any
+# trailing argv is forwarded to `maturin` (running `... sh -c "..."` therefore
+# fails with `unrecognized subcommand 'sh'`). We must install `openssl-devel`
+# *before* maturin runs (fastembed → hf-hub → native-tls → openssl-sys needs
+# libssl headers that the base manylinux_2_28 image omits), so override the
+# entrypoint to `/bin/sh` and let the shell receive `-c "..."` directly.
 docker run --rm \
+  --entrypoint /bin/sh \
   -v "$PWD:/io" \
   -e CARGO_TARGET_DIR=/io/target-manylinux-semantic \
   -w /io/pkg/dcc-mcp-core-semantic \
   ghcr.io/pyo3/maturin:v1.13.3 \
-  sh -c "dnf install -y openssl-devel && maturin build --release --manylinux 2_28 --out wheels ${maturin_args_str}"
+  -c "dnf install -y openssl-devel && maturin build --release --manylinux 2_28 --out wheels ${maturin_args_str}"
 
 if command -v sudo >/dev/null 2>&1; then
   sudo chown -R "$(id -u):$(id -g)" pkg/dcc-mcp-core-semantic/wheels


### PR DESCRIPTION
## Summary

- Fix the manylinux **`build-semantic-wheels`** failure where `Build wheel (Linux abi3)` and `Build wheel (Linux py37)` both died at step 7 with `error: unrecognized subcommand 'sh'` (release run [#26675960809](https://github.com/loonghao/dcc-mcp-core/actions/runs/26675960809/job/78627643873)).
- Bump the `loonghao/vx` GitHub Action across every workflow and composite action (`build-wheel/action.yml`, `ci.yml`, `dcc-integration.yml`, `python-matrix-full.yml`, `release-please-lock-sync.yml`, `release.yml`, `rust-coverage.yml`, `rust-matrix-full.yml`) from `v0.9.7` → `v0.9.11`, including the pinned `version:` input.
- Refresh the stale `DCC_MCP_VERSION=v0.17.17` snippets in `README.md` / `README_zh.md` to the current released `v0.17.44` so the install instructions track the live tag. `llms.txt` already syncs via the release-please marker.

## Root Cause (semantic-wheel job)

`ghcr.io/pyo3/maturin:v1.13.3` declares `maturin` as the Docker `ENTRYPOINT`. The previous fix tried to install `openssl-devel` ahead of the wheel build by appending `sh -c "dnf install ... && maturin build ..."` to `docker run`, but Docker forwards that whole argv to the entrypoint — i.e. it became `maturin sh -c "..."`, which maturin rejects:

```
error: unrecognized subcommand 'sh'
Usage: maturin [OPTIONS] <COMMAND>
```

## Fix

Override the entrypoint to `/bin/sh` so `-c "..."` lands on the shell instead of on maturin:

```diff
 docker run --rm \
+  --entrypoint /bin/sh \
   -v "$PWD:/io" \
   -e CARGO_TARGET_DIR=/io/target-manylinux-semantic \
   -w /io/pkg/dcc-mcp-core-semantic \
   ghcr.io/pyo3/maturin:v1.13.3 \
-  sh -c "dnf install -y openssl-devel && maturin build ..."
+  -c "dnf install -y openssl-devel && maturin build ..."
```

Behavior is equivalent to the intended flow:

1. `dnf install -y openssl-devel` provides the libssl headers that fastembed → hf-hub → native-tls → openssl-sys needs (the base manylinux_2_28 image omits them).
2. `maturin build --release --manylinux 2_28 --out wheels …` runs with the same argv as before.

## Test plan

- [ ] CI green on this branch — both `build-semantic-wheels (ubuntu-latest, linux-abi3)` and `(ubuntu-22.04, linux-py37)` should now reach `maturin build` instead of crashing on argv parsing.
- [ ] All other release jobs (`build-wheels`, `build-binaries`, `publish-clawhub-skills`, etc.) still pass with the new `loonghao/vx@v0.9.11`.
- [ ] After merge, the next release-please tag should successfully publish the `dcc-mcp-core-semantic` linux abi3 + py37 wheels to GitHub Releases / PyPI.