### PR TITLE
ci: isolate PyPI publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -480,21 +480,13 @@ jobs:
       publish: true
     secrets: inherit
 
-  # ── Publish to PyPI ──
-  publish:
-    needs: [release-please, build-wheels, build-binaries, build-semantic-wheels]
-    if: |
-      needs.release-please.outputs.release_created == 'true' &&
-      needs.build-wheels.result == 'success' &&
-      needs.build-binaries.result == 'success' &&
-      needs.build-semantic-wheels.result == 'success'
+  # ── Validate release metadata once before publishing artefacts ──
+  validate-release-version:
+    needs: [release-please]
+    if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/dcc-mcp-core
     permissions:
-      id-token: write
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -539,6 +531,135 @@ jobs:
                       print(f"::warning::Cargo.lock:{name} has {ver}, expected {release_version}")
           PY
 
+  # ── Publish dcc-mcp-core to PyPI ──
+  publish-core-pypi:
+    needs: [release-please, validate-release-version, build-wheels]
+    if: |
+      needs.release-please.outputs.release_created == 'true' &&
+      needs.validate-release-version.result == 'success' &&
+      needs.build-wheels.result == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dcc-mcp-core
+    permissions:
+      id-token: write
+      actions: read
+      contents: read
+    steps:
+      - name: Download dcc-mcp-core wheel artefacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: List dcc-mcp-core artefacts
+        run: ls -la dist/
+
+      - name: Upload dcc-mcp-core to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          verbose: true
+          print-hash: true
+          skip-existing: true
+
+  # ── Publish dcc-mcp-server to PyPI ──
+  publish-server-pypi:
+    needs: [release-please, validate-release-version, build-binaries]
+    if: |
+      needs.release-please.outputs.release_created == 'true' &&
+      needs.validate-release-version.result == 'success' &&
+      needs.build-binaries.result == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dcc-mcp-server
+    permissions:
+      id-token: write
+      actions: read
+      contents: read
+    steps:
+      - name: Download dcc-mcp-server wheel artefacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: server-wheel-*
+          path: dist-server
+          merge-multiple: true
+
+      - name: List dcc-mcp-server artefacts
+        run: ls -la dist-server/
+
+      # The PyPI project must have a Trusted Publisher for:
+      # Owner = dcc-mcp, Repo = dcc-mcp-core, Workflow = release.yml,
+      # Environment = pypi, Project = dcc-mcp-server.
+      - name: Upload dcc-mcp-server to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist-server
+          verbose: true
+          print-hash: true
+          skip-existing: true
+
+  # ── Publish dcc-mcp-core-semantic to PyPI ──
+  publish-semantic-pypi:
+    needs: [release-please, validate-release-version, build-semantic-wheels]
+    if: |
+      needs.release-please.outputs.release_created == 'true' &&
+      needs.validate-release-version.result == 'success' &&
+      needs.build-semantic-wheels.result == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dcc-mcp-core-semantic
+    permissions:
+      id-token: write
+      actions: read
+      contents: read
+    steps:
+      - name: Download dcc-mcp-core-semantic wheel artefacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: semantic-wheel-*
+          path: dist-semantic
+          merge-multiple: true
+
+      - name: List dcc-mcp-core-semantic artefacts
+        run: ls -la dist-semantic/
+
+      # The PyPI project must have a Trusted Publisher for:
+      # Owner = dcc-mcp, Repo = dcc-mcp-core, Workflow = release.yml,
+      # Environment = pypi, Project = dcc-mcp-core-semantic.
+      - name: Upload dcc-mcp-core-semantic to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist-semantic
+          verbose: true
+          print-hash: true
+          skip-existing: true
+
+  # ── Keep GitHub Release assets complete even if PyPI rejects one package ──
+  publish-github-release-assets:
+    needs:
+      - release-please
+      - build-wheels
+      - build-binaries
+      - build-semantic-wheels
+      - publish-core-pypi
+      - publish-server-pypi
+      - publish-semantic-pypi
+    if: |
+      always() &&
+      needs.release-please.outputs.release_created == 'true' &&
+      needs.build-wheels.result == 'success' &&
+      needs.build-binaries.result == 'success' &&
+      needs.build-semantic-wheels.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
       - name: Download dcc-mcp-core wheel artefacts
         uses: actions/download-artifact@v8
         with:
@@ -562,64 +683,12 @@ jobs:
 
       - name: List artefacts
         run: |
-          echo "── dcc-mcp-core wheels ──"
+          echo "dcc-mcp-core wheels:"
           ls -la dist/
-          echo "── dcc-mcp-server wheels ──"
-          ls -la dist-server/ 2>/dev/null || echo "(no server wheels — check build-binaries job)"
-          echo "── dcc-mcp-core-semantic wheels ──"
-          ls -la dist-semantic/ 2>/dev/null || echo "(no semantic wheels — check build-semantic-wheels job)"
-
-      # ── PyPI: dcc-mcp-core (existing trusted publisher) ──
-      # continue-on-error so that a PyPI failure (e.g. file already exists from
-      # a previous partial run) does not block the GitHub Release upload below.
-      - name: Upload dcc-mcp-core to PyPI
-        id: pypi-core
-        continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist
-          verbose: true
-          print-hash: true
-          skip-existing: true
-
-      # ── PyPI: dcc-mcp-server (new — requires its own trusted publisher) ──
-      # Setup steps for the maintainer (one-time):
-      #   1. https://pypi.org/manage/account/publishing/
-      #   2. Add a new "pending publisher" with:
-      #      Owner = loonghao, Repo = dcc-mcp-core,
-      #      Workflow = release.yml, Environment = pypi, Project = dcc-mcp-server
-      # Until that's configured this step degrades gracefully — the
-      # wheels are still published to GitHub Release below.
-      - name: Upload dcc-mcp-server to PyPI
-        id: pypi-server
-        if: hashFiles('dist-server/*.whl') != ''
-        continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist-server
-          verbose: true
-          print-hash: true
-          skip-existing: true
-
-      # ── PyPI: dcc-mcp-core-semantic (companion wheel, issue #1395) ──
-      # Trusted publisher setup (one-time, identical pattern to dcc-mcp-server):
-      #   1. https://pypi.org/manage/account/publishing/
-      #   2. Add a new "pending publisher" with:
-      #      Owner = loonghao, Repo = dcc-mcp-core,
-      #      Workflow = release.yml, Environment = pypi,
-      #      Project = dcc-mcp-core-semantic
-      # Until that's configured this step degrades gracefully — the
-      # wheels are still published to GitHub Release below by the safety net.
-      - name: Upload dcc-mcp-core-semantic to PyPI
-        id: pypi-semantic
-        if: hashFiles('dist-semantic/*.whl') != ''
-        continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist-semantic
-          verbose: true
-          print-hash: true
-          skip-existing: true
+          echo "dcc-mcp-server wheels:"
+          ls -la dist-server/
+          echo "dcc-mcp-core-semantic wheels:"
+          ls -la dist-semantic/
 
       # Always attempt the GitHub Release upload, even if PyPI failed; this is
       # the user-visible artefact set and must be complete per release tag.
@@ -627,7 +696,6 @@ jobs:
       # per-platform wheel directly to the Release. This step is the safety
       # net for the (unlikely) case where the per-platform upload was skipped.
       - name: Upload wheels to GitHub Release (safety net)
-        if: always()
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
@@ -636,8 +704,38 @@ jobs:
             dist-server/*
             dist-semantic/*
 
-      - name: Fail job if PyPI upload failed
-        if: steps.pypi-core.outcome == 'failure' || steps.pypi-server.outcome == 'failure' || steps.pypi-semantic.outcome == 'failure'
+  # ── Aggregate release publication status for branch protection / humans ──
+  publish:
+    needs:
+      - release-please
+      - publish-core-pypi
+      - publish-server-pypi
+      - publish-semantic-pypi
+      - publish-github-release-assets
+    if: always() && needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Summarize publication
         run: |
-          echo "::error::PyPI upload failed (core=${{ steps.pypi-core.outcome }} server=${{ steps.pypi-server.outcome }} semantic=${{ steps.pypi-semantic.outcome }}); GitHub Release artefacts were still uploaded above."
-          exit 1
+          core="${{ needs.publish-core-pypi.result }}"
+          server="${{ needs.publish-server-pypi.result }}"
+          semantic="${{ needs.publish-semantic-pypi.result }}"
+          release_assets="${{ needs.publish-github-release-assets.result }}"
+
+          echo "PyPI dcc-mcp-core: ${core}"
+          echo "PyPI dcc-mcp-server: ${server}"
+          echo "PyPI dcc-mcp-core-semantic: ${semantic}"
+          echo "GitHub Release assets: ${release_assets}"
+
+          failed=0
+          if [ "$core" != "success" ] || [ "$server" != "success" ] || [ "$semantic" != "success" ]; then
+            echo "::error::PyPI upload failed (core=${core} server=${server} semantic=${semantic})."
+            failed=1
+          fi
+          if [ "$release_assets" != "success" ]; then
+            echo "::error::GitHub Release safety-net upload did not complete (result=${release_assets})."
+            failed=1
+          fi
+          exit "$failed"

--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ This project uses [Release Please](https://github.com/googleapis/release-please)
 1. **Develop**: Create a branch from `main` and commit using [Conventional Commits](https://www.conventionalcommits.org/).
 2. **Merge**: Open a PR and merge to `main`.
 3. **Release PR**: Release Please automatically creates / updates a release PR that bumps the version and updates `CHANGELOG.md`.
-4. **Publish**: When the release PR merges, a GitHub Release is created with `dcc-mcp-cli` and `dcc-mcp-server` binaries, `dcc-mcp-core` wheels are published to PyPI, and `dcc-mcp-server` wheels are uploaded when its trusted publisher is configured.
+4. **Publish**: When the release PR merges, a GitHub Release is created with `dcc-mcp-cli` and `dcc-mcp-server` binaries, and separate PyPI jobs publish `dcc-mcp-core`, `dcc-mcp-server`, and `dcc-mcp-core-semantic` wheels through Trusted Publishing.
 
 ### Commit Message Format
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,106 @@
+"""Release workflow structure tests."""
+
+from __future__ import annotations
+
+from conftest import REPO_ROOT
+from dcc_mcp_core import yaml_loads
+
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+PYPI_ACTION = "pypa/gh-action-pypi-publish@release/v1"
+
+
+def _release_jobs() -> dict:
+    workflow = yaml_loads(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]
+
+
+def _pypi_steps(job: dict) -> list[dict]:
+    return [step for step in job.get("steps", []) if step.get("uses") == PYPI_ACTION]
+
+
+def test_release_workflow_publishes_each_pypi_project_in_its_own_job() -> None:
+    jobs = _release_jobs()
+    expected = {
+        "publish-core-pypi": {
+            "needs": ["release-please", "validate-release-version", "build-wheels"],
+            "url": "https://pypi.org/p/dcc-mcp-core",
+            "artifact_pattern": "wheels-*",
+            "artifact_path": "dist",
+            "packages_dir": "dist",
+        },
+        "publish-server-pypi": {
+            "needs": ["release-please", "validate-release-version", "build-binaries"],
+            "url": "https://pypi.org/p/dcc-mcp-server",
+            "artifact_pattern": "server-wheel-*",
+            "artifact_path": "dist-server",
+            "packages_dir": "dist-server",
+        },
+        "publish-semantic-pypi": {
+            "needs": ["release-please", "validate-release-version", "build-semantic-wheels"],
+            "url": "https://pypi.org/p/dcc-mcp-core-semantic",
+            "artifact_pattern": "semantic-wheel-*",
+            "artifact_path": "dist-semantic",
+            "packages_dir": "dist-semantic",
+        },
+    }
+
+    for job_id, config in expected.items():
+        job = jobs[job_id]
+        assert job["runs-on"] == "ubuntu-latest"
+        assert job["needs"] == config["needs"]
+        assert job["environment"] == {"name": "pypi", "url": config["url"]}
+        assert job["permissions"] == {
+            "id-token": "write",
+            "actions": "read",
+            "contents": "read",
+        }
+
+        download = job["steps"][0]
+        assert download["uses"] == "actions/download-artifact@v8"
+        assert download["with"]["pattern"] == config["artifact_pattern"]
+        assert download["with"]["path"] == config["artifact_path"]
+        assert download["with"]["merge-multiple"] is True
+
+        publish_steps = _pypi_steps(job)
+        assert len(publish_steps) == 1
+        publish = publish_steps[0]
+        assert "continue-on-error" not in publish
+        assert publish["with"] == {
+            "packages-dir": config["packages_dir"],
+            "verbose": True,
+            "print-hash": True,
+            "skip-existing": True,
+        }
+
+    assert sum(len(_pypi_steps(job)) for job in jobs.values()) == 3
+
+
+def test_release_workflow_keeps_github_release_safety_net_after_pypi_jobs() -> None:
+    jobs = _release_jobs()
+    safety = jobs["publish-github-release-assets"]
+    assert safety["needs"] == [
+        "release-please",
+        "build-wheels",
+        "build-binaries",
+        "build-semantic-wheels",
+        "publish-core-pypi",
+        "publish-server-pypi",
+        "publish-semantic-pypi",
+    ]
+    assert "always()" in safety["if"]
+    assert safety["permissions"] == {"actions": "read", "contents": "write"}
+
+    summary = jobs["publish"]
+    assert summary["needs"] == [
+        "release-please",
+        "publish-core-pypi",
+        "publish-server-pypi",
+        "publish-semantic-pypi",
+        "publish-github-release-assets",
+    ]
+    assert "always()" in summary["if"]
+    run = summary["steps"][0]["run"]
+    assert "needs.publish-core-pypi.result" in run
+    assert "needs.publish-server-pypi.result" in run
+    assert "needs.publish-semantic-pypi.result" in run
+    assert "needs.publish-github-release-assets.result" in run


### PR DESCRIPTION
## Summary
- split PyPI publishing into one job per package for dcc-mcp-core, dcc-mcp-server, and dcc-mcp-core-semantic
- keep the GitHub Release safety-net upload separate so release assets are still refreshed if one PyPI project rejects its upload
- add workflow structure tests and refresh the README release-process note

## Root Cause
The release workflow invoked pypa/gh-action-pypi-publish three times in one job. Trusted Publishing credentials are project-scoped, and the action does not support multiple invocations in the same job, so later package uploads could reuse credentials that were only valid for the first project.

## Validation
- vx python -m pytest -q tests/test_release_workflow.py tests/test_clawhub_sync.py
- vx actionlint .github/workflows/release.yml
- vx git diff --check
