### PR TITLE
feat(ci): add macOS cp37 wheel via Rosetta 2 cross-compilation

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -70,10 +70,9 @@ jobs:
           artifact-name: wheels-macos-universal2
 
   # ── Python 3.7 builds (non-abi3) — separate wheel for Python 3.7 only ──
-  # Note: macOS Python 3.7 build is not included because:
-  # - macOS-13 (x86_64) runners have been retired (Sept 2025)
-  # - macOS-15 (ARM64) does not support Python 3.7
-  # Users needing Python 3.7 on macOS should install from source distribution
+  # macOS cp37 wheels are cross-compiled from ARM64 (macos-latest) to x86_64.
+  # Python 3.7.17 x86_64 is downloaded from python.org and runs via Rosetta 2;
+  # the Rust extension is compiled for x86_64-apple-darwin.
 
   linux-py37:
     runs-on: ubuntu-22.04  # Python 3.7 not available on Ubuntu 24.04
@@ -108,3 +107,100 @@ jobs:
           test-wheel: ${{ inputs.test-wheel || 'true' }}
           artifact-name: wheels-windows-x64-py37
           use-sccache: 'false'
+
+  macos-py37:
+    # macOS ARM64 runner cross-compiling to x86_64.
+    # Python 3.7 has no native ARM64 build, so we download the x86_64
+    # installer from python.org and run it via Rosetta 2. The Rust
+    # extension targets x86_64-apple-darwin.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+
+      - name: Install Python 3.7.17 (x86_64, Rosetta 2)
+        shell: bash
+        run: |
+          curl -fsSL -o /tmp/python-3.7.17-macosx10.9.pkg \
+            https://www.python.org/ftp/python/3.7.17/python-3.7.17-macosx10.9.pkg
+          sudo installer -pkg /tmp/python-3.7.17-macosx10.9.pkg -target /
+          PY37=/Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7
+          echo "PY37=${PY37}" >> "$GITHUB_ENV"
+          "${PY37}" --version
+          "${PY37}" -c "import sys; print(sys.version); print(sys.maxsize > 2**32)"
+          file "${PY37}"
+          "${PY37}" -m pip install --upgrade "pip>=20.0"
+
+      - name: Setup host Python (runs maturin)
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.95.0'
+
+      - name: Add x86_64-apple-darwin Rust target
+        run: rustup target add x86_64-apple-darwin
+
+      - uses: loonghao/vx@v0.9.11
+        with:
+          version: "0.9.11"
+          cache-key-prefix: "vx-tools-v0.9.7"
+          cache: "false"
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: rust-macos-py37
+          shared-key: rust-macos-py37
+
+      - name: Install maturin (host Python 3.11)
+        shell: bash
+        run: python -m pip install "maturin>=1.5,<2.0"
+
+      - name: Resolve build features (py37 non-abi3)
+        id: resolve-features
+        shell: bash
+        run: |
+          features=$(vx just print-wheel-features-py37)
+          echo "features=${features}" >> "$GITHUB_OUTPUT"
+
+      - name: Build wheel (x86_64-apple-darwin, cp37)
+        shell: bash
+        env:
+          DCC_MCP_ADMIN_UI_PREBUILT: "1"
+          ARCHFLAGS: "-arch x86_64"
+          MACOSX_DEPLOYMENT_TARGET: "10.9"
+        run: |
+          python -m maturin build \
+            --release \
+            --out dist \
+            --target x86_64-apple-darwin \
+            --features "${{ steps.resolve-features.outputs.features }}" \
+            -i "${PY37}"
+
+      - name: Check wheel contents
+        shell: bash
+        run: |
+          "${PY37}" -m pip install check-wheel-contents
+          "${PY37}" -m check_wheel_contents --ignore W004 dist/*.whl
+
+      - name: Test wheel
+        if: ${{ inputs.test-wheel || 'true' }}
+        shell: bash
+        run: |
+          "${PY37}" -m venv test-env
+          source test-env/bin/activate
+          pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
+          pip check
+          python tests/test_imports.py
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-macos-x86_64-py37
+          path: dist/
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,105 @@ jobs:
           use-sccache: 'false'
           prebuild-admin-ui: "false"
 
+  # macOS cp37: cross-compile from ARM64 runner to x86_64 via Rosetta 2.
+  # The composite build-wheel action can't be used because actions/setup-python
+  # does not provide Python 3.7 on ARM64 macOS. We download the x86_64 Python
+  # 3.7 installer from python.org instead.
+  build-wheel-py37-macos:
+    name: Build wheel (py3.7, macos-latest)
+    needs: [admin-ui-bundle]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download admin UI bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: admin-ui-bundle
+          path: crates/dcc-mcp-gateway/src/gateway/admin/generated
+
+      - name: Install Python 3.7.17 (x86_64, Rosetta 2)
+        shell: bash
+        run: |
+          curl -fsSL -o /tmp/python-3.7.17-macosx10.9.pkg \
+            https://www.python.org/ftp/python/3.7.17/python-3.7.17-macosx10.9.pkg
+          sudo installer -pkg /tmp/python-3.7.17-macosx10.9.pkg -target /
+          PY37=/Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7
+          echo "PY37=${PY37}" >> "$GITHUB_ENV"
+          "${PY37}" --version
+          "${PY37}" -m pip install --upgrade "pip>=20.0"
+
+      - name: Setup host Python (runs maturin)
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.95.0'
+
+      - name: Add x86_64-apple-darwin Rust target
+        run: rustup target add x86_64-apple-darwin
+
+      - uses: loonghao/vx@v0.9.11
+        with:
+          version: "0.9.11"
+          cache-key-prefix: "vx-tools-v0.9.7"
+          cache: "false"
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: rust-macos-py37
+          shared-key: rust-macos-py37
+
+      - name: Install maturin (host Python 3.11)
+        shell: bash
+        run: python -m pip install "maturin>=1.5,<2.0"
+
+      - name: Resolve build features (py37 non-abi3)
+        id: resolve-features
+        shell: bash
+        run: |
+          features=$(vx just print-wheel-features-py37)
+          echo "features=${features}" >> "$GITHUB_OUTPUT"
+
+      - name: Build wheel (x86_64-apple-darwin, cp37)
+        shell: bash
+        env:
+          DCC_MCP_ADMIN_UI_PREBUILT: "1"
+          ARCHFLAGS: "-arch x86_64"
+          MACOSX_DEPLOYMENT_TARGET: "10.9"
+        run: |
+          python -m maturin build \
+            --release \
+            --out dist \
+            --target x86_64-apple-darwin \
+            --features "${{ steps.resolve-features.outputs.features }}" \
+            -i "${PY37}"
+
+      - name: Check wheel contents
+        shell: bash
+        run: |
+          "${PY37}" -m pip install check-wheel-contents
+          "${PY37}" -m check_wheel_contents --ignore W004 dist/*.whl
+
+      - name: Test wheel
+        shell: bash
+        run: |
+          "${PY37}" -m venv test-env
+          source test-env/bin/activate
+          pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
+          pip check
+          python tests/test_imports.py
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheel-py37-macos-latest
+          path: dist/
+          retention-days: 30
+
   # ── Lint Python source ──
   # ubuntu-22.04: setup-python still offers 3.7 for the cp37 syntax gate.
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,8 +314,13 @@ jobs:
   # an opt-in PyPI package. Users only pay this wheel's cost when they
   # explicitly `pip install 'dcc-mcp-core[semantic]'`. The matrix mirrors
   # `build-wheels.yml` so the opt-in surface covers the same OS / Python set
-  # as the main wheel, minus macOS Python 3.7 (impossible on hosted runners:
-  # macOS-13 retired Sept 2025, macOS-15 ARM64 has no 3.7 build).
+  # as the main wheel, minus macOS cp37. macOS cp37 is NOT buildable for the
+  # semantic wheel because `ort-sys 2.x` no longer ships prebuilt ONNX Runtime
+  # binaries for `x86_64-apple-darwin`. The main `dcc-mcp-core` wheel now
+  # provides macOS cp37 via cross-compilation (see build-wheels.yml macos-py37
+  # job); users who need semantic embeddings on macOS Python 3.7 should use
+  # the pure-Python `fastembed` backend (automatic fallback in the Python
+  # wrapper).
   #
   # IMPORTANT: ort 2.x (pulled in transitively by fastembed-rs) requires
   # glibc >= 2.27, so Linux wheels target manylinux_2_28 — NOT manylinux2014


### PR DESCRIPTION
## Summary

Cross-compile macOS cp37 (Python 3.7) wheels on ARM64 runners by downloading Python 3.7.17 x86_64 from python.org and running it via Rosetta 2. The Rust extension targets `x86_64-apple-darwin`.

Fixes the macOS cp37 wheel gap that blocked **Maya 2020/2022 on macOS** (embedded Python 3.7) — users previously had to install from sdist, which is not viable in production DCC environments.

## Changes

### `build-wheels.yml` — New `macos-py37` job
- Runs on `macos-latest` (ARM64)
- Downloads Python 3.7.17 x86_64 installer from python.org
- Python 3.7 runs via **Rosetta 2** (transparent x86_64 emulation)
- Rust cross-compiles to `x86_64-apple-darwin`
- Produces: `dcc_mcp_core-*-cp37-cp37m-macosx_10_9_x86_64.whl`
- Includes wheel content validation and import test

### `ci.yml` — New `build-wheel-py37-macos` job
- PR CI coverage for macOS cp37 build path
- Same cross-compilation approach as release build

### `release.yml` — Comment updates
- Reflects that `dcc-mcp-core` now provides macOS cp37 via cross-compilation
- Documents `dcc-mcp-core-semantic` exclusion reason: `ort-sys 2.x` has no `x86_64-apple-darwin` ONNX Runtime binaries
- Users needing semantic embeddings on macOS py3.7 can use the pure-Python `fastembed` backend (automatic fallback)

## How it works

```
macos-latest (ARM64) runner
├── Python 3.11 (host) → runs maturin
├── Python 3.7.17 (x86_64 via Rosetta 2) → ABI detection target  
├── Rust target: x86_64-apple-darwin
├── ARCHFLAGS=-arch x86_64
└── Output: cp37-cp37m-macosx_10_9_x86_64 wheel
```

## Risks / Notes
- **Rosetta 2** is pre-installed on GitHub Actions macOS ARM64 runners — no additional setup needed
- First build is slower than native ARM64 (cross-compilation overhead), but stays within CI limits
- Python 3.7.17 is the last 3.7.x release, permanently available at python.org
- The new artifact name `wheels-macos-x86_64-py37` matches the existing `wheels-*` pattern in release publish

Ref: PIP-178