### PR TITLE
feat(gateway): wire Python gateway ensure defaults (PIP-485)

### DIFF
--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -366,6 +366,8 @@ _LAZY: dict[str, str] = {
     "start_embedded_dcc_server": "dcc_mcp_core.factory",
     "DccGatewayElection": "dcc_mcp_core.gateway_election",
     "DccSkillHotReloader": "dcc_mcp_core.hotreload",
+    # Gateway daemon helpers (PIP-485)
+    "ensure_gateway_daemon": "dcc_mcp_core._server.gateway_guardian",
     "read_custom_skill_paths": "dcc_mcp_core.admin_sqlite_lane",
     "resolve_admin_db_path": "dcc_mcp_core.admin_sqlite_lane",
     # Pure-Python constants

--- a/python/dcc_mcp_core/_server/config.py
+++ b/python/dcc_mcp_core/_server/config.py
@@ -149,7 +149,8 @@ def build_mcp_http_config(
     )
 
     gateway = options.gateway
-    if gateway.port is not None and gateway.port > 0:
+    # Explicit port (including 0 to disable) overrides the Rust default.
+    if gateway.port is not None:
         config.gateway_port = gateway.port
     if gateway.registry_dir:
         config.registry_dir = gateway.registry_dir

--- a/python/dcc_mcp_core/_server/options.py
+++ b/python/dcc_mcp_core/_server/options.py
@@ -76,11 +76,17 @@ class GatewayOptions:
         scene: str | None = None,
         enable_failover: bool = True,
     ) -> GatewayOptions:
-        """Resolve gateway options, reading env-vars where parameters are ``None``."""
+        """Resolve gateway options, reading env-vars where parameters are ``None``.
+
+        When ``port`` is ``None`` and ``DCC_MCP_GATEWAY_PORT`` is not set (or
+        invalid), the result keeps ``port=None`` so downstream builders can
+        fall back to the Rust-side default (9765).  Pass ``port=0`` explicitly
+        to disable the gateway.
+        """
         resolved_port = port
         if resolved_port is None:
             env_val = os.environ.get("DCC_MCP_GATEWAY_PORT", "")
-            resolved_port = int(env_val) if env_val.isdigit() else 0
+            resolved_port = int(env_val) if env_val.isdigit() else None
 
         resolved_registry_dir = registry_dir
         if resolved_registry_dir is None:

--- a/tests/test_dcc_adapter_base.py
+++ b/tests/test_dcc_adapter_base.py
@@ -1185,6 +1185,7 @@ class TestPublicExports:
             "create_dcc_server",
             "make_start_stop",
             "get_server_instance",
+            "ensure_gateway_daemon",
         ]:
             assert name in dcc_mcp_core.__all__, f"{name!r} missing from __all__"
 

--- a/tests/test_dcc_server_options.py
+++ b/tests/test_dcc_server_options.py
@@ -47,10 +47,11 @@ class TestGatewayOptions:
         gw = GatewayOptions.from_env()
         assert gw.port == 9999
 
-    def test_from_env_invalid_port_defaults_to_zero(self, monkeypatch):
+    def test_from_env_invalid_port_preserves_none(self, monkeypatch):
+        """Invalid DCC_MCP_GATEWAY_PORT keeps port=None so Rust default is used."""
         monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "not_a_number")
         gw = GatewayOptions.from_env()
-        assert gw.port == 0
+        assert gw.port is None
 
     def test_from_env_reads_registry_dir(self, monkeypatch):
         monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", "/some/registry")
@@ -62,9 +63,22 @@ class TestGatewayOptions:
         gw = GatewayOptions.from_env(port=1234)
         assert gw.port == 1234
 
-    def test_from_env_no_env_port_gives_zero(self, monkeypatch):
+    def test_from_env_no_env_port_keeps_none(self, monkeypatch):
+        """When DCC_MCP_GATEWAY_PORT is not set, port stays None (use Rust default 9765)."""
         monkeypatch.delenv("DCC_MCP_GATEWAY_PORT", raising=False)
         gw = GatewayOptions.from_env()
+        assert gw.port is None
+
+    def test_from_env_explicit_zero_port_disables_gateway(self, monkeypatch):
+        """Explicit port=0 should disable gateway through build_mcp_http_config."""
+        monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "9999")
+        gw = GatewayOptions.from_env(port=0)
+        assert gw.port == 0  # explicit 0 wins over env
+
+    def test_from_env_direct_zero_port_disables_gateway(self, monkeypatch):
+        """GatewayOptions(port=0) means gateway is explicitly disabled."""
+        monkeypatch.delenv("DCC_MCP_GATEWAY_PORT", raising=False)
+        gw = GatewayOptions.from_env(port=0)
         assert gw.port == 0
 
     def test_frozen(self):


### PR DESCRIPTION
## Summary

- Export `ensure_gateway_daemon` from the top-level `dcc_mcp_core` package for embedded PyO3 adapters.
- Fix `GatewayOptions.from_env()` so an unset/invalid `DCC_MCP_GATEWAY_PORT` keeps `port=None` and lets Rust apply the default 9765; explicit `port=0` still disables gateway via `build_mcp_http_config`.
- Add regression tests for gateway option resolution and public export surface.

Closes [PIP-485](https://github.com/dcc-mcp/dcc-mcp-core/issues/485) / parent [PIP-483](https://github.com/dcc-mcp/dcc-mcp-core/issues/483).

## Test plan

- [ ] CI green (Rust + Python matrix)
- [ ] `tests/test_dcc_server_options.py` gateway port resolution cases
- [ ] `ensure_gateway_daemon` present in `dcc_mcp_core.__all__`
