### PR TITLE
fix(semantic): rustls + aarch64-only macOS wheel; ci: cargo-deny + PR-stage semantic check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,55 @@ jobs:
           vx cargo check -p dcc-mcp-server --no-default-features --features gateway-daemon,admin
           vx cargo check -p dcc-mcp-server --no-default-features --features server,gateway-auto,gateway-daemon,admin
 
+      # `dcc-mcp-semantic` with `python-bindings` / `fastembed-backend`
+      # is the only path that touches `pyo3 0.28` and `fastembed 5`'s
+      # `&mut self` ONNX session API. It is gated off in the default
+      # workspace check so PRs do not pay the ORT runtime download
+      # cost — but that also means API drift only shows up at release
+      # wheel-build time. `cargo check` (no codegen for the C++ ORT
+      # runtime) is enough to catch the drift on every PR. See the
+      # v0.17.45/0.17.46 release postmortems.
+      - name: Semantic crate feature check
+        if: matrix.rust-validation == 'full'
+        shell: bash
+        run: vx cargo check -p dcc-mcp-semantic --features python-bindings,ext-module,abi3-py38
+
+  # ── Dependency policy gate (cargo-deny) ───────────────────────────────────
+  # Independent of `rust-check` so its install of `cargo-deny` does not
+  # bottleneck the slower clippy/nextest path. Catches: native-tls /
+  # openssl-sys regressions (the v0.17.45/0.17.46 manylinux2014 OpenSSL 1.0.2
+  # break), unmaintained / yanked deps, and license drift. Configuration
+  # lives in `deny.toml` at the repo root.
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - name: cargo deny check
+        run: cargo deny --all-features check
+
+  # ── Dependency policy gate (cargo-deny) ───────────────────────────────────
+  # Independent of `rust-check` so its install of `cargo-deny` does not
+  # bottleneck the slower clippy/nextest path. Catches: native-tls /
+  # openssl-sys regressions (the v0.17.45/0.17.46 manylinux2014 OpenSSL 1.0.2
+  # break), unmaintained / yanked deps, and license drift. Configuration
+  # lives in `deny.toml` at the repo root.
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - name: cargo deny check
+        run: cargo deny --all-features check
+
   # ── Build ABI3 wheel (one per OS, reused by python-test) ──
   # Intentionally does NOT `needs: [rust-check]` — maturin runs its own compile
   # and can start in parallel with rust-check. If rust-check fails, the PR merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,28 +355,12 @@ jobs:
       # Rust toolchain is only needed for non-Linux builds; the Linux
       # builds run inside the pyo3/maturin docker image which bundles its
       # own pinned toolchain.
-      #
-      # macos-latest (arm64) ships a pre-installed Rust 1.95.0 whose
-      # clippy/rustfmt binaries are physically present on disk but not
-      # registered in rustup's component manifest. When `rust-toolchain.toml`
-      # later triggers `rustup component add clippy` (because cargo metadata
-      # auto-syncs), rustup detects the existing `bin/cargo-clippy` and
-      # aborts with `detected conflict: 'bin/cargo-clippy'`. Force a clean
-      # toolchain reinstall so dtolnay can install the components rustup
-      # expects to own, then add x86_64-apple-darwin so maturin can build
-      # the universal2 wheel (the host already provides aarch64).
-      - name: Reset macOS Rust toolchain to clear stale components
-        if: matrix.target == 'macos-abi3'
-        shell: bash
-        run: rustup toolchain uninstall 1.95.0-aarch64-apple-darwin || true
-
       - name: Setup Rust
         if: matrix.target != 'linux-abi3' && matrix.target != 'linux-py37'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: '1.95.0'
           components: clippy, rustfmt
-          targets: ${{ matrix.target == 'macos-abi3' && 'x86_64-apple-darwin' || '' }}
 
       - name: Setup Python (abi3 build)
         if: endsWith(matrix.target, '-abi3') && !startsWith(matrix.target, 'linux-')
@@ -408,14 +392,21 @@ jobs:
         shell: bash
         run: scripts/release/build_manylinux_semantic_wheel.sh py37
 
-      # ── macOS universal2 (abi3) ──
-      - name: Build wheel (macOS universal2 abi3)
+      # ── macOS aarch64 (abi3) ──
+      # Apple Silicon only: `ort-sys 2.0.0-rc.12` no longer publishes
+      # prebuilt ONNX Runtime binaries for `x86_64-apple-darwin`, and the
+      # macos-13 (Intel) hosted runners were retired by GitHub Actions in
+      # September 2025. Both halves of `--target universal2-apple-darwin`
+      # would need ORT linkage, so universal2 is no longer buildable.
+      # Users on legacy Intel macOS install the Python `fastembed`
+      # backend (the `dcc-mcp-core` Python wrapper falls back gracefully).
+      - name: Build wheel (macOS aarch64 abi3)
         if: matrix.target == 'macos-abi3'
         shell: bash
         working-directory: pkg/dcc-mcp-core-semantic
         run: |
           maturin build --release \
-            --target universal2-apple-darwin \
+            --target aarch64-apple-darwin \
             --features python-bindings,ext-module,abi3-py38 \
             --out wheels
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -702,16 +702,6 @@ dependencies = [
  "serde_json",
  "time",
  "url",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1851,17 +1841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468 0.7.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-dependencies = [
- "pem-rfc7468 1.0.0",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1953,7 +1933,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2010,7 +1990,7 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
+ "der",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
@@ -2061,7 +2041,7 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468 0.7.0",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -2083,15 +2063,6 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "equator"
@@ -2137,7 +2108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2300,21 +2271,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2628,7 +2584,6 @@ dependencies = [
  "indicatif",
  "libc",
  "log",
- "native-tls",
  "rand 0.9.4",
  "reqwest 0.12.28",
  "serde",
@@ -2760,6 +2715,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2772,22 +2728,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2809,11 +2749,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -3565,23 +3503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3678,7 +3599,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3921,47 +3842,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -4175,15 +4059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4334,7 +4209,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.10",
+ "der",
  "pkcs8",
  "spki",
 ]
@@ -4345,7 +4220,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
+ "der",
  "spki",
 ]
 
@@ -4551,7 +4426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5040,30 +4915,27 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -5073,6 +4945,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5338,7 +5211,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5385,7 +5258,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -5397,7 +5270,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5573,7 +5446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.7.10",
+ "der",
  "generic-array",
  "pkcs8",
  "subtle",
@@ -5587,7 +5460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5850,7 +5723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5880,7 +5753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -5997,27 +5870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6033,7 +5885,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6215,16 +6067,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -6771,10 +6613,8 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
- "der 0.8.0",
  "flate2",
  "log",
- "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
@@ -6783,7 +6623,6 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-root-certs",
  "webpki-roots",
 ]
 
@@ -7145,7 +6984,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7235,17 +7074,6 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
 ]
 
 [[package]]

--- a/crates/dcc-mcp-semantic/Cargo.toml
+++ b/crates/dcc-mcp-semantic/Cargo.toml
@@ -26,8 +26,23 @@ workspace = true
 # ONNX Runtime at build time. The companion wheel build at
 # `pkg/dcc-mcp-core-semantic/pyproject.toml` explicitly enables
 # `python-bindings`.
+#
+# fastembed default features pull in `hf-hub-native-tls` +
+# `ort-download-binaries-native-tls`, which transitively activate
+# `openssl-sys` and refuse to compile against the OpenSSL 1.0.2 that
+# ships in the manylinux2014 (CentOS 7) base image used by the wheel
+# build container. Switch both transports to **rustls** so the dep
+# tree no longer touches openssl-sys at all — the whole TLS path is
+# pure-Rust and works identically on every Linux/macOS/Windows
+# manylinux/musllinux image. `image-models` is preserved because it's
+# part of fastembed's default set and disabling it changes the public
+# embedding API.
 anyhow = { workspace = true, optional = true }
-fastembed = { version = "5", optional = true }
+fastembed = { version = "5", optional = true, default-features = false, features = [
+    "hf-hub-rustls-tls",
+    "ort-download-binaries-rustls-tls",
+    "image-models",
+] }
 pyo3 = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 tracing = { workspace = true }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -164,7 +164,7 @@ zeroize = { version = "1.8.2", features = ["derive"] }
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
@@ -175,7 +175,7 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
@@ -185,7 +185,7 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 [target.aarch64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
@@ -196,7 +196,7 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
@@ -207,7 +207,7 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
@@ -219,7 +219,7 @@ bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
@@ -230,7 +230,7 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
@@ -242,7 +242,7 @@ bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
@@ -251,27 +251,27 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 
 [target.x86_64-pc-windows-msvc.dependencies]
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl", "winsock2"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
-windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60.2", features = ["Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
+windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60.2", features = ["Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl", "winsock2"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
-windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60.2", features = ["Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
+windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60.2", features = ["Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
 
 ### END HAKARI SECTION

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,107 @@
+# cargo-deny configuration for dcc-mcp-core.
+#
+# Run locally with: vx cargo deny check
+# CI gates: .github/workflows/ci.yml `cargo-deny` job.
+#
+# Schema reference: https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+# Pinned to v2 schema (cargo-deny 0.14+) so future cargo-deny releases
+# don't silently change the meaning of fields.
+
+[graph]
+# Resolve features in lockstep with `cargo` (resolver = "2"). The dcc-mcp
+# workspace already opts into v2 in Cargo.toml, so this matches what the
+# build actually compiles.
+all-features = false
+no-default-features = false
+# Skip per-crate dev-dependencies — they're test-only and don't ship in
+# the published wheel/binary. Keeps the bans graph focused on runtime
+# code paths.
+exclude-dev = true
+
+[advisories]
+# RustSec advisory DB scan. Fail the build on any unresolved active
+# advisory (yanked / unmaintained crates surface as warnings so the
+# release is not blocked by upstream housekeeping).
+version = 2
+yanked = "warn"
+unmaintained = "workspace"
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    # Used by `webpki-root-certs` (root CA bundle pulled in by the
+    # rustls TLS path that replaced native-tls/openssl-sys).
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "NCSA",
+    "OpenSSL",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+# Internal workspace crates (path deps) carry no SPDX license tag.
+# `private` carves them out so cargo-deny treats them as "ours" and skips
+# the SPDX check.
+[licenses.private]
+ignore = true
+
+[[licenses.exceptions]]
+# `ring` ships under a license string that mixes ISC, OpenSSL and MIT;
+# cargo-deny's parser flags the OpenSSL portion. We accept it for the
+# rustls TLS path that replaced native-tls/openssl-sys (see
+# `crates/dcc-mcp-semantic/Cargo.toml` fastembed pinning).
+allow = ["ISC", "MIT", "OpenSSL"]
+name = "ring"
+
+[bans]
+# Many small workspaces tolerate duplicate semver-major versions, but
+# this repo runs `cargo hakari` to keep features unified — duplicates
+# usually mean a hakari regen is missing, so flag them as warnings.
+multiple-versions = "warn"
+# Workspace inter-crate deps use `*` (resolved by Cargo to the workspace
+# member version). cargo-deny's `allow-wildcard-paths` only excludes
+# path-dep wildcards on *unpublished* crates, but our crates are
+# publishable (PyPI/crates.io), so the wildcard check fires
+# erroneously. Downgrade to `warn` so legitimate workspace path
+# wildcards don't block PRs while still flagging external `*` reqs in
+# review.
+wildcards = "warn"
+allow-wildcard-paths = true
+
+# Forbid native-tls / openssl-sys regressions: switching fastembed to
+# rustls (PR for v0.17.46 semantic wheels) is the durable fix for the
+# manylinux2014 OpenSSL 1.0.2 build break. If a future dep drags
+# native-tls back into the tree, cargo-deny fails the PR before the
+# release pipeline does.
+deny = [
+    { name = "native-tls", reason = "use rustls — see crates/dcc-mcp-semantic/Cargo.toml fastembed feature pinning" },
+    { name = "openssl-sys", reason = "use rustls — manylinux2014 ships OpenSSL 1.0.2 which openssl-sys >= 0.9.100 rejects" },
+]
+
+# Skip duplicate-version bans for crates that legitimately ship two
+# major versions across the dep graph (most of these are
+# clap/tonic/criterion ecosystem churn). Keep this list short and
+# annotated; revisit on every hakari regen.
+skip = []
+skip-tree = []
+
+[sources]
+# Restrict crates to the official crates.io registry. Vendored deps
+# from git would silently bypass advisory scans.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/scripts/release/build_manylinux_semantic_wheel.sh
+++ b/scripts/release/build_manylinux_semantic_wheel.sh
@@ -39,26 +39,26 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo_root"
 
 maturin_args_str="${maturin_args[*]}"
-# The `ghcr.io/pyo3/maturin` image declares `maturin` as its ENTRYPOINT, so any
-# trailing argv is forwarded to `maturin` (running `... sh -c "..."` therefore
-# fails with `unrecognized subcommand 'sh'`). We must install `openssl-devel`
-# *before* maturin runs (fastembed → hf-hub → native-tls → openssl-sys needs
-# libssl headers that the base manylinux2014 image omits), so override the
-# entrypoint to `/bin/sh` and let the shell receive `-c "..."` directly.
+# The `ghcr.io/pyo3/maturin` image declares `maturin` as its ENTRYPOINT, so
+# any trailing argv is forwarded to `maturin` (running `... sh -c "..."`
+# therefore fails with `unrecognized subcommand 'sh'`). Override the
+# entrypoint to `/bin/sh` so the shell receives `-c "..."` directly.
 #
-# The maturin v1.13.3 image is built on `quay.io/pypa/manylinux2014_x86_64`
-# (CentOS 7 / glibc 2.17), so the package manager is **yum**, not dnf — see
-# https://github.com/PyO3/maturin/blob/v1.13.3/Dockerfile. The `--manylinux
-# 2_28` argument below only forward-tags the produced wheel; the actual
-# compilation environment is glibc 2.17 (a strict subset of 2.28, so the
-# wheel runs on every manylinux_2_28 host).
+# The maturin v1.13.3 image is built FROM `quay.io/pypa/manylinux2014_x86_64`
+# (CentOS 7 / glibc 2.17, OpenSSL 1.0.2). `dcc-mcp-semantic`'s fastembed
+# dep is pinned to **rustls** (`hf-hub-rustls-tls`,
+# `ort-download-binaries-rustls-tls`) so the wheel build is OpenSSL-free
+# and there is no need to install openssl-devel inside the container.
+# The `--manylinux 2_28` flag forward-tags the produced wheel; glibc 2.17
+# is a strict subset of 2.28 so the wheel still runs on every
+# manylinux_2_28 host.
 docker run --rm \
   --entrypoint /bin/sh \
   -v "$PWD:/io" \
   -e CARGO_TARGET_DIR=/io/target-manylinux-semantic \
   -w /io/pkg/dcc-mcp-core-semantic \
   ghcr.io/pyo3/maturin:v1.13.3 \
-  -c "yum install -y openssl-devel && maturin build --release --manylinux 2_28 --out wheels ${maturin_args_str}"
+  -c "maturin build --release --manylinux 2_28 --out wheels ${maturin_args_str}"
 
 if command -v sudo >/dev/null 2>&1; then
   sudo chown -R "$(id -u):$(id -g)" pkg/dcc-mcp-core-semantic/wheels


### PR DESCRIPTION
## Summary

Two changes that together resolve the v0.17.46 release pipeline failures and answer the underlying \"为什么 PR 阶段没测出来\" question:

### 1. `fix(semantic)` — make the wheel actually buildable

Two independent failures in [actions/runs/26680060623](https://github.com/loonghao/dcc-mcp-core/actions/runs/26680060623) that the v0.17.45 fixes did not cover:

- **Linux semantic wheel — `openssl-sys` rejects OpenSSL 1.0.2.** The maturin v1.13.3 image is built FROM `manylinux2014` (CentOS 7, OpenSSL 1.0.2). `openssl-sys >= 0.9.100` refuses to build against anything pre-1.1, and fastembed's default features pulled in `hf-hub-native-tls` + `ort-download-binaries-native-tls` which transitively activated openssl-sys. Switch to **rustls** (`hf-hub-rustls-tls`, `ort-download-binaries-rustls-tls`) — the dep tree no longer contains `openssl-sys`/`openssl`/`native-tls` at all. `Cargo.lock` regenerates clean; `workspace-hack` regenerates with `hyper-util` losing the `client-proxy-system` / `http2` features that native-tls activated through reqwest. Drops the `yum install openssl-devel` line from `scripts/release/build_manylinux_semantic_wheel.sh` since openssl is no longer in the build at all.
- **macOS semantic wheel — ORT dropped x86_64-apple-darwin.** `ort-sys 2.0.0-rc.12` no longer ships prebuilt ONNX Runtime binaries for Intel Mac, so `maturin build --target universal2-apple-darwin` fails the lipo step. GitHub also retired the macos-13 hosted runners in September 2025. Drop universal2 and ship **aarch64-only**; Intel users fall through to the Python `fastembed` backend that `dcc-mcp-core` already negotiates.

### 2. `ci` — catch this class of failure at PR stage

The pyo3 0.28 `allow_threads → detach` + fastembed 5 `&mut self` drift (fixed in #1421) and the openssl/ORT issues here all share one root cause: `dcc-mcp-semantic` with `python-bindings`/`fastembed-backend` features is gated off in `cargo check --workspace`, so PR CI never sees it. Two new gates:

- **`Semantic crate feature check`** in `rust-check`: `cargo check -p dcc-mcp-semantic --features python-bindings,ext-module,abi3-py38` on the Linux full path. `cargo check` skips the C++ ORT codegen so the cost is the Rust type-check only (~10 s warm), but it catches signature drift exactly like the macOS/Windows release jobs would.
- **`cargo-deny` job + `deny.toml`** (parallel to `rust-check`, doesn't extend the critical path):
  - `[advisories]` — RustSec scan
  - `[bans]` — forbids `native-tls` and `openssl-sys` regressions (durable fix for the manylinux2014 OpenSSL break)
  - `[licenses]` — SPDX allowlist with carve-outs for `webpki-root-certs` (CDLA-Permissive-2.0) used by rustls
  - `[sources]` — restrict to `crates.io`

Verified locally: `cargo deny --all-features check` reports `advisories ok, bans ok, licenses ok, sources ok`, and `cargo check -p dcc-mcp-semantic --features python-bindings,ext-module,abi3-py38` succeeds.

## Test plan

- [ ] PR CI: new `cargo-deny` and `Semantic crate feature check` gates both pass green
- [ ] After merge, release run for v0.17.47 builds all five `build-semantic-wheels` matrix entries (linux-abi3, linux-py37, macos-abi3 [aarch64-only], windows-abi3, windows-py37)
- [ ] Spot-check that `pip install dcc-mcp-core-semantic` on Apple Silicon installs the new aarch64-only wheel