### PR TITLE
docs: update sidebar navigation and add missing Chinese translations

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -88,6 +88,37 @@ export default defineConfig({
                 { text: 'FAQ', link: '/guide/faq' },
               ]
             },
+            {
+              text: 'DCC Integration',
+              items: [
+                { text: 'Admin UI', link: '/guide/admin-ui' },
+                { text: 'App UI Workflows', link: '/guide/app-ui-workflows' },
+                { text: 'Host Adapter', link: '/guide/host-adapter' },
+                { text: 'Adapter Runtime Contracts', link: '/guide/adapter-runtime-contracts' },
+                { text: 'Adapter Install Lifecycle', link: '/guide/adapter-install-lifecycle' },
+                { text: 'Adapter Dispatcher Migration', link: '/guide/adapter-dispatcher-migration' },
+              ]
+            },
+            {
+              text: 'Catalog & Skills',
+              items: [
+                { text: 'Catalog', link: '/guide/catalog' },
+                { text: 'Skill Maintenance', link: '/guide/skill-maintenance' },
+                { text: 'Rez Skill Packages', link: '/guide/rez-skill-packages' },
+                { text: 'Context Bundles', link: '/guide/context-bundles' },
+                { text: 'Translate', link: '/guide/translate' },
+              ]
+            },
+            {
+              text: 'Observability & Networking',
+              items: [
+                { text: 'Observability', link: '/guide/observability' },
+                { text: 'Middleware', link: '/guide/middleware' },
+                { text: 'OpenAPI Mount', link: '/guide/openapi-mount' },
+                { text: 'DCC REST Skill API', link: '/guide/dcc-rest-skill-api' },
+                { text: 'Cross-DCC Verification', link: '/guide/cross-dcc-verification' },
+              ]
+            },
           ],
           '/api/': [
             {
@@ -143,6 +174,9 @@ export default defineConfig({
                 { text: 'Hot Reload', link: '/api/hot-reload' },
                 { text: 'Server Factory', link: '/api/factory' },
                 { text: 'Callable Dispatcher', link: '/api/dispatcher' },
+                { text: 'Adapter Context', link: '/api/adapter-context' },
+                { text: 'Guardrails', link: '/api/guardrails' },
+                { text: 'Project', link: '/api/project' },
               ],
             }
           ],
@@ -236,6 +270,37 @@ export default defineConfig({
                 { text: '常见问题', link: '/zh/guide/faq' },
               ]
             },
+            {
+              text: 'DCC 集成',
+              items: [
+                { text: '管理界面', link: '/zh/guide/admin-ui' },
+                { text: 'App UI 工作流', link: '/zh/guide/app-ui-workflows' },
+                { text: '主机适配器', link: '/zh/guide/host-adapter' },
+                { text: '适配器运行时契约', link: '/zh/guide/adapter-runtime-contracts' },
+                { text: '适配器安装生命周期', link: '/zh/guide/adapter-install-lifecycle' },
+                { text: '适配器调度器迁移', link: '/zh/guide/adapter-dispatcher-migration' },
+              ]
+            },
+            {
+              text: '目录与技能',
+              items: [
+                { text: '技能目录', link: '/zh/guide/catalog' },
+                { text: '技能维护', link: '/zh/guide/skill-maintenance' },
+                { text: 'Rez 技能包', link: '/zh/guide/rez-skill-packages' },
+                { text: '上下文束', link: '/zh/guide/context-bundles' },
+                { text: '翻译', link: '/zh/guide/translate' },
+              ]
+            },
+            {
+              text: '可观测性与网络',
+              items: [
+                { text: '可观测性', link: '/zh/guide/observability' },
+                { text: '中间件', link: '/zh/guide/middleware' },
+                { text: 'OpenAPI 挂载', link: '/zh/guide/openapi-mount' },
+                { text: 'DCC REST Skill API', link: '/zh/guide/dcc-rest-skill-api' },
+                { text: '跨 DCC 验证', link: '/zh/guide/cross-dcc-verification' },
+              ]
+            },
           ],
           '/zh/api/': [
             {
@@ -291,6 +356,9 @@ export default defineConfig({
                 { text: '热重载', link: '/zh/api/hot-reload' },
                 { text: '服务器工厂', link: '/zh/api/factory' },
                 { text: '可调用对象调度器', link: '/zh/api/dispatcher' },
+                { text: '适配器上下文', link: '/zh/api/adapter-context' },
+                { text: '防护栏', link: '/zh/api/guardrails' },
+                { text: '项目', link: '/zh/api/project' },
               ],
             }
           ]

--- a/docs/zh/api/adapter-context.md
+++ b/docs/zh/api/adapter-context.md
@@ -1,0 +1,77 @@
+# 适配器上下文和策略辅助工具
+
+此 API 为 DCC 适配器提供共享契约，用于简洁指令、工具后快照、可视反馈、响应整形、工具集配置文件和可搜索的 API 文档。
+
+## 指令资源
+
+```python
+from dcc_mcp_core import AdapterInstructionSet, register_adapter_instruction_resources
+
+register_adapter_instruction_resources(
+    server,
+    AdapterInstructionSet(
+        dcc="maya",
+        instructions="Use screenshots after visual scene changes.",
+        capabilities={"screenshots": True, "in_process_execution": True},
+        troubleshooting="If execution stalls, check for modal dialogs.",
+        adapter_version="0.3.0",
+    ),
+)
+```
+
+这将注册：
+
+- `docs://adapter/<dcc>/instructions`
+- `docs://adapter/<dcc>/capabilities`
+- `docs://adapter/<dcc>/troubleshooting`（提供时）
+
+`DccServerBase.register_adapter_instructions(...)` 是嵌入式适配器的薄包装器。
+
+## 上下文快照
+
+适配器可以在变异工具后附加一个小的、有界的场景/文档快照：
+
+```python
+from dcc_mcp_core import DccContextSnapshot, append_context_snapshot
+
+result = append_context_snapshot(
+    {"success": True, "message": "Layer created"},
+    DccContextSnapshot(
+        dcc="photoshop",
+        document={"name": "hero.psd"},
+        active_layer={"name": "Glow"},
+        counts={"layers": 12},
+    ),
+)
+```
+
+`DccServerBase.set_context_snapshot_provider(callable)` 存储提供者，`DccServerBase.append_context_snapshot(result)` 应用它。
+
+## 响应整形
+
+`ResponseShapePolicy` 截断大型列表、字典和字符串，并添加带有省略计数和 `next_query` 提示的 `_meta["dcc.response_shape"]`。
+
+```python
+from dcc_mcp_core import ResponseShapePolicy, shape_response
+
+payload = shape_response(scene_graph, ResponseShapePolicy(max_items=200, max_bytes=256_000))
+```
+
+## 可视反馈
+
+`VisualFeedbackPolicy` 标准化资源支持的预览：
+
+```python
+from dcc_mcp_core import VisualFeedbackPolicy, build_visual_feedback_context
+
+context = build_visual_feedback_context(
+    resource="output://viewport.png",
+    width=1280,
+    height=720,
+    policy=VisualFeedbackPolicy(mode="after_mutation", max_size=800),
+)
+```
+
+## 工具集配置文件
+
+`DccToolsetProfile` 和 `ToolsetProfileRegistry` 在技能组之上提供高级层，用于适配器模式，如 `modeling-basic`、`rendering` 或 `photoshop-layer-editing`。

--- a/docs/zh/api/guardrails.md
+++ b/docs/zh/api/guardrails.md
@@ -1,0 +1,40 @@
+# 弱 DCC 执行防护栏
+
+`DccWeakSandbox` 是一个可选的、有界的辅助工具，用于在执行生成的 DCC 代码时阻止已知危险的宿主操作。
+
+它**不是**安全沙箱。它仅在 `with` 块期间替换适配器选择的 Python 属性/函数，并在块退出时恢复它们。
+
+```python
+import sys
+from dcc_mcp_core import DccBlockedCall, DccWeakSandbox
+
+with DccWeakSandbox(
+    blocked_calls=[
+        DccBlockedCall(
+            "sys.exit",
+            "terminates the embedded DCC Python process",
+            target=sys,
+            attribute="exit",
+        ),
+    ],
+):
+    exec(code, namespace)
+```
+
+适配器也可以提供显式的属性覆盖：
+
+```python
+with DccWeakSandbox(
+    attr_overrides={
+        sys: {
+            "exit": DccWeakSandbox.blocked_callable(
+                "sys.exit",
+                "terminates the host process",
+            ),
+        },
+    },
+):
+    exec(code, namespace)
+```
+
+被阻止的调用会引发带有被阻止调用名称和原因的 `DccGuardrailError`。将此用于实际的适配器防护栏，如退出/出厂重置/首选项重置操作；不要将其视为对恶意代码的保护。

--- a/docs/zh/api/project.md
+++ b/docs/zh/api/project.md
@@ -1,0 +1,35 @@
+# 项目状态 API
+
+DCC 会话的项目级状态持久化（issue #576）。这是作业范围检查点的持久伴侣：它在场景或文档旁边的 `.dcc-mcp/project.json` 中存储场景/会话上下文。
+
+**导出的符号：** `DccProject`、`ProjectState`、`PROJECT_DIR_NAME`、`PROJECT_STATE_FILE`
+
+## ProjectState
+
+```python
+ProjectState(
+    scene_path="",
+    loaded_assets=[],
+    active_skills=[],
+    checkpoint_ids=[],
+    metadata={},
+)
+```
+
+`metadata` 是 DCC 特定的扩展空间，用于单位、上轴、渲染层、时间线范围、活动文档 ID 或适配器会话详细信息。
+
+## DccProject
+
+```python
+from dcc_mcp_core import DccProject
+
+project = DccProject.open("/project/shot_010/main.ma")
+project.add_asset("/assets/char_v001.ma")
+project.activate_skill("maya-lookdev")
+project.add_checkpoint_id("job_abc123")
+project.update_metadata(units="cm", up_axis="y")
+
+payload = project_resume_session()
+```
+
+`DccProject.open(scene_path)` 在缺少时在场景目录中创建 `.dcc-mcp/project.json`。变异辅助工具会自动保存，`DccProject.load(scene_path_or_project_dir)` 为后续会话恢复状态。

--- a/docs/zh/guide/adapter-dispatcher-migration.md
+++ b/docs/zh/guide/adapter-dispatcher-migration.md
@@ -1,0 +1,55 @@
+# 适配器调度器迁移
+
+当您需要将 DCC 适配器从本地调度器副本迁移到由 #1273、#1274、#1275 和 #1276 引入的共享核心原语时，请使用本指南。目标是让适配器仅保留宿主生命周期胶水代码，而 `dcc-mcp-core` 负责请求验证、队列管理、取消、超时处理、泵生命周期和标准结果信封。
+
+## 决策表
+
+| 适配器形态 | 使用 | 适配器仍需负责 |
+|------------|------|----------------|
+| 携带 Qt 的 DCC 伴生进程（Maya、Houdini、3ds Max、Nuke、Cinema 4D、Substance Painter、Mari） | `dcc_mcp_core.qt_dispatcher.start_qt_server` 和 `qtserver://` Rust 客户端 | 插件启动/关闭、会话元数据和宿主动作回调 |
+| 脚本支撑的伴生进程动作分发 | `SidecarActionDispatcher` 作为 Qt 分发处理器 | `server_provider`、`action_resolver` 和执行器钩子如 `maya_executor(...)` 或 `script_executor(...)` |
+| 具有主线程亲和性的交互式 UI 宿主 | `HostUiDispatcherBase` 子类加上 `HostPumpController` | `poke_host_pump()` 和用于宿主定时器原语的小型 `HostPumpTimerAdapter` |
+| 非 Qt UI 宿主，具有原生定时器 | `HostUiDispatcherBase` 加上自定义的 `HostPumpTimerAdapter` | 仅定时器安装/卸载/调度映射 |
+| 无头或批处理宿主（`mayapy`、`hython`、pytest） | `InProcessCallableDispatcher` 或 `DccServerBase.register_inprocess_executor(None)` | 验证宿主进程是否可安全内联调用 |
+| 不运行技能脚本的原生宿主 RPC | 保留 `HostRpcClient` 实现 | 原生协议帧和宿主特定的 RPC 错误 |
+| 适配器一致性测试 | `ManualHostTimerAdapter` 和假伴生进程/服务器夹具 | 仅断言适配器特定的元数据和宿主回调接线 |
+
+这些原语可用后，请勿在适配器仓库中复制 `_qt_dispatcher.py`、`qt_bridge.py`、队列实现、取消标志、超时循环或伴生进程载荷验证器。
+
+## 迁移清单
+
+1. 清点本地调度器文件，并使用上述决策表对每个文件进行分类。
+2. 使用 `dcc_mcp_core.qt_dispatcher.start_qt_server(...)` 替换 JSON 行 Qt 服务器副本。
+3. 为脚本支撑的技能动作组合 `SidecarActionDispatcher`。将动作查找保留在适配器中，但让核心规范化载荷、缺失源错误、执行器异常和 JSON 安全结果信封。
+4. 使用 `HostUiDispatcherBase` 子类替换本地 UI 线程作业队列。仅实现 `poke_host_pump()` 和可选的诊断钩子，如 `format_exception_error`、`format_timeout_error`、`on_job_queued`、`on_job_started` 和 `on_job_finished`。
+5. 将定时器生命周期移入 `HostPumpController`。将宿主的空闲回调、.NET 定时器、Blender 定时器或 Qt `QTimer` 映射到 `HostPumpTimerAdapter`。
+6. 仅在调度器能够实际运行主线程工作后连接就绪性。适配器冒烟测试可能需要 `host_execution_bridge` 和 `main_thread_executor` 就绪位。
+7. 在接触实际 DCC 之前，使用假服务器和 `ManualHostTimerAdapter` 添加或更新适配器一致性测试。使用 `tests/test_dispatcher_migration_conformance.py` 中的核心夹具作为最小契约。
+8. 当宿主可用时，在适配器仓库中运行一次实际冒烟测试。如果不可用，请在 PR 中记录差距，并保持假一致性路径在 CI 中可运行。
+
+## 核心一致性夹具
+
+`tests/test_dispatcher_migration_conformance.py` 模拟了两个适配器家族：
+
+- 类似 Maya 的 Qt 伴生进程，使用 `SidecarActionDispatcher`，解析捆绑的技能脚本，通过 `HostUiDispatcherBase` 执行，并通过 `HostPumpController` 驱动泵。
+- 类似 3ds Max 的脚本伴生进程，将显式 `source_file` 传递给 `SidecarActionDispatcher.script_executor(...)`。
+
+夹具涵盖成功分发、格式错误的载荷、缺失服务器、未知动作、缺失源文件、执行器故障、取消、超时和关闭清理。适配器仓库应复制测试的形态，而非核心实现代码。
+
+## 适配器说明
+
+### Maya
+
+使用 `start_qt_server(...)` 作为伴生进程端点，并让 Maya 插件负责进程生命周期、动作注册和会话元数据。通过 `SidecarActionDispatcher.maya_executor(...)` 路由脚本支撑的技能。当技能需要 UI 线程时，使用 `HostUiDispatcherBase` 子类，其 `poke_host_pump()` 映射到 Maya 的空闲或延迟执行原语。
+
+### 3ds Max
+
+当 Qt 可用时，使用共享 Qt 调度器替换本地 TCP/JSON 桥接代码。将 MaxScript 或 .NET 定时器胶水保留在 `HostPumpTimerAdapter` 中，通过 `SidecarActionDispatcher.script_executor(...)` 路由脚本支撑的技能，并将 Max 特定的诊断放在调度器钩子中而非队列内部。
+
+### Blender
+
+使用 `HostUiDispatcherBase` 处理 UI 线程工作，并将 `bpy.app.timers` 适配到定时器适配器契约。批处理 Blender 或 pytest 路径应使用 `InProcessCallableDispatcher`，而非假装存在 UI 泵。
+
+### Houdini
+
+携带 Qt 的 Houdini 会话可以使用 `QtHostTimerAdapter` 和 `start_qt_server(...)`。无头 `hython` 路径应在适配器验证所调用的 DCC API 无需 UI 循环即可安全运行后，保持内联。

--- a/docs/zh/guide/adapter-install-lifecycle.md
+++ b/docs/zh/guide/adapter-install-lifecycle.md
@@ -1,0 +1,163 @@
+# 适配器安装生命周期
+
+适配器安装程序通常在其正在更新的 DCC 进程内运行。在 Windows 上，导入 `dcc_mcp_core._core` 会加载 `_core.pyd`；该原生模块会保持锁定状态直到进程退出，因此在删除适配器捆绑的包树时，卸载或升级可能会失败。
+
+对于必须保持导入轻量级的安装程序和卸载程序代码，请使用 `dcc_mcp_core.install_lifecycle`。该模块仅使用 Python 标准库，不会导入 `_core`。
+
+## Rez 或文件系统部署布局
+
+流水线团队可以在包正式构建之前使用相同的引导脚本。首先解析包根目录，然后将返回的路径前置到启动伴生进程或网关的进程环境中：
+
+```python
+from dcc_mcp_core.install_lifecycle import resolve_deployment_layout
+
+layout = resolve_deployment_layout(
+    r"G:\_thm\rez_local_cache\ext",
+    adapter_package="dcc_mcp_maya",
+)
+
+python_paths = layout["environment"]["prepend"]["PYTHONPATH"]
+path_entries = layout["environment"]["prepend"]["PATH"]
+```
+
+当 Rez 激活时，辅助工具优先使用 `REZ_<PACKAGE>_ROOT` 变量，如 `REZ_DCC_MCP_CORE_ROOT`、`REZ_DCC_MCP_SERVER_ROOT` 和 `REZ_DCC_MCP_MAYA_ROOT`。没有 Rez 时，传递共享缓存根目录或显式 `package_roots` 映射：
+
+```python
+layout = resolve_deployment_layout(
+    package_roots={
+        "dcc_mcp_core": r"G:\_thm\rez_local_cache\ext\dcc_mcp_core",
+        "dcc_mcp_server": r"G:\_thm\rez_local_cache\ext\dcc_mcp_server",
+        "dcc_mcp_maya": r"G:\_thm\rez_local_cache\ext\dcc_mcp_maya",
+    },
+    adapter_package="dcc_mcp_maya",
+)
+```
+
+这使开发、松散内部交付和打包的 Rez 部署保持在同一代码路径上。
+
+## 导入轻量级预检
+
+```python
+from dcc_mcp_core.install_lifecycle import inspect_install_root
+
+diagnostic = inspect_install_root(r"C:\Users\me\Documents\3dsMax\scripts\dcc_mcp_3dsmax")
+if diagnostic["requires_restart"]:
+    schedule_deferred_cleanup(diagnostic)
+```
+
+`inspect_install_root()` 检查当前进程中已加载的模块。如果安装根目录下的原生工件已加载，它会返回：
+
+```json
+{
+  "status": "requires_restart",
+  "requires_restart": true,
+  "locked_path": "C:\\...\\dcc_mcp_core\\_core.pyd",
+  "recommended_next_action": "Defer cleanup until the DCC host restarts, then remove or replace the install root."
+}
+```
+
+## 注册表查询和伴生进程停止
+
+安装程序可以检查共享的 FileRegistry，而无需创建任何 Rust 支持的对象：
+
+```python
+from dcc_mcp_core.install_lifecycle import query_runtime_state
+from dcc_mcp_core.install_lifecycle import stop_runtime_entries
+
+state = query_runtime_state(dcc_type="3dsmax", role="per-dcc-sidecar")
+stop = stop_runtime_entries(dcc_type="3dsmax")
+```
+
+默认情况下，`stop_runtime_entries()` 仅定位发布 `metadata.sidecar_pid` 的行。除非显式传递 `include_host_processes=True`，否则不会终止父 DCC 进程。
+
+## 混合运行时版本计划
+
+网关可以同时看到多个 DCC 运行时。例如，Maya 可能仍在运行旧的伴生进程，而 3ds Max 已经启动了更新的版本。独立处理每个注册的实例，并从注册表元数据规划重启：
+
+```python
+from dcc_mcp_core.install_lifecycle import plan_runtime_updates
+from dcc_mcp_core.install_lifecycle import query_runtime_state
+
+state = query_runtime_state()
+plan = plan_runtime_updates(
+    state,
+    target_versions={
+        "core": "0.17.21",
+        "server": "0.17.21",
+        "adapter": "1.2.0",
+    },
+)
+```
+
+`ServiceEntry.version` 是 DCC 应用程序的版本，如 `Maya 2026` 或 `Photoshop 25.9`；它不是 `dcc-mcp-core` 包版本。运行时行必须通过元数据键发布包版本，如 `dcc_mcp_core_version`、`dcc_mcp_server_version` 和 `adapter_version`。当缺少包元数据时，`plan_runtime_updates()` 报告 `action=verify_runtime_metadata` 而不是将 DCC 应用版本视为包版本。
+
+每个计划行报告组件漂移和重启操作：
+
+```json
+{
+  "dcc_type": "maya",
+  "action": "restart_sidecar",
+  "restart_scope": "sidecar",
+  "stale_components": ["core", "server", "adapter"],
+  "recommended_next_action": "Stop the registered sidecar, restart it from the target deployment, then re-run MCP readiness."
+}
+```
+
+当 `sidecar_pid` 存在时，管理界面应将 `action=restart_sidecar` 渲染为安全的伴生进程重启按钮。如果行报告 `manual_restart_required`，则运行时由宿主拥有，必须重启 DCC 进程后才能重置或期望 MCP 调用使用更新的代码。如果行报告 `verify_runtime_metadata`，则注册表行缺少足够的包版本元数据来安全决策；在假定其使用目标部署之前，请验证或重启该运行时。
+
+在任何停止或重启之后，使用实例 MCP 端点验证就绪性，并在发送重置调用之前刷新网关注册表状态。
+
+网关管理 JSON 已在每个实例上公开这些操作员提示：
+
+```json
+{
+  "lifecycle": {
+    "role": "per-dcc-sidecar",
+    "owner": "release-smoke-test",
+    "session": "test",
+    "sidecar_pid": 31337,
+    "supports_safe_stop": true,
+    "safe_stop_url": "http://127.0.0.1:19000/safe-stop",
+    "safe_stop_method": "POST",
+    "restartable": true,
+    "restart_command": "rez-env dcc_mcp_maya -- maya-sidecar"
+  }
+}
+```
+
+启动自己的 DCC 进程的发布冒烟测试应发布稳定的公共生命周期元数据（`owner`、`session`），并在支持时发布 `safe_stop_url` 回调。网关和 `dcc-mcp-cli stop-instance` 仅将安全停止请求转发到该显式回调，从不直接终止进程。
+
+## 安全删除或替换
+
+```python
+from dcc_mcp_core.install_lifecycle import safe_remove_tree
+from dcc_mcp_core.install_lifecycle import safe_replace_tree
+
+removed = safe_remove_tree(install_root)
+replaced = safe_replace_tree(staged_payload, install_root)
+```
+
+当预检通过时，两个辅助工具都会尝试立即清理。如果 Windows 报告原生文件锁定，结果会为延迟启动钩子进行结构化：
+
+```json
+{
+  "status": "requires_restart",
+  "requires_restart": true,
+  "locked_path": "C:\\...\\_core.pyd",
+  "reason": "windows_file_lock",
+  "deferred_operation": {
+    "operation": "remove_tree",
+    "path": "C:\\...\\dcc_mcp_3dsmax"
+  }
+}
+```
+
+当 DCC 特定的安装程序需要仅 JSON 的控制路径时，从子进程运行相同的辅助工具：
+
+```bash
+python -m dcc_mcp_core.install_lifecycle inspect C:\path\to\adapter
+python -m dcc_mcp_core.install_lifecycle stop --dcc-type 3dsmax
+python -m dcc_mcp_core.install_lifecycle layout --cache-root G:\_thm\rez_local_cache\ext --adapter-package dcc_mcp_maya
+python -m dcc_mcp_core.install_lifecycle plan-update --target-version core=0.17.21 --target-version server=0.17.21
+python -m dcc_mcp_core.install_lifecycle remove C:\path\to\adapter
+```

--- a/docs/zh/guide/adapter-runtime-contracts.md
+++ b/docs/zh/guide/adapter-runtime-contracts.md
@@ -1,0 +1,82 @@
+# 适配器运行时契约
+
+核心为代理在工具和作业运行期间需要的运行时材料暴露了小型、与 DCC 无关的契约。适配器保留宿主特定的收集和安全策略；核心标准化形状和资源移交路径。
+
+## 会话事件
+
+使用 `SessionEventBuffer` 处理有界的 stdout/stderr/log/progress/checkpoint 事件。将其注册为 MCP 资源：
+
+```python
+from dcc_mcp_core import SessionEventBuffer
+
+events = SessionEventBuffer("maya-001", maxlen=1000, max_message_bytes=4096)
+server.resources().register_session_event_buffer(events)
+events.append("python", "stdout", "Created rig control", tool_call_id="req-1")
+```
+
+客户端读取 `events://session/maya-001?cursor=N&limit=100`。响应包含 `next_cursor`，因此客户端无需实时订阅即可避免重复事件。`drain=true` 可用于需要读取时消耗行为的客户端。
+
+## 工件引用
+
+对于大型或二进制输出，使用现有的 `FileRef` / `ArtefactStore` 路径：
+
+- `artefact://sha256/<hex>` 永远不会暴露适配器文件系统路径。
+- 伴生进程携带 MIME、大小、摘要、显示名称、会话/工具/作业/关联字段、过期时间和适配器元数据。
+- 有界存储可以强制执行最大载荷字节数、最大保留条目数、最大总字节数和默认 TTL。
+
+工具结果应在上下文中返回小型 `FileRef` 对象，并让客户端通过 `resources/read` 获取字节。
+
+## 调试描述符
+
+使用 `DebugSessionDescriptor` 发布可选的附加元数据，而无需向核心添加硬调试器依赖。描述符支持 `unavailable`、`available`、`listening`、`client_connected` 和 `error` 状态，以及主机/端口、运行时/进程标识、路径映射、日志 URI、设置说明和适配器元数据。
+
+Python 适配器可以使用：
+
+```python
+from dcc_mcp_core import DebugSessionDescriptor
+
+descriptor = DebugSessionDescriptor.listening("debugpy", "127.0.0.1", 5678)
+```
+
+通过文档/自定义资源或适配器拥有的可选工具发布结果 `descriptor.to_dict()`。
+
+## App UI 自动化契约
+
+`app_ui` 契约是架构和工作流，不是通用点击机器人。适配器可以使用 Qt、原生可访问性 API、webview 或 DCC 特定的 UI API 实现它。公共工具名称使用 `app_ui__*`，因为该能力有意比 DCC 专用的 UI 命名空间更广泛：相同的契约可以描述 DCC 偏好设置对话框、外部启动器、许可证实用程序或其他适配器拥有的应用程序窗口。
+
+Rust 架构位于 `dcc-mcp-app-ui` crate 中，因此 UI 自动化契约可以独立于 HTTP 服务器层演进。Python 适配器继续从 `dcc_mcp_core.adapter_contracts` 导入匹配的数据类。
+
+核心形状包括：
+
+- `UiControlNode` 和 `UiSnapshot` 用于有界的 UI 树。
+- `UiFindRequest` 用于通过查询、角色、标签或对象名称定位控件。
+- `UiActionRequest` 用于一个有界操作，如单击、设置文本、切换、设置选中、选择选项或聚焦。
+- `UiWaitCondition` 和 `UiWaitResult` 用于工具内轮询，如"等待状态文本等于 Applied"或"等待模态框消失"。
+- `UiActionResult` 包含结构化错误，如 `stale_control`、`denied`、`unsupported_action` 和可选的截图/工件引用。
+- `AppUiPolicy` 和 `AppUiAuditRecord` 用于作用域操作控制和隐私保护的审计输出。
+
+当控件过时时，适配器必须返回结构化错误而不是挂起，适配器端安全策略仍决定允许哪些操作。
+
+首选代理循环：
+
+1. `app_ui__snapshot` 观察一个作用域应用程序窗口并返回 `snapshot_id`。
+2. `app_ui__find` 通过查询、角色、标签或对象名称解析稳定的控件 ID。
+3. `app_ui__act` 对该控件 ID 执行一个操作。在可用时传递 `snapshot_id`，以便过时的控件以 `stale_control` 失败，而不是对错误目标执行操作。
+4. `app_ui__wait_for` 在一次调用内轮询，直到预期的 UI 状态为真，或返回带有结构化详细信息的 `timeout`。
+5. `app_ui__snapshot` 验证最终状态。
+
+首先使用原生 DCC 技能或 API。仅当行为在应用程序 UI 中可见但未通过可靠的宿主 API 暴露时，才使用 `app_ui__*`。工作流示例和恢复模式位于 [app-ui-workflows.md](app-ui-workflows.md)。
+
+安全期望：
+
+- 快照/查找工具是只读的，当后端支持时可以在任何线程上运行。
+- 变异操作应声明保守的安全注释，宿主要求时的主线程亲和性，以及反映 UI 轮询的超时。
+- 在 `tools.yaml` 中声明 MCP `annotations`、`execution`、`affinity` 和 `timeout_hint_secs`。网关 `search_tools` / `/v1/search` 携带紧凑的安全提示，`describe_tool` / `/v1/describe` 暴露完整架构加上 `_meta.dcc` 亲和性、执行、超时和风险提示。
+- 网关实例行包括 `diagnostics.app_ui.status`：当 `app_ui__*` 能力被索引时为 `available`，当不存在时为 `unavailable`，或当适配器注册表元数据发布 `app_ui.status=disabled` 时为 `disabled_by_policy`（可选带 `app_ui.reason`）。
+- 策略应默认禁用全桌面访问。限定到适配器拥有的进程、窗口或显式允许列表。除非用户明确选择特定后端的全桌面回退，否则保持 `AppUiPolicy.require_scoped_window` 启用。
+- 原始坐标单击和键盘快捷键是高风险的。除非适配器明确选择加入并记录回退，否则保持禁用。
+- 审计记录应包括操作类型、目标控件 ID/角色/标签（安全时）、前后焦点 ID、成功/失败和结构化错误代码。敏感的键入文本和截图字节应被编辑或仅作为工件/资源引用返回。
+
+捆绑的 `app-ui` 技能默认为测试和适配器创作的确定性模拟后端。设置 `DCC_MCP_APP_UI_BACKEND=chrome` 以使用实验性 CDP 后端，并通过相同的 `app_ui__snapshot`、`app_ui__find`、`app_ui__act` 和 `app_ui__wait_for` 工具驱动浏览器或 webview 搜索。CDP 后端支持预设：`reuse` 首先附加到现有 DevTools 端点以便可以重用当前浏览器令牌，`isolated` 启动临时 Chrome 配置文件，`auroraview` 使用 `DCC_MCP_APP_UI_AURORAVIEW_CDP_PORT`、`AURORAVIEW_CDP_PORT`、`DCC_MCP_APP_UI_CDP_PORT` 或端口 `9222` 附加到 AuroraView 的 CDP 端点。相同的运行时还支持 `edge` 用于 Microsoft Edge CDP 和 `agent-browser` 用于 Vercel 的 `agent-browser` CLI，该 CLI 通过 `agent-browser get cdp-url` 公开其 DevTools URL，并可以在 CI 中通过 `agent-browser install` 配置。
+
+在 Windows 上设置 `DCC_MCP_APP_UI_BACKEND=windows-uia` 以使用参考 Windows UI Automation 后端。它通过 PowerShell 辅助程序使用 OS UIAutomationClient API，并保持在相同的契约之后。后端拒绝无作用域的全桌面访问：通过调用策略或 `DCC_MCP_APP_UI_UIA_*` 环境变量提供允许的窗口标题、进程 ID 或进程名称。它将 UIA 控件类型映射到规范化的 app_ui 角色，并返回结构化的 `missing_window`、`not_found`、`unsupported_action`、`policy_disabled`、`stale_control` 和 `timeout` 错误。

--- a/docs/zh/guide/app-ui-workflows.md
+++ b/docs/zh/guide/app-ui-workflows.md
@@ -1,0 +1,151 @@
+# App UI 代理工作流
+
+`app_ui` 是用于仅界面工作的有界回退。首先优先使用原生 DCC 技能：它们通常携带更强的架构、更好的撤销语义和宿主感知的分发。当您需要的状态仅存在于窗口、模态对话框、webview、启动器、许可证工具或设置面板中时，使用 `app_ui__*`。
+
+## 决策规则
+
+在以下情况下使用原生 DCC 工具：
+
+- 宿主 API 直接暴露状态或操作。
+- 操作会更改场景数据、文件、包、渲染或项目状态。
+- 您需要可靠的批处理执行、撤销集成或主线程宿主语义。
+
+在以下情况下使用 `app_ui`：
+
+- 唯一可用的控制路径是可见的 UI 表面。
+- 您需要解除模态对话框、向导、浏览器视图、安装程序提示或适配器拥有的伴生进程应用的阻止。
+- 原生工具已报告需要手动 UI 确认。
+
+不要将 `app_ui` 用作缺少类型化工具的快捷方式。如果工作流常见且稳定，请首先添加原生技能/API，并将 `app_ui` 保留为诊断或紧急路径。
+
+## 标准循环
+
+每个工作流应保持相同的形状：
+
+1. `app_ui__snapshot` 观察有界窗口并返回 `snapshot_id`。
+2. `app_ui__find` 通过标签、文本、角色或对象名称解析控件 ID。
+3. `app_ui__act` 执行一个操作。传递 `snapshot_id` 以便在操作前检测过时的控件。
+4. `app_ui__wait_for` 在一次工具调用内轮询，直到 UI 达到预期状态或返回结构化的 `timeout`。
+5. `app_ui__snapshot` 验证最终状态。
+
+对于网关客户端，在调用前发现和检查工具：
+
+```json
+{"name": "search_tools", "arguments": {"query": "app_ui snapshot", "dcc_type": "maya"}}
+{"name": "describe_tool", "arguments": {"tool_slug": "<slug from search>"}}
+```
+
+REST 客户端通过 `/v1/search`、`/v1/describe` 和 `/v1/call` 使用相同的序列。
+
+## 示例：模态对话框
+
+当 DCC 原生操作打开了没有宿主 API 等效项的确认对话框时，使用此方法。
+
+调用 `app_ui__snapshot` 并验证根窗口是预期的对话框。然后找到确认按钮：
+
+```json
+{"session_id": "maya-confirm-export", "label": "Overwrite", "role": "button"}
+```
+
+仅对解析的控件 ID 和当前快照执行操作：
+
+```json
+{
+  "session_id": "maya-confirm-export",
+  "control_id": "overwrite",
+  "action": "click",
+  "snapshot_id": "<snapshot_id>"
+}
+```
+
+等待模态框消失或状态文本更改：
+
+```json
+{
+  "session_id": "maya-confirm-export",
+  "condition": {
+    "kind": "control_missing",
+    "control_id": "overwrite",
+    "timeout_ms": 5000,
+    "interval_ms": 100
+  }
+}
+```
+
+最后在存在时使用原生 DCC 验证工具。例如，通过类型化技能验证导出的文件或场景状态已更改，而不仅仅是通过 UI。
+
+## 示例：设置面板
+
+当设置仅存在于首选项面板或 webview 中时，使用此方法。
+
+1. 快照有界的应用程序窗口。
+2. 通过可见标签而不是索引查找设置。
+3. 设置文本、复选框或选择。
+4. 单击面板的 apply/save 控件。
+5. 等待稳定的状态消息。
+6. 再次快照并验证设置值。
+
+模拟后端载荷镜像预期的真实工作流：
+
+```json
+{"session_id": "settings-demo", "label": "Project name"}
+```
+
+```json
+{
+  "session_id": "settings-demo",
+  "control_id": "project-name",
+  "action": "set_text",
+  "text": "Hero",
+  "snapshot_id": "<snapshot_id>"
+}
+```
+
+```json
+{
+  "session_id": "settings-demo",
+  "condition": {
+    "kind": "value_equals",
+    "control_id": "project-name",
+    "value": "Hero",
+    "timeout_ms": 1000,
+    "interval_ms": 50
+  }
+}
+```
+
+键入的文本应在审计记录中被编辑，除非适配器策略明确允许敏感值。
+
+## 示例：等待 UI 状态
+
+优先使用 `app_ui__wait_for` 而不是代理端轮询循环。它将重试保持在后端附近，避免重复的 MCP 往返，并在状态永不出现时返回一个结构化的超时信封。
+
+良好的等待条件是稳定的和语义化的：
+
+- 在状态标签（如 `Applied` 或 `Complete`）上使用 `text_equals`。
+- 在编辑后在文本字段上使用 `value_equals`。
+- 在复选框上使用 `checked_equals`。
+- 对于模态框生命周期使用 `control_exists` 或 `control_missing`。
+- 对于工作后变得可操作的控件使用 `enabled` 或 `disabled`。
+
+避免等待屏幕坐标、像素颜色或视觉顺序，除非后端没有可访问性树且适配器明确记录了该回退。
+
+## 恢复示例
+
+`stale_control`：从 `app_ui__snapshot` 重新开始，然后使用新的 `snapshot_id` 重复 `find` 和 `act`。永远不要盲目重试相同的过时控件 ID。
+
+`missing_window`：验证预期的 DCC/应用程序进程是否仍在运行，以及后端是否限定到正确的窗口标题或进程 ID。如果窗口因工作流完成而消失，请切换到原生验证工具。
+
+`policy_disabled`：停止 UI 操作。优先使用原生技能，或要求用户进行更窄的策略更改，如允许一个窗口的文本输入。不要静默扩展到全桌面访问。
+
+`timeout`：获取新的快照并检查最后观察到的 UI 状态。如果状态仍在进行中，请使用合理的超时再调用 `wait_for` 一次。如果状态被阻止，请向用户显示当前控件/状态文本或切换到宿主诊断技能。
+
+## 验证
+
+对于涉及 `app_ui` 的代码更改，请包含至少一个可执行路径：
+
+- 用于契约映射和结构化错误的单元测试。
+- 用于 snapshot -> find -> act -> wait -> verify 的模拟后端工作流测试。
+- 当涉及网关 `/v1/*` 路由或 REST 信封时的 VRS 跟踪。
+
+VRS 跟踪 `tests/vrs/traces/core-1134-app-ui-mock-workflow.jsonl` 固定了模拟后端工作流和恢复信封，用于实时网关运行。当没有注册 `app_ui__snapshot` 能力时，它会干净地跳过。

--- a/docs/zh/guide/skill-maintenance.md
+++ b/docs/zh/guide/skill-maintenance.md
@@ -10,7 +10,7 @@
 
 ## 实现前的所有权
 
-在添加或更改捆绑适配器技能之前，请阅读 [`docs/POLICY_SKILL_OWNERSHIP.md`](../POLICY_SKILL_OWNERSHIP.md) 和相关适配器的 `SKILL_OWNERSHIP.yml`（如果存在）。
+在添加或更改捆绑适配器技能之前，请阅读 [`docs/POLICY_SKILL_OWNERSHIP.md`](../../POLICY_SKILL_OWNERSHIP.md) 和相关适配器的 `SKILL_OWNERSHIP.yml`（如果存在）。
 
 - 常见文件操作（`open`、`save`、`import`、`export`、`read_file`、`write_file`、路径探测）必须为每个适配器有一个主要拥有技能包。
 - 不要仅仅为了提高可发现性而将文件操作工具复制到第二个技能中；相反，添加别名、搜索提示、配方或指向主要所有者的 `next-tools`。

--- a/docs/zh/guide/skill-maintenance.md
+++ b/docs/zh/guide/skill-maintenance.md
@@ -1,0 +1,68 @@
+# 技能包维护（DCC 适配器 + 捆绑核心技能）
+
+本指南是 dcc-mcp-core 和下游适配器（例如 dcc-mcp-maya）中 SKILL 包的**单一维护契约**。仓库内的**参考实现**位于：
+
+- `python/dcc_mcp_core/skills/dcc-diagnostics/` — 基础设施技能：丰富的 frontmatter `description`、`search-hint`、`layer`，工具目的在 SKILL.md 正文中明确说明。
+- `python/dcc_mcp_core/skills/media/` — 基础设施技能：类型化的 vx 管理的 FFmpeg/FFprobe 包装器，用于 DCC 渲染/播放blast 工件，而不暴露任意 shell 或 vx 执行。
+- `python/dcc_mcp_core/skills/workflow/` — 编排技能：示例 JSON 链和明确的"何时不使用"边界。
+
+在创作或审查任何新技能时，请使用这两个树。
+
+## 实现前的所有权
+
+在添加或更改捆绑适配器技能之前，请阅读 [`docs/POLICY_SKILL_OWNERSHIP.md`](../POLICY_SKILL_OWNERSHIP.md) 和相关适配器的 `SKILL_OWNERSHIP.yml`（如果存在）。
+
+- 常见文件操作（`open`、`save`、`import`、`export`、`read_file`、`write_file`、路径探测）必须为每个适配器有一个主要拥有技能包。
+- 不要仅仅为了提高可发现性而将文件操作工具复制到第二个技能中；相反，添加别名、搜索提示、配方或指向主要所有者的 `next-tools`。
+- 如果重复不可避免，请在同一 PR 中的 `SKILL_OWNERSHIP.yml` 中记录理由和所有者。
+
+## Frontmatter（SKILL.md）
+
+- 保持 `description` 作为**主要代理面向契约**（MCP `get_skill_info` / 搜索摘要不提供 Markdown 正文）。
+- 在 `metadata.dcc-mcp` 下：始终根据适配器策略设置 `tools`、`layer`、`dcc`、`version`、`search-hint`、`tags`。
+- 可选但推荐用于长篇注释：
+  - `recipes:` — 基于锚点的代码片段（当宿主注册 `recipes__*` 工具时）。
+  - `skill-reference-docs:` — 相对于技能根目录的 **glob 列表**，以便 `skill_refs__list` / `skill_refs__read` 可以在 `references/`（或其他目录）下提供任意 Markdown/文本，而无需硬编码一个文件名。
+- 旧版 `introspection:` 单路径仍被 `skill-reference-docs` 解析支持；对于新包，请优先使用 `skill-reference-docs`。
+
+## tools.yaml
+
+- 每个工具**必须**声明 `execution`、`affinity` 和现实的 `timeout_hint_secs`（当 `execution: async` 时）。
+- **导入/导出/保存/路径**：描述应说明**绝对路径与工作区相对路径**、所需插件和常见故障后续步骤（例如父目录必须存在、使用 `file_exists`、导出前保存场景）。简短描述使网关 `describe_tool` 无用 — 目标是提供足够的文本，使代理无需猜测即可成功。
+
+## Python（或其他）脚本
+
+- 尽早验证输入；返回带有 `possible_solutions` 的 `skill_error` / `ToolResult` 风格信封，而不是让 Maya 打开模态对话框。
+- 对于写操作：确保父目录存在或返回结构化错误。
+- 导出后：在可行时验证输出文件存在且非零大小。
+
+## 代码检查（dcc-mcp-maya）
+
+从 Maya 适配器仓库运行：
+
+```bash
+python tools/lint_skills.py
+```
+
+规则包括 IO 描述长度提示和 `references/` 元数据覆盖率。当您添加新的横切关注点约定时，请扩展 `tools/lint_skills.py`。
+
+## 网关面向代理
+
+- 优先使用网关 MCP `search` → `describe`，然后使用 REST `/v1/call`（或每宿主 `load_skill` 然后使用类型化工具）。长篇散文应放在 `recipes` / `skill-reference-docs` 中，而不仅仅是 frontmatter 下的 SKILL.md 正文中。
+
+## 适配器启动注册
+
+公开可选元数据驱动工具的适配器应使用 `register_metadata_driven_tools(...)`，而不是复制扫描/导入/注册包装器。当未提供 `skills` 时，辅助工具使用 `scan_and_load_lenient(...)` 进行扫描，注册默认的 `recipes` 和 `skill-reference-docs` 扩展，并返回带有每个扩展 `registered`、`failed` 或 `skipped` 状态的报告。
+
+```python
+from dcc_mcp_core import register_metadata_driven_tools
+
+report = register_metadata_driven_tools(
+    server,
+    dcc_name="maya",
+    extra_paths=[studio_skill_root],
+)
+logger.info("metadata tools: %s", report.to_dict())
+```
+
+当适配器已为服务器启动扫描了技能根目录时，传递显式 `skills=loaded_skills`；这使发现保持单次通过，同时保留相同的可选扩展错误策略。


### PR DESCRIPTION
## Summary

This PR updates the documentation sidebar navigation and adds missing Chinese translations.

### Changes

**Sidebar Navigation Updates:**
- Added missing guide pages: admin-ui, app-ui-workflows, adapter-runtime-contracts, adapter-install-lifecycle, adapter-dispatcher-migration, host-adapter, catalog, skill-maintenance, rez-skill-packages, context-bundles, translate, observability, middleware, openapi-mount, dcc-rest-skill-api, cross-dcc-verification
- Added missing API pages: adapter-context, guardrails, project
- Organized into logical sections: DCC Integration, Catalog & Skills, Observability & Networking

**Chinese Translations Added:**
- Guide docs: adapter-dispatcher-migration, adapter-install-lifecycle, adapter-runtime-contracts, app-ui-workflows, skill-maintenance
- API docs: adapter-context, guardrails, project

### Motivation

The sidebar was missing 16 guide pages and 3 API pages that existed in the docs/ directory but were not accessible through navigation. Additionally, 8 documents lacked Chinese translations, breaking the bilingual parity of the documentation.

### Testing

- Verified all new sidebar links point to existing documentation files
- Verified Chinese translations maintain content parity with English originals
- Local VitePress build confirmed no broken links