### PR TITLE
[codex] add marketplace catalog discovery CLI

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -1,6 +1,6 @@
 //! Public DCC-MCP catalog for ecosystem discovery.
 //!
-//! Provides [`CatalogEntry`] (a typed YAML record), and two discovery
+//! Provides [`CatalogEntry`] (a typed YAML/JSON record), and two discovery
 //! functions — [`search`] and [`describe`] — that can be wired up as
 //! gateway MCP tools (`dcc_catalog__search` / `dcc_catalog__describe`).
 //!
@@ -41,13 +41,44 @@ pub struct CatalogEntry {
     /// Searchable tags.
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Package version advertised by a marketplace catalog.
+    #[serde(default)]
+    pub version: Option<String>,
+    /// Minimum dcc-mcp-core version required by this package.
+    #[serde(default)]
+    pub min_core_version: Option<String>,
+    /// Installation metadata for CLI-driven marketplace installs.
+    #[serde(default)]
+    pub install: Option<CatalogInstall>,
+    /// Maintainer or publishing organization.
+    #[serde(default)]
+    pub maintainer: Option<String>,
+}
+
+/// Installation metadata for a marketplace catalog entry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CatalogInstall {
+    /// Install source type (`git`, `zip`, `path`, ...).
+    #[serde(rename = "type")]
+    pub install_type: String,
+    /// Source URL or local path.
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Git ref, tag, branch, or revision where applicable.
+    #[serde(default, rename = "ref")]
+    pub ref_: Option<String>,
+    /// Optional content hash for archive installs.
+    #[serde(default)]
+    pub sha256: Option<String>,
 }
 
 /// Top-level catalog document.
 #[derive(Debug, Deserialize)]
 struct CatalogDoc {
     #[allow(dead_code)]
-    version: String,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default, alias = "items", alias = "skills")]
     entries: Vec<CatalogEntry>,
 }
 
@@ -68,7 +99,7 @@ pub fn load_from_file(path: impl AsRef<Path>) -> Result<Vec<CatalogEntry>, Catal
     load_from_str(&text)
 }
 
-/// Parse catalog entries from a YAML string.
+/// Parse catalog entries from a YAML or JSON string.
 pub fn load_from_str(yaml: &str) -> Result<Vec<CatalogEntry>, CatalogError> {
     let doc: CatalogDoc =
         serde_yaml_ng::from_str(yaml).map_err(|e| CatalogError::Parse(e.to_string()))?;
@@ -80,7 +111,8 @@ pub fn load_from_str(yaml: &str) -> Result<Vec<CatalogEntry>, CatalogError> {
 /// Search catalog entries.
 ///
 /// `query` is matched case-insensitively against `name`, `description`,
-/// `dcc`, and `tags`.  An empty query returns all entries.
+/// `dcc`, `tags`, version/maintainer metadata, and install URL.  An empty query
+/// returns all entries.
 pub fn search(entries: &[CatalogEntry], query: &str) -> Vec<CatalogEntry> {
     if query.is_empty() {
         return entries.to_vec();
@@ -93,6 +125,16 @@ pub fn search(entries: &[CatalogEntry], query: &str) -> Vec<CatalogEntry> {
                 || e.description.to_lowercase().contains(&q)
                 || e.dcc.iter().any(|d| d.to_lowercase().contains(&q))
                 || e.tags.iter().any(|t| t.to_lowercase().contains(&q))
+                || e.version
+                    .as_deref()
+                    .is_some_and(|version| version.to_lowercase().contains(&q))
+                || e.maintainer
+                    .as_deref()
+                    .is_some_and(|maintainer| maintainer.to_lowercase().contains(&q))
+                || e.install
+                    .as_ref()
+                    .and_then(|install| install.url.as_deref())
+                    .is_some_and(|url| url.to_lowercase().contains(&q))
         })
         .cloned()
         .collect()
@@ -194,5 +236,35 @@ entries:
         f.write_all(SAMPLE_YAML.as_bytes()).unwrap();
         let entries = load_from_file(f.path()).unwrap();
         assert_eq!(entries.len(), 3);
+    }
+
+    #[test]
+    fn test_load_marketplace_json_with_install_metadata() {
+        let json = r#"
+{
+  "version": "1",
+  "entries": [{
+    "name": "dcc-asset-hunyuan-download",
+    "description": "Search and download Hunyuan 3D models",
+    "dcc": ["maya", "blender"],
+    "tags": ["asset", "hunyuan", "download"],
+    "version": "0.1.0",
+    "min_core_version": "0.17.0",
+    "maintainer": "dcc-mcp",
+    "install": {
+      "type": "git",
+      "url": "https://github.com/dcc-mcp/dcc-asset-hunyuan-download",
+      "ref": "v0.1.0"
+    }
+  }]
+}
+"#;
+
+        let entries = load_from_str(json).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].version.as_deref(), Some("0.1.0"));
+        let install = entries[0].install.as_ref().unwrap();
+        assert_eq!(install.install_type, "git");
+        assert_eq!(install.ref_.as_deref(), Some("v0.1.0"));
     }
 }

--- a/crates/dcc-mcp-cli/src/application/marketplace.rs
+++ b/crates/dcc-mcp-cli/src/application/marketplace.rs
@@ -1,0 +1,294 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use thiserror::Error;
+
+use crate::domain::marketplace::{
+    MarketplaceHit, MarketplaceInspectResult, MarketplaceSearchResult, MarketplaceSource,
+    MarketplaceSourceConfig, MarketplaceSourceOrigin, StoredMarketplaceSource, builtin_source,
+    entry_targets_dcc, normalise_source,
+};
+
+const ENV_MARKETPLACE_SOURCES: &str = "DCC_MCP_MARKETPLACE_SOURCES";
+const ENV_MARKETPLACE_SOURCES_FILE: &str = "DCC_MCP_MARKETPLACE_SOURCES_FILE";
+const ENV_MARKETPLACE_NO_DEFAULT_SOURCES: &str = "DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES";
+
+#[derive(Debug, Error)]
+pub enum MarketplaceError {
+    #[error("marketplace source config path could not be resolved: {0}")]
+    ConfigPath(String),
+    #[error("marketplace source config I/O error for '{0}': {1}")]
+    ConfigIo(String, #[source] std::io::Error),
+    #[error("marketplace source config parse error for '{0}': {1}")]
+    ConfigParse(String, #[source] serde_json::Error),
+    #[error("marketplace source fetch failed for '{0}': {1}")]
+    Fetch(String, #[source] reqwest::Error),
+    #[error("marketplace source read failed for '{0}': {1}")]
+    Read(String, #[source] std::io::Error),
+    #[error(transparent)]
+    Catalog(#[from] dcc_mcp_catalog::CatalogError),
+    #[error("marketplace entry '{0}' was not found")]
+    NotFound(String),
+}
+
+pub struct MarketplaceService {
+    config_path: PathBuf,
+    client: reqwest::Client,
+}
+
+impl MarketplaceService {
+    pub fn new() -> Result<Self, MarketplaceError> {
+        Ok(Self {
+            config_path: default_config_path()?,
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(20))
+                .build()
+                .map_err(|err| MarketplaceError::Fetch("client".into(), err))?,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn with_config_path(config_path: PathBuf) -> Self {
+        Self {
+            config_path,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub fn add_source(&self, raw_source: &str) -> Result<Vec<MarketplaceSource>, MarketplaceError> {
+        let source = normalise_source(raw_source, MarketplaceSourceOrigin::Config);
+        let mut config = self.load_config()?;
+        if !config
+            .sources
+            .iter()
+            .any(|stored| stored.url == source.url || stored.name == source.name)
+        {
+            config.sources.push(StoredMarketplaceSource {
+                name: source.name,
+                url: source.url,
+            });
+            self.save_config(&config)?;
+        }
+        self.list_sources()
+    }
+
+    pub fn list_sources(&self) -> Result<Vec<MarketplaceSource>, MarketplaceError> {
+        let mut sources = Vec::new();
+        if !default_sources_disabled() {
+            sources.push(builtin_source());
+        }
+
+        sources.extend(self.config_sources()?);
+        sources.extend(env_sources());
+        Ok(dedupe_sources(sources))
+    }
+
+    pub async fn search(
+        &self,
+        query: Option<String>,
+        dcc: Option<String>,
+        explicit_sources: Vec<String>,
+        limit: Option<usize>,
+    ) -> Result<MarketplaceSearchResult, MarketplaceError> {
+        let sources = self.sources_for_query(explicit_sources)?;
+        let mut hits = Vec::new();
+        for source in sources {
+            let entries = self.load_source_entries(&source).await?;
+            let matched = dcc_mcp_catalog::search(&entries, query.as_deref().unwrap_or(""));
+            for entry in matched {
+                if let Some(dcc) = dcc.as_deref()
+                    && !entry_targets_dcc(&entry, dcc)
+                {
+                    continue;
+                }
+                hits.push(MarketplaceHit {
+                    source: source.clone(),
+                    entry,
+                });
+                if limit.is_some_and(|limit| hits.len() >= limit) {
+                    break;
+                }
+            }
+            if limit.is_some_and(|limit| hits.len() >= limit) {
+                break;
+            }
+        }
+        Ok(MarketplaceSearchResult {
+            query,
+            dcc,
+            count: hits.len(),
+            hits,
+        })
+    }
+
+    pub async fn inspect(
+        &self,
+        name: String,
+        explicit_sources: Vec<String>,
+    ) -> Result<MarketplaceInspectResult, MarketplaceError> {
+        let sources = self.sources_for_query(explicit_sources)?;
+        let mut matches = Vec::new();
+        for source in sources {
+            let entries = self.load_source_entries(&source).await?;
+            if let Some(entry) = dcc_mcp_catalog::describe(&entries, &name) {
+                matches.push(MarketplaceHit {
+                    source: source.clone(),
+                    entry,
+                });
+            }
+        }
+        if matches.is_empty() {
+            return Err(MarketplaceError::NotFound(name));
+        }
+        Ok(MarketplaceInspectResult {
+            name,
+            count: matches.len(),
+            matches,
+        })
+    }
+
+    fn sources_for_query(
+        &self,
+        explicit_sources: Vec<String>,
+    ) -> Result<Vec<MarketplaceSource>, MarketplaceError> {
+        if explicit_sources.is_empty() {
+            return self.list_sources();
+        }
+        Ok(dedupe_sources(
+            explicit_sources
+                .iter()
+                .map(|source| normalise_source(source, MarketplaceSourceOrigin::Explicit))
+                .collect(),
+        ))
+    }
+
+    async fn load_source_entries(
+        &self,
+        source: &MarketplaceSource,
+    ) -> Result<Vec<dcc_mcp_catalog::CatalogEntry>, MarketplaceError> {
+        let text = if source.url.starts_with("http://") || source.url.starts_with("https://") {
+            self.client
+                .get(&source.url)
+                .header("User-Agent", "dcc-mcp-cli marketplace")
+                .send()
+                .await
+                .map_err(|err| MarketplaceError::Fetch(source.url.clone(), err))?
+                .error_for_status()
+                .map_err(|err| MarketplaceError::Fetch(source.url.clone(), err))?
+                .text()
+                .await
+                .map_err(|err| MarketplaceError::Fetch(source.url.clone(), err))?
+        } else {
+            let path = source
+                .url
+                .strip_prefix("file://")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from(&source.url));
+            std::fs::read_to_string(&path)
+                .map_err(|err| MarketplaceError::Read(path.display().to_string(), err))?
+        };
+        dcc_mcp_catalog::load_from_str(&text).map_err(Into::into)
+    }
+
+    fn config_sources(&self) -> Result<Vec<MarketplaceSource>, MarketplaceError> {
+        Ok(self
+            .load_config()?
+            .sources
+            .into_iter()
+            .map(|source| MarketplaceSource {
+                name: source.name,
+                url: source.url,
+                origin: MarketplaceSourceOrigin::Config,
+            })
+            .collect())
+    }
+
+    fn load_config(&self) -> Result<MarketplaceSourceConfig, MarketplaceError> {
+        if !self.config_path.exists() {
+            return Ok(MarketplaceSourceConfig::default());
+        }
+        let text = std::fs::read_to_string(&self.config_path).map_err(|err| {
+            MarketplaceError::ConfigIo(self.config_path.display().to_string(), err)
+        })?;
+        serde_json::from_str(&text).map_err(|err| {
+            MarketplaceError::ConfigParse(self.config_path.display().to_string(), err)
+        })
+    }
+
+    fn save_config(&self, config: &MarketplaceSourceConfig) -> Result<(), MarketplaceError> {
+        if let Some(parent) = self.config_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|err| MarketplaceError::ConfigIo(parent.display().to_string(), err))?;
+        }
+        let text = serde_json::to_string_pretty(config)
+            .expect("MarketplaceSourceConfig serialization should not fail");
+        std::fs::write(&self.config_path, text)
+            .map_err(|err| MarketplaceError::ConfigIo(self.config_path.display().to_string(), err))
+    }
+}
+
+fn default_config_path() -> Result<PathBuf, MarketplaceError> {
+    if let Ok(path) = std::env::var(ENV_MARKETPLACE_SOURCES_FILE)
+        && !path.trim().is_empty()
+    {
+        return Ok(PathBuf::from(path));
+    }
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .ok_or_else(|| MarketplaceError::ConfigPath("home directory is unavailable".into()))?;
+    Ok(PathBuf::from(home)
+        .join(".dcc-mcp")
+        .join("marketplace")
+        .join("sources.json"))
+}
+
+fn env_sources() -> Vec<MarketplaceSource> {
+    std::env::var(ENV_MARKETPLACE_SOURCES)
+        .ok()
+        .into_iter()
+        .flat_map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|source| !source.is_empty())
+                .map(|source| normalise_source(source, MarketplaceSourceOrigin::Env))
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn default_sources_disabled() -> bool {
+    std::env::var(ENV_MARKETPLACE_NO_DEFAULT_SOURCES)
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
+fn dedupe_sources(sources: Vec<MarketplaceSource>) -> Vec<MarketplaceSource> {
+    let mut seen = BTreeSet::new();
+    let mut out = Vec::new();
+    for source in sources {
+        if seen.insert(source.url.clone()) {
+            out.push(source);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn add_source_persists_to_config_file() {
+        let dir = tempdir().unwrap();
+        let service = MarketplaceService::with_config_path(dir.path().join("sources.json"));
+
+        let sources = service.add_source("studio/private").unwrap();
+
+        assert!(sources.iter().any(|source| source.name == "studio/private"));
+        let saved = std::fs::read_to_string(dir.path().join("sources.json")).unwrap();
+        assert!(saved.contains("studio/private"));
+    }
+}

--- a/crates/dcc-mcp-cli/src/application/mod.rs
+++ b/crates/dcc-mcp-cli/src/application/mod.rs
@@ -1,2 +1,3 @@
 pub mod client;
 pub mod install;
+pub mod marketplace;

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -90,6 +90,10 @@ mod tests {
             dcc: dcc.iter().map(|value| value.to_string()).collect(),
             url: Some("https://example.invalid/adapter".into()),
             tags: vec!["official".into()],
+            version: None,
+            min_core_version: None,
+            install: None,
+            maintainer: None,
         }
     }
 

--- a/crates/dcc-mcp-cli/src/domain/marketplace.rs
+++ b/crates/dcc-mcp-cli/src/domain/marketplace.rs
@@ -1,0 +1,116 @@
+use dcc_mcp_catalog::CatalogEntry;
+use serde::{Deserialize, Serialize};
+
+pub const OFFICIAL_MARKETPLACE_SOURCE: &str =
+    "https://raw.githubusercontent.com/dcc-mcp/marketplace/main/marketplace.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MarketplaceSource {
+    pub name: String,
+    pub url: String,
+    pub origin: MarketplaceSourceOrigin,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MarketplaceSourceOrigin {
+    Builtin,
+    Config,
+    Env,
+    Explicit,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StoredMarketplaceSource {
+    pub name: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct MarketplaceSourceConfig {
+    #[serde(default)]
+    pub sources: Vec<StoredMarketplaceSource>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MarketplaceHit {
+    pub source: MarketplaceSource,
+    pub entry: CatalogEntry,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MarketplaceSearchResult {
+    pub query: Option<String>,
+    pub dcc: Option<String>,
+    pub count: usize,
+    pub hits: Vec<MarketplaceHit>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MarketplaceInspectResult {
+    pub name: String,
+    pub count: usize,
+    pub matches: Vec<MarketplaceHit>,
+}
+
+pub fn builtin_source() -> MarketplaceSource {
+    MarketplaceSource {
+        name: "dcc-mcp/marketplace".to_string(),
+        url: OFFICIAL_MARKETPLACE_SOURCE.to_string(),
+        origin: MarketplaceSourceOrigin::Builtin,
+    }
+}
+
+pub fn normalise_source(raw: &str, origin: MarketplaceSourceOrigin) -> MarketplaceSource {
+    let trimmed = raw.trim();
+    let url = if trimmed.eq_ignore_ascii_case("dcc-mcp/marketplace") {
+        OFFICIAL_MARKETPLACE_SOURCE.to_string()
+    } else if looks_like_github_slug(trimmed) {
+        format!("https://raw.githubusercontent.com/{trimmed}/main/marketplace.json")
+    } else {
+        trimmed.to_string()
+    };
+    let name = if trimmed.eq_ignore_ascii_case("dcc-mcp/marketplace") {
+        "dcc-mcp/marketplace".to_string()
+    } else if looks_like_github_slug(trimmed) {
+        trimmed.to_string()
+    } else {
+        url.clone()
+    };
+    MarketplaceSource { name, url, origin }
+}
+
+pub fn entry_targets_dcc(entry: &CatalogEntry, dcc: &str) -> bool {
+    entry
+        .dcc
+        .iter()
+        .any(|value| value.eq_ignore_ascii_case(dcc))
+}
+
+fn looks_like_github_slug(value: &str) -> bool {
+    let Some((owner, repo)) = value.split_once('/') else {
+        return false;
+    };
+    !owner.is_empty() && !repo.is_empty() && !value.contains("://") && !value.contains('\\')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalises_official_slug() {
+        let source = normalise_source("dcc-mcp/marketplace", MarketplaceSourceOrigin::Explicit);
+        assert_eq!(source.name, "dcc-mcp/marketplace");
+        assert_eq!(source.url, OFFICIAL_MARKETPLACE_SOURCE);
+    }
+
+    #[test]
+    fn normalises_github_slug_to_raw_marketplace_json() {
+        let source = normalise_source("studio/private", MarketplaceSourceOrigin::Explicit);
+        assert_eq!(
+            source.url,
+            "https://raw.githubusercontent.com/studio/private/main/marketplace.json"
+        );
+    }
+}

--- a/crates/dcc-mcp-cli/src/domain/mod.rs
+++ b/crates/dcc-mcp-cli/src/domain/mod.rs
@@ -1,2 +1,3 @@
 pub mod install;
+pub mod marketplace;
 pub mod rest;

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -11,6 +11,7 @@ use serde_json::{Map, Value};
 
 use crate::application::client::DccMcpClient;
 use crate::application::install::InstallService;
+use crate::application::marketplace::MarketplaceService;
 use crate::domain::install::InstallRequest;
 use crate::domain::rest::{
     CallRequest, DescribeRequest, DirectCallRequest, Endpoint, LoadSkillRequest, SearchRequest,
@@ -134,8 +135,43 @@ enum Command {
         #[arg(long, env = "DCC_MCP_CATALOG_PATH")]
         catalog: Option<PathBuf>,
     },
+    /// Search and manage DCC-MCP marketplace sources.
+    Marketplace {
+        #[command(subcommand)]
+        action: MarketplaceAction,
+    },
     /// Validate local SKILL.md packages before loading them at runtime.
     Lint(LintArgs),
+}
+
+#[derive(Debug, Subcommand)]
+enum MarketplaceAction {
+    /// Add a marketplace source (raw URL, local file, or GitHub owner/repo).
+    Add {
+        #[arg(value_name = "SOURCE")]
+        source: String,
+    },
+    /// List configured marketplace sources.
+    List,
+    /// Search marketplace entries across configured sources.
+    Search {
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long)]
+        dcc: Option<String>,
+        /// Use this source for the query instead of configured sources.
+        #[arg(long = "source")]
+        sources: Vec<String>,
+        #[arg(long)]
+        limit: Option<usize>,
+    },
+    /// Inspect one marketplace entry by exact name.
+    Inspect {
+        name: String,
+        /// Use this source for the query instead of configured sources.
+        #[arg(long = "source")]
+        sources: Vec<String>,
+    },
 }
 
 #[derive(Debug, clap::Args)]
@@ -324,6 +360,22 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                 version,
                 catalog_path: catalog,
             })?)?
+        }
+        Command::Marketplace { action } => {
+            let service = MarketplaceService::new()?;
+            match action {
+                MarketplaceAction::Add { source } => to_json(service.add_source(&source)?)?,
+                MarketplaceAction::List => to_json(service.list_sources()?)?,
+                MarketplaceAction::Search {
+                    query,
+                    dcc,
+                    sources,
+                    limit,
+                } => to_json(service.search(query, dcc, sources, limit).await?)?,
+                MarketplaceAction::Inspect { name, sources } => {
+                    to_json(service.inspect(name, sources).await?)?
+                }
+            }
         }
         Command::Lint(lint_args) => {
             let result = run_lint_cmd(&lint_args)?;

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -319,6 +319,21 @@ fn run_json(args: &[&str]) -> Value {
     serde_json::from_slice(&output.stdout).unwrap()
 }
 
+fn run_json_with_env(args: &[&str], envs: &[(&str, &str)]) -> Value {
+    let mut command = cli_command();
+    command.args(args);
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
 fn run_text(args: &[&str]) -> String {
     let output = cli_command().args(args).output().unwrap();
     assert!(
@@ -567,6 +582,96 @@ entries:
     assert_eq!(plan["version"], "2026");
     assert_eq!(plan["adapter"]["name"], "dcc-mcp-maya");
     assert_eq!(plan["steps"].as_array().unwrap().len(), 4);
+}
+
+#[test]
+fn marketplace_add_list_search_and_inspect_local_source() {
+    let tmp = TempDir::new().unwrap();
+    let catalog_path = tmp.path().join("marketplace.json");
+    std::fs::write(
+        &catalog_path,
+        r#"
+{
+  "version": "1",
+  "entries": [{
+    "name": "dcc-asset-hunyuan-download",
+    "description": "Search and download Hunyuan 3D models via official API",
+    "dcc": ["maya", "blender"],
+    "tags": ["asset", "hunyuan", "download", "domain"],
+    "version": "0.1.0",
+    "min_core_version": "0.17.0",
+    "maintainer": "dcc-mcp",
+    "install": {
+      "type": "git",
+      "url": "https://github.com/dcc-mcp/dcc-asset-hunyuan-download",
+      "ref": "v0.1.0"
+    }
+  }, {
+    "name": "dcc-asset-polyhaven",
+    "description": "Search and download Poly Haven CC0 assets",
+    "dcc": ["blender"],
+    "tags": ["asset", "polyhaven", "download"],
+    "version": "0.1.0",
+    "install": {
+      "type": "git",
+      "url": "https://github.com/dcc-mcp/dcc-asset-polyhaven",
+      "ref": "v0.1.0"
+    }
+  }]
+}
+"#,
+    )
+    .unwrap();
+
+    let source = catalog_path.to_string_lossy().to_string();
+    let config_path = tmp
+        .path()
+        .join("sources.json")
+        .to_string_lossy()
+        .to_string();
+    let envs = [
+        ("DCC_MCP_MARKETPLACE_SOURCES_FILE", config_path.as_str()),
+        ("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES", "1"),
+    ];
+
+    let sources = run_json_with_env(&["marketplace", "add", &source], &envs);
+    assert_eq!(sources.as_array().unwrap().len(), 1);
+    assert_eq!(sources[0]["url"], source);
+
+    let listed = run_json_with_env(&["marketplace", "list"], &envs);
+    assert_eq!(listed.as_array().unwrap().len(), 1);
+    assert_eq!(listed[0]["origin"], "config");
+
+    let search = run_json_with_env(
+        &[
+            "marketplace",
+            "search",
+            "--query",
+            "download",
+            "--dcc",
+            "maya",
+        ],
+        &envs,
+    );
+    assert_eq!(search["count"], 1);
+    assert_eq!(
+        search["hits"][0]["entry"]["name"],
+        "dcc-asset-hunyuan-download"
+    );
+    assert_eq!(search["hits"][0]["entry"]["install"]["type"], "git");
+
+    let inspect = run_json_with_env(
+        &[
+            "marketplace",
+            "inspect",
+            "dcc-asset-hunyuan-download",
+            "--source",
+            &source,
+        ],
+        &envs,
+    );
+    assert_eq!(inspect["count"], 1);
+    assert_eq!(inspect["matches"][0]["entry"]["install"]["ref"], "v0.1.0");
 }
 
 #[test]

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -51,6 +51,9 @@ dcc-mcp-cli call maya_scene__get_session_info --dcc-type maya --instance-id abc1
 dcc-mcp-cli wait-ready --dcc-type maya --instance-id abc12345 --require skill_catalog,host_execution_bridge
 dcc-mcp-cli stop-instance --dcc-type maya --instance-id abc12345 --expected-owner release-smoke-test
 dcc-mcp-cli install --dcc-type maya --version 2026
+dcc-mcp-cli marketplace add dcc-mcp/marketplace
+dcc-mcp-cli marketplace search --query hunyuan --dcc maya
+dcc-mcp-cli marketplace inspect dcc-asset-hunyuan-download
 dcc-mcp-cli lint path/to/skills
 ```
 
@@ -68,12 +71,26 @@ dcc-mcp-cli lint path/to/skills
 | `wait-ready [--dcc-type <dcc>] [--instance-id <id>] [--require <bits>]` | `GET /v1/instances` + per-instance `/v1/readyz` | Wait for smoke-test readiness bits such as `skill_catalog` or `host_execution_bridge`. |
 | `stop-instance --dcc-type <dcc> --instance-id <id>` | `POST /v1/dcc/{dcc}/instances/{id}/stop` | Forward a guarded safe-stop request to instances that advertise `safe_stop_url`. |
 | `install --dcc-type <dcc> [--version <v>]` | catalog-backed local plan | Resolve the matching adapter and emit an auditable install plan. |
+| `marketplace add <source>` | local source registry | Register a marketplace source (`dcc-mcp/marketplace`, a GitHub `owner/repo`, raw JSON URL, or local catalog file). |
+| `marketplace list` | local source registry | List the built-in, configured, and environment-provided marketplace sources. |
+| `marketplace search [--query <q>] [--dcc <dcc>] [--source <source>]` | marketplace catalog JSON/YAML | Search skill package entries across configured or explicit sources. |
+| `marketplace inspect <name> [--source <source>]` | marketplace catalog JSON/YAML | Print exact entry metadata including version and install fields. |
 | `lint [PATH ...]` | local filesystem validator | Recursively validate SKILL.md packages two levels below each path by default. |
 
 `install` intentionally starts as a planning contract: it resolves catalog
 entries and spells out the runtime / adapter / verification steps without
 silently modifying DCC plugin folders. DCC-specific installers can attach to
 that contract incrementally.
+
+`marketplace` is the CLI-first discovery surface for official and private
+skill package catalogs. The built-in source is
+`https://raw.githubusercontent.com/dcc-mcp/marketplace/main/marketplace.json`.
+Additional sources are persisted under
+`~/.dcc-mcp/marketplace/sources.json`, overridden with
+`DCC_MCP_MARKETPLACE_SOURCES_FILE`, or supplied ephemerally with
+`DCC_MCP_MARKETPLACE_SOURCES` (comma-separated). `marketplace install/update`
+are separate follow-up commands; this discovery layer only reads catalog
+metadata.
 
 `lint` reuses the production `dcc-mcp-skills` validator, so local checks and
 runtime loading fail for the same structural problems. CI runs the same command


### PR DESCRIPTION
## Summary

- Extend `dcc-mcp-catalog` entries with marketplace metadata (`version`, `min_core_version`, `maintainer`, and `install` fields).
- Add `dcc-mcp-cli marketplace add/list/search/inspect` with built-in official source, local source config, environment-provided sources, and explicit per-query sources.
- Document the marketplace discovery commands and environment variables in the CLI reference.

## Why

PIP-511 converged on a CLI-first Skills Marketplace model. This PR delivers the first shippable slice: source registration and catalog discovery, without yet implementing package installation or update execution.

## Validation

- `vx cargo test -p dcc-mcp-catalog`
- `vx cargo test -p dcc-mcp-cli`

## Notes

- `skills/dcc-mcp-creator/` and `skills/dcc-mcp-skills-creator/` do not need updates for this slice because it only adds CLI marketplace discovery and catalog metadata parsing; it does not change adapter/server wiring or skill authoring schema.
- The pre-commit `cargo clippy` hook was attempted but failed before commit due to unrelated admin-ui build errors (`@tanstack/react-query` missing and existing TypeScript implicit-any errors in `admin-ui/src`). The scoped Rust package tests above pass.

## Follow-Up

- Add `marketplace install/uninstall` for `~/.dcc-mcp/marketplace/<dcc>/<name>/`.
- Add installed-state tracking, skill path registration, and reload integration.
