### PR TITLE
fix(release): retry flaky admin-ui npm ci on release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,9 +120,21 @@ jobs:
           version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
 
+      # Workflow YAML comes from main on workflow_dispatch backfill, but the
+      # checkout ref is the release tag. Wrap the tag's prebuild script with
+      # retries so flaky npm ("Exit handler never called!") can still recover.
       - name: Build admin UI bundle
         shell: bash
-        run: scripts/release/prebuild_admin_ui.sh
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if scripts/release/prebuild_admin_ui.sh; then
+              exit 0
+            fi
+            echo "::warning::admin UI prebuild attempt ${attempt}/3 failed; retrying in 15s..."
+            sleep 15
+          done
+          exit 1
 
       - name: Upload admin UI bundle
         uses: actions/upload-artifact@v4

--- a/scripts/release/prebuild_admin_ui.sh
+++ b/scripts/release/prebuild_admin_ui.sh
@@ -4,7 +4,23 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo_root"
 
-vx npm --prefix admin-ui ci --ignore-scripts
+# npm occasionally crashes with "Exit handler never called!" on CI runners
+# (see rust-coverage.yml). Retry a few times before failing the release job.
+vx node --version
+
+max_attempts=3
+for attempt in $(seq 1 "$max_attempts"); do
+  if vx npm --prefix admin-ui ci --ignore-scripts; then
+    break
+  fi
+  if [[ "$attempt" -eq "$max_attempts" ]]; then
+    echo "::error::npm ci failed after ${max_attempts} attempts" >&2
+    exit 1
+  fi
+  echo "::warning::npm ci failed (attempt ${attempt}/${max_attempts}); retrying in 15s..." >&2
+  sleep 15
+done
+
 vx npm --prefix admin-ui run build
 test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
 


### PR DESCRIPTION
## Summary

- Release **v0.17.52** stopped after `build-admin-ui` hit npm''s intermittent `Exit handler never called!` error; only `dcc_mcp_core_semantic` wheels were uploaded and `publish` never ran.
- Retry `npm ci` inside `scripts/release/prebuild_admin_ui.sh` and wrap the release workflow step so `workflow_dispatch` backfills against an existing tag can recover without retagging.

## Test plan

- [ ] Merge to `main`
- [ ] Run `gh workflow run release.yml -f release_tag=v0.17.52 -f release_version=0.17.52`
- [ ] Confirm GitHub Release v0.17.52 has core/server wheels, CLI/server binaries, and attestations (parity with v0.17.51)