### PR TITLE
fix(mcp): simplify exposed input schemas

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -1173,11 +1173,7 @@ pub fn gateway_tool_defs() -> serde_json::Value {
                     "stop_on_error": {"type": "boolean", "default": false},
                     "response_format": {"type": "string", "enum": ["json", "toon"], "description": "Wrapper-level output format; it is not forwarded to the backend capability."},
                     "compact": {"type": "boolean", "description": "Alias for response_format=toon when true."}
-                },
-                "anyOf": [
-                    {"required": ["tool_slug"]},
-                    {"required": ["calls"]}
-                ]
+                }
             },
             "annotations": {
                 "readOnlyHint": false,
@@ -1251,7 +1247,7 @@ mod tests {
     }
 
     #[test]
-    fn gateway_call_schema_accepts_single_and_batch_shapes() {
+    fn gateway_call_schema_keeps_compatibility_shape() {
         let defs = gateway_tool_defs();
         let call = defs
             .as_array()
@@ -1260,14 +1256,13 @@ mod tests {
             .find(|tool| tool["name"] == "call")
             .expect("call tool advertised");
 
-        assert_eq!(
-            call["inputSchema"]["anyOf"][0]["required"],
-            json!(["tool_slug"])
-        );
-        assert_eq!(
-            call["inputSchema"]["anyOf"][1]["required"],
-            json!(["calls"])
-        );
+        assert_eq!(call["inputSchema"]["type"], "object");
+        assert!(call["inputSchema"].get("anyOf").is_none());
+        assert!(call["inputSchema"].get("oneOf").is_none());
+        assert!(call["inputSchema"].get("allOf").is_none());
+        assert!(call["inputSchema"].get("not").is_none());
+        assert!(call["inputSchema"].get("required").is_none());
+        assert!(call["inputSchema"]["properties"]["tool_slug"].is_object());
         assert_eq!(call["inputSchema"]["properties"]["calls"]["maxItems"], 25);
         assert_eq!(call["annotations"]["destructiveHint"], true);
     }

--- a/crates/dcc-mcp-http-server/src/mcp_tool_catalog.rs
+++ b/crates/dcc-mcp-http-server/src/mcp_tool_catalog.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use serde_json::json;
+use serde_json::{Map, Value, json};
 
 use dcc_mcp_actions::registry::{ToolMeta, ToolRegistry};
 use dcc_mcp_gateway_core::naming::{
@@ -11,6 +11,12 @@ use dcc_mcp_gateway_core::naming::{
 use dcc_mcp_jsonrpc::{McpTool, McpToolAnnotations};
 use dcc_mcp_models::SkillScope;
 use dcc_mcp_skills::SkillSummary;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaProjection {
+    Full,
+    ToolsListCompatible,
+}
 
 #[must_use]
 pub fn build_lazy_action_tools() -> Vec<McpTool> {
@@ -118,10 +124,13 @@ pub fn action_meta_to_mcp_tool(
     include_output_schema: bool,
     bare_eligible: &HashSet<(String, String)>,
     declared_capabilities: &[String],
+    schema_projection: SchemaProjection,
 ) -> McpTool {
     let schema_is_incomplete = meta.input_schema.is_null();
     let input_schema = if schema_is_incomplete {
         json!({"type": "object"})
+    } else if schema_projection == SchemaProjection::ToolsListCompatible {
+        simplify_mcp_input_schema(&meta.input_schema)
     } else {
         meta.input_schema.clone()
     };
@@ -167,6 +176,111 @@ pub fn action_meta_to_mcp_tool(
         annotations,
         meta: build_tool_meta(meta, declared_capabilities, schema_is_incomplete),
     }
+}
+
+/// Return a client-compatible projection of a tool input schema for MCP
+/// ``tools/list``.
+///
+/// The registry keeps the original JSON Schema for server-side validation.
+/// This projection strips JSON Schema composition/conditional keywords that
+/// several MCP clients reject during tool registration, while preserving the
+/// basic object/property/required shape that helps agents form calls.
+#[must_use]
+pub fn simplify_mcp_input_schema(schema: &Value) -> Value {
+    let simplified = simplify_schema_value(schema, true);
+    let Some(obj) = simplified.as_object() else {
+        return json!({"type": "object", "properties": {}});
+    };
+
+    let mut out = obj.clone();
+    match out.get("type").and_then(Value::as_str) {
+        Some("object") => {}
+        _ => {
+            out.insert("type".to_string(), Value::String("object".to_string()));
+        }
+    }
+    out.entry("properties".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    Value::Object(out)
+}
+
+fn simplify_schema_value(schema: &Value, root: bool) -> Value {
+    match schema {
+        Value::Object(original) => {
+            if let Some(nullable) = simplify_nullable_union(original) {
+                return simplify_schema_value(&nullable, root);
+            }
+
+            let mut out = Map::new();
+            for (key, value) in original {
+                if is_complex_schema_keyword(key) {
+                    continue;
+                }
+                if root && key == "enum" {
+                    continue;
+                }
+                if key == "type"
+                    && let Some(types) = value.as_array()
+                {
+                    let non_null: Vec<&Value> = types
+                        .iter()
+                        .filter(|item| item.as_str() != Some("null"))
+                        .collect();
+                    if non_null.len() == 1 {
+                        out.insert(key.clone(), non_null[0].clone());
+                    }
+                    continue;
+                }
+                out.insert(key.clone(), simplify_schema_value(value, false));
+            }
+            Value::Object(out)
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| simplify_schema_value(item, false))
+                .collect(),
+        ),
+        _ => schema.clone(),
+    }
+}
+
+fn simplify_nullable_union(schema: &Map<String, Value>) -> Option<Value> {
+    let alternatives = schema
+        .get("anyOf")
+        .or_else(|| schema.get("oneOf"))
+        .and_then(Value::as_array)?;
+    let non_null: Vec<&Value> = alternatives
+        .iter()
+        .filter(|item| item.get("type").and_then(Value::as_str) != Some("null"))
+        .collect();
+    if non_null.len() == 1 && non_null.len() + 1 == alternatives.len() {
+        let mut merged = schema.clone();
+        merged.remove("anyOf");
+        merged.remove("oneOf");
+        if let Some(alt) = non_null[0].as_object() {
+            for (key, value) in alt {
+                merged.entry(key.clone()).or_insert_with(|| value.clone());
+            }
+        }
+        return Some(Value::Object(merged));
+    }
+    None
+}
+
+fn is_complex_schema_keyword(key: &str) -> bool {
+    matches!(
+        key,
+        "anyOf"
+            | "oneOf"
+            | "allOf"
+            | "not"
+            | "if"
+            | "then"
+            | "else"
+            | "dependentSchemas"
+            | "dependentRequired"
+    )
 }
 
 #[must_use]
@@ -345,5 +459,112 @@ pub fn build_group_stub(group: &str, tool_names: &[String]) -> McpTool {
         output_schema: None,
         annotations: None,
         meta: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dcc_mcp_models::ToolAnnotations;
+
+    #[test]
+    fn simplify_mcp_input_schema_removes_composition_but_keeps_shape() {
+        let schema = json!({
+            "type": "object",
+            "oneOf": [
+                {"required": ["spec"]},
+                {"required": ["skill", "name"]}
+            ],
+            "properties": {
+                "spec": {
+                    "description": "Inline spec.",
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "object"}
+                    ]
+                },
+                "label": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "null"}
+                    ]
+                },
+                "count": {
+                    "type": ["integer", "null"],
+                    "minimum": 1
+                }
+            },
+            "required": ["spec"]
+        });
+
+        let simplified = simplify_mcp_input_schema(&schema);
+        assert_eq!(simplified["type"], "object");
+        assert_eq!(simplified["required"], json!(["spec"]));
+        assert!(simplified.get("oneOf").is_none());
+        assert!(simplified["properties"]["spec"].get("oneOf").is_none());
+        assert_eq!(
+            simplified["properties"]["spec"]["description"],
+            "Inline spec."
+        );
+        assert_eq!(simplified["properties"]["label"]["type"], "string");
+        assert_eq!(simplified["properties"]["count"]["type"], "integer");
+        assert_eq!(simplified["properties"]["count"]["minimum"], 1);
+    }
+
+    #[test]
+    fn action_meta_to_mcp_tool_projects_schema_by_requested_mode() {
+        let mut meta = ToolMeta {
+            name: "workflows_run".to_string(),
+            description: "Run workflow".to_string(),
+            category: "workflow".to_string(),
+            dcc: "core".to_string(),
+            version: "1.0.0".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "anyOf": [
+                    {"required": ["tool_slug"]},
+                    {"required": ["calls"]}
+                ],
+                "properties": {
+                    "tool_slug": {"type": "string"},
+                    "calls": {"type": "array", "maxItems": 25}
+                }
+            }),
+            annotations: ToolAnnotations {
+                destructive_hint: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let original = meta.input_schema.clone();
+
+        let described =
+            action_meta_to_mcp_tool(&meta, true, &HashSet::new(), &[], SchemaProjection::Full);
+        assert_eq!(described.input_schema, original);
+
+        let listed = action_meta_to_mcp_tool(
+            &meta,
+            false,
+            &HashSet::new(),
+            &[],
+            SchemaProjection::ToolsListCompatible,
+        );
+        assert_eq!(listed.input_schema["type"], "object");
+        assert!(listed.input_schema.get("anyOf").is_none());
+        assert_eq!(listed.input_schema["properties"]["calls"]["maxItems"], 25);
+        assert_eq!(meta.input_schema, original);
+
+        meta.input_schema = Value::String("not an object".to_string());
+        let tool = action_meta_to_mcp_tool(
+            &meta,
+            false,
+            &HashSet::new(),
+            &[],
+            SchemaProjection::ToolsListCompatible,
+        );
+        assert_eq!(
+            tool.input_schema,
+            json!({"type": "object", "properties": {}})
+        );
     }
 }

--- a/crates/dcc-mcp-http-server/src/mcp_tool_list_builder.rs
+++ b/crates/dcc-mcp-http-server/src/mcp_tool_list_builder.rs
@@ -8,7 +8,8 @@ use dcc_mcp_naming::validate_tool_name;
 
 use crate::handlers::build_core_tools;
 use crate::mcp_tool_catalog::{
-    action_meta_to_mcp_tool, build_group_stub, build_lazy_action_tools, build_skill_stub,
+    SchemaProjection, action_meta_to_mcp_tool, build_group_stub, build_lazy_action_tools,
+    build_skill_stub,
 };
 use crate::server_state::ServerState;
 
@@ -51,6 +52,7 @@ pub fn assemble_full_tool_list(
                 include_output_schema,
                 &bare_eligible,
                 state.declared_capabilities.as_ref(),
+                SchemaProjection::ToolsListCompatible,
             ));
         } else if !meta.group.is_empty() {
             inactive_groups

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/dynamic.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/dynamic.rs
@@ -10,7 +10,7 @@ use crate::dynamic_tools::{
     build_execution_wrapper, handle_deregister_tool, handle_list_dynamic_tools,
     handle_register_tool,
 };
-use crate::mcp_tool_catalog::{action_meta_to_mcp_tool, resolve_action_by_id};
+use crate::mcp_tool_catalog::{SchemaProjection, action_meta_to_mcp_tool, resolve_action_by_id};
 use crate::server_state::ServerState;
 
 pub(in crate::rmcp_tool_call_dispatch) fn handle_list_actions(
@@ -76,6 +76,7 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_describe_action(
         include_output_schema,
         &bare_eligible_for_describe,
         state.declared_capabilities.as_ref(),
+        SchemaProjection::Full,
     );
     let payload = serde_json::to_value(tool).unwrap_or_default();
     CallToolResult::text(serde_json::to_string(&payload).unwrap_or_default())

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -215,6 +215,15 @@ activation/deactivation. To force a fresh build for a single request, send
 `_meta.dcc.refresh=true` on the `tools/list` call. The cache does **not**
 apply to `tools/call` — only to `tools/list` response construction.
 
+**MCP-facing input schemas stay simple:**
+`tools/list` should expose a client-compatible object schema: top-level
+`type: object`, `properties`, `required`, primitive property types, bounds, and
+short descriptions. Do not rely on JSON Schema composition or conditionals
+(`anyOf`, `oneOf`, `allOf`, `not`, `if`/`then`/`else`, dependent schemas) to
+express tool semantics. Keep those rules in the handler/tool script so clients
+can register the MCP tool first, then receive normal validation errors at call
+time.
+
 **USD project resources (issue #1209):**
 ```python
 from dcc_mcp_core import register_usd_project_resources

--- a/python/dcc_mcp_core/script_materialization_tools.py
+++ b/python/dcc_mcp_core/script_materialization_tools.py
@@ -67,7 +67,6 @@ _MATERIALIZE_INPUT_SCHEMA: dict[str, Any] = {
             "description": "Optional trace id.",
         },
     },
-    "anyOf": [{"required": ["content"]}, {"required": ["code"]}],
 }
 
 

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -112,6 +112,11 @@ Generated `tools.yaml` entries follow the modern contract:
 - Local tool names are snake_case and client-safe. Do not use dotted names.
 - Loaded tools are published as `<skill-name>__<tool_name>` when namespacing is needed.
 - `input_schema` and `output_schema` are declared explicitly.
+- Keep MCP-facing `input_schema` shapes simple: prefer a top-level object with
+  `properties`, `required`, primitive `type`, bounds, and descriptions. Put
+  mutually exclusive forms, conditional requirements, and cross-field rules in
+  the tool script or handler validation instead of `anyOf`, `oneOf`, `allOf`,
+  `not`, `if`/`then`/`else`, or dependent-schema keywords.
 - `execution` is `sync` or `async`; use `async` for deferred/long-running work.
 - `affinity` is explicit. Use `main` for host API or scene mutation work and `any` for pure work.
 - `enforce_thread_affinity: true` is emitted so adapter dispatch stays honest.

--- a/tests/test_script_materialization_tools.py
+++ b/tests/test_script_materialization_tools.py
@@ -62,7 +62,11 @@ def test_materialize_script_tool_list_entry_stays_compact(tmp_path: Path) -> Non
         tool = next(tool for tool in body["result"]["tools"] if tool["name"] == "materialize_script")
         payload = json.dumps(tool, separators=(",", ":"), sort_keys=True).encode("utf-8")
         assert len(payload) < 2048
-        assert tool["inputSchema"]["anyOf"] == [{"required": ["content"]}, {"required": ["code"]}]
+        assert tool["inputSchema"]["type"] == "object"
+        assert "anyOf" not in tool["inputSchema"]
+        assert "oneOf" not in tool["inputSchema"]
+        assert "allOf" not in tool["inputSchema"]
+        assert "not" not in tool["inputSchema"]
         assert set(tool["outputSchema"]["required"]) == {
             "file_ref",
             "file_path",


### PR DESCRIPTION
## Summary
- remove the top-level `anyOf` from the `materialize_script` MCP input schema so clients that require a plain top-level object can register the tool
- project registered action schemas into a simplified MCP `tools/list` shape that strips JSON Schema composition/conditionals while keeping basic object/property constraints
- keep runtime validation in handlers/tool code, including `content` vs `code` and gateway single-call vs batch-call rules
- update skill authoring guidance to prefer simple MCP-facing schemas and move cross-field logic into application validation

## Related
- Fixes loonghao/dcc-mcp-blender#64

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests/test_script_materialization_tools.py`
- `vx cargo test -p dcc-mcp-http-server mcp_tool_catalog --lib`
- `vx cargo test -p dcc-mcp-gateway gateway_call_schema_keeps_compatibility_shape --lib`
- `vx git diff --check`
- pre-commit: `cargo fmt`, `cargo clippy`