### PR TITLE
fix(gateway): ignore stale rows in fingerprints

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/fingerprint.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/fingerprint.rs
@@ -1,4 +1,5 @@
 use super::super::http_registration::entry_mcp_url;
+use super::helpers::is_fingerprint_eligible_instance;
 use super::*;
 
 /// Compute a fingerprint of the aggregated tool list across every live backend.
@@ -53,18 +54,11 @@ pub(crate) async fn compute_tools_fingerprint_with_own(
             .into_iter()
             .filter(|e| {
                 !e.is_stale(stale_timeout)
-                    && e.dcc_type != super::GATEWAY_SENTINEL_DCC_TYPE
-                    && !matches!(
-                        e.status,
-                        dcc_mcp_transport::discovery::types::ServiceStatus::ShuttingDown
-                            | dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
-                            | dcc_mcp_transport::discovery::types::ServiceStatus::Booting
-                    )
+                    && is_fingerprint_eligible_instance(e)
                     && match own_host {
                         Some(h) => !super::super::is_own_instance(e, h, own_port),
                         None => true,
                     }
-                    && !e.dcc_type.eq_ignore_ascii_case("unknown")
             })
             .collect()
     };

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/helpers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/helpers.rs
@@ -1,4 +1,17 @@
 use super::*;
+use dcc_mcp_transport::discovery::types::ServiceStatus;
+
+pub(crate) fn is_fingerprint_eligible_instance(entry: &ServiceEntry) -> bool {
+    entry.dcc_type != super::GATEWAY_SENTINEL_DCC_TYPE
+        && !entry.dcc_type.eq_ignore_ascii_case("unknown")
+        && !matches!(
+            entry.status,
+            ServiceStatus::ShuttingDown
+                | ServiceStatus::Unreachable
+                | ServiceStatus::Booting
+                | ServiceStatus::Stale
+        )
+}
 
 pub(crate) async fn live_backends(gs: &GatewayState) -> Vec<ServiceEntry> {
     let reg = gs.registry.read().await;

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/prompts.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/prompts.rs
@@ -21,6 +21,7 @@ use super::*;
 
 use super::super::backend_client::{fetch_prompts, forward_prompts_get, try_fetch_prompts};
 use super::super::http_registration::entry_mcp_url;
+use super::helpers::is_fingerprint_eligible_instance;
 
 /// Build the unified `prompts/list` result by aggregating every live backend.
 ///
@@ -244,18 +245,11 @@ pub(crate) async fn compute_prompts_fingerprint_with_own(
             .into_iter()
             .filter(|e| {
                 !e.is_stale(stale_timeout)
-                    && e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE
-                    && !matches!(
-                        e.status,
-                        dcc_mcp_transport::discovery::types::ServiceStatus::ShuttingDown
-                            | dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
-                            | dcc_mcp_transport::discovery::types::ServiceStatus::Booting
-                    )
+                    && is_fingerprint_eligible_instance(e)
                     && match own_host {
                         Some(h) => !super::super::is_own_instance(e, h, own_port),
                         None => true,
                     }
-                    && !e.dcc_type.eq_ignore_ascii_case("unknown")
             })
             .collect()
     };

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/resources.rs
@@ -15,14 +15,14 @@ use futures::future::join_all;
 use serde_json::{Value, json};
 
 use dcc_mcp_gateway_core::resource_uri::encode_resource_uri;
-use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceStatus};
+use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};
 
 use super::super::backend_client::fetch_resources;
 use super::super::handlers::resources::GATEWAY_EVENTS_URI;
 use super::super::http_registration::entry_mcp_url;
 use super::super::native_resources::pointers_for_list as gateway_native_pointers;
 use super::super::state::GatewayState;
-use super::helpers::live_backends;
+use super::helpers::{is_fingerprint_eligible_instance, live_backends};
 
 fn backend_mcp_url(entry: &ServiceEntry) -> String {
     entry_mcp_url(entry)
@@ -34,12 +34,7 @@ fn backend_mcp_url(entry: &ServiceEntry) -> String {
 /// toggle, which the fingerprint keeps permissive to avoid emitting a
 /// spurious `resources/list_changed` when the toggle flips.
 fn is_registry_row_eligible_for_resources(entry: &ServiceEntry) -> bool {
-    entry.dcc_type != GATEWAY_SENTINEL_DCC_TYPE
-        && !entry.dcc_type.eq_ignore_ascii_case("unknown")
-        && !matches!(
-            entry.status,
-            ServiceStatus::ShuttingDown | ServiceStatus::Unreachable | ServiceStatus::Booting
-        )
+    is_fingerprint_eligible_instance(entry)
 }
 
 async fn fetch_resources_for_entries(
@@ -62,7 +57,7 @@ pub(crate) async fn fetch_backend_resources(
     gs: &GatewayState,
 ) -> Vec<(uuid::Uuid, String, Vec<Value>)> {
     // `live_instances` already filters out sentinel rows, own row, stale
-    // rows, and rows in `ShuttingDown | Unreachable | Booting`, and
+    // rows, and non-live status rows, and
     // respects the `allow_unknown_tools` toggle — no further filter is
     // needed here.
     let instances = live_backends(gs).await;
@@ -271,11 +266,12 @@ mod eligibility_tests {
     }
 
     #[test]
-    fn rejects_shutting_down_unreachable_and_booting() {
+    fn rejects_non_live_statuses() {
         for status in [
             ServiceStatus::ShuttingDown,
             ServiceStatus::Unreachable,
             ServiceStatus::Booting,
+            ServiceStatus::Stale,
         ] {
             assert!(
                 !is_registry_row_eligible_for_resources(&entry("maya", status)),


### PR DESCRIPTION
## Summary
- share the gateway aggregator fingerprint eligibility filter across tools, prompts, and resources
- exclude explicit `ServiceStatus::Stale` rows from all watcher fingerprints
- extend the resources eligibility regression test to cover stale rows

## Validation
- vx cargo fmt --package dcc-mcp-gateway --check
- vx cargo test -p dcc-mcp-gateway gateway::aggregator
- vx cargo clippy -p dcc-mcp-gateway --all-targets
- vx git diff --check

Docs/skill guidance checked; this is an internal gateway liveness parity fix, so no guidance update needed.