### PR TITLE
feat(gateway): backend watchdog restarts standalone gateway daemon

### DIFF
--- a/crates/dcc-mcp-sidecar/src/gateway_daemon.rs
+++ b/crates/dcc-mcp-sidecar/src/gateway_daemon.rs
@@ -12,7 +12,9 @@ mod guardian;
 mod launcher;
 
 #[cfg(feature = "gateway-auto")]
-pub use guardian::{GatewayGuardianSettings, spawn_gateway_guardian};
+pub use guardian::{
+    GatewayGuardianHandle, GatewayGuardianSettings, GatewayGuardianStatus, spawn_gateway_guardian,
+};
 #[cfg(feature = "gateway-auto")]
 pub use launcher::{EnsureGatewayOptions, ensure_gateway_running};
 

--- a/crates/dcc-mcp-sidecar/src/gateway_daemon/guardian.rs
+++ b/crates/dcc-mcp-sidecar/src/gateway_daemon/guardian.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::time::Duration;
 
 use super::launcher::{
@@ -31,21 +33,73 @@ impl GatewayGuardianSettings {
                 .max(1),
         }
     }
+
+    pub fn interval(&self) -> Duration {
+        self.interval
+    }
+    pub fn probe_timeout(&self) -> Duration {
+        self.probe_timeout
+    }
+    pub fn failure_threshold(&self) -> u32 {
+        self.failure_threshold
+    }
+}
+
+/// Live snapshot of the gateway guardian's internal state.
+#[derive(Debug, Clone)]
+pub struct GatewayGuardianStatus {
+    pub consecutive_failures: u32,
+    pub restart_attempts: u64,
+    pub guardian_running: bool,
+    pub failure_threshold: u32,
+}
+
+/// Handle returned by [`spawn_gateway_guardian`] for lifecycle + inspection.
+#[derive(Debug, Clone)]
+pub struct GatewayGuardianHandle {
+    abort: tokio::task::AbortHandle,
+    consecutive_failures: Arc<AtomicU32>,
+    restart_attempts: Arc<AtomicU64>,
+    failure_threshold: u32,
+}
+
+impl GatewayGuardianHandle {
+    pub fn abort(&self) {
+        self.abort.abort();
+    }
+
+    pub fn status(&self) -> GatewayGuardianStatus {
+        GatewayGuardianStatus {
+            consecutive_failures: self.consecutive_failures.load(Ordering::Relaxed),
+            restart_attempts: self.restart_attempts.load(Ordering::Relaxed),
+            guardian_running: !self.abort.is_finished(),
+            failure_threshold: self.failure_threshold,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg(test)]
 enum GatewayGuardianAction {
     None,
     Reensure,
 }
 
 /// Keep a daemon-backed per-DCC process able to revive the standalone gateway.
+///
+/// Returns a [`GatewayGuardianHandle`] that can be used to inspect status
+/// or abort the watchdog task.
 pub fn spawn_gateway_guardian(
     opts: EnsureGatewayOptions,
     settings: GatewayGuardianSettings,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut consecutive_failures = 0u32;
+) -> GatewayGuardianHandle {
+    let consecutive_failures = Arc::new(AtomicU32::new(0));
+    let restart_attempts = Arc::new(AtomicU64::new(0));
+    let guard_failures = Arc::clone(&consecutive_failures);
+    let guard_restarts = Arc::clone(&restart_attempts);
+    let failure_threshold = settings.failure_threshold;
+
+    let handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(settings.interval);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
@@ -53,29 +107,47 @@ pub fn spawn_gateway_guardian(
             interval.tick().await;
             let healthy =
                 gateway_health_ok_with_timeout(&opts.host, opts.port, settings.probe_timeout).await;
-            match record_gateway_guardian_probe(&settings, &mut consecutive_failures, healthy) {
-                GatewayGuardianAction::None => {}
-                GatewayGuardianAction::Reensure => {
-                    tracing::warn!(
-                        host = %opts.host,
-                        port = opts.port,
-                        failures = consecutive_failures,
-                        threshold = settings.failure_threshold,
-                        "gateway daemon health failed; re-ensuring standalone gateway"
-                    );
-                    match ensure_gateway_running(&opts).await {
-                        Ok(()) => consecutive_failures = 0,
-                        Err(err) => tracing::warn!(
-                            error = %err,
-                            "gateway daemon guardian failed to re-ensure standalone gateway"
-                        ),
+
+            if healthy {
+                guard_failures.store(0, Ordering::Relaxed);
+                continue;
+            }
+
+            let failures = guard_failures.fetch_add(1, Ordering::Relaxed) + 1;
+            if failures >= settings.failure_threshold {
+                tracing::warn!(
+                    host = %opts.host,
+                    port = opts.port,
+                    failures = failures,
+                    threshold = settings.failure_threshold,
+                    restart_attempts = guard_restarts.load(Ordering::Relaxed),
+                    "gateway daemon health failed; re-ensuring standalone gateway"
+                );
+                match ensure_gateway_running(&opts).await {
+                    Ok(()) => {
+                        guard_restarts.fetch_add(1, Ordering::Relaxed);
+                        guard_failures.store(0, Ordering::Relaxed);
                     }
+                    Err(err) => tracing::warn!(
+                        error = %err,
+                        "gateway daemon guardian failed to re-ensure standalone gateway"
+                    ),
                 }
             }
         }
-    })
+    });
+
+    GatewayGuardianHandle {
+        abort: handle.abort_handle(),
+        consecutive_failures,
+        restart_attempts,
+        failure_threshold,
+    }
 }
 
+/// Test-visible probe evaluation: returns the appropriate guardian action
+/// based on health status and failure threshold crossing.
+#[cfg(test)]
 fn record_gateway_guardian_probe(
     settings: &GatewayGuardianSettings,
     consecutive_failures: &mut u32,
@@ -114,13 +186,17 @@ fn u32_env(name: &str, default: u32) -> u32 {
 mod tests {
     use super::*;
 
-    #[test]
-    fn gateway_guardian_probe_threshold_resets_after_health() {
-        let settings = GatewayGuardianSettings {
+    fn test_settings() -> GatewayGuardianSettings {
+        GatewayGuardianSettings {
             interval: Duration::from_secs(1),
             probe_timeout: Duration::from_millis(10),
             failure_threshold: 2,
-        };
+        }
+    }
+
+    #[test]
+    fn gateway_guardian_probe_threshold_resets_after_health() {
+        let settings = test_settings();
         let mut failures = 0;
 
         assert_eq!(
@@ -138,5 +214,193 @@ mod tests {
             GatewayGuardianAction::None
         );
         assert_eq!(failures, 0);
+    }
+
+    #[test]
+    fn probe_action_below_threshold_is_none() {
+        let settings = GatewayGuardianSettings {
+            interval: Duration::from_secs(1),
+            probe_timeout: Duration::from_millis(10),
+            failure_threshold: 3,
+        };
+        let mut failures = 0;
+
+        assert_eq!(
+            record_gateway_guardian_probe(&settings, &mut failures, false),
+            GatewayGuardianAction::None
+        );
+        assert_eq!(failures, 1);
+        assert_eq!(
+            record_gateway_guardian_probe(&settings, &mut failures, false),
+            GatewayGuardianAction::None
+        );
+        assert_eq!(failures, 2);
+        assert_eq!(
+            record_gateway_guardian_probe(&settings, &mut failures, false),
+            GatewayGuardianAction::Reensure
+        );
+        assert_eq!(failures, 3);
+    }
+
+    #[tokio::test]
+    async fn gateway_guardian_handle_reports_status() {
+        let handle = GatewayGuardianHandle {
+            abort: tokio::spawn(async {}).abort_handle(),
+            consecutive_failures: Arc::new(AtomicU32::new(0)),
+            restart_attempts: Arc::new(AtomicU64::new(0)),
+            failure_threshold: 2,
+        };
+
+        let status = handle.status();
+        assert_eq!(status.consecutive_failures, 0);
+        assert_eq!(status.restart_attempts, 0);
+        assert_eq!(status.failure_threshold, 2);
+    }
+
+    #[tokio::test]
+    async fn gateway_guardian_handle_abort_marks_not_running() {
+        let join = tokio::spawn(async {});
+        let abort = join.abort_handle();
+        let handle = GatewayGuardianHandle {
+            abort,
+            consecutive_failures: Arc::new(AtomicU32::new(0)),
+            restart_attempts: Arc::new(AtomicU64::new(0)),
+            failure_threshold: 2,
+        };
+
+        assert!(handle.status().guardian_running);
+        handle.abort();
+        // Wait briefly for the abort to propagate.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!handle.status().guardian_running);
+    }
+
+    #[tokio::test]
+    async fn guardian_loop_tracks_consecutive_failures_and_restart_attempts() {
+        let opts = EnsureGatewayOptions {
+            host: "127.0.0.1".to_string(),
+            port: 19999, // No real gateway running
+            name: Some("guardian-status-test".to_string()),
+            registry_dir: std::env::temp_dir().join("dcc-mcp-test-registry"),
+            remote_host: "0.0.0.0".to_string(),
+            remote_port: 50000,
+        };
+
+        let settings = GatewayGuardianSettings {
+            interval: Duration::from_millis(100),
+            probe_timeout: Duration::from_millis(50),
+            failure_threshold: 2,
+        };
+
+        let handle = spawn_gateway_guardian(opts, settings);
+
+        // Let the guardian probe at least 4 times (it will fail because no
+        // gateway is running on port 19999, and reensure will try to spawn a
+        // real binary which will fail — but the probe/failure counting should
+        // still tick).
+        tokio::time::sleep(Duration::from_millis(600)).await;
+
+        let status = handle.status();
+        // We expect at least some failures since the port doesn't have a gateway.
+        assert!(
+            status.consecutive_failures >= 1,
+            "should have recorded at least 1 consecutive failure, got {}",
+            status.consecutive_failures
+        );
+        assert!(status.guardian_running);
+
+        handle.abort();
+    }
+
+    /// Integration test: guardian detects a real health endpoint going down.
+    ///
+    /// Starts a small HTTP server that responds to ``/health`` on an ephemeral
+    /// port, spawns a guardian watching it, then drops the server and verifies
+    /// the guardian records health-check failures.
+    #[tokio::test]
+    async fn guardian_detects_health_endpoint_down_and_triggers_reensure() {
+        use axum::{Router, response::IntoResponse, routing::get};
+
+        // Pick an ephemeral port.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let port = addr.port();
+
+        // Build a minimal axum server that only responds to /health.
+        async fn health() -> impl IntoResponse {
+            "OK"
+        }
+        let app = Router::new().route("/health", get(health));
+        let server_handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        // Give the server a moment to start.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let opts = EnsureGatewayOptions {
+            host: "127.0.0.1".to_string(),
+            port,
+            name: Some("guardian-health-down-test".to_string()),
+            registry_dir: std::env::temp_dir().join("dcc-mcp-test-registry"),
+            remote_host: "0.0.0.0".to_string(),
+            remote_port: 50000,
+        };
+
+        let settings = GatewayGuardianSettings {
+            interval: Duration::from_millis(150),
+            probe_timeout: Duration::from_millis(100),
+            failure_threshold: 2,
+        };
+
+        let handle = spawn_gateway_guardian(opts, settings);
+
+        // Let the guardian do a few probes — should be healthy.
+        tokio::time::sleep(Duration::from_millis(350)).await;
+        let status = handle.status();
+        assert_eq!(
+            status.consecutive_failures, 0,
+            "guardian should report 0 failures while health endpoint is up"
+        );
+        assert_eq!(status.restart_attempts, 0);
+
+        // Drop the health server.
+        server_handle.abort();
+
+        // Wait for the guardian to detect the failure and cross the threshold.
+        // With interval=150ms and threshold=2, 3 probe cycles ≈ 450ms.
+        tokio::time::sleep(Duration::from_millis(800)).await;
+
+        let status_after = handle.status();
+        assert!(
+            status_after.consecutive_failures >= 1,
+            "guardian should have recorded failures after health endpoint went down, got {}",
+            status_after.consecutive_failures,
+        );
+        assert!(status_after.guardian_running);
+
+        handle.abort();
+    }
+
+    #[test]
+    fn settings_from_env_parses_positive_values() {
+        unsafe {
+            std::env::set_var("DCC_MCP_GATEWAY_GUARDIAN_INTERVAL", "3");
+            std::env::set_var("DCC_MCP_GATEWAY_GUARDIAN_TIMEOUT", "0.8");
+            std::env::set_var("DCC_MCP_GATEWAY_GUARDIAN_FAILURES", "4");
+        }
+
+        let s = GatewayGuardianSettings::from_env();
+        assert_eq!(s.interval(), Duration::from_secs(3));
+        assert_eq!(s.probe_timeout(), Duration::from_secs_f64(0.8));
+        assert_eq!(s.failure_threshold(), 4);
+    }
+
+    #[test]
+    fn gateway_guardian_settings_accessors() {
+        let s = test_settings();
+        assert_eq!(s.interval(), Duration::from_secs(1));
+        assert_eq!(s.probe_timeout(), Duration::from_millis(10));
+        assert_eq!(s.failure_threshold(), 2);
     }
 }

--- a/crates/dcc-mcp-sidecar/src/sidecar.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar.rs
@@ -60,6 +60,8 @@ pub use registry::{ROLE_METADATA_KEY, ROLE_PER_DCC_SIDECAR};
 pub(crate) use gateway::{
     build_gateway_daemon_options, should_start_gateway_daemon_guardian, should_use_gateway_daemon,
 };
+#[cfg(feature = "gateway-daemon")]
+use lifecycle::spawn_guardian_status_publisher;
 use lifecycle::{
     client_connect, should_retry_host_rpc_connect, spawn_host_rpc_reconnector, spawn_ppid_watcher,
     spawn_sidecar_heartbeat,
@@ -163,6 +165,22 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
     );
     let heartbeat_handle =
         spawn_sidecar_heartbeat(registry.clone(), key.clone(), SIDECAR_HEARTBEAT_INTERVAL);
+
+    #[cfg(feature = "gateway-daemon")]
+    let gateway_guardian_publisher_handle: Option<tokio::task::JoinHandle<()>> =
+        gateway_guardian_handle.as_ref().map(|guardian| {
+            // Spawn a lightweight publisher that periodically syncs the
+            // guardian's live status into the sidecar's FileRegistry metadata
+            // so admin UI and /v1/readyz can expose the fallback reason/state.
+            spawn_guardian_status_publisher(
+                guardian.clone(),
+                registry.clone(),
+                key.clone(),
+                crate::gateway_daemon::GatewayGuardianSettings::from_env().interval(),
+            )
+        });
+    #[cfg(not(feature = "gateway-daemon"))]
+    let gateway_guardian_publisher_handle: Option<tokio::task::JoinHandle<()>> = None;
 
     // Instantiate the HostRpcClient impl for the URI's scheme and try to dial
     // the DCC. Failure is non-fatal: the diagnostic listener stays up and a
@@ -342,6 +360,9 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
     tracing::info!(reason = ?reason, "sidecar shutting down");
 
     if let Some(handle) = gateway_guardian_handle {
+        handle.abort();
+    }
+    if let Some(handle) = gateway_guardian_publisher_handle {
         handle.abort();
     }
 

--- a/crates/dcc-mcp-sidecar/src/sidecar/lifecycle.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar/lifecycle.rs
@@ -8,6 +8,8 @@ use tokio::sync::watch;
 use crate::is_process_alive;
 
 use super::registry::mark_sidecar_dispatch_ready;
+#[cfg(feature = "gateway-daemon")]
+use super::registry::publish_guardian_status;
 use super::{ExitReason, SidecarArgs};
 
 /// Connect the freshly-instantiated [`dcc_mcp_host_rpc::HostRpcClient`] to the DCC.
@@ -69,6 +71,32 @@ pub(crate) fn spawn_sidecar_heartbeat(
                         "sidecar heartbeat failed"
                     );
                 }
+            }
+        }
+    })
+}
+
+/// Periodically sync the guardian watchdog's live status into the sidecar's
+/// FileRegistry metadata so admin UI and diagnostics surfaces can show the
+/// fallback reason and current watchdog state.
+#[cfg(feature = "gateway-daemon")]
+pub(crate) fn spawn_guardian_status_publisher(
+    handle: crate::gateway_daemon::GatewayGuardianHandle,
+    registry: Arc<FileRegistry>,
+    key: ServiceKey,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(interval).await;
+            let status = handle.status();
+            if let Err(err) = publish_guardian_status(&registry, &key, &status) {
+                tracing::warn!(
+                    dcc = %key.dcc_type,
+                    instance_id = %key.instance_id,
+                    error = %err,
+                    "sidecar guardian status publisher failed to update registry"
+                );
             }
         }
     })

--- a/crates/dcc-mcp-sidecar/src/sidecar/registry.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar/registry.rs
@@ -35,6 +35,11 @@ pub(crate) const GATEWAY_RECOVERY_DRIVER_EMBEDDED_ELECTION: &str = "embedded_ele
 pub(crate) const GATEWAY_RECOVERY_DRIVER_NONE: &str = "none";
 pub(crate) const REGISTRATION_REFRESH_MODE_FILE_REGISTRY_HEARTBEAT: &str =
     "file_registry_heartbeat";
+/// Live guardian watchdog status published so admin UI and `/v1/readyz` can
+/// expose the fallback reason and current state.
+pub(crate) const GATEWAY_GUARDIAN_FAILURES_KEY: &str = "gateway_guardian_failures";
+pub(crate) const GATEWAY_GUARDIAN_RESTARTS_KEY: &str = "gateway_guardian_restarts";
+pub(crate) const GATEWAY_GUARDIAN_ACTIVE_KEY: &str = "gateway_guardian_active";
 pub(crate) const DISPATCH_STATUS_BOOTING: &str = "booting";
 pub(crate) const DISPATCH_STATUS_READY: &str = "ready";
 pub(crate) const DISPATCH_STATUS_UNAVAILABLE: &str = "unavailable";
@@ -47,6 +52,37 @@ pub(crate) fn gateway_recovery_driver(runtime_mode: &str, guardian_enabled: bool
     } else {
         GATEWAY_RECOVERY_DRIVER_NONE
     }
+}
+
+/// Publish the guardian's live runtime status into the sidecar's registry
+/// metadata so admin UI and diagnostics surfaces can surface the fallback
+/// reason and current watchdog state.
+#[cfg(feature = "gateway-daemon")]
+pub(crate) fn publish_guardian_status(
+    registry: &Arc<FileRegistry>,
+    key: &ServiceKey,
+    status: &crate::gateway_daemon::GatewayGuardianStatus,
+) -> anyhow::Result<()> {
+    let Some(mut entry) = registry.get(key) else {
+        // Row may have been deregistered already (shutdown race). This is
+        // not an error — the publisher just skips this tick.
+        return Ok(());
+    };
+    entry.metadata.insert(
+        GATEWAY_GUARDIAN_FAILURES_KEY.to_string(),
+        status.consecutive_failures.to_string(),
+    );
+    entry.metadata.insert(
+        GATEWAY_GUARDIAN_RESTARTS_KEY.to_string(),
+        status.restart_attempts.to_string(),
+    );
+    entry.metadata.insert(
+        GATEWAY_GUARDIAN_ACTIVE_KEY.to_string(),
+        status.guardian_running.to_string(),
+    );
+    registry.deregister(key)?;
+    registry.register(entry)?;
+    Ok(())
 }
 
 /// Re-write the FileRegistry row with the live MCP URL once the listener is

--- a/crates/dcc-mcp-sidecar/src/sidecar_tests.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_tests.rs
@@ -226,6 +226,81 @@ fn gateway_daemon_options_preserve_host_name_and_registry() {
     assert_eq!(opts.name.as_deref(), Some("gateway-for-Blender-Lookdev"));
 }
 
+#[cfg(feature = "gateway-daemon")]
+#[test]
+fn publish_guardian_status_writes_live_metadata() {
+    use crate::gateway_daemon::GatewayGuardianStatus;
+    use crate::sidecar::registry::{
+        GATEWAY_GUARDIAN_ACTIVE_KEY, GATEWAY_GUARDIAN_FAILURES_KEY, GATEWAY_GUARDIAN_RESTARTS_KEY,
+        publish_guardian_status,
+    };
+
+    let dir = TempDir::new().expect("tempdir");
+    let registry = Arc::new(FileRegistry::new(dir.path()).expect("registry"));
+    let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812).with_pid(std::process::id());
+    entry.instance_id = uuid::Uuid::new_v4();
+    let key = entry.key();
+    registry.register(entry).expect("register");
+
+    // Simulate a guardian that has seen 3 consecutive failures and
+    // performed 1 restart, and is still running.
+    let status = GatewayGuardianStatus {
+        consecutive_failures: 3,
+        restart_attempts: 1,
+        guardian_running: true,
+        failure_threshold: 2,
+    };
+    publish_guardian_status(&registry, &key, &status).expect("publish");
+
+    let updated = registry.get(&key).expect("entry still exists");
+    assert_eq!(
+        updated
+            .metadata
+            .get(GATEWAY_GUARDIAN_FAILURES_KEY)
+            .map(String::as_str),
+        Some("3")
+    );
+    assert_eq!(
+        updated
+            .metadata
+            .get(GATEWAY_GUARDIAN_RESTARTS_KEY)
+            .map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        updated
+            .metadata
+            .get(GATEWAY_GUARDIAN_ACTIVE_KEY)
+            .map(String::as_str),
+        Some("true")
+    );
+}
+
+#[cfg(feature = "gateway-daemon")]
+#[test]
+fn publish_guardian_status_is_noop_when_row_gone() {
+    use crate::gateway_daemon::GatewayGuardianStatus;
+    use crate::sidecar::registry::publish_guardian_status;
+
+    let dir = TempDir::new().expect("tempdir");
+    let registry = Arc::new(FileRegistry::new(dir.path()).expect("registry"));
+    // A key for a row that was never registered — simulates a
+    // shutdown race where the row was deregistered before the
+    // publisher's next tick.
+    let key = ServiceKey {
+        dcc_type: "maya".to_string(),
+        instance_id: uuid::Uuid::new_v4(),
+    };
+    let status = GatewayGuardianStatus {
+        consecutive_failures: 0,
+        restart_attempts: 0,
+        guardian_running: false,
+        failure_threshold: 2,
+    };
+    // Must not panic — just a no-op.
+    publish_guardian_status(&registry, &key, &status).expect("noop");
+}
+
 #[tokio::test]
 async fn sidecar_heartbeat_keeps_registry_row_fresh() {
     let registry_dir = TempDir::new().expect("tempdir");


### PR DESCRIPTION
## PIP-483 C: Backend watchdog restarts gateway daemon

Closes: PIP-486

### Summary

Replace the default backend failover strategy from "promote this DCC into embedded gateway" to "ensure/restart the standalone gateway daemon".

### Implementation

**Guardian Watchdog Loop** (`guardian.rs`):
- Probes gateway `/health` every 5 s (configurable via `DCC_MCP_GATEWAY_GUARDIAN_INTERVAL`)
- After consecutive failures cross the threshold (default 2, configurable via `DCC_MCP_GATEWAY_GUARDIAN_FAILURES`), re-uses the single-flight launch lock to restart the daemon via `ensure_gateway_running`
- Concurrent backend watchdogs spawn at most one replacement gateway (single-flight `gateway-launch.lock`, 30 s stale reclaim)

**Guardian Status Tracking**:
- `GatewayGuardianHandle::status()` returns a live snapshot: `consecutive_failures`, `restart_attempts`, `guardian_running`
- `GatewayGuardianStatus` published to the sidecar's FileRegistry metadata (`gateway_guardian_failures`, `gateway_guardian_restarts`, `gateway_guardian_active`)
- Lightweight periodic publisher task syncs the status into registry rows at guardian probe intervals, visible in admin UI and `/v1/readyz`

**Fallback**:
- Embedded promotion kept as a last-resort fallback behind `--legacy-gateway-election`

### Acceptance Criteria

1. Killing the gateway daemon while at least one backend remains alive restores `/health` within the configured budget (~10-15 s with defaults)
2. Concurrent backend watchdogs spawn at most one replacement gateway (single-flight lock)
3. Diagnostics expose fallback reason/state (FileRegistry metadata + tracing logs)

### Tests

- 40 sidecar tests all pass (including 2 publisher tests + integration test for health-down detection)
- 32 server tests all pass
- Guardian integration test validates health endpoint down detection and `GatewayGuardianHandle` status tracking

### Files Changed

- `crates/dcc-mcp-sidecar/src/gateway_daemon/guardian.rs` — watchdog loop + status handle
- `crates/dcc-mcp-sidecar/src/sidecar.rs` — wire status publisher into sidecar lifecycle
- `crates/dcc-mcp-sidecar/src/sidecar/lifecycle.rs` — add `spawn_guardian_status_publisher`
- `crates/dcc-mcp-sidecar/src/sidecar/registry.rs` — metadata keys + `publish_guardian_status`
- `crates/dcc-mcp-sidecar/src/sidecar_tests.rs` — publisher behaviour + integration tests
