### PR TITLE
fix(ci): unblock v0.17.45 wheel builds and Rust coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,12 +355,28 @@ jobs:
       # Rust toolchain is only needed for non-Linux builds; the Linux
       # builds run inside the pyo3/maturin docker image which bundles its
       # own pinned toolchain.
+      #
+      # macos-latest (arm64) ships a pre-installed Rust 1.95.0 whose
+      # clippy/rustfmt binaries are physically present on disk but not
+      # registered in rustup's component manifest. When `rust-toolchain.toml`
+      # later triggers `rustup component add clippy` (because cargo metadata
+      # auto-syncs), rustup detects the existing `bin/cargo-clippy` and
+      # aborts with `detected conflict: 'bin/cargo-clippy'`. Force a clean
+      # toolchain reinstall so dtolnay can install the components rustup
+      # expects to own, then add x86_64-apple-darwin so maturin can build
+      # the universal2 wheel (the host already provides aarch64).
+      - name: Reset macOS Rust toolchain to clear stale components
+        if: matrix.target == 'macos-abi3'
+        shell: bash
+        run: rustup toolchain uninstall 1.95.0-aarch64-apple-darwin || true
+
       - name: Setup Rust
         if: matrix.target != 'linux-abi3' && matrix.target != 'linux-py37'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: '1.95.0'
-          targets: ${{ matrix.target == 'macos-abi3' && 'aarch64-apple-darwin' || '' }}
+          components: clippy, rustfmt
+          targets: ${{ matrix.target == 'macos-abi3' && 'x86_64-apple-darwin' || '' }}
 
       - name: Setup Python (abi3 build)
         if: endsWith(matrix.target, '-abi3') && !startsWith(matrix.target, 'linux-')

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -37,6 +37,16 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
+      # `dcc-mcp-server` enables `dcc-mcp-gateway/admin` by default, so
+      # `cargo llvm-cov --workspace` triggers `crates/dcc-mcp-gateway/build.rs`
+      # which runs `npm ci --ignore-scripts` inside `admin-ui/`. Concurrent
+      # cargo + npm in coverage mode hits a known npm bug (`Exit handler
+      # never called!`) that crashes the build script. Pre-build the admin
+      # UI bundle once on the host so the build script reuses it via
+      # `DCC_MCP_ADMIN_UI_PREBUILT=1` and never invokes npm during coverage.
+      - name: Pre-build admin UI bundle
+        shell: bash
+        run: scripts/release/prebuild_admin_ui.sh
       - name: Run Rust coverage
         run: vx just rust-cov
       - name: Upload Rust coverage to Codecov

--- a/crates/dcc-mcp-semantic/src/embedder.rs
+++ b/crates/dcc-mcp-semantic/src/embedder.rs
@@ -77,7 +77,7 @@ impl NativeEmbedder {
             opts = opts.with_cache_dir(dir.clone());
         }
 
-        let model = TextEmbedding::try_new(opts).map_err(|err| EmbedderError::Load {
+        let mut model = TextEmbedding::try_new(opts).map_err(|err| EmbedderError::Load {
             model: model_name.clone(),
             source: anyhow::Error::msg(err.to_string()),
         })?;
@@ -115,7 +115,13 @@ impl NativeEmbedder {
 
     /// Embed a single text. Empty / whitespace-only inputs short-circuit
     /// to a zero vector of length [`Self::dim`] without invoking the model.
-    pub fn embed_one(&self, text: &str) -> Result<Vec<f32>, EmbedderError> {
+    ///
+    /// Takes `&mut self` because `fastembed::TextEmbedding::embed` requires
+    /// `&mut self` (it advances internal ONNX session state). The PyO3
+    /// wrapper handles the borrow at the `pyclass` level via runtime
+    /// borrow checking — concurrent embed calls from different Python
+    /// threads need separate `NativeEmbedder` instances.
+    pub fn embed_one(&mut self, text: &str) -> Result<Vec<f32>, EmbedderError> {
         if text.trim().is_empty() {
             return Ok(vec![0.0; self.dim]);
         }
@@ -131,7 +137,9 @@ impl NativeEmbedder {
     /// Batch embed. Empty inputs in the batch are padded with zero vectors
     /// in the corresponding output positions; non-empty inputs are sent to
     /// fastembed in one batch call so the ONNX session is invoked once.
-    pub fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbedderError> {
+    ///
+    /// Takes `&mut self` for the same reason as [`Self::embed_one`].
+    pub fn embed_batch(&mut self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbedderError> {
         if texts.is_empty() {
             return Ok(Vec::new());
         }

--- a/crates/dcc-mcp-semantic/src/lib.rs
+++ b/crates/dcc-mcp-semantic/src/lib.rs
@@ -3,7 +3,8 @@
 //! This crate is the **Rust-native opt-in** companion to the Python-side
 //! `OnnxEmbedder` in `dcc-mcp-core`. It exposes a single [`NativeEmbedder`]
 //! pyclass that wraps `fastembed::TextEmbedding` and releases the GIL during
-//! ONNX inference via [`pyo3::Python::allow_threads`].
+//! ONNX inference via [`pyo3::Python::detach`] (the pyo3 0.28 successor to
+//! the older `allow_threads` name).
 //!
 //! Shipped as a separate PyPI wheel `dcc-mcp-core-semantic` that the
 //! `dcc-mcp-core[semantic]` extra pulls in. The main `dcc-mcp-core` wheel

--- a/crates/dcc-mcp-semantic/src/py.rs
+++ b/crates/dcc-mcp-semantic/src/py.rs
@@ -4,10 +4,10 @@
 //!
 //! 1. Convert between Python types (`Option<String>`, `Vec<String>`,
 //!    `Vec<f32>`) and the Rust core.
-//! 2. Release the GIL via [`pyo3::Python::allow_threads`] around every
-//!    fastembed call so concurrent Python threads can drive multiple
-//!    embedders (or other Python work) without serialising on the GIL
-//!    during ONNX inference.
+//! 2. Release the GIL via [`pyo3::Python::detach`] (renamed from
+//!    `allow_threads` in pyo3 0.28) around every fastembed call so
+//!    concurrent Python threads can drive multiple embedders (or other
+//!    Python work) without serialising on the GIL during ONNX inference.
 
 use std::path::PathBuf;
 
@@ -69,15 +69,20 @@ impl PyNativeEmbedder {
     /// Embed a single string. Returns a Python list of floats so the
     /// Python-side wrapper can convert to `array.array("d", ...)` without
     /// going through numpy.
-    fn embed(&self, py: Python<'_>, text: &str) -> PyResult<Vec<f32>> {
-        py.allow_threads(|| self.inner.embed_one(text))
-            .map_err(map_err)
+    ///
+    /// Takes `&mut self` because `fastembed::TextEmbedding::embed`
+    /// requires `&mut self` (it advances internal ONNX session state).
+    /// PyO3's runtime borrow checker enforces single-thread access on
+    /// the Python side, so callers wanting concurrency should hold a
+    /// separate `NativeEmbedder` per thread.
+    fn embed(&mut self, py: Python<'_>, text: &str) -> PyResult<Vec<f32>> {
+        py.detach(|| self.inner.embed_one(text)).map_err(map_err)
     }
 
     /// Batch embed. Equivalent to calling :meth:`embed` per input but
     /// invokes the ONNX session once for the whole batch.
-    fn embed_batch(&self, py: Python<'_>, texts: Vec<String>) -> PyResult<Vec<Vec<f32>>> {
-        py.allow_threads(|| self.inner.embed_batch(&texts))
+    fn embed_batch(&mut self, py: Python<'_>, texts: Vec<String>) -> PyResult<Vec<Vec<f32>>> {
+        py.detach(|| self.inner.embed_batch(&texts))
             .map_err(map_err)
     }
 

--- a/scripts/release/build_manylinux_semantic_wheel.sh
+++ b/scripts/release/build_manylinux_semantic_wheel.sh
@@ -43,15 +43,22 @@ maturin_args_str="${maturin_args[*]}"
 # trailing argv is forwarded to `maturin` (running `... sh -c "..."` therefore
 # fails with `unrecognized subcommand 'sh'`). We must install `openssl-devel`
 # *before* maturin runs (fastembed → hf-hub → native-tls → openssl-sys needs
-# libssl headers that the base manylinux_2_28 image omits), so override the
+# libssl headers that the base manylinux2014 image omits), so override the
 # entrypoint to `/bin/sh` and let the shell receive `-c "..."` directly.
+#
+# The maturin v1.13.3 image is built on `quay.io/pypa/manylinux2014_x86_64`
+# (CentOS 7 / glibc 2.17), so the package manager is **yum**, not dnf — see
+# https://github.com/PyO3/maturin/blob/v1.13.3/Dockerfile. The `--manylinux
+# 2_28` argument below only forward-tags the produced wheel; the actual
+# compilation environment is glibc 2.17 (a strict subset of 2.28, so the
+# wheel runs on every manylinux_2_28 host).
 docker run --rm \
   --entrypoint /bin/sh \
   -v "$PWD:/io" \
   -e CARGO_TARGET_DIR=/io/target-manylinux-semantic \
   -w /io/pkg/dcc-mcp-core-semantic \
   ghcr.io/pyo3/maturin:v1.13.3 \
-  -c "dnf install -y openssl-devel && maturin build --release --manylinux 2_28 --out wheels ${maturin_args_str}"
+  -c "yum install -y openssl-devel && maturin build --release --manylinux 2_28 --out wheels ${maturin_args_str}"
 
 if command -v sudo >/dev/null 2>&1; then
   sudo chown -R "$(id -u):$(id -g)" pkg/dcc-mcp-core-semantic/wheels


### PR DESCRIPTION
## Summary

Resolves the four failures from the v0.17.45 release pipeline ([actions/runs/26677615627](https://github.com/loonghao/dcc-mcp-core/actions/runs/26677615627)) and the Rust Coverage run on the follow-up Cargo sync ([actions/runs/26677615628](https://github.com/loonghao/dcc-mcp-core/actions/runs/26677615628)).

### Code fix — `dcc-mcp-semantic` was never compiled in default workspace check

The `fastembed-backend` / `python-bindings` features are off in the workspace's default `cargo check`, so two API drifts shipped silently and only fired during the wheel build:

- **`pyo3 0.28` renamed `Python::allow_threads` → `Python::detach`.** Other call sites in `dcc-mcp-host` had already been updated; this crate was missed.
- **`fastembed 5.x` `TextEmbedding::embed` now takes `&mut self`** (internal ONNX session state). Propagated `&mut self` through `NativeEmbedder::{embed_one,embed_batch}` and the PyO3 wrapper. PyO3's runtime borrow check on `#[pymethods]` preserves the existing Python contract — concurrent embeds still need one `NativeEmbedder` per thread.

### CI infra fixes

- **Linux semantic wheel — `dnf: command not found` (exit 127).** `ghcr.io/pyo3/maturin:v1.13.3` is built FROM `quay.io/pypa/manylinux2014_x86_64` (CentOS 7), so the package manager is **yum**, not dnf. The existing `--manylinux 2_28` flag forward-tags the wheel; glibc 2.17 is a strict subset of 2.28 so the build environment is still valid.
- **macOS semantic wheel — `detected conflict: 'bin/cargo-clippy'`.** macos-latest (arm64) ships a pre-installed Rust 1.95.0 whose clippy/rustfmt binaries exist on disk but aren't tracked by rustup's component manifest. `rust-toolchain.toml` triggers an auto-sync that conflicts on the unexpected file. Uninstall the toolchain first so dtolnay can re-install it cleanly with `components: clippy, rustfmt`. Also swap the redundant `targets: aarch64-apple-darwin` (already the host triple) for `x86_64-apple-darwin` — the other half of `--target universal2-apple-darwin`.
- **Rust coverage — `npm error Exit handler never called!`** from `crates/dcc-mcp-gateway/build.rs`. `dcc-mcp-server` enables `dcc-mcp-gateway/admin` by default, so `cargo llvm-cov --workspace` spawns `npm ci --ignore-scripts` concurrently with parallel cargo compilation; that combination hits a known npm crash. Pre-build the admin UI bundle on the host before coverage so the build script reuses it via `DCC_MCP_ADMIN_UI_PREBUILT=1` and never invokes npm during coverage.

## Test plan

- [ ] Release workflow `build-semantic-wheels` matrix passes for all five targets (linux-abi3, linux-py37, macos-abi3, windows-abi3, windows-py37)
- [ ] `Rust Coverage` workflow completes and uploads to Codecov
- [ ] Spot-check that the produced semantic wheels still load via `python -c "import dcc_mcp_core_semantic._native"` (manual after merge)