### PR TITLE
fix(gateway): reject ambiguous instance resource prefixes

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
@@ -131,15 +131,10 @@ pub async fn build_payload(gs: &GatewayState, query: &Query) -> Result<Value, St
         }
         Query::Single { instance_id } => {
             let reg = gs.registry.read().await;
-            let all = gs.live_instances(&reg);
-            let entry = all
-                .iter()
-                .find(|e| {
-                    let s = e.instance_id.to_string();
-                    s == *instance_id || s.starts_with(instance_id.as_str())
-                })
-                .ok_or_else(|| format!("Instance '{instance_id}' not found"))?;
-            Ok(gs.instance_json(entry))
+            let entry = gs
+                .resolve_instance(&reg, Some(instance_id.as_str()), None)
+                .map_err(|err| err.to_string())?;
+            Ok(gs.instance_json(&entry))
         }
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -1090,6 +1090,89 @@ async fn test_read_alive_instances_filters_sentinel_and_self() {
     );
 }
 
+#[tokio::test]
+async fn gateway_instances_resource_lists_many_dcc_rows_without_gateway_sentinel() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+    {
+        let r = registry.read().await;
+        let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", 9765);
+        sentinel.version = Some(env!("CARGO_PKG_VERSION").into());
+        r.register(sentinel).unwrap();
+
+        for i in 0..10 {
+            r.register(ServiceEntry::new("maya", "127.0.0.1", 18000 + i))
+                .unwrap();
+            r.register(ServiceEntry::new("houdini", "127.0.0.1", 18100 + i))
+                .unwrap();
+        }
+    }
+
+    let gs = test_gateway_state_with_own(registry.clone(), "127.0.0.1", 9765);
+    let payload = crate::gateway::native_resources::instances::build_payload(
+        &gs,
+        &crate::gateway::native_resources::instances::Query::List {
+            include_stale: true,
+            include_dead: false,
+        },
+    )
+    .await
+    .expect("gateway://instances payload");
+
+    assert_eq!(payload["total"], 20);
+    assert_eq!(payload["by_source"]["file"], 20);
+    let rows = payload["instances"].as_array().expect("instances array");
+    assert_eq!(
+        rows.iter()
+            .filter(|row| row["dcc_type"] == serde_json::json!("maya"))
+            .count(),
+        10
+    );
+    assert_eq!(
+        rows.iter()
+            .filter(|row| row["dcc_type"] == serde_json::json!("houdini"))
+            .count(),
+        10
+    );
+    assert!(
+        rows.iter()
+            .all(|row| row["dcc_type"] != serde_json::json!(GATEWAY_SENTINEL_DCC_TYPE)),
+        "gateway://instances must expose only addressable DCC services"
+    );
+}
+
+#[tokio::test]
+async fn gateway_instances_resource_rejects_ambiguous_instance_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+    {
+        let r = registry.read().await;
+        let mut first = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        first.instance_id = uuid::Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        r.register(first).unwrap();
+        let mut second = ServiceEntry::new("houdini", "127.0.0.1", 18813);
+        second.instance_id = uuid::Uuid::parse_str("abcdef9923456789abcdef0123456789").unwrap();
+        r.register(second).unwrap();
+    }
+
+    let gs = test_gateway_state(registry.clone());
+    let err = crate::gateway::native_resources::instances::build_payload(
+        &gs,
+        &crate::gateway::native_resources::instances::Query::Single {
+            instance_id: "abcdef".to_string(),
+        },
+    )
+    .await
+    .expect_err("ambiguous resource prefix should be rejected");
+
+    assert!(
+        err.contains("multiple-instances-match"),
+        "ambiguous prefix should produce the same resolver error as REST routing: {err}"
+    );
+}
+
 // ── Sub-state view tests (issue #839) ──────────────────────────────────
 
 /// The discovery view exposes exactly the subset a registry-facing

--- a/docs/api/resources.md
+++ b/docs/api/resources.md
@@ -47,7 +47,7 @@ modeled as an MCP resource instead of a tool:
 | `gateway://instances` | `application/json` | Live DCC registry. Rows include `instance_id`, `dcc_type`, health/status fields, metadata, and `mcp_url` for direct sessions. |
 | `gateway://instances?include_stale=false` | `application/json` | Same registry with stale-but-parseable rows hidden. |
 | `gateway://instances?include_dead=true` | `application/json` | Rawer registry view including rows whose owner process has exited. |
-| `gateway://instances/{instance_id}` | `application/json` | One instance selected by full UUID or unique prefix. |
+| `gateway://instances/{instance_id}` | `application/json` | One instance selected by full UUID, `instance_short`, or a unique 4+ character UUID prefix. |
 | `gateway://diagnostics/process` | `application/json` | Gateway process metadata plus live/stale/unhealthy instance counts; optional `?dcc_type=<type>` filter. |
 | `gateway://diagnostics/audit` | `application/json` | Pending-call and resource-subscription summary. Backend audit logs remain per-instance. |
 | `gateway://diagnostics/metrics` | `application/json` | Local gateway tool count, live backend count, timeout settings, and `publishes_backend_tools=false`. |

--- a/docs/zh/api/resources.md
+++ b/docs/zh/api/resources.md
@@ -49,7 +49,7 @@ Resources 在 `initialize` 中通告为：
 | `gateway://instances` | `application/json` | 实时 DCC 注册表。行内包含 `instance_id`、`dcc_type`、健康/状态字段、metadata，以及用于直连会话的 `mcp_url`。 |
 | `gateway://instances?include_stale=false` | `application/json` | 隐藏 stale 但可解析行的同一注册表视图。 |
 | `gateway://instances?include_dead=true` | `application/json` | 更接近原始注册表的视图，包含拥有进程已退出的行。 |
-| `gateway://instances/{instance_id}` | `application/json` | 通过完整 UUID 或唯一前缀选择的单个实例。 |
+| `gateway://instances/{instance_id}` | `application/json` | 通过完整 UUID、`instance_short` 或唯一的 4 字符以上 UUID 前缀选择的单个实例。 |
 | `resources://gateway/events` | `application/jsonl` | Gateway 竞争和选举事件 ring buffer。 |
 
 `resources/list` 只通告 `gateway://instances` 根指针；不会枚举每个


### PR DESCRIPTION
## Summary
- route `gateway://instances/{id}` through the shared instance resolver so ambiguous or too-short prefixes are rejected
- add regression coverage for a 10 Maya + 10 Houdini registry view excluding the gateway sentinel
- document single-instance resource IDs as full UUID, `instance_short`, or unique 4+ character UUID prefix

## Validation
- vx cargo test -p dcc-mcp-gateway
- vx cargo clippy -p dcc-mcp-gateway --all-targets
- vx git diff --check