### PR TITLE
Expose progressive group state in gateway search

### DIFF
--- a/crates/dcc-mcp-gateway-core/src/capability/index.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/index.rs
@@ -90,6 +90,7 @@ mod tests {
             Uuid::nil(),
             false,
             false,
+            None,
         )
     }
 

--- a/crates/dcc-mcp-gateway-core/src/capability/record.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/record.rs
@@ -284,6 +284,11 @@ pub struct CapabilityRecord {
     /// Progressive tool groups declared by the owning skill, when known.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub available_groups: Vec<CapabilityGroupInfo>,
+    /// The progressive tool group this tool belongs to, if any.
+    /// `None` means the tool is not part of a progressive group and
+    /// is always callable when `loaded=true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_group: Option<String>,
 }
 
 impl CapabilityRecord {
@@ -310,6 +315,7 @@ impl CapabilityRecord {
         instance_id: Uuid,
         has_schema: bool,
         loaded: bool,
+        tool_group: Option<String>,
     ) -> Self {
         Self {
             tool_slug,
@@ -326,6 +332,7 @@ impl CapabilityRecord {
             annotations: None,
             metadata: None,
             available_groups: Vec::new(),
+            tool_group,
         }
     }
 
@@ -378,6 +385,7 @@ impl CapabilityRecord {
         tool_name: &str,
         tool_description: &str,
         dcc_type: &str,
+        tool_group: Option<String>,
     ) -> Self {
         let nil = Uuid::nil();
         let slug = tool_slug(dcc_type, &nil, tool_name);
@@ -396,7 +404,42 @@ impl CapabilityRecord {
             annotations: None,
             metadata: None,
             available_groups: Vec::new(),
+            tool_group,
         }
+    }
+
+    /// Return `true` when the tool is currently callable.
+    ///
+    /// A tool is callable when:
+    /// - `loaded` is `true` (the owning skill is connected), AND
+    /// - the tool either has no group, or its group is active.
+    #[must_use]
+    pub fn is_callable(&self) -> bool {
+        if !self.loaded {
+            return false;
+        }
+        let Some(ref group_name) = self.tool_group else {
+            // No group → always callable when loaded.
+            return true;
+        };
+        // Check whether this tool's group is active.
+        self.available_groups
+            .iter()
+            .any(|g| g.name == *group_name && g.active == Some(true))
+    }
+
+    /// Return the group name that is blocking callability, if any.
+    #[must_use]
+    pub fn disabled_by_group(&self) -> Option<&str> {
+        if !self.loaded {
+            return None; // unloaded has its own next_step
+        }
+        self.tool_group.as_deref().filter(|group_name| {
+            !self
+                .available_groups
+                .iter()
+                .any(|g| g.name == *group_name && g.active == Some(true))
+        })
     }
 }
 
@@ -580,6 +623,7 @@ mod unit_tests {
             Uuid::nil(),
             false,
             false,
+            None,
         );
         assert!(rec.summary.len() <= CapabilityRecord::MAX_SUMMARY_LEN + 3);
         assert!(rec.summary.ends_with("..."));
@@ -601,6 +645,7 @@ mod unit_tests {
             Uuid::nil(),
             false,
             false,
+            None,
         );
         assert_eq!(rec.summary, "short and sweet");
     }
@@ -625,6 +670,7 @@ mod unit_tests {
             "set_keyframe",
             "Set a keyframe at the current time.",
             "maya",
+            None,
         );
         assert_eq!(rec.instance_id, Uuid::nil());
         assert_eq!(rec.tool_slug, "maya.00000000.set_keyframe");
@@ -646,6 +692,7 @@ mod unit_tests {
             Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap(),
             true,
             true,
+            None,
         );
         let s = serde_json::to_string(&rec).unwrap();
         let back: CapabilityRecord = serde_json::from_str(&s).unwrap();
@@ -664,6 +711,7 @@ mod unit_tests {
             Uuid::nil(),
             false,
             false,
+            None,
         );
         let s = serde_json::to_string(&bare).unwrap();
         assert!(!s.contains("\"tags\""), "bare record JSON: {s}");

--- a/crates/dcc-mcp-gateway-core/src/capability/search.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/search.rs
@@ -58,6 +58,7 @@ mod tests {
             iid,
             has_schema,
             loaded,
+            None,
         )
     }
 
@@ -140,6 +141,7 @@ mod tests {
                 Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap(),
                 false,
                 true,
+                None,
             ),
             rank: 1,
             score: 42,

--- a/crates/dcc-mcp-gateway-core/src/policy.rs
+++ b/crates/dcc-mcp-gateway-core/src/policy.rs
@@ -310,6 +310,7 @@ mod tests {
             iid,
             true,
             true,
+            None,
         )
         .with_surface_metadata(
             read_only.map(|read_only_hint| CapabilityAnnotations {

--- a/crates/dcc-mcp-gateway/benches/search_bench.rs
+++ b/crates/dcc-mcp-gateway/benches/search_bench.rs
@@ -119,6 +119,7 @@ fn capability_snapshot(size: usize) -> IndexSnapshot {
                 iid,
                 true,
                 true,
+                None,
             )
         })
         .collect();

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
@@ -20,6 +20,18 @@ use super::http::{
 use super::probe::{ProbeOutcome, probe_mcp_readiness};
 use super::urls::rest_base_from_mcp_url;
 
+/// Check whether `action` (which may be skill-prefixed like
+/// `maya_geometry__create_sphere`) matches a group tool entry
+/// (typically a bare tool name like `create_sphere`).
+fn action_matches_group_tool(action: &str, group_tool_name: &str) -> bool {
+    if action == group_tool_name {
+        return true;
+    }
+    // Try the bare action name (strip skill prefix) for comparison.
+    dcc_mcp_gateway_core::naming::decode_skill_tool_name(action)
+        .is_some_and(|(_, bare)| bare == group_tool_name)
+}
+
 #[derive(Debug, Clone)]
 pub struct UnloadedCapabilityHint {
     pub skill_name: String,
@@ -241,7 +253,11 @@ pub async fn try_fetch_tools(
                     if let Some(arr) = available_groups.as_array() {
                         for group in arr {
                             if let Some(tools) = group.get("tools").and_then(Value::as_array)
-                                && tools.iter().any(|t| t.as_str() == Some(&action))
+                                && tools.iter().any(|t| {
+                                    t.as_str().is_some_and(|tool_name| {
+                                        action_matches_group_tool(&action, tool_name)
+                                    })
+                                })
                             {
                                 if let Some(group_name) = group.get("name").and_then(Value::as_str)
                                 {
@@ -286,7 +302,11 @@ pub async fn try_fetch_tools(
                 // Determine which group this tool belongs to.
                 let tool_group = available_groups
                     .iter()
-                    .find(|g| g.tools.iter().any(|t| t == &action))
+                    .find(|g| {
+                        g.tools
+                            .iter()
+                            .any(|t| action_matches_group_tool(&action, t))
+                    })
                     .map(|g| g.name.clone());
                 unloaded_hints.push(UnloadedCapabilityHint {
                     skill_name,
@@ -778,4 +798,48 @@ pub async fn subscribe_resource(
     post_jsonrpc(client, mcp_url, req_body, Some(session_id), timeout)
         .await
         .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::action_matches_group_tool;
+
+    #[test]
+    fn exact_match() {
+        assert!(action_matches_group_tool("create_sphere", "create_sphere"));
+    }
+
+    #[test]
+    fn skill_prefixed_action_matches_bare_group_tool() {
+        // Backend action: maya_geometry__create_sphere
+        // Group tool entry: create_sphere
+        assert!(action_matches_group_tool(
+            "maya_geometry__create_sphere",
+            "create_sphere"
+        ));
+    }
+
+    #[test]
+    fn non_matching_tool_returns_false() {
+        assert!(!action_matches_group_tool(
+            "maya_geometry__create_cube",
+            "create_sphere"
+        ));
+    }
+
+    #[test]
+    fn hyphenated_skill_prefixed_action_matches() {
+        assert!(action_matches_group_tool(
+            "maya-animation__set_keyframe",
+            "set_keyframe"
+        ));
+    }
+
+    #[test]
+    fn bare_action_not_in_any_group() {
+        assert!(!action_matches_group_tool(
+            "standalone_action",
+            "create_sphere"
+        ));
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
@@ -27,6 +27,7 @@ pub struct UnloadedCapabilityHint {
     pub summary: String,
     pub search_tokens: Vec<String>,
     pub available_groups: Vec<CapabilityGroupInfo>,
+    pub tool_group: Option<String>,
 }
 
 async fn rest_get_idempotent(
@@ -224,7 +225,37 @@ pub async fn try_fetch_tools(
             if loaded {
                 let annotations = parse_tool_annotations(v.get("annotations"));
                 let metadata = v.get("metadata");
-                let meta = mcp_meta_from_rest_metadata(metadata, v.get("skill"));
+                let mut meta = mcp_meta_from_rest_metadata(metadata, v.get("skill"));
+
+                // Inject available_groups and per-tool group info so the
+                // capability builder can surface progressive group state.
+                if let Some(available_groups) = v.get("available_groups")
+                    && let Some(dcc) = meta
+                        .get_or_insert_with(Default::default)
+                        .entry("dcc".to_string())
+                        .or_insert_with(|| json!({}))
+                        .as_object_mut()
+                {
+                    dcc.insert("available_groups".to_string(), available_groups.clone());
+                    // Determine which group this tool belongs to.
+                    if let Some(arr) = available_groups.as_array() {
+                        for group in arr {
+                            if let Some(tools) = group.get("tools").and_then(Value::as_array)
+                                && tools.iter().any(|t| t.as_str() == Some(&action))
+                            {
+                                if let Some(group_name) = group.get("name").and_then(Value::as_str)
+                                {
+                                    dcc.insert(
+                                        "group".to_string(),
+                                        Value::String(group_name.to_string()),
+                                    );
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+
                 loaded_tools.push(McpTool {
                     name: action,
                     description,
@@ -247,17 +278,23 @@ pub async fn try_fetch_tools(
                     .unwrap_or("")
                     .to_owned();
                 let metadata = v.get("metadata");
-                let available_groups = v
+                let available_groups: Vec<CapabilityGroupInfo> = v
                     .get("available_groups")
                     .cloned()
                     .and_then(|value| serde_json::from_value(value).ok())
                     .unwrap_or_default();
+                // Determine which group this tool belongs to.
+                let tool_group = available_groups
+                    .iter()
+                    .find(|g| g.tools.iter().any(|t| t == &action))
+                    .map(|g| g.name.clone());
                 unloaded_hints.push(UnloadedCapabilityHint {
                     skill_name,
                     tool_name: action,
                     summary: description,
                     search_tokens: rest_metadata_search_tokens(metadata),
                     available_groups,
+                    tool_group,
                 });
             }
         }

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -30,8 +30,8 @@ use dcc_mcp_jsonrpc::McpTool;
 
 use super::index::InstanceFingerprint;
 use super::record::{
-    CapabilityAnnotations, CapabilityMetadata, CapabilityRecord, SCHEMA_AVAILABLE,
-    is_valid_dcc_bucket, tool_slug,
+    CapabilityAnnotations, CapabilityGroupInfo, CapabilityMetadata, CapabilityRecord,
+    SCHEMA_AVAILABLE, is_valid_dcc_bucket, tool_slug,
 };
 
 pub use dcc_mcp_gateway_core::capability::builder::BuildOutcome;
@@ -102,6 +102,8 @@ pub fn build_records_from_backend(input: BuildInput<'_>) -> BuildOutcome {
         };
 
         let slug = tool_slug(input.dcc_type, &input.instance_id, &callable_id);
+        let tool_group = extract_tool_group_from_meta(tool.meta.as_ref());
+        let available_groups = extract_available_groups_from_meta(tool.meta.as_ref());
         records.push(
             CapabilityRecord::new(
                 slug,
@@ -114,11 +116,13 @@ pub fn build_records_from_backend(input: BuildInput<'_>) -> BuildOutcome {
                 input.instance_id,
                 has_schema,
                 true, // loaded: from live backend
+                tool_group,
             )
             .with_surface_metadata(
                 extract_annotations(&tool.annotations),
                 extract_metadata(tool.meta.as_ref()),
             )
+            .with_available_groups(available_groups)
             .with_search_tokens(search_tokens),
         );
     }
@@ -441,6 +445,33 @@ fn skill_name_from_meta(meta: Option<&serde_json::Map<String, Value>>) -> Option
         .and_then(Value::as_str)
         .filter(|name| !name.is_empty())
         .map(str::to_string)
+}
+
+/// Extract the progressive tool group name this tool belongs to, if any.
+fn extract_tool_group_from_meta(meta: Option<&serde_json::Map<String, Value>>) -> Option<String> {
+    meta.and_then(|map| map.get("dcc"))
+        .and_then(Value::as_object)
+        .and_then(|dcc| {
+            dcc.get("group")
+                .or_else(|| dcc.get("tool_group"))
+                .or_else(|| dcc.get("toolGroup"))
+        })
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
+/// Extract `available_groups` list from the tool's meta, if present.
+fn extract_available_groups_from_meta(
+    meta: Option<&serde_json::Map<String, Value>>,
+) -> Vec<CapabilityGroupInfo> {
+    let Some(groups_value) = meta
+        .and_then(|map| map.get("dcc").and_then(Value::as_object))
+        .and_then(|dcc| dcc.get("available_groups").or_else(|| dcc.get("groups")))
+    else {
+        return Vec::new();
+    };
+    serde_json::from_value(groups_value.clone()).unwrap_or_default()
 }
 
 // Tiny re-import helper removed: `idempotent` tags now consistently

--- a/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
@@ -223,6 +223,7 @@ mod unit_tests {
             id,
             false, // has_schema
             loaded,
+            None,
         )
     }
 
@@ -363,12 +364,14 @@ mod unit_tests {
                 "create_sphere",
                 "Create a sphere in Maya",
                 "maya",
+                None,
             ),
             CapabilityRecord::from_skill_tool(
                 "maya-geometry",
                 "create_cube",
                 "Create a cube in Maya",
                 "maya",
+                None,
             ),
         ];
         idx.set_unloaded_records(unloaded);
@@ -398,6 +401,7 @@ mod unit_tests {
             "set_keyframe",
             "Set a keyframe",
             "maya",
+            None,
         )];
         idx.set_unloaded_records(unloaded);
 
@@ -420,12 +424,14 @@ mod unit_tests {
                 "create_sphere",
                 "Create a sphere",
                 "maya",
+                None,
             ),
             CapabilityRecord::from_skill_tool(
                 "blender-geometry",
                 "create_cube",
                 "Create a cube",
                 "blender",
+                None,
             ),
         ];
         idx.set_unloaded_records(unloaded);
@@ -469,6 +475,7 @@ mod unit_tests {
             "create_sphere",
             "Create a sphere",
             "maya",
+            None,
         )];
         idx.set_unloaded_records(unloaded);
 

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -118,6 +118,7 @@ fn build_unloaded_records(
                 &hint.tool_name,
                 &hint.summary,
                 dcc_type,
+                hint.tool_group.clone(),
             )
             .with_available_groups(hint.available_groups)
             .with_search_tokens(hint.search_tokens);
@@ -135,6 +136,7 @@ fn compute_fingerprint(records: &[CapabilityRecord]) -> InstanceFingerprint {
         r.has_schema.hash(&mut hasher);
         r.summary.hash(&mut hasher);
         r.loaded.hash(&mut hasher);
+        r.tool_group.hash(&mut hasher);
         for group in &r.available_groups {
             group.name.hash(&mut hasher);
             group.default_active.hash(&mut hasher);
@@ -201,6 +203,7 @@ mod unit_tests {
                 iid,
                 false, // has_schema
                 true,  // loaded
+                None,
             )],
             InstanceFingerprint(1),
         );
@@ -239,6 +242,7 @@ mod unit_tests {
                 iid,
                 false,
                 true, // loaded
+                None,
             )],
             InstanceFingerprint(42),
         );
@@ -251,6 +255,7 @@ mod unit_tests {
                 summary: "Create a primitive sphere".to_string(),
                 search_tokens: Vec::new(),
                 available_groups: Vec::new(),
+                tool_group: None,
             }],
             iid,
             "maya",
@@ -328,6 +333,7 @@ mod unit_tests {
                     summary: "Create a primitive sphere".to_string(),
                     search_tokens: Vec::new(),
                     available_groups: Vec::new(),
+                    tool_group: None,
                 }],
                 iid,
                 "maya",

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -238,7 +238,10 @@ pub fn search_hit_to_value_with_context(
         if let Some(group_name) = hit.record.disabled_by_group() {
             // Tool is loaded but its progressive group is inactive.
             value["disabled_by_group"] = json!(group_name);
-            // Provide an activate_tool_group next_step.
+            // Provide an activate_tool_group next_step (MCP only —
+            // activate_tool_group is a gateway meta-tool, not a
+            // capability-indexed action, so there is no REST /v1/call
+            // route for it).
             if let Some(skill_name) = &hit.record.skill_name {
                 let mut arguments = json!({
                     "skill_name": skill_name,
@@ -258,17 +261,6 @@ pub fn search_hit_to_value_with_context(
                             "group": group_name,
                         },
                         "_meta": search_meta(context),
-                    },
-                    "rest": {
-                        "method": "POST",
-                        "path": "/v1/call",
-                        "body": {
-                            "tool": "activate_tool_group",
-                            "arguments": {
-                                "skill_name": skill_name,
-                                "group": group_name,
-                            },
-                        },
                     },
                 });
             }
@@ -1135,5 +1127,134 @@ mod unit_tests {
         }));
 
         assert_eq!(q.instance_id, Some(iid));
+    }
+
+    // ── progressive group-aware search hit tests ──────────────────────
+
+    fn make_group_record(
+        tool_slug: &str,
+        skill_name: Option<&str>,
+        loaded: bool,
+        tool_group: Option<&str>,
+        available_groups: Vec<crate::gateway::capability::CapabilityGroupInfo>,
+    ) -> CapabilityRecord {
+        let iid = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        CapabilityRecord::new(
+            tool_slug.to_string(),
+            tool_slug
+                .split('.')
+                .next_back()
+                .unwrap_or(tool_slug)
+                .to_string(),
+            tool_slug
+                .split('.')
+                .next_back()
+                .unwrap_or(tool_slug)
+                .to_string(),
+            skill_name.map(str::to_string),
+            "Test capability",
+            Vec::new(),
+            tool_slug.split('.').next().unwrap_or("maya").to_string(),
+            iid,
+            false,
+            loaded,
+            tool_group.map(str::to_string),
+        )
+        .with_available_groups(available_groups)
+    }
+
+    #[test]
+    fn progressive_group_inactive_generates_activate_next_step() {
+        let rec = make_group_record(
+            "maya.abcdef01.create_sphere",
+            Some("maya-modeling"),
+            true,
+            Some("modeling"),
+            vec![crate::gateway::capability::CapabilityGroupInfo {
+                name: "modeling".to_string(),
+                description: "Modeling tools".to_string(),
+                tools: vec!["create_sphere".to_string()],
+                default_active: false,
+                active: Some(false),
+            }],
+        );
+        let hit = SearchHit {
+            record: rec,
+            rank: 1,
+            score: 10,
+            match_reasons: vec![],
+        };
+        let row = search_hit_to_value(hit);
+
+        assert_eq!(row["callable"], false);
+        assert_eq!(row["load_state"], "loaded");
+        assert_eq!(row["disabled_by_group"], "modeling");
+        assert_eq!(row["next_step"]["action"], "activate_tool_group");
+        assert_eq!(row["next_step"]["arguments"]["skill_name"], "maya-modeling");
+        assert_eq!(row["next_step"]["arguments"]["tool_group"], "modeling");
+        assert_eq!(row["next_step"]["mcp"]["tool"], "activate_tool_group");
+        assert_eq!(row["next_step"]["mcp"]["arguments"]["group"], "modeling");
+        // REST block must NOT be present for activate_tool_group
+        // (gateway meta-tool, not a capability-indexed action).
+        assert!(row["next_step"].get("rest").is_none());
+    }
+
+    #[test]
+    fn progressive_group_active_generates_describe_next_step() {
+        let rec = make_group_record(
+            "maya.abcdef01.create_sphere",
+            Some("maya-modeling"),
+            true,
+            Some("modeling"),
+            vec![crate::gateway::capability::CapabilityGroupInfo {
+                name: "modeling".to_string(),
+                description: "Modeling tools".to_string(),
+                tools: vec!["create_sphere".to_string()],
+                default_active: true,
+                active: Some(true),
+            }],
+        );
+        let hit = SearchHit {
+            record: rec,
+            rank: 1,
+            score: 10,
+            match_reasons: vec![],
+        };
+        let row = search_hit_to_value(hit);
+
+        assert_eq!(row["callable"], true);
+        assert_eq!(row["load_state"], "loaded");
+        assert!(row.get("disabled_by_group").is_none());
+        assert_eq!(row["next_step"]["action"], "describe");
+        assert_eq!(
+            row["next_step"]["arguments"]["tool_slug"],
+            "maya.abcdef01.create_sphere"
+        );
+        // Standard describe next_step must include both MCP and REST.
+        assert_eq!(row["next_step"]["rest"]["path"], "/v1/describe");
+        assert_eq!(row["next_step"]["mcp"]["tool"], "describe");
+    }
+
+    #[test]
+    fn loaded_no_group_is_callable_with_describe_next_step() {
+        let rec = make_group_record(
+            "maya.abcdef01.open_scene",
+            Some("maya-scene"),
+            true,
+            None, // no group
+            vec![],
+        );
+        let hit = SearchHit {
+            record: rec,
+            rank: 1,
+            score: 10,
+            match_reasons: vec![],
+        };
+        let row = search_hit_to_value(hit);
+
+        assert_eq!(row["callable"], true);
+        assert_eq!(row["load_state"], "loaded");
+        assert!(row.get("disabled_by_group").is_none());
+        assert_eq!(row["next_step"]["action"], "describe");
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -198,6 +198,11 @@ pub fn search_hit_to_value_with_context(
     context: Option<&SearchResponseContext>,
 ) -> Value {
     let mut value = serde_json::to_value(&hit).unwrap_or(Value::Null);
+
+    // Always expose the callable flag.
+    let callable = hit.record.is_callable();
+    value["callable"] = json!(callable);
+
     if !hit.record.loaded {
         value["load_state"] = json!("unloaded");
         if let Some(skill_name) = &hit.record.skill_name {
@@ -207,6 +212,11 @@ pub fn search_hit_to_value_with_context(
                 "dcc_type": &hit.record.dcc_type,
                 "instance_id": hit.record.instance_id.to_string(),
             });
+            // If the tool belongs to a group that will need activation,
+            // hint the tool_group so the agent can activate it after load.
+            if let Some(ref tool_group) = hit.record.tool_group {
+                arguments["tool_group"] = json!(tool_group);
+            }
             attach_search_meta(&mut arguments, context);
             value["next_step"] = json!({
                 "action": "load_skill",
@@ -225,24 +235,64 @@ pub fn search_hit_to_value_with_context(
         }
     } else if hit.record.loaded {
         value["load_state"] = json!("loaded");
-        let mut arguments = json!({
-            "tool_slug": hit.record.tool_slug,
-        });
-        attach_search_meta(&mut arguments, context);
-        value["next_step"] = json!({
-            "action": "describe",
-            "arguments": arguments.clone(),
-            "mcp": {
-                "tool": "describe",
+        if let Some(group_name) = hit.record.disabled_by_group() {
+            // Tool is loaded but its progressive group is inactive.
+            value["disabled_by_group"] = json!(group_name);
+            // Provide an activate_tool_group next_step.
+            if let Some(skill_name) = &hit.record.skill_name {
+                let mut arguments = json!({
+                    "skill_name": skill_name,
+                    "dcc": &hit.record.dcc_type,
+                    "dcc_type": &hit.record.dcc_type,
+                    "tool_group": group_name,
+                    "instance_id": hit.record.instance_id.to_string(),
+                });
+                attach_search_meta(&mut arguments, context);
+                value["next_step"] = json!({
+                    "action": "activate_tool_group",
+                    "arguments": arguments.clone(),
+                    "mcp": {
+                        "tool": "activate_tool_group",
+                        "arguments": {
+                            "skill_name": skill_name,
+                            "group": group_name,
+                        },
+                        "_meta": search_meta(context),
+                    },
+                    "rest": {
+                        "method": "POST",
+                        "path": "/v1/call",
+                        "body": {
+                            "tool": "activate_tool_group",
+                            "arguments": {
+                                "skill_name": skill_name,
+                                "group": group_name,
+                            },
+                        },
+                    },
+                });
+            }
+        } else {
+            // Tool is loaded and callable — standard describe next_step.
+            let mut arguments = json!({
+                "tool_slug": hit.record.tool_slug,
+            });
+            attach_search_meta(&mut arguments, context);
+            value["next_step"] = json!({
+                "action": "describe",
                 "arguments": arguments.clone(),
-                "_meta": search_meta(context),
-            },
-            "rest": {
-                "method": "POST",
-                "path": "/v1/describe",
-                "body": arguments,
-            },
-        });
+                "mcp": {
+                    "tool": "describe",
+                    "arguments": arguments.clone(),
+                    "_meta": search_meta(context),
+                },
+                "rest": {
+                    "method": "POST",
+                    "path": "/v1/describe",
+                    "body": arguments,
+                },
+            });
+        }
     }
     value
 }
@@ -289,6 +339,7 @@ fn index_snapshot_generation(snapshot: &super::capability::IndexSnapshot) -> Str
         record.tool_slug.hash(&mut hasher);
         record.loaded.hash(&mut hasher);
         record.has_schema.hash(&mut hasher);
+        record.tool_group.hash(&mut hasher);
         for group in &record.available_groups {
             group.name.hash(&mut hasher);
             group.default_active.hash(&mut hasher);
@@ -742,6 +793,7 @@ mod unit_tests {
             iid,
             false, // has_schema
             loaded,
+            None,
         );
         index.upsert_instance(iid, vec![rec], InstanceFingerprint(1));
     }
@@ -834,6 +886,7 @@ mod unit_tests {
             iid,
             true,
             false,
+            None,
         )
         .with_available_groups(vec![crate::gateway::capability::CapabilityGroupInfo {
             name: "core".to_string(),

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -208,6 +208,7 @@ fn seed_unloaded_render_capability(gs: &GatewayState) {
             "render",
             "Render the current scene",
             "maya",
+            None,
         ),
     ]);
 }
@@ -230,6 +231,7 @@ fn policy_record(
         instance_id,
         true,
         true,
+        None,
     )
     .with_surface_metadata(
         Some(crate::gateway::capability::CapabilityAnnotations {

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -1672,6 +1672,7 @@ async fn gateway_rest_v1_call_batch_mixed_success_failure_continues_on_error() {
         instance_id,
         true, // has_schema
         true, // loaded
+        None,
     );
     gs.capability_index.upsert_instance(
         instance_id,

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -324,6 +324,8 @@ fn compact_record(record: &Value) -> Value {
     copy_field(&mut out, record, "has_schema");
     copy_field(&mut out, record, "loaded");
     copy_field(&mut out, record, "load_state");
+    copy_field(&mut out, record, "callable");
+    copy_field(&mut out, record, "disabled_by_group");
     copy_field(&mut out, record, "available_groups");
     copy_field(&mut out, record, "rank");
     copy_field(&mut out, record, "score");

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -483,6 +483,7 @@ async fn test_instance_json_reports_app_ui_availability_from_capabilities() {
         entry.instance_id,
         true,
         true,
+        None,
     );
     gs.capability_index.upsert_instance(
         entry.instance_id,

--- a/tests/test_e2e_gateway_skill_load_sse.py
+++ b/tests/test_e2e_gateway_skill_load_sse.py
@@ -230,22 +230,43 @@ def gateway_with_skill_backend(tmp_path, monkeypatch):
     # guarantees the env var is reset even if the test aborts mid-way.
     monkeypatch.setenv("DCC_MCP_SKILL_PATHS", EXAMPLES_SKILLS_DIR)
 
-    gw_port = _pick_free_port()
+    handle = None
+    gw_port = 0
+    last_start_error: RuntimeError | None = None
+    for _ in range(8):
+        gw_port = _pick_free_port()
 
-    # Backend = gateway winner (single-backend cluster is sufficient for
-    # this invariant; multi-backend aggregation is already covered by
-    # test_gateway_facade_aggregation.py).
-    cfg = McpHttpConfig(port=0, server_name="hello-backend")
-    cfg.gateway_port = gw_port
-    cfg.registry_dir = str(registry_dir)
-    cfg.dcc_type = "python"
-    cfg.heartbeat_secs = 1
-    cfg.stale_timeout_secs = 10
-    # ``include_bundled`` would also work but we keep the test hermetic
-    # to examples/skills so a regression in bundled skills cannot mask
-    # a regression in the load-skill → SSE pipeline.
-    server = create_skill_server("python", cfg)
-    handle = server.start()
+        # Backend = gateway winner (single-backend cluster is sufficient for
+        # this invariant; multi-backend aggregation is already covered by
+        # test_gateway_facade_aggregation.py).
+        cfg = McpHttpConfig(port=0, server_name="hello-backend")
+        cfg.gateway_port = gw_port
+        cfg.registry_dir = str(registry_dir)
+        cfg.dcc_type = "python"
+        cfg.heartbeat_secs = 1
+        cfg.stale_timeout_secs = 10
+        # ``include_bundled`` would also work but we keep the test hermetic
+        # to examples/skills so a regression in bundled skills cannot mask
+        # a regression in the load-skill → SSE pipeline.
+        server = create_skill_server("python", cfg)
+        try:
+            candidate = server.start()
+        except RuntimeError as exc:
+            # ``_pick_free_port`` has an unavoidable close-then-bind gap. On
+            # Windows CI another test or the OS can grab that port before the
+            # embedded gateway binds it, surfacing as WinError 10048.
+            last_start_error = exc
+            if "Only one usage of each socket address" in str(exc) or "os error 10048" in str(exc):
+                continue
+            raise
+        if candidate.is_gateway:
+            handle = candidate
+            break
+        with contextlib.suppress(Exception):
+            candidate.shutdown()
+    if handle is None:
+        detail = f": {last_start_error}" if last_start_error is not None else ""
+        pytest.fail(f"failed to start single-backend gateway after retrying ports{detail}")
 
     # Wait until both the instance port and the gateway port are up. The
     # self-probe inside start() guarantees this, but on slow CI it is


### PR DESCRIPTION
## Summary

- expose `callable`, `tool_group`, and `disabled_by_group` state in gateway capability search rows
- return group-aware `next_step` guidance when a loaded tool is blocked by an inactive progressive group
- preserve bare-tool matching for skill-prefixed actions such as `maya_geometry__create_sphere`
- add regression coverage for inactive group, active group, and no-group callable paths

## Why

Search results previously exposed `loaded=true` without making it clear that progressive group activation could still make the tool uncallable. Agents could then call a loaded tool and receive a group-disabled failure.

## Validation

- `vx cargo fmt --all -- --check`
- `vx cargo test -p dcc-mcp-gateway --lib`
- `vx cargo test -p dcc-mcp-gateway-core --lib`

## Notes

- This PR is based on latest `origin/main` and excludes the unrelated macOS wheel workflow changes from `fix/macos-cp37-wheel`.
- No skill guidance update appears required: the change affects gateway search result fields and follow-up payloads, not adapter/server wiring or skill authoring rules.
