### PR TITLE
docs(gateway): clarify daemon-backed auto mode

### DIFF
--- a/crates/dcc-mcp-server/src/cli.rs
+++ b/crates/dcc-mcp-server/src/cli.rs
@@ -7,7 +7,7 @@ use crate::{capture, translate};
 /// DCC-MCP subcommands.
 #[derive(Debug, Subcommand)]
 pub(crate) enum SubCmd {
-    /// Run the default per-DCC server with first-wins auto-gateway.
+    /// Run the default per-DCC server with daemon-backed auto-gateway.
     Auto(ServerArgs),
     /// Run a per-DCC server, optionally without participating in auto-gateway.
     Serve(ServeArgs),

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -219,8 +219,8 @@ dcc-mcp-server --app maya
 # 2) Per-DCC server only, never competing for the shared gateway port.
 dcc-mcp-server serve --no-auto-gateway --app maya
 
-# 3) Gateway-winner on a workstation with multiple DCCs.
-#    First terminal wins the gateway port, subsequent ones register as plain instances.
+# 3) Daemon-backed backend on a workstation with multiple DCCs.
+#    Each process ensures the same gateway daemon and registers as a backend.
 dcc-mcp-server auto --app maya --server-name maya-shotgun-alpha \
                --scene /shots/ep101/sh0200/shot.ma \
                --log-dir /var/log/dcc-mcp

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -169,16 +169,17 @@ complete, copy-pasteable command set; pick the one that matches your
 constraints and read the migration guide for the path between them
 ([`docs/guide/migration/from-embedded-to-daemon.md`](migration/from-embedded-to-daemon.md)).
 
-### Recipe 1 — Single workstation (embedded auto-gateway)
+### Recipe 1 — Single workstation (daemon-backed auto-gateway)
 
-Default zero-config flow. One DCC adapter wins the gateway port and
-serves the whole machine.
+Default zero-config flow. The first DCC ensures the machine-wide gateway
+daemon is running; every DCC, including that first one, registers as a
+backend behind the same gateway URL.
 
 ```bash
 # Maya plugin host:
 dcc-mcp-server --app maya
 
-# Same workstation, second DCC — joins the elected gateway as a backend:
+# Same workstation, second DCC — registers behind the same gateway daemon:
 dcc-mcp-server --app blender
 ```
 
@@ -896,7 +897,8 @@ let cfg = GatewayConfig { auth, ..GatewayConfig::default() };
 
 By default `GatewayAuth::disabled()` is used, which preserves the
 historical zero-auth behaviour and remains the safe default for the
-embedded auto-gateway (Recipe 1 in the topology section).
+single-workstation daemon-backed auto-gateway (Recipe 1 in the topology
+section).
 
 ### Wire format
 

--- a/docs/guide/migration/from-embedded-to-daemon.md
+++ b/docs/guide/migration/from-embedded-to-daemon.md
@@ -1,21 +1,26 @@
-# Migrating from Embedded Auto-Gateway to a Standalone Daemon
+# Migrating Legacy Embedded Auto-Gateway to a Standalone Daemon
 
 > **[中文版](../../zh/guide/migration/from-embedded-to-daemon)**
 
-This guide walks you through moving a working zero-config single-workstation
-setup (embedded auto-gateway) to one of the supported multi-process / multi-
-machine topologies introduced by epic [#1367][epic]. The default zero-config
-flow is **not** going away — every step here is opt-in.
+This guide is for older deployments, or adapters explicitly launched with
+`--legacy-gateway-election`, that still use the embedded first-wins gateway.
+Current `dcc-mcp-server` zero-config startup is already daemon-backed: a
+per-DCC process ensures the machine-wide `dcc-mcp-server gateway` daemon and
+then registers as a backend. The steps below are only needed when you are
+retiring a legacy embedded topology or moving to a separately managed daemon /
+multi-machine discovery source introduced by epic [#1367][epic].
 
 [epic]: https://github.com/loonghao/dcc-mcp-core/issues/1367
 
 ## When should you migrate?
 
-Stay on the embedded auto-gateway if:
+Staying on legacy embedded auto-gateway is reasonable only if:
 
 - You only run DCC tools on a single workstation, and
 - All DCC processes (Maya, Blender, Houdini, …) are started on the same OS
-  user and share the local `FileRegistry`.
+  user and share the local `FileRegistry`, and
+- You deliberately pass `--legacy-gateway-election` for compatibility with an
+  older supervisor.
 
 Migrate to a standalone gateway daemon when **any** of the following is
 true:
@@ -29,15 +34,14 @@ true:
   lifetime (a restart of Maya should not blink the gateway URL for active
   agents).
 
-## Step 0 — Take a baseline snapshot
+## Step 0 — Take a legacy baseline snapshot
 
-Before changing anything, run the embedded flow once and capture the
+Before changing a legacy deployment, run the embedded flow once and capture the
 state so you have something to compare against and roll back to:
 
 ```bash
-# Start any DCC adapter (e.g. Maya) normally so the embedded auto-gateway
-# binds the well-known port.
-dcc-mcp-server --app maya
+# Start any DCC adapter (e.g. Maya) with the legacy embedded election path.
+dcc-mcp-server --app maya --legacy-gateway-election
 
 # In another terminal, list the live instances the gateway sees:
 curl -s http://127.0.0.1:9765/v1/instances | jq '.by_source'
@@ -47,24 +51,32 @@ Save the output. After the migration the `by_source` counts should still
 make sense (`file` may become `http`/`relay`/`mdns` depending on which
 topology you adopt).
 
-## Step 1 — Stop competing for the gateway port from embedded adapters
+## Step 1 — Stop competing for the gateway port from legacy adapters
 
-The first reversible change is to tell every DCC adapter to **never** bid
-for the gateway port. This lets you operate the gateway daemon out of
-band while keeping the same registry, scenes, and skill paths.
+For same-workstation deployments, the simplest migration is to remove
+`--legacy-gateway-election` and use the current default `auto` path. Each DCC
+process will ensure the same standalone daemon and register as a backend:
 
 ```bash
-# Every DCC sidecar / plugin host launcher gets the new flag:
-dcc-mcp-server serve --no-auto-gateway --app maya
-dcc-mcp-server serve --no-auto-gateway --app blender
+dcc-mcp-server --app maya
+dcc-mcp-server --app blender
 ```
 
-`serve --no-auto-gateway` is a strict subset of `auto` — it never tries
-to bind `--gateway-port`. The DCC still registers itself with whichever
-gateway is reachable (whether embedded in a peer, or standalone).
+If an external supervisor owns the daemon lifecycle and you only want DCC
+processes to publish FileRegistry rows, disable daemon launch/guardian from the
+adapter process:
 
-Roll back: drop the `--no-auto-gateway` flag and the adapter rejoins
-first-wins election.
+```bash
+dcc-mcp-server --app maya --no-ensure-gateway
+dcc-mcp-server --app blender --no-ensure-gateway
+```
+
+`serve --no-auto-gateway` remains available for per-DCC-only launches: it sets
+`gateway_port=0`, so the process never ensures, guards, or binds the gateway
+port. With the `gateway-auto` feature enabled it still writes a FileRegistry
+service row, which a separately managed same-machine daemon can read.
+
+Roll back to the legacy topology only by re-adding `--legacy-gateway-election`.
 
 ## Step 2 — Start the standalone gateway daemon
 
@@ -86,10 +98,9 @@ behavior contract.
 
 [standalone]: ../gateway.md#standalone-gateway-daemon-1358
 
-Roll back: stop the daemon. Embedded adapters will detect the missing
-gateway sentinel on their next election tick and (if they did **not**
-have `--no-auto-gateway`) take over. See [Gateway Election → Failover
-Diagnostics][failover-diag] for how to inspect that state.
+Roll back: stop the daemon and restart the adapters with
+`--legacy-gateway-election`. See [Gateway Election → Failover
+Diagnostics][failover-diag] for how to inspect that legacy state.
 
 [failover-diag]: ../gateway-election.md#failover-diagnostics-issue-1355
 
@@ -130,9 +141,10 @@ curl -s http://127.0.0.1:9765/v1/health
 #    different `source`.
 curl -s http://127.0.0.1:9765/v1/instances | jq '.by_source'
 
-# 3. The failover diagnostic on each embedded adapter reports
-#    "failover_disabled_by_adapter" (because of --no-auto-gateway) or
-#    "gateway_port_not_configured" — both are stable, expected states.
+# 3. Gateway metadata reports the intended mode:
+#    "daemon-backed" for default auto-launch,
+#    "failover_disabled_by_adapter" for --no-ensure-gateway, or
+#    "gateway_port_not_configured" for --no-auto-gateway / gateway_port=0.
 ```
 
 Rollback recipe in one block:
@@ -141,10 +153,8 @@ Rollback recipe in one block:
 # Stop the daemon.
 pkill -f "dcc-mcp-server gateway"
 
-# Restart every DCC adapter without --no-auto-gateway. The first one up
-# wins the gateway port and the topology is back to single-workstation
-# embedded auto-gateway.
-dcc-mcp-server --app maya
+# Restart every DCC adapter with the legacy election flag.
+dcc-mcp-server --app maya --legacy-gateway-election
 ```
 
 ## Related reading

--- a/docs/zh/guide/gateway.md
+++ b/docs/zh/guide/gateway.md
@@ -102,8 +102,8 @@ generic standalone）。运行时满足：
 
 | 场景 | 推荐模式 |
 |------|----------|
-| 单艺术家本机，单 DCC | per-DCC server 默认自带的 auto-gateway |
-| 工作站多 DCC | 任意；auto-gateway 让最先启动的 DCC 当选 |
+| 单艺术家本机，单 DCC | per-DCC server 默认确保机器级 gateway daemon 并注册为后端 |
+| 工作站多 DCC | `auto` / `serve`；每个 DCC 确保同一个 daemon 并注册为后端 |
 | 渲染机 / 共享主机 / CI | `dcc-mcp-server gateway` daemon，sidecar 拉起 DCC |
 | 无任何 DCC 安装的 headless agent | `dcc-mcp-server gateway` daemon —— DCC 通过 `FileRegistry` / HTTP 注册接入 |
 

--- a/docs/zh/guide/migration/from-embedded-to-daemon.md
+++ b/docs/zh/guide/migration/from-embedded-to-daemon.md
@@ -1,20 +1,24 @@
-# 从内嵌自动网关迁移到独立守护进程
+# 从 legacy 内嵌自动网关迁移到独立守护进程
 
 > **[English](../../../guide/migration/from-embedded-to-daemon)**
 
-本指南介绍如何把"零配置单工作站（内嵌自动网关）"迁移到 epic
-[#1367][epic] 引入的多进程 / 多机拓扑之一。默认零配置流程**不会**被移除，
-本文里每一步都是可选的。
+本指南面向仍在使用内嵌 first-wins gateway 的旧部署，或显式带
+`--legacy-gateway-election` 启动的适配器。当前 `dcc-mcp-server` 的
+零配置启动已经是 daemon-backed：per-DCC 进程会确保机器级
+`dcc-mcp-server gateway` daemon 已启动，然后把自己注册为 backend。只有在
+淘汰 legacy 内嵌拓扑，或迁到独立托管 daemon / 多机发现源时，才需要下面的
+步骤；这些拓扑来自 epic [#1367][epic]。
 
 [epic]: https://github.com/loonghao/dcc-mcp-core/issues/1367
 
 ## 什么时候迁移？
 
-继续用内嵌自动网关：
+只有满足下列条件时，才建议继续使用 legacy 内嵌自动网关：
 
 - 只在一台工作站上跑 DCC 工具，并且
 - 所有 DCC 进程（Maya、Blender、Houdini 等）以同一个 OS 用户启动并共享本机
-  `FileRegistry`。
+  `FileRegistry`，并且
+- 你为了兼容旧 supervisor 主动传入 `--legacy-gateway-election`。
 
 满足下列任意一条时迁移到独立网关守护进程：
 
@@ -26,13 +30,13 @@
 - 你希望网关在线时间独立于任意一个 DCC 的生命周期（Maya 重启不应该让正在
   使用网关的 agent 掉线）。
 
-## 第 0 步 —— 留一份基线
+## 第 0 步 —— 留一份 legacy 基线
 
-改动前先把内嵌模式跑一次，记录现状以便对比 / 回滚：
+改动 legacy 部署前，先把内嵌模式跑一次，记录现状以便对比 / 回滚：
 
 ```bash
-# 用正常方式启动任意 DCC 适配器（例如 Maya），让内嵌自动网关绑定标准端口。
-dcc-mcp-server --app maya
+# 用 legacy 内嵌选举路径启动任意 DCC 适配器（例如 Maya）。
+dcc-mcp-server --app maya --legacy-gateway-election
 
 # 另一个终端列出网关看见的实例：
 curl -s http://127.0.0.1:9765/v1/instances | jq '.by_source'
@@ -41,22 +45,31 @@ curl -s http://127.0.0.1:9765/v1/instances | jq '.by_source'
 保存输出。迁移后 `by_source` 计数应该仍然合理（`file` 可能转为
 `http` / `relay` / `mdns`，取决于你选择的拓扑）。
 
-## 第 1 步 —— 让所有内嵌适配器停止竞争网关端口
+## 第 1 步 —— 让 legacy 适配器停止竞争网关端口
 
-第一个可逆改动：告诉每个 DCC 适配器**永远不要**抢网关端口。这样你就可以
-带外管理网关守护进程，同时保留原本的 registry、scene、skill paths。
+同一工作站部署最简单的迁移方式，是去掉 `--legacy-gateway-election`，直接
+使用当前默认 `auto` 路径。每个 DCC 进程都会确保同一个独立 daemon 并注册
+为 backend：
 
 ```bash
-# 每个 DCC sidecar / 插件宿主的启动命令加新 flag：
-dcc-mcp-server serve --no-auto-gateway --app maya
-dcc-mcp-server serve --no-auto-gateway --app blender
+dcc-mcp-server --app maya
+dcc-mcp-server --app blender
 ```
 
-`serve --no-auto-gateway` 是 `auto` 的严格子集 —— 它永远不会试图绑定
-`--gateway-port`。DCC 仍然会向当前可达的网关注册（无论那个网关是内嵌在
-其他适配器里、还是独立守护进程）。
+如果外部 supervisor 负责 daemon 生命周期，而 DCC 进程只需要发布
+FileRegistry 行，可以禁用 adapter 侧的 daemon 拉起/guardian：
 
-回滚：去掉 `--no-auto-gateway`，适配器重新加入 first-wins 选举。
+```bash
+dcc-mcp-server --app maya --no-ensure-gateway
+dcc-mcp-server --app blender --no-ensure-gateway
+```
+
+`serve --no-auto-gateway` 仍可用于 per-DCC-only 启动：它会设置
+`gateway_port=0`，因此进程不会 ensure、guardian 或绑定网关端口。在启用
+`gateway-auto` feature 的构建里，它仍会写 FileRegistry service row，独立
+托管的同机 daemon 可以读取。
+
+只有重新加上 `--legacy-gateway-election`，才会回滚到旧内嵌拓扑。
 
 ## 第 2 步 —— 启动独立网关守护进程
 
@@ -76,9 +89,8 @@ inline 执行工具；每个 `tools/call` 都会被转发到拥有该工具的 D
 
 [standalone]: ../gateway.md#standalone-gateway-daemon-1358
 
-回滚：停掉守护进程。内嵌适配器会在下一轮选举 tick 探测到 sentinel 不
-存在，**如果**它们没有 `--no-auto-gateway` 就会接管。具体观察方式见
-[网关选举 → 故障转移诊断][failover-diag]。
+回滚：停掉守护进程，并用 `--legacy-gateway-election` 重启适配器。具体观察
+方式见 [网关选举 → 故障转移诊断][failover-diag]。
 
 [failover-diag]: ../gateway-election.md#故障转移诊断-issue-1355
 
@@ -114,9 +126,10 @@ curl -s http://127.0.0.1:9765/v1/health
 # 2. 之前可见的所有 DCC 仍然在列表里，可能 source 字段变了。
 curl -s http://127.0.0.1:9765/v1/instances | jq '.by_source'
 
-# 3. 每个内嵌适配器的故障转移诊断上报
-#    "failover_disabled_by_adapter"（因为加了 --no-auto-gateway）或
-#    "gateway_port_not_configured" —— 都是稳定预期状态。
+# 3. Gateway metadata 上报预期模式：
+#    默认 auto-launch 是 "daemon-backed"；
+#    --no-ensure-gateway 是 "failover_disabled_by_adapter"；
+#    --no-auto-gateway / gateway_port=0 是 "gateway_port_not_configured"。
 ```
 
 一键回滚：
@@ -125,9 +138,8 @@ curl -s http://127.0.0.1:9765/v1/instances | jq '.by_source'
 # 停掉守护进程。
 pkill -f "dcc-mcp-server gateway"
 
-# 重启每个 DCC 适配器但去掉 --no-auto-gateway。第一个起来的实例赢得
-# 网关端口，拓扑回到"单工作站内嵌自动网关"。
-dcc-mcp-server --app maya
+# 用 legacy 选举 flag 重启每个 DCC 适配器。
+dcc-mcp-server --app maya --legacy-gateway-election
 ```
 
 ## 延伸阅读


### PR DESCRIPTION
## Summary
- clarify that `dcc-mcp-server` default/auto/serve paths are daemon-backed, not embedded first-wins
- update gateway topology and migration docs in English and Chinese for the legacy embedded path
- align CLI help wording with the current daemon-backed auto mode

## Validation
- `vx cargo test -p dcc-mcp-server server_gateway_daemon_guardian_runs_only_in_daemon_backed_mode`
- `vx cargo test -p dcc-mcp-server server_registration_metadata_reports_gateway_guardian_mode`
- `vx cargo fmt --package dcc-mcp-server --check`
- `vx git diff --check`