### PR TITLE
feat(server): Sentry error monitoring and webhook analytics documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +351,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +441,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -1594,6 +1627,7 @@ dependencies = [
  "futures-util",
  "reqwest 0.13.4",
  "rusqlite",
+ "sentry",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -1859,6 +1893,16 @@ dependencies = [
  "tracing",
  "uuid",
  "workspace-hack",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
 ]
 
 [[package]]
@@ -2311,6 +2355,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,6 +2569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,7 +2692,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "ureq",
+ "ureq 3.3.0",
  "windows-sys 0.61.2",
 ]
 
@@ -2663,6 +2728,17 @@ name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "http"
@@ -2753,7 +2829,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2766,6 +2842,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -3541,6 +3633,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3560,6 +3669,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "no_std_io2"
@@ -3792,6 +3913,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3800,6 +3942,51 @@ dependencies = [
  "bitflags",
  "dispatch2",
  "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -3815,7 +4002,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags",
+ "block2",
+ "libc",
  "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3829,6 +4019,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-open-directory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3837,6 +4038,58 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3880,10 +4133,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -3998,7 +4288,7 @@ dependencies = [
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -4009,7 +4299,23 @@ checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
- "ureq",
+ "ureq 3.3.0",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4953,6 +5259,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -4960,9 +5267,11 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4973,6 +5282,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -4983,7 +5293,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5217,6 +5527,12 @@ dependencies = [
  "rand 0.10.1",
  "thiserror",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -5519,6 +5835,102 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "sentry"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb7daabbc631b13f48e991f4d828f12ec43e2acd3fb2972b445bdc138231ee2"
+dependencies = [
+ "httpdate",
+ "native-tls",
+ "reqwest 0.12.28",
+ "rustls",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq 2.12.1",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbd964934e339213e5ffe2682575ae390327945856c067408ae121d1ceae72"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "356d87fef14b05475f46e8554bf26833230c92bcac106d74f0f5719dce4a7850"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e73bfcabac5a7f9e2e38f898ba0afc6bed36fb96108b246213b698e00f12268c"
+dependencies = [
+ "rand 0.9.4",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29abe64e33902f6fefafdb652dc0efed303cea655324e85db9fbb8d83d503c44"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd32bfd54bd829a92ee9b32894b05c726edcdc40d9c580ce7b3f4a56f13a45"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7205055c5bde8131c62e4f5367f4291956c331a64e1a32e737e8d81b26b3bcb"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "serde"
@@ -6108,6 +6520,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6507,6 +6929,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6645,6 +7076,22 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "native-tls",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
@@ -6661,7 +7108,7 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -6686,6 +7133,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6977,6 +7425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -7440,6 +7897,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "httparse",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "image",
  "indexmap",
@@ -7471,6 +7929,7 @@ dependencies = [
  "regex-syntax",
  "reqwest 0.13.4",
  "rustls",
+ "rustls-pki-types",
  "rustls-webpki",
  "serde",
  "serde_core",
@@ -7484,6 +7943,7 @@ dependencies = [
  "sync_wrapper",
  "time",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "toml_datetime",
@@ -7494,6 +7954,7 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
  "typenum",
+ "url",
  "winapi",
  "windows",
  "windows-sys 0.60.2",

--- a/crates/dcc-mcp-server/Cargo.toml
+++ b/crates/dcc-mcp-server/Cargo.toml
@@ -52,10 +52,23 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 # admin) or `gateway-daemon` (standalone daemon subcommand) is enabled.
 dcc-mcp-gateway = { version = "0.17.0", path = "../dcc-mcp-gateway", optional = true }
 
+# Sentry error monitoring (backend). Controlled by DCC_MCP_SENTRY_DSN
+# env var at startup; no-op when absent. Feature-gated so slim builds
+# (gateway-only) can skip the dependency entirely.
+sentry = { version = "0.39", default-features = false, features = [
+    "backtrace",
+    "contexts",
+    "panic",
+    "reqwest",
+    "rustls",
+    "transport",
+], optional = true }
+
 [features]
 # Default matches today's binary: per-DCC MCP server with embedded
-# first-wins gateway election and the read-only Admin UI.
-default = ["server", "gateway-auto", "gateway-daemon", "admin"]
+# first-wins gateway election, the read-only Admin UI, and Sentry
+# error monitoring (auto-disabled when DCC_MCP_SENTRY_DSN is absent).
+default = ["server", "gateway-auto", "gateway-daemon", "admin", "sentry"]
 
 # Per-DCC MCP HTTP server (mandatory for the default `dcc-mcp-server`
 # entry point). Currently a marker feature; opting it out leaves only
@@ -112,6 +125,10 @@ prometheus = [
 
 otlp-exporter = ["dcc-mcp-telemetry/otlp-exporter", "dep:dcc-mcp-telemetry"]
 telemetry = ["dep:dcc-mcp-telemetry"]
+
+# Sentry error monitoring (Rust backend). Controlled by DCC_MCP_SENTRY_DSN
+# env var at startup. Does nothing when the env var is absent.
+sentry = ["dep:sentry"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -564,9 +564,7 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Auto-init Sentry from DCC_MCP_SENTRY_DSN ─────────────────────────
     #[cfg(feature = "sentry")]
-    {
-        sentry_init::init_sentry();
-    }
+    let _sentry_guard = sentry_init::init_sentry();
 
     let args = Args::parse();
 

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -108,6 +108,8 @@ use sysinfo::{Pid, ProcessesToUpdate, System};
 mod capture;
 mod cli;
 mod event_webhooks;
+#[cfg(feature = "sentry")]
+mod sentry_init;
 mod translate;
 
 #[cfg(feature = "gateway-auto")]
@@ -558,6 +560,12 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(not(feature = "telemetry"))]
     {
         // No telemetry crate compiled in — nothing to do.
+    }
+
+    // ── Auto-init Sentry from DCC_MCP_SENTRY_DSN ─────────────────────────
+    #[cfg(feature = "sentry")]
+    {
+        sentry_init::init_sentry();
     }
 
     let args = Args::parse();

--- a/crates/dcc-mcp-server/src/sentry_init.rs
+++ b/crates/dcc-mcp-server/src/sentry_init.rs
@@ -1,0 +1,69 @@
+//! Sentry error monitoring (Rust backend).
+//!
+//! Initialises the Sentry SDK when `DCC_MCP_SENTRY_DSN` is set at startup.
+//! Panics are automatically captured and dispatched to the configured Sentry
+//! project. Use `sentry::capture_error` or `sentry::capture_message` for
+//! explicit instrumentation points.
+//!
+//! ## Environment variables
+//!
+//! | Variable | Default | Purpose |
+//! |----------|---------|---------|
+//! | `DCC_MCP_SENTRY_DSN` | (disabled) | Sentry project DSN |
+//! | `DCC_MCP_SENTRY_ENVIRONMENT` | `production` | Environment tag |
+//! | `DCC_MCP_SENTRY_RELEASE` | crate version | Release identifier |
+//! | `DCC_MCP_SENTRY_SAMPLE_RATE` | `1.0` | Error sample rate (0.0–1.0) |
+
+/// Initialise the Sentry SDK if `DCC_MCP_SENTRY_DSN` is set.
+///
+/// Returns `true` when Sentry was successfully initialised.
+pub fn init_sentry() -> bool {
+    let Some(dsn) = std::env::var("DCC_MCP_SENTRY_DSN")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+    else {
+        return false;
+    };
+
+    let environment: std::borrow::Cow<'static, str> = std::env::var("DCC_MCP_SENTRY_ENVIRONMENT")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .map(Into::into)
+        .unwrap_or_else(|| "production".into());
+
+    let release: std::borrow::Cow<'static, str> = std::env::var("DCC_MCP_SENTRY_RELEASE")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .map(Into::into)
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").into());
+
+    let sample_rate: f32 = std::env::var("DCC_MCP_SENTRY_SAMPLE_RATE")
+        .ok()
+        .and_then(|s| s.parse::<f32>().ok())
+        .filter(|r| r.is_finite() && *r >= 0.0 && *r <= 1.0)
+        .unwrap_or(1.0);
+
+    let dsn_log = dsn.clone();
+
+    let guard = sentry::init(sentry::ClientOptions {
+        dsn: Some(
+            dsn.parse()
+                .expect("DCC_MCP_SENTRY_DSN must be a valid Sentry DSN"),
+        ),
+        release: Some(release),
+        environment: Some(environment),
+        traces_sample_rate: sample_rate,
+        ..Default::default()
+    });
+
+    // Leak the guard so Sentry stays alive for the process lifetime.
+    std::mem::forget(guard);
+
+    tracing::info!(
+        dsn = %dsn_log,
+        sample_rate,
+        "sentry initialised",
+    );
+
+    true
+}

--- a/crates/dcc-mcp-server/src/sentry_init.rs
+++ b/crates/dcc-mcp-server/src/sentry_init.rs
@@ -16,54 +16,54 @@
 
 /// Initialise the Sentry SDK if `DCC_MCP_SENTRY_DSN` is set.
 ///
-/// Returns `true` when Sentry was successfully initialised.
-pub fn init_sentry() -> bool {
-    let Some(dsn) = std::env::var("DCC_MCP_SENTRY_DSN")
+/// Returns the client guard that must be held for the process lifetime.
+/// Dropping the guard flushes pending events and shuts down the SDK.
+pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
+    let dsn = std::env::var("DCC_MCP_SENTRY_DSN")
         .ok()
-        .filter(|s| !s.trim().is_empty())
-    else {
-        return false;
-    };
+        .filter(|s| !s.trim().is_empty())?;
 
-    let environment: std::borrow::Cow<'static, str> = std::env::var("DCC_MCP_SENTRY_ENVIRONMENT")
+    let environment = std::env::var("DCC_MCP_SENTRY_ENVIRONMENT")
         .ok()
         .filter(|s| !s.trim().is_empty())
-        .map(Into::into)
         .unwrap_or_else(|| "production".into());
 
-    let release: std::borrow::Cow<'static, str> = std::env::var("DCC_MCP_SENTRY_RELEASE")
+    let release = std::env::var("DCC_MCP_SENTRY_RELEASE")
         .ok()
         .filter(|s| !s.trim().is_empty())
-        .map(Into::into)
         .unwrap_or_else(|| env!("CARGO_PKG_VERSION").into());
 
-    let sample_rate: f32 = std::env::var("DCC_MCP_SENTRY_SAMPLE_RATE")
+    let sample_rate = std::env::var("DCC_MCP_SENTRY_SAMPLE_RATE")
         .ok()
         .and_then(|s| s.parse::<f32>().ok())
         .filter(|r| r.is_finite() && *r >= 0.0 && *r <= 1.0)
         .unwrap_or(1.0);
 
-    let dsn_log = dsn.clone();
+    let parsed_dsn: sentry::types::Dsn = match dsn.parse() {
+        Ok(dsn) => dsn,
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                "DCC_MCP_SENTRY_DSN is not a valid Sentry DSN; skipping Sentry init"
+            );
+            return None;
+        }
+    };
 
     let guard = sentry::init(sentry::ClientOptions {
-        dsn: Some(
-            dsn.parse()
-                .expect("DCC_MCP_SENTRY_DSN must be a valid Sentry DSN"),
-        ),
-        release: Some(release),
-        environment: Some(environment),
+        dsn: Some(parsed_dsn),
+        release: Some(release.into()),
+        environment: Some(environment.into()),
         traces_sample_rate: sample_rate,
         ..Default::default()
     });
 
-    // Leak the guard so Sentry stays alive for the process lifetime.
-    std::mem::forget(guard);
-
     tracing::info!(
-        dsn = %dsn_log,
+        sentry_enabled = true,
+        environment = %std::env::var("DCC_MCP_SENTRY_ENVIRONMENT").unwrap_or_else(|_| "production".into()),
         sample_rate,
         "sentry initialised",
     );
 
-    true
+    Some(guard)
 }

--- a/crates/dcc-mcp-server/src/sentry_init.rs
+++ b/crates/dcc-mcp-server/src/sentry_init.rs
@@ -54,7 +54,7 @@ pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
         dsn: Some(parsed_dsn),
         release: Some(release.into()),
         environment: Some(environment.into()),
-        traces_sample_rate: sample_rate,
+        sample_rate,
         ..Default::default()
     });
 

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -65,6 +65,9 @@ rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls", "stream"] }
+rustls = { version = "0.23.40", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-pki-types = { version = "1.14.1", features = ["std"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["ring", "std"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
 serde_json = { version = "1.0.150", features = ["alloc", "preserve_order", "raw_value"] }
@@ -85,6 +88,7 @@ tracing = { version = "0.1.44", features = ["log"] }
 tracing-core = { version = "0.1.36" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 typenum = { version = "1.20.0", default-features = false, features = ["const-generics"] }
+url = { version = "2.5.8", features = ["serde"] }
 winnow = { version = "1.0.3" }
 zerocopy = { version = "0.8.48", default-features = false, features = ["derive", "simd"] }
 zeroize = { version = "1.8.2", features = ["derive"] }
@@ -142,6 +146,9 @@ rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls", "stream"] }
+rustls = { version = "0.23.40", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-pki-types = { version = "1.14.1", features = ["std"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["ring", "std"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
 serde_json = { version = "1.0.150", features = ["alloc", "preserve_order", "raw_value"] }
@@ -163,6 +170,7 @@ tracing = { version = "0.1.44", features = ["log"] }
 tracing-core = { version = "0.1.36" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 typenum = { version = "1.20.0", default-features = false, features = ["const-generics"] }
+url = { version = "2.5.8", features = ["serde"] }
 winnow = { version = "1.0.3" }
 zerocopy = { version = "0.8.48", default-features = false, features = ["derive", "simd"] }
 zeroize = { version = "1.8.2", features = ["derive"] }
@@ -170,10 +178,12 @@ zeroize = { version = "1.8.2", features = ["derive"] }
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -181,20 +191,24 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -202,10 +216,12 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -213,10 +229,12 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -225,10 +243,12 @@ bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -236,10 +256,12 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -248,36 +270,42 @@ bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl", "winsock2"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60.2", features = ["Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl", "winsock2"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60.2", features = ["Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 ### END HAKARI SECTION

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -852,8 +852,9 @@ endpoints. Each webhook specifies:
 - `delivery.attempts` — retry count (default `3`).
 - `delivery.timeout_ms` — per-attempt timeout (default `2_000` ms).
 - `backoff_ms` — per-retry delay sequence (default `[200, 1000, 5000]` ms).
-- `payload_template` — optional `{{source.dcc_type}}` / `{{attributes.*}}`
-  template string. When omitted, the raw event envelope is POSTed as JSON.
+- `payload_template` — optional template string using double-braced
+  `source.dcc_type` / `attributes.*` paths. When omitted, the raw event
+  envelope is POSTed as JSON.
 
 Example `webhooks.yaml` to forward analytics events:
 

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -838,6 +838,68 @@ are documented in `crates/dcc-mcp-telemetry/src/prometheus.rs`.
 values above, including `xff_trusted_depth`), and a `circuits` snapshot
 (`tracked_backends`, `circuits_open`).
 
+### Event webhooks
+
+Set `DCC_MCP_WEBHOOKS_CONFIG` to a YAML file path to forward EventBus
+envelopes (`tool.*`, `skill.*`, `trace.*`, `gateway.*`) to external HTTP
+endpoints. Each webhook specifies:
+
+- `name` — stable identifier for logs and delivery-failed events.
+- `url` — `http` / `https` endpoint.
+- `events` — event name patterns (e.g. `["tool.*", "trace.*"]`).
+- `filters` — optional dotted-path matchers with `*`-wildcard support
+  (e.g. `attributes.tool_slug: "maya.*"`).
+- `delivery.attempts` — retry count (default `3`).
+- `delivery.timeout_ms` — per-attempt timeout (default `2_000` ms).
+- `backoff_ms` — per-retry delay sequence (default `[200, 1000, 5000]` ms).
+- `payload_template` — optional `{{source.dcc_type}}` / `{{attributes.*}}`
+  template string. When omitted, the raw event envelope is POSTed as JSON.
+
+Example `webhooks.yaml` to forward analytics events:
+
+```yaml
+queue_capacity: 256
+webhooks:
+  - name: analytics-forwarder
+    url: https://internal.example.com/api/dcc-analytics
+    events:
+      - "tool.*"
+      - "skill.*"
+      - "trace.*"
+      - "gateway.instance.*"
+    headers:
+      Authorization: "Bearer ${ANALYTICS_WEBHOOK_TOKEN}"
+    delivery:
+      attempts: 3
+      timeout_ms: 5000
+    filters:
+      - name: "tool.completed"
+      - name: "skill.loaded"
+```
+
+The webhook runtime starts automatically when the env var points at a
+valid YAML file. Headers support `${ENV_VAR}` interpolation so tokens
+stay out of version control.
+
+### Sentry error monitoring (Rust backend)
+
+Set `DCC_MCP_SENTRY_DSN` to your Sentry project DSN. The SDK initialises
+at server startup and captures panics automatically. Use
+`sentry::capture_error` or `sentry::capture_message` for explicit
+instrumentation points.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `DCC_MCP_SENTRY_DSN` | (disabled) | Sentry project DSN |
+| `DCC_MCP_SENTRY_ENVIRONMENT` | `production` | Environment tag |
+| `DCC_MCP_SENTRY_RELEASE` | crate version | Release identifier for source-map / commit correlation |
+| `DCC_MCP_SENTRY_SAMPLE_RATE` | `1.0` | Error event sample rate (0.0–1.0) |
+
+The feature is compiled by default and skips initialisation entirely when
+`DCC_MCP_SENTRY_DSN` is absent, so zero-config deployments pay no overhead.
+Build with `--no-default-features` and opt out of `sentry` to exclude the
+crate from the binary entirely.
+
 ## Dynamic Capability Index and Bounded Tool Exposure (#652-#657)
 
 For large multi-DCC deployments, the gateway **never** publishes every backend

--- a/tests/test_gateway_prompts_aggregation.py
+++ b/tests/test_gateway_prompts_aggregation.py
@@ -107,6 +107,31 @@ def _split_gateway_prefixed(name: str) -> tuple[str, str] | None:
     return prefix, decoded
 
 
+def _bare_prompt_names(prompts: list[dict]) -> set[str]:
+    decoded = (_split_gateway_prefixed(prompt["name"]) for prompt in prompts)
+    return {bare for split in decoded if split is not None for bare in (split[1],)}
+
+
+def _wait_for_gateway_prompts(gateway_url: str, expected: set[str], timeout: float = 20.0) -> None:
+    """Wait until the gateway prompts watcher has observed loaded backend skills."""
+    deadline = time.monotonic() + timeout
+    last_resp: dict | None = None
+
+    while time.monotonic() < deadline:
+        last_resp = _post_mcp(gateway_url, "prompts/list")
+        if "error" not in last_resp:
+            prompts = last_resp.get("result", {}).get("prompts", [])
+            if expected.issubset(_bare_prompt_names(prompts)):
+                return
+        time.sleep(0.25)
+
+    prompts = [] if last_resp is None else last_resp.get("result", {}).get("prompts", [])
+    names = [p.get("name") for p in prompts]
+    pytest.fail(
+        f"gateway prompts did not include {sorted(expected)} within {timeout}s; names={names}; last_resp={last_resp}"
+    )
+
+
 def _start_backend(dcc: str, skill_parent: Path, registry_dir: Path, gw_port: int) -> object:
     """Start an ``McpHttpServer`` via ``create_skill_server`` discovering ``skill_parent``."""
     cfg = McpHttpConfig(port=0, server_name=f"{dcc}-prompts-backend")
@@ -212,9 +237,13 @@ def prompts_cluster(tmp_path_factory):
         )
         assert "error" not in resp, f"load_skill({skill}) on {backend_url} failed: {resp.get('error')}"
 
-    # One more tick so the prompts watcher picks up the newly loaded
-    # prompts before the first assertion runs.
-    time.sleep(3.2)
+    # The gateway prompts watcher is asynchronous and can lag on slower
+    # macOS/Python 3.8 runners. Poll the public surface until it reflects
+    # the loaded backend skills instead of relying on a fixed sleep.
+    _wait_for_gateway_prompts(
+        gateway_url,
+        {"bake_animation", "render_preview", "export_gltf"},
+    )
 
     try:
         yield {


### PR DESCRIPTION
## Summary

Continues [PIP-494](mention://issue/ae58aa6b-96cd-4635-9c24-5368a1745450) P2 — Sentry error monitoring and webhook analytics.

### Changes

**Sentry Rust integration** (`dcc-mcp-server`):
- New `sentry_init.rs` module initialises Sentry SDK at server startup
- Driven by environment variables: `DCC_MCP_SENTRY_DSN`, `DCC_MCP_SENTRY_ENVIRONMENT`, `DCC_MCP_SENTRY_RELEASE`, `DCC_MCP_SENTRY_SAMPLE_RATE`
- DSN absent → no init (zero overhead); compile-out via `--no-default-features`
- **Safe defaults**:
  - DSN is never logged (only `sentry_enabled=true` + environment + sample_rate)
  - Invalid DSN produces a `tracing::warn!` and returns `None` instead of panicking
  - Guard held in `main` scope for proper event flush on graceful shutdown

**Webhook analytics** (documentation only — existing runtime already supports it):
- Added webhook configuration examples in `docs/guide/gateway.md`
- Subscribe to `tool.*`, `skill.*`, `trace.*` events to push analytics data to internal data platforms

### Review fixes

This PR incorporates fixes for all 4 review findings on the original P2 branch:
1. DSN logged in plaintext → removed, log `sentry_enabled=true` only
2. `dsn.parse().expect()` panics on malformed DSN → graceful `warn!` + `None`
3. `std::mem::forget(guard)` leaks guard → held in `main` scope as `_sentry_guard`
4. Branch not based on latest main → rebased on `6170652a`

### Verification

- `cargo check -p dcc-mcp-server` ✅
- `cargo check -p dcc-mcp-server --no-default-features` ✅
- `cargo test -p dcc-mcp-server` — 7 passed (4 webhook + 3 bridge)