### PR TITLE
feat(marketplace): add update/outdated commands and migrate gateway catalog to marketplace repo

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -99,10 +99,19 @@ pub fn load_from_file(path: impl AsRef<Path>) -> Result<Vec<CatalogEntry>, Catal
     load_from_str(&text)
 }
 
-/// Parse catalog entries from a YAML or JSON string.
-pub fn load_from_str(yaml: &str) -> Result<Vec<CatalogEntry>, CatalogError> {
+/// Parse catalog entries from a JSON or YAML string.
+///
+/// Tries JSON first (marketplace repo uses `marketplace.json`), then falls
+/// back to YAML for backward compatibility with `dcc-mcp-catalog.yml`.
+pub fn load_from_str(text: &str) -> Result<Vec<CatalogEntry>, CatalogError> {
+    let trimmed = text.trim();
+    // JSON detection: starts with `{` or `[` and doesn't start with `---`.
+    let looks_like_json = trimmed.starts_with('{') || trimmed.starts_with('[');
+    if looks_like_json && let Ok(doc) = serde_json::from_str::<CatalogDoc>(trimmed) {
+        return Ok(doc.entries);
+    }
     let doc: CatalogDoc =
-        serde_yaml_ng::from_str(yaml).map_err(|e| CatalogError::Parse(e.to_string()))?;
+        serde_yaml_ng::from_str(text).map_err(|e| CatalogError::Parse(e.to_string()))?;
     Ok(doc.entries)
 }
 

--- a/crates/dcc-mcp-cli/src/application/marketplace.rs
+++ b/crates/dcc-mcp-cli/src/application/marketplace.rs
@@ -348,6 +348,7 @@ impl MarketplaceService {
                 (None, _) => false,
             };
             if is_outdated && let Some(entry) = entry {
+                let latest_install = entry.install.as_ref();
                 outdated.push(OutdatedMarketplacePackage {
                     name: pkg.name,
                     dcc: pkg.dcc,
@@ -355,9 +356,15 @@ impl MarketplaceService {
                     latest_version: entry.version,
                     source_name: pkg.source_name,
                     source_url: pkg.source_url,
-                    install_type: pkg.install_type,
-                    install_url: pkg.install_url,
-                    install_ref: pkg.install_ref,
+                    install_type: latest_install
+                        .map(|install| install.install_type.clone())
+                        .unwrap_or(pkg.install_type),
+                    install_url: latest_install
+                        .and_then(|install| install.url.clone())
+                        .or(pkg.install_url),
+                    install_ref: latest_install
+                        .and_then(|install| install.ref_.clone())
+                        .or(pkg.install_ref),
                     path: pkg.path,
                 });
             }
@@ -446,7 +453,13 @@ impl MarketplaceService {
         dest: &Path,
     ) -> Result<MarketplaceUpdateResult, MarketplaceError> {
         let git_dir = dest.join(".git");
-        if git_dir.is_dir() {
+        let install_url_changed = pkg.install_url.as_deref().is_some_and(|url| {
+            self.git_remote_url(dest)
+                .ok()
+                .is_some_and(|remote_url| remote_url.trim() != url)
+        });
+
+        if git_dir.is_dir() && !install_url_changed {
             // Existing git repo: fetch the ref and checkout
             if let Some(ref_) = pkg.install_ref.as_deref() {
                 self.git_fetch_and_checkout(dest, ref_)?;
@@ -455,17 +468,28 @@ impl MarketplaceService {
                 self.git_pull(dest)?;
             }
         } else {
-            // Re-clone: remove old, clone fresh from URL
-            if dest.exists() {
-                remove_install_path(dest)?;
-            }
-            let install = dcc_mcp_catalog::CatalogInstall {
-                install_type: "git".to_string(),
-                url: pkg.install_url.clone(),
-                ref_: pkg.install_ref.clone(),
-                sha256: None,
-            };
-            install_from_git(&install, &dest.to_path_buf())?;
+            // Missing or changed git checkout: go through install(), which stages
+            // the replacement before deleting the existing package.
+            let result = self
+                .install(
+                    pkg.name.clone(),
+                    Some(pkg.dcc.clone()),
+                    vec![pkg.source_url.clone()],
+                    true,
+                )
+                .await?;
+            return Ok(MarketplaceUpdateResult {
+                updated: true,
+                name: pkg.name.clone(),
+                dcc: pkg.dcc.clone(),
+                previous_version: pkg.installed_version.clone(),
+                new_version: result.version,
+                path: result.path,
+                install_type: result.install_type,
+                source_name: pkg.source_name.clone(),
+                source_url: pkg.source_url.clone(),
+                reload_required: true,
+            });
         }
 
         // Determine new version by re-reading catalog
@@ -528,6 +552,21 @@ impl MarketplaceService {
             )));
         }
         Ok(())
+    }
+
+    fn git_remote_url(&self, repo_path: &Path) -> Result<String, MarketplaceError> {
+        let output = Command::new("git")
+            .args(["remote", "get-url", "origin"])
+            .current_dir(repo_path)
+            .output()
+            .map_err(|err| MarketplaceError::CommandFailed(format!("git remote get-url: {err}")))?;
+        if !output.status.success() {
+            return Err(MarketplaceError::CommandFailed(format!(
+                "git remote get-url failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
     async fn find_latest_entry_for_package(

--- a/crates/dcc-mcp-cli/src/application/marketplace.rs
+++ b/crates/dcc-mcp-cli/src/application/marketplace.rs
@@ -11,8 +11,9 @@ use thiserror::Error;
 use crate::domain::marketplace::{
     InstalledMarketplacePackage, MarketplaceHit, MarketplaceInspectResult,
     MarketplaceInstallResult, MarketplaceInstalledList, MarketplaceInstalledState,
-    MarketplaceSearchResult, MarketplaceSource, MarketplaceSourceConfig, MarketplaceSourceOrigin,
-    MarketplaceUninstallResult, StoredMarketplaceSource, builtin_source, entry_targets_dcc,
+    MarketplaceOutdatedList, MarketplaceSearchResult, MarketplaceSource, MarketplaceSourceConfig,
+    MarketplaceSourceOrigin, MarketplaceUninstallResult, MarketplaceUpdateResult,
+    OutdatedMarketplacePackage, StoredMarketplaceSource, builtin_source, entry_targets_dcc,
     normalise_source,
 };
 
@@ -319,6 +320,260 @@ impl MarketplaceService {
             count: packages.len(),
             packages,
         })
+    }
+
+    pub async fn outdated(
+        &self,
+        dcc: Option<String>,
+        names: Vec<String>,
+    ) -> Result<MarketplaceOutdatedList, MarketplaceError> {
+        let packages = self.list_installed(dcc)?.packages;
+        let filtered: Vec<InstalledMarketplacePackage> = if names.is_empty() {
+            packages
+        } else {
+            packages
+                .into_iter()
+                .filter(|p| names.iter().any(|name| name == &p.name))
+                .collect()
+        };
+        let sources = self.list_sources()?;
+        let mut outdated = Vec::new();
+        for pkg in filtered {
+            let entry = self.find_latest_entry_for_package(&sources, &pkg).await?;
+            let is_outdated = match (&entry, &pkg.version) {
+                (Some(entry), Some(installed)) => {
+                    entry.version.as_deref() != Some(installed.as_str())
+                }
+                (Some(_), None) => true,
+                (None, _) => false,
+            };
+            if is_outdated && let Some(entry) = entry {
+                outdated.push(OutdatedMarketplacePackage {
+                    name: pkg.name,
+                    dcc: pkg.dcc,
+                    installed_version: pkg.version,
+                    latest_version: entry.version,
+                    source_name: pkg.source_name,
+                    source_url: pkg.source_url,
+                    install_type: pkg.install_type,
+                    install_url: pkg.install_url,
+                    install_ref: pkg.install_ref,
+                    path: pkg.path,
+                });
+            }
+        }
+        Ok(MarketplaceOutdatedList {
+            dcc: None,
+            count: outdated.len(),
+            packages: outdated,
+        })
+    }
+
+    pub async fn update(
+        &self,
+        name: Option<String>,
+        all: bool,
+        dcc: Option<String>,
+    ) -> Result<Vec<MarketplaceUpdateResult>, MarketplaceError> {
+        let outdated = self
+            .outdated(dcc.clone(), name.into_iter().collect())
+            .await?;
+        if outdated.packages.is_empty() {
+            return Ok(Vec::new());
+        }
+        if !all && outdated.packages.len() > 1 {
+            // If --all not set and multiple outdated, suggest passing --all
+            return Err(MarketplaceError::CommandFailed(format!(
+                "{} packages are outdated; use --all to update all, or specify a name. Use 'marketplace outdated' to list them.",
+                outdated.packages.len()
+            )));
+        }
+
+        let mut results = Vec::new();
+        for pkg in outdated.packages {
+            let dest = PathBuf::from(&pkg.path);
+            let previous_version = pkg.installed_version.clone();
+
+            let update_result = match pkg.install_type.as_str() {
+                "git" => self.update_git_package(&pkg, &dest).await,
+                _ => {
+                    // For non-git types, re-install from catalog
+                    self.install(
+                        pkg.name.clone(),
+                        Some(pkg.dcc.clone()),
+                        vec![pkg.source_url.clone()],
+                        true, // force
+                    )
+                    .await
+                    .map(|result| MarketplaceUpdateResult {
+                        updated: true,
+                        name: pkg.name.clone(),
+                        dcc: pkg.dcc.clone(),
+                        previous_version,
+                        new_version: result.version,
+                        path: result.path,
+                        install_type: result.install_type,
+                        source_name: pkg.source_name.clone(),
+                        source_url: pkg.source_url.clone(),
+                        reload_required: true,
+                    })
+                }
+            }?;
+
+            // Update installed state with new version
+            if let Some(ref vs) = update_result.new_version {
+                self.upsert_installed(InstalledMarketplacePackage {
+                    name: update_result.name.clone(),
+                    dcc: update_result.dcc.clone(),
+                    version: Some(vs.clone()),
+                    path: update_result.path.clone(),
+                    source_name: update_result.source_name.clone(),
+                    source_url: update_result.source_url.clone(),
+                    install_type: update_result.install_type.clone(),
+                    install_url: pkg.install_url.clone(),
+                    install_ref: pkg.install_ref.clone(),
+                    installed_at_ms: now_ms(),
+                })?;
+            }
+            results.push(update_result);
+        }
+        Ok(results)
+    }
+
+    async fn update_git_package(
+        &self,
+        pkg: &OutdatedMarketplacePackage,
+        dest: &Path,
+    ) -> Result<MarketplaceUpdateResult, MarketplaceError> {
+        let git_dir = dest.join(".git");
+        if git_dir.is_dir() {
+            // Existing git repo: fetch the ref and checkout
+            if let Some(ref_) = pkg.install_ref.as_deref() {
+                self.git_fetch_and_checkout(dest, ref_)?;
+            } else {
+                // No ref specified, pull default branch
+                self.git_pull(dest)?;
+            }
+        } else {
+            // Re-clone: remove old, clone fresh from URL
+            if dest.exists() {
+                remove_install_path(dest)?;
+            }
+            let install = dcc_mcp_catalog::CatalogInstall {
+                install_type: "git".to_string(),
+                url: pkg.install_url.clone(),
+                ref_: pkg.install_ref.clone(),
+                sha256: None,
+            };
+            install_from_git(&install, &dest.to_path_buf())?;
+        }
+
+        // Determine new version by re-reading catalog
+        let sources = self.list_sources()?;
+        let new_version = self
+            .find_latest_entry_for_package_by_source_url(&sources, &pkg.source_url, &pkg.name)
+            .await?
+            .and_then(|entry| entry.version);
+
+        Ok(MarketplaceUpdateResult {
+            updated: true,
+            name: pkg.name.clone(),
+            dcc: pkg.dcc.clone(),
+            previous_version: pkg.installed_version.clone(),
+            new_version,
+            path: dest.display().to_string(),
+            install_type: pkg.install_type.clone(),
+            source_name: pkg.source_name.clone(),
+            source_url: pkg.source_url.clone(),
+            reload_required: true,
+        })
+    }
+
+    fn git_fetch_and_checkout(&self, repo_path: &Path, ref_: &str) -> Result<(), MarketplaceError> {
+        let output = Command::new("git")
+            .args(["fetch", "origin", "--tags"])
+            .current_dir(repo_path)
+            .output()
+            .map_err(|err| MarketplaceError::CommandFailed(format!("git fetch: {err}")))?;
+        if !output.status.success() {
+            return Err(MarketplaceError::CommandFailed(format!(
+                "git fetch failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+        let output = Command::new("git")
+            .args(["checkout", ref_])
+            .current_dir(repo_path)
+            .output()
+            .map_err(|err| MarketplaceError::CommandFailed(format!("git checkout: {err}")))?;
+        if !output.status.success() {
+            return Err(MarketplaceError::CommandFailed(format!(
+                "git checkout failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+        Ok(())
+    }
+
+    fn git_pull(&self, repo_path: &Path) -> Result<(), MarketplaceError> {
+        let output = Command::new("git")
+            .args(["pull", "--ff-only"])
+            .current_dir(repo_path)
+            .output()
+            .map_err(|err| MarketplaceError::CommandFailed(format!("git pull: {err}")))?;
+        if !output.status.success() {
+            return Err(MarketplaceError::CommandFailed(format!(
+                "git pull failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+        Ok(())
+    }
+
+    async fn find_latest_entry_for_package(
+        &self,
+        sources: &[MarketplaceSource],
+        pkg: &InstalledMarketplacePackage,
+    ) -> Result<Option<dcc_mcp_catalog::CatalogEntry>, MarketplaceError> {
+        for source in sources {
+            if source.url == pkg.source_url {
+                let entries = self.load_source_entries(source).await?;
+                if let Some(entry) = dcc_mcp_catalog::describe(&entries, &pkg.name) {
+                    return Ok(Some(entry));
+                }
+            }
+        }
+        // Source may have been removed; try direct URL
+        let temp_source = MarketplaceSource {
+            name: pkg.source_name.clone(),
+            url: pkg.source_url.clone(),
+            origin: MarketplaceSourceOrigin::Explicit,
+        };
+        let entries = self.load_source_entries(&temp_source).await?;
+        Ok(dcc_mcp_catalog::describe(&entries, &pkg.name))
+    }
+
+    async fn find_latest_entry_for_package_by_source_url(
+        &self,
+        sources: &[MarketplaceSource],
+        source_url: &str,
+        name: &str,
+    ) -> Result<Option<dcc_mcp_catalog::CatalogEntry>, MarketplaceError> {
+        for source in sources {
+            if source.url == source_url {
+                let entries = self.load_source_entries(source).await?;
+                if let Some(entry) = dcc_mcp_catalog::describe(&entries, name) {
+                    return Ok(Some(entry));
+                }
+            }
+        }
+        let temp_source = MarketplaceSource {
+            name: source_url.to_string(),
+            url: source_url.to_string(),
+            origin: MarketplaceSourceOrigin::Explicit,
+        };
+        let entries = self.load_source_entries(&temp_source).await?;
+        Ok(dcc_mcp_catalog::describe(&entries, name))
     }
 
     async fn resolve_install_hit(

--- a/crates/dcc-mcp-cli/src/domain/marketplace.rs
+++ b/crates/dcc-mcp-cli/src/domain/marketplace.rs
@@ -105,6 +105,41 @@ pub struct MarketplaceInstalledList {
     pub packages: Vec<InstalledMarketplacePackage>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OutdatedMarketplacePackage {
+    pub name: String,
+    pub dcc: String,
+    pub installed_version: Option<String>,
+    pub latest_version: Option<String>,
+    pub source_name: String,
+    pub source_url: String,
+    pub install_type: String,
+    pub install_url: Option<String>,
+    pub install_ref: Option<String>,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MarketplaceOutdatedList {
+    pub dcc: Option<String>,
+    pub count: usize,
+    pub packages: Vec<OutdatedMarketplacePackage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MarketplaceUpdateResult {
+    pub updated: bool,
+    pub name: String,
+    pub dcc: String,
+    pub previous_version: Option<String>,
+    pub new_version: Option<String>,
+    pub path: String,
+    pub install_type: String,
+    pub source_name: String,
+    pub source_url: String,
+    pub reload_required: bool,
+}
+
 pub fn builtin_source() -> MarketplaceSource {
     MarketplaceSource {
         name: "dcc-mcp/marketplace".to_string(),

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -195,6 +195,25 @@ enum MarketplaceAction {
         #[arg(long)]
         dcc: Option<String>,
     },
+    /// List installed packages that have newer versions in the catalog.
+    Outdated {
+        #[arg(long)]
+        dcc: Option<String>,
+        /// Only check these package names.
+        #[arg(value_name = "NAME")]
+        names: Vec<String>,
+    },
+    /// Upgrade installed marketplace packages to the latest catalog version.
+    Update {
+        /// Upgrade a specific package by name.
+        name: Option<String>,
+        /// Upgrade all outdated packages.
+        #[arg(long, short = 'a')]
+        all: bool,
+        /// Filter to installed packages for this DCC.
+        #[arg(long)]
+        dcc: Option<String>,
+    },
 }
 
 #[derive(Debug, clap::Args)]
@@ -408,6 +427,12 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                     to_json(service.uninstall(name, dcc)?)?
                 }
                 MarketplaceAction::ListInstalled { dcc } => to_json(service.list_installed(dcc)?)?,
+                MarketplaceAction::Outdated { dcc, names } => {
+                    to_json(service.outdated(dcc, names).await?)?
+                }
+                MarketplaceAction::Update { name, all, dcc } => {
+                    to_json(service.update(name, all, dcc).await?)?
+                }
             }
         }
         Command::Lint(lint_args) => {

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -366,6 +366,37 @@ fn write_skill(root: &std::path::Path, relative: &str, content: &str) -> std::pa
     dir
 }
 
+fn run_git(repo: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .env("GIT_AUTHOR_NAME", "dcc-mcp-test")
+        .env("GIT_AUTHOR_EMAIL", "dcc-mcp-test@example.com")
+        .env("GIT_COMMITTER_NAME", "dcc-mcp-test")
+        .env("GIT_COMMITTER_EMAIL", "dcc-mcp-test@example.com")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?}\nstdout: {}\nstderr: {}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit_git_skill_version(repo: &std::path::Path, version: &str, marker: &str) {
+    std::fs::write(
+        repo.join("SKILL.md"),
+        format!("---\nname: git-skill\ndescription: Git skill {version}\n---\n"),
+    )
+    .unwrap();
+    std::fs::write(repo.join("marker.txt"), marker).unwrap();
+    run_git(repo, &["add", "."]);
+    run_git(repo, &["commit", "-m", version]);
+    run_git(repo, &["tag", version]);
+}
+
 #[test]
 fn list_search_describe_and_call_gateway_rest_surface() {
     let fixture = spawn_gateway_fixture();
@@ -964,6 +995,118 @@ fn marketplace_force_install_keeps_existing_package_when_replacement_fails() {
     );
     assert!(stderr.contains("does not contain SKILL.md"));
     assert!(installed_path.join("SKILL.md").is_file());
+}
+
+#[test]
+fn marketplace_update_git_package_uses_latest_catalog_ref() {
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("git-skill-repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    run_git(&repo, &["init"]);
+    run_git(&repo, &["config", "user.name", "dcc-mcp-test"]);
+    run_git(&repo, &["config", "user.email", "dcc-mcp-test@example.com"]);
+    commit_git_skill_version(&repo, "v0.1.0", "v1");
+    commit_git_skill_version(&repo, "v0.2.0", "v2");
+
+    let catalog_path = tmp.path().join("marketplace.json");
+    let source = catalog_path.to_string_lossy().to_string();
+    let config_path = tmp
+        .path()
+        .join("sources.json")
+        .to_string_lossy()
+        .to_string();
+    let install_root = tmp
+        .path()
+        .join("marketplace-root")
+        .to_string_lossy()
+        .to_string();
+    let envs = [
+        ("DCC_MCP_MARKETPLACE_SOURCES_FILE", config_path.as_str()),
+        ("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES", "1"),
+        ("DCC_MCP_MARKETPLACE_INSTALL_ROOT", install_root.as_str()),
+    ];
+
+    let catalog_v1 = json!({
+        "version": "1",
+        "entries": [{
+            "name": "git-skill",
+            "description": "Git skill",
+            "dcc": ["maya"],
+            "tags": ["test"],
+            "version": "0.1.0",
+            "install": {
+                "type": "git",
+                "url": repo.to_string_lossy(),
+                "ref": "v0.1.0"
+            }
+        }]
+    });
+    std::fs::write(
+        &catalog_path,
+        serde_json::to_string_pretty(&catalog_v1).unwrap(),
+    )
+    .unwrap();
+
+    let installed = run_json_with_env(
+        &[
+            "marketplace",
+            "install",
+            "git-skill",
+            "--dcc",
+            "maya",
+            "--source",
+            &source,
+        ],
+        &envs,
+    );
+    let installed_path = std::path::PathBuf::from(installed["path"].as_str().unwrap());
+    assert_eq!(
+        std::fs::read_to_string(installed_path.join("marker.txt")).unwrap(),
+        "v1"
+    );
+
+    let catalog_v2 = json!({
+        "version": "1",
+        "entries": [{
+            "name": "git-skill",
+            "description": "Git skill",
+            "dcc": ["maya"],
+            "tags": ["test"],
+            "version": "0.2.0",
+            "install": {
+                "type": "git",
+                "url": repo.to_string_lossy(),
+                "ref": "v0.2.0"
+            }
+        }]
+    });
+    std::fs::write(
+        &catalog_path,
+        serde_json::to_string_pretty(&catalog_v2).unwrap(),
+    )
+    .unwrap();
+
+    let outdated = run_json_with_env(
+        &["marketplace", "outdated", "git-skill", "--dcc", "maya"],
+        &envs,
+    );
+    assert_eq!(outdated["count"], 1);
+    assert_eq!(outdated["packages"][0]["latest_version"], "0.2.0");
+    assert_eq!(outdated["packages"][0]["install_ref"], "v0.2.0");
+
+    let updated = run_json_with_env(
+        &["marketplace", "update", "git-skill", "--dcc", "maya"],
+        &envs,
+    );
+    assert_eq!(updated[0]["new_version"], "0.2.0");
+    assert_eq!(
+        std::fs::read_to_string(installed_path.join("marker.txt")).unwrap(),
+        "v2"
+    );
+
+    let listed = run_json_with_env(&["marketplace", "list-installed", "--dcc", "maya"], &envs);
+    assert_eq!(listed["packages"][0]["version"], "0.2.0");
+    assert_eq!(listed["packages"][0]["install_ref"], "v0.2.0");
 }
 
 #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/catalog.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/catalog.rs
@@ -1,13 +1,20 @@
 //! `gateway://catalog*` MCP resources — public DCC-MCP package catalog.
 //!
-//! Replaces the legacy `dcc_catalog__search` / `dcc_catalog__describe`
-//! MCP tools (#813 phase 2). The catalog is a static YAML file shipped
-//! beside the binary; it is a textbook read-only view that belongs in
-//! `resources/read`, not `tools/list`.
+//! Fetches from the official marketplace repository at
+//! `https://raw.githubusercontent.com/dcc-mcp/marketplace/main/marketplace.json`
+//! and falls back to a local `dcc-mcp-catalog.yml` when the network is
+//! unavailable. Set `DCC_MCP_CATALOG_PATH` to override the local fallback.
+
+use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
+use tokio::sync::RwLock;
 
 use super::util::{parse_query, split_uri};
+
+/// Marketplace raw URL — canonical source of truth for the catalog.
+pub const MARKETPLACE_CATALOG_URL: &str =
+    "https://raw.githubusercontent.com/dcc-mcp/marketplace/main/marketplace.json";
 
 /// Root URI for the catalog index.
 pub const ROOT_URI: &str = "gateway://catalog";
@@ -15,12 +22,128 @@ pub const ROOT_URI: &str = "gateway://catalog";
 /// URI prefix for single-entry reads (e.g. `gateway://catalog/dcc-mcp-maya-skills`).
 pub const PREFIX: &str = "gateway://catalog/";
 
+/// How long to cache the marketplace catalog in memory before re-fetching.
+const CACHE_TTL: Duration = Duration::from_secs(300);
+
+fn offline_mode() -> bool {
+    std::env::var("DCC_MCP_MARKETPLACE_OFFLINE")
+        .map(|v| matches!(v.as_str(), "1" | "true"))
+        .unwrap_or(false)
+}
+
+/// Catalog entries plus the instant they were loaded.
+struct CatalogSnapshot {
+    entries: Vec<dcc_mcp_catalog::CatalogEntry>,
+    fetched_at: Instant,
+}
+
+/// A cached catalog loader that fetches from the marketplace repo on first
+/// access and refreshes after `CACHE_TTL`.
+pub struct CatalogLoader {
+    client: reqwest::Client,
+    cache: RwLock<Option<CatalogSnapshot>>,
+}
+
+impl CatalogLoader {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .build()
+                .expect("CatalogLoader reqwest::Client should build"),
+            cache: RwLock::new(None),
+        }
+    }
+
+    /// Return catalog entries, preferring a fresh fetch from the marketplace
+    /// URL with local-file fallback.
+    pub async fn load_entries(&self) -> Result<Vec<dcc_mcp_catalog::CatalogEntry>, String> {
+        // Serve cached entries when within TTL.
+        {
+            let cache = self.cache.read().await;
+            if let Some(ref snap) = *cache
+                && snap.fetched_at.elapsed() < CACHE_TTL
+            {
+                return Ok(snap.entries.clone());
+            }
+        }
+
+        // Try marketplace URL first (unless offline), then local file fallback.
+        let entries = if offline_mode() {
+            tracing::debug!("marketplace offline mode; loading from local file");
+            load_from_local_file()?
+        } else {
+            match self.fetch_marketplace().await {
+                Ok(entries) => {
+                    tracing::info!(count = entries.len(), "catalog loaded from marketplace");
+                    entries
+                }
+                Err(marketplace_err) => {
+                    tracing::warn!(
+                        error = %marketplace_err,
+                        "marketplace catalog fetch failed, falling back to local file"
+                    );
+                    load_from_local_file()?
+                }
+            }
+        };
+
+        let mut cache = self.cache.write().await;
+        *cache = Some(CatalogSnapshot {
+            entries: entries.clone(),
+            fetched_at: Instant::now(),
+        });
+        Ok(entries)
+    }
+
+    /// Clear the cached entries (useful for tests that swap catalog files).
+    pub async fn clear_cache(&self) {
+        let mut cache = self.cache.write().await;
+        *cache = None;
+    }
+
+    async fn fetch_marketplace(&self) -> Result<Vec<dcc_mcp_catalog::CatalogEntry>, String> {
+        let url = std::env::var("DCC_MCP_MARKETPLACE_CATALOG_URL")
+            .unwrap_or_else(|_| MARKETPLACE_CATALOG_URL.to_string());
+        if offline_mode() {
+            return Err("marketplace offline (DCC_MCP_MARKETPLACE_OFFLINE=1)".into());
+        }
+        let text = self
+            .client
+            .get(&url)
+            .header("User-Agent", "dcc-mcp-gateway catalog")
+            .send()
+            .await
+            .map_err(|e| format!("marketplace fetch error: {e}"))?
+            .error_for_status()
+            .map_err(|e| format!("marketplace HTTP error: {e}"))?
+            .text()
+            .await
+            .map_err(|e| format!("marketplace read error: {e}"))?;
+        dcc_mcp_catalog::load_from_str(&text).map_err(|e| format!("marketplace parse error: {e}"))
+    }
+}
+
+impl Default for CatalogLoader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Thread-local default loader. Created lazily via `catalog_entries()`.
+static LOADER: std::sync::LazyLock<CatalogLoader> = std::sync::LazyLock::new(CatalogLoader::new);
+
+/// Convenience wrapper that always uses the default loader.
+async fn catalog_entries() -> Result<Vec<dcc_mcp_catalog::CatalogEntry>, String> {
+    LOADER.load_entries().await
+}
+
 /// Resource pointer emitted in `resources/list`.
 pub fn pointer() -> Value {
     json!({
         "uri":         ROOT_URI,
         "name":        "Public DCC-MCP catalog",
-        "description": "Searchable index of adapters, skill packs, and plugins. Optional ?query=<keyword> filters by name / description / DCC / tags. Single entries: gateway://catalog/{name}.",
+        "description": "Searchable index of adapters, skill packs, and plugins from dcc-mcp/marketplace. Optional ?query=<keyword> filters by name / description / DCC / tags. Single entries: gateway://catalog/{name}.",
         "mimeType":    "application/json"
     })
 }
@@ -62,14 +185,8 @@ pub fn parse(uri: &str) -> Option<Query> {
 }
 
 /// Render the payload for a `gateway://catalog*` read.
-///
-/// Catalog I/O is synchronous (small YAML file); we expose an `async fn`
-/// for symmetry with the other resource families and to leave room for
-/// I/O pools in the future.
 pub async fn build_payload(query: &Query) -> Result<Value, String> {
-    let path = catalog_yml_path();
-    let entries =
-        dcc_mcp_catalog::load_from_file(&path).map_err(|e| format!("catalog load error: {e}"))?;
+    let entries = catalog_entries().await?;
 
     match query {
         Query::List { query } => {
@@ -78,6 +195,7 @@ pub async fn build_payload(query: &Query) -> Result<Value, String> {
             Ok(json!({
                 "total":   hits.len(),
                 "query":   query,
+                "source":  "marketplace",
                 "entries": hits,
             }))
         }
@@ -86,6 +204,17 @@ pub async fn build_payload(query: &Query) -> Result<Value, String> {
             None => Err(format!("catalog entry '{name}' not found")),
         },
     }
+}
+
+/// Fallback: load catalog from the local `.yml` file.
+fn load_from_local_file() -> Result<Vec<dcc_mcp_catalog::CatalogEntry>, String> {
+    let path = catalog_yml_path();
+    dcc_mcp_catalog::load_from_file(&path).map_err(|e| {
+        format!(
+            "local catalog load error ({path}): {e}",
+            path = path.display()
+        )
+    })
 }
 
 /// Resolve the path to `dcc-mcp-catalog.yml`.
@@ -209,9 +338,13 @@ entries:
     #[tokio::test]
     async fn build_payload_list_empty_query_returns_all() {
         let _env_guard = CATALOG_ENV_LOCK.lock().await;
+        LOADER.clear_cache().await;
         let f = write_catalog_yaml(TWO_ENTRY_YAML);
         // SAFETY: process-wide env mutation is serialized by CATALOG_ENV_LOCK.
-        unsafe { std::env::set_var("DCC_MCP_CATALOG_PATH", f.path()) };
+        unsafe {
+            std::env::set_var("DCC_MCP_MARKETPLACE_OFFLINE", "1");
+            std::env::set_var("DCC_MCP_CATALOG_PATH", f.path());
+        }
 
         let v = build_payload(&Query::List {
             query: String::new(),
@@ -221,15 +354,22 @@ entries:
 
         assert_eq!(v["total"], 2);
         // SAFETY: cleanup symmetrical to set_var above.
-        unsafe { std::env::remove_var("DCC_MCP_CATALOG_PATH") };
+        unsafe {
+            std::env::remove_var("DCC_MCP_MARKETPLACE_OFFLINE");
+            std::env::remove_var("DCC_MCP_CATALOG_PATH");
+        }
     }
 
     #[tokio::test]
     async fn build_payload_list_keyword_filters_results() {
         let _env_guard = CATALOG_ENV_LOCK.lock().await;
+        LOADER.clear_cache().await;
         let f = write_catalog_yaml(TWO_ENTRY_YAML);
         // SAFETY: process-wide env mutation is serialized by CATALOG_ENV_LOCK.
-        unsafe { std::env::set_var("DCC_MCP_CATALOG_PATH", f.path()) };
+        unsafe {
+            std::env::set_var("DCC_MCP_MARKETPLACE_OFFLINE", "1");
+            std::env::set_var("DCC_MCP_CATALOG_PATH", f.path());
+        }
 
         let v = build_payload(&Query::List {
             query: "maya".to_string(),
@@ -240,15 +380,22 @@ entries:
         assert_eq!(v["total"], 1);
         assert_eq!(v["entries"][0]["name"], "maya-skills");
         // SAFETY: see above.
-        unsafe { std::env::remove_var("DCC_MCP_CATALOG_PATH") };
+        unsafe {
+            std::env::remove_var("DCC_MCP_MARKETPLACE_OFFLINE");
+            std::env::remove_var("DCC_MCP_CATALOG_PATH");
+        }
     }
 
     #[tokio::test]
     async fn build_payload_single_existing_entry_returns_data() {
         let _env_guard = CATALOG_ENV_LOCK.lock().await;
+        LOADER.clear_cache().await;
         let f = write_catalog_yaml(ONE_ENTRY_YAML);
         // SAFETY: process-wide env mutation is serialized by CATALOG_ENV_LOCK.
-        unsafe { std::env::set_var("DCC_MCP_CATALOG_PATH", f.path()) };
+        unsafe {
+            std::env::set_var("DCC_MCP_MARKETPLACE_OFFLINE", "1");
+            std::env::set_var("DCC_MCP_CATALOG_PATH", f.path());
+        }
 
         let v = build_payload(&Query::Single {
             name: "maya-skills".to_string(),
@@ -259,15 +406,22 @@ entries:
         assert_eq!(v["name"], "maya-skills");
         assert_eq!(v["dcc"][0], "maya");
         // SAFETY: see above.
-        unsafe { std::env::remove_var("DCC_MCP_CATALOG_PATH") };
+        unsafe {
+            std::env::remove_var("DCC_MCP_MARKETPLACE_OFFLINE");
+            std::env::remove_var("DCC_MCP_CATALOG_PATH");
+        }
     }
 
     #[tokio::test]
     async fn build_payload_single_missing_entry_errors() {
         let _env_guard = CATALOG_ENV_LOCK.lock().await;
+        LOADER.clear_cache().await;
         let f = write_catalog_yaml(ONE_ENTRY_YAML);
         // SAFETY: process-wide env mutation is serialized by CATALOG_ENV_LOCK.
-        unsafe { std::env::set_var("DCC_MCP_CATALOG_PATH", f.path()) };
+        unsafe {
+            std::env::set_var("DCC_MCP_MARKETPLACE_OFFLINE", "1");
+            std::env::set_var("DCC_MCP_CATALOG_PATH", f.path());
+        }
 
         let err = build_payload(&Query::Single {
             name: "does-not-exist".to_string(),
@@ -277,6 +431,9 @@ entries:
 
         assert!(err.contains("not found"));
         // SAFETY: see above.
-        unsafe { std::env::remove_var("DCC_MCP_CATALOG_PATH") };
+        unsafe {
+            std::env::remove_var("DCC_MCP_MARKETPLACE_OFFLINE");
+            std::env::remove_var("DCC_MCP_CATALOG_PATH");
+        }
     }
 }

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -56,6 +56,9 @@ dcc-mcp-cli marketplace search --query hunyuan --dcc maya
 dcc-mcp-cli marketplace inspect dcc-asset-hunyuan-download
 dcc-mcp-cli marketplace install dcc-asset-hunyuan-download --dcc maya
 dcc-mcp-cli marketplace list-installed --dcc maya
+dcc-mcp-cli marketplace outdated --dcc maya
+dcc-mcp-cli marketplace update dcc-mcp-maya-skills --dcc maya
+dcc-mcp-cli marketplace update --all
 dcc-mcp-cli lint path/to/skills
 ```
 
@@ -80,6 +83,8 @@ dcc-mcp-cli lint path/to/skills
 | `marketplace install <name> [--dcc <dcc>] [--source <source>] [--force]` | marketplace catalog + local filesystem/git | Install a skill package to `~/.dcc-mcp/marketplace/<dcc>/<name>/`. |
 | `marketplace list-installed [--dcc <dcc>]` | local installed-state file | List locally installed marketplace packages and their versions/paths. |
 | `marketplace uninstall <name> --dcc <dcc>` | local installed-state file + filesystem | Remove an installed marketplace package. |
+| `marketplace outdated [NAME...] [--dcc <dcc>]` | marketplace catalog + local installed state | Compare installed versions against latest catalog entries and list packages with newer versions available. |
+| `marketplace update [<name>] [--all] [--dcc <dcc>]` | marketplace catalog + git/filesystem + local installed state | Upgrade installed packages to the latest catalog version. For `git` installs, fetches the new ref in place; for other types, re-installs from the catalog. Use `--all` to update every outdated package. |
 | `lint [PATH ...]` | local filesystem validator | Recursively validate SKILL.md packages two levels below each path by default. |
 
 `install` intentionally starts as a planning contract: it resolves catalog
@@ -100,6 +105,13 @@ supports `install.type: git` and `install.type: path`; `zip` entries are
 reserved for a later archive installer. DCC adapters include
 `~/.dcc-mcp/marketplace/<dcc>` in their skill search paths, so installed skills
 are discovered on adapter startup or the next `reload_skill_paths`.
+
+`update` compares each installed package version against the latest catalog
+entry. For `git`-type installs, if a `.git` directory already exists the
+command runs `git fetch && git checkout <ref>` in place; otherwise it
+re-clones. The local installed-state file is updated with the new version
+metadata. Installed packages with no matching catalog entry (e.g. the
+source was removed) are silently skipped.
 
 `lint` reuses the production `dcc-mcp-skills` validator, so local checks and
 runtime loading fail for the same structural problems. CI runs the same command


### PR DESCRIPTION
## Summary

Continues [PIP-511](mention://issue/e99a41eb-b518-4af8-abf0-ac6814dc1f70) marketplace implementation.

### PIP-511-c: marketplace update and outdated commands

- `marketplace outdated [--dcc <dcc>] [NAME...]` compares installed versions against latest catalog entries and lists packages with newer versions available.
- `marketplace update [<name>] [--all] [--dcc <dcc>]` upgrades installed packages:
  - Git installs fetch and checkout the latest catalog ref in place when the origin URL is unchanged.
  - Missing git checkouts or changed origin URLs reinstall through the staged install flow.
  - Non-git installs reinstall through the normal catalog install flow with `force`.
  - Installed state (`installed.json`) is updated with the latest version and latest install metadata after success.
  - Multiple outdated packages require `--all`.
- Review hardening: update now uses the latest catalog install URL/ref/type instead of stale installed-state metadata, preventing false upgrades where state says `0.2.0` but the git checkout remains on the old ref.

### PIP-511-d: gateway catalog migration

`gateway://catalog` MCP resource now fetches from `https://raw.githubusercontent.com/dcc-mcp/marketplace/main/marketplace.json`:

- `CatalogLoader` fetches on first access and caches in memory for 5 minutes.
- Network failures fall back to local `dcc-mcp-catalog.yml`.
- `DCC_MCP_MARKETPLACE_OFFLINE=1` skips HTTP fetches for CI/offline deployments.
- `DCC_MCP_MARKETPLACE_CATALOG_URL` overrides the marketplace source URL.
- `dcc_mcp_catalog::load_from_str` parses marketplace JSON first, then legacy YAML.
- List payloads include `source: "marketplace"` for diagnosis.

### Validation

- `vx cargo fmt --check`
- `vx cargo test -p dcc-mcp-catalog`
- `vx cargo test -p dcc-mcp-cli`
- `vx cargo clippy -p dcc-mcp-cli --all-targets -- -D warnings`
- `vx cargo test -p dcc-mcp-gateway native_resources::catalog`

`dcc-mcp-gateway` catalog tests pass; the targeted gateway test run emits existing dead-code warnings outside this change.
