### PR TITLE
feat(gateway): passthrough bounded request meta

### DIFF
--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -353,6 +353,7 @@ tools:
 8. **Wire lifecycle hooks for policy control** — use `BEFORE_TOOL_CALL` + `HookDeny` to block dangerous operations without modifying tool code
 9. **Enable agent memory for smarter searches** — `MemoryRecorder` auto-injects `memory_prefer_tools`/`memory_avoid_tools` so search ranking improves over time
 10. **Use `register_all_builtin_skills` for a complete baseline** — one call registers diagnostics, introspection, feedback, recipes, UI inspector, and script materialization tools
+11. **Read `_meta` for request-level context** — tools receive `params._meta.agent_context` (caller identity), `credential_profile` (env tier), `permission_hint` (read-only/read-write), and `project_scope` (data isolation). See [agents-reference.md](docs/guide/agents-reference.md#request-level-context-passthrough-_meta----pip-520) for patterns.
 
 ---
 

--- a/crates/dcc-mcp-actions/src/chain_exec.rs
+++ b/crates/dcc-mcp-actions/src/chain_exec.rs
@@ -150,7 +150,7 @@ impl ActionChain {
             };
 
             // Dispatch
-            let dispatch_result = dispatcher.dispatch(&step.action, params);
+            let dispatch_result = dispatcher.dispatch(&step.action, params, None);
 
             match dispatch_result {
                 Ok(res) => {

--- a/crates/dcc-mcp-actions/src/dispatcher.rs
+++ b/crates/dcc-mcp-actions/src/dispatcher.rs
@@ -19,7 +19,7 @@
 //! use serde_json::{json, Value};
 //!
 //! let registry = ToolRegistry::new();
-//! let mut dispatcher = ToolDispatcher::new(registry.clone());
+//! let dispatcher = ToolDispatcher::new(registry.clone());
 //!
 //! // 1. Register metadata
 //! registry.register_action(ToolMeta {
@@ -40,7 +40,7 @@
 //! });
 //!
 //! // 3. Dispatch
-//! let result = dispatcher.dispatch("create_sphere", json!({"radius": 2.0}));
+//! let result = dispatcher.dispatch("create_sphere", json!({"radius": 2.0}), None);
 //! assert!(result.is_ok());
 //! ```
 
@@ -179,7 +179,7 @@ pub struct DispatchResult {
 /// use serde_json::json;
 ///
 /// let registry = ToolRegistry::new();
-/// let mut dispatcher = ToolDispatcher::new(registry.clone());
+/// let dispatcher = ToolDispatcher::new(registry.clone());
 ///
 /// registry.register_action(ToolMeta {
 ///     name: "echo".into(),
@@ -188,7 +188,7 @@ pub struct DispatchResult {
 /// });
 /// dispatcher.register_handler("echo", |params| Ok(params));
 ///
-/// let result = dispatcher.dispatch("echo", json!({"msg": "hello"})).unwrap();
+/// let result = dispatcher.dispatch("echo", json!({"msg": "hello"}), None).unwrap();
 /// assert_eq!(result.output, json!({"msg": "hello"}));
 /// ```
 #[derive(Clone)]
@@ -291,7 +291,26 @@ impl ToolDispatcher {
     /// 2. Look up metadata from the registry (for schema validation).
     /// 3. Validate `params` against `input_schema` (unless schema is empty and
     ///    `skip_empty_schema_validation` is `true`).
-    /// 4. Call the handler and return the result.
+    /// 4. Inject `meta` as `params["_meta"]` **after** validation — safe for
+    ///    tools that declare `additionalProperties: false`.
+    /// 5. Call the handler and return the result.
+    ///
+    /// ## Request-level context (`meta`)
+    ///
+    /// When `meta` is `Some`, the following keys are injected into
+    /// `params["_meta"]` before the handler runs:
+    /// - `agent_context` — server-derived caller identity (actor, agent,
+    ///   session, model, source IP)
+    /// - `credential_profile` — environment tier selector (`"prod"`,
+    ///   `"staging"`, `"dev"`)
+    /// - `permission_hint` — `"read-only"` or `"read-write"`
+    /// - `project_scope` — project identifier for data isolation
+    /// - `search_id` — telemetry correlation id
+    ///
+    /// Tool handlers access this via `params["_meta"]` (Rust) or
+    /// `params.get("_meta", {})` (Python).  See the agent reference
+    /// (`docs/guide/agents-reference.md#request-level-context-passthrough-_meta----pip-520`)
+    /// for usage patterns.
     ///
     /// # Errors
     ///
@@ -303,8 +322,9 @@ impl ToolDispatcher {
         &self,
         action_name: &str,
         params: Value,
+        meta: Option<Value>,
     ) -> Result<DispatchResult, DispatchError> {
-        self.dispatch_inner(action_name, params, true)
+        self.dispatch_inner(action_name, params, meta, true)
     }
 
     #[cfg_attr(not(feature = "python-bindings"), allow(dead_code))]
@@ -313,13 +333,14 @@ impl ToolDispatcher {
         action_name: &str,
         params: Value,
     ) -> Result<DispatchResult, DispatchError> {
-        self.dispatch_inner(action_name, params, false)
+        self.dispatch_inner(action_name, params, None, false)
     }
 
     fn dispatch_inner(
         &self,
         action_name: &str,
-        params: Value,
+        mut params: Value,
+        meta: Option<Value>,
         emit_events: bool,
     ) -> Result<DispatchResult, DispatchError> {
         let started = Instant::now();
@@ -366,6 +387,8 @@ impl ToolDispatcher {
         }
 
         // 3. Validation via pluggable strategy (#493).
+        //    Runs on the original params WITHOUT _meta — safe for tools
+        //    that declare `additionalProperties: false`.
         let outcome = match select_strategy(meta_opt.as_ref(), self.skip_empty_schema_validation)
             .validate(&params)
         {
@@ -378,6 +401,15 @@ impl ToolDispatcher {
                 return Err(err);
             }
         };
+
+        // 3b. Inject _meta into params AFTER validation so the handler
+        //     can consume request-level context (e.g. agent_context,
+        //     credential_profile, permission_hint, project_scope).
+        if let Value::Object(ref mut map) = params
+            && let Some(m) = meta
+        {
+            map.insert("_meta".to_string(), m);
+        }
 
         // 4. Call handler.
         if emit_events
@@ -622,7 +654,7 @@ mod tests {
         dispatcher.register_handler("echo", Ok);
 
         let result = dispatcher
-            .dispatch("echo", json!({"msg": "hello"}))
+            .dispatch("echo", json!({"msg": "hello"}), None)
             .unwrap();
         assert_eq!(result.action, "echo");
         assert_eq!(result.output, json!({"msg": "hello"}));
@@ -641,12 +673,14 @@ mod tests {
         let dispatcher = ToolDispatcher::new(reg);
         dispatcher.register_handler("main_only", |_| Ok(json!({"ok": true})));
 
-        let err = dispatcher.dispatch("main_only", json!({})).unwrap_err();
+        let err = dispatcher
+            .dispatch("main_only", json!({}), None)
+            .unwrap_err();
         assert!(matches!(err, DispatchError::ThreadAffinityViolation { .. }));
         assert!(err.to_string().contains("THREAD_AFFINITY_VIOLATION"));
 
         let result = with_thread_affinity(ThreadAffinity::Main, || {
-            dispatcher.dispatch("main_only", json!({}))
+            dispatcher.dispatch("main_only", json!({}), None)
         })
         .unwrap();
         assert_eq!(result.output, json!({"ok": true}));
@@ -665,7 +699,7 @@ mod tests {
         });
 
         let result = dispatcher
-            .dispatch("test_action", json!({"radius": 5.0}))
+            .dispatch("test_action", json!({"radius": 5.0}), None)
             .unwrap();
         assert_eq!(result.output["radius"], json!(5.0));
         assert!(!result.validation_skipped);
@@ -696,7 +730,7 @@ mod tests {
             });
 
         let result = dispatcher
-            .dispatch("echo", json!({"msg": "hello"}))
+            .dispatch("echo", json!({"msg": "hello"}), None)
             .unwrap();
         assert_eq!(result.output, json!({"msg": "hello"}));
 
@@ -749,7 +783,9 @@ mod tests {
             })
             .unwrap();
 
-        let err = dispatcher.dispatch("delete_scene", json!({})).unwrap_err();
+        let err = dispatcher
+            .dispatch("delete_scene", json!({}), None)
+            .unwrap_err();
 
         assert!(matches!(
             err,
@@ -795,7 +831,7 @@ mod tests {
                     .push((event.name.clone(), event.attributes.clone()));
             });
 
-        let result = dispatcher.dispatch("soft_fail", json!({})).unwrap();
+        let result = dispatcher.dispatch("soft_fail", json!({}), None).unwrap();
         assert_eq!(result.output["success"], false);
 
         let events = events.lock().unwrap();
@@ -829,7 +865,9 @@ mod tests {
                     .push((event.name.clone(), event.attributes.clone()));
             });
 
-        let err = dispatcher.dispatch("test_action", json!({})).unwrap_err();
+        let err = dispatcher
+            .dispatch("test_action", json!({}), None)
+            .unwrap_err();
         assert!(matches!(err, DispatchError::ValidationFailed(_)));
 
         let events = events.lock().unwrap();
@@ -846,7 +884,7 @@ mod tests {
         dispatcher.register_handler("test_action", |_params| Ok(json!("ok")));
 
         let result = dispatcher
-            .dispatch("test_action", json!({"anything": "goes"}))
+            .dispatch("test_action", json!({"anything": "goes"}), None)
             .unwrap();
         assert!(result.validation_skipped);
     }
@@ -857,7 +895,7 @@ mod tests {
         let dispatcher = ToolDispatcher::new(reg);
         dispatcher.register_handler("orphan", |_| Ok(json!("no meta needed")));
 
-        let result = dispatcher.dispatch("orphan", json!(null)).unwrap();
+        let result = dispatcher.dispatch("orphan", json!(null), None).unwrap();
         assert!(result.validation_skipped);
     }
 
@@ -868,7 +906,7 @@ mod tests {
         let reg = ToolRegistry::new();
         let dispatcher = ToolDispatcher::new(reg);
 
-        let err = dispatcher.dispatch("missing", json!({})).unwrap_err();
+        let err = dispatcher.dispatch("missing", json!({}), None).unwrap_err();
         assert!(matches!(err, DispatchError::HandlerNotFound(_)));
         assert!(err.to_string().contains("missing"));
     }
@@ -881,7 +919,9 @@ mod tests {
         }));
         dispatcher.register_handler("test_action", |_| Ok(json!("ok")));
 
-        let err = dispatcher.dispatch("test_action", json!({})).unwrap_err();
+        let err = dispatcher
+            .dispatch("test_action", json!({}), None)
+            .unwrap_err();
         assert!(matches!(err, DispatchError::ValidationFailed(_)));
         assert!(err.to_string().contains("radius"));
     }
@@ -895,7 +935,7 @@ mod tests {
         dispatcher.register_handler("test_action", |_| Ok(json!("ok")));
 
         let err = dispatcher
-            .dispatch("test_action", json!({"x": "not_a_number"}))
+            .dispatch("test_action", json!({"x": "not_a_number"}), None)
             .unwrap_err();
         assert!(matches!(err, DispatchError::ValidationFailed(_)));
     }
@@ -906,7 +946,7 @@ mod tests {
         let dispatcher = ToolDispatcher::new(reg);
         dispatcher.register_handler("failing", |_| Err("something went wrong".into()));
 
-        let err = dispatcher.dispatch("failing", json!({})).unwrap_err();
+        let err = dispatcher.dispatch("failing", json!({}), None).unwrap_err();
         assert!(matches!(err, DispatchError::HandlerError(_)));
         assert!(err.to_string().contains("something went wrong"));
     }
@@ -962,7 +1002,7 @@ mod tests {
         dispatcher.register_handler("action", |_| Ok(json!("v1")));
         dispatcher.register_handler("action", |_| Ok(json!("v2")));
 
-        let result = dispatcher.dispatch("action", json!({})).unwrap();
+        let result = dispatcher.dispatch("action", json!({}), None).unwrap();
         assert_eq!(result.output, json!("v2"));
     }
 
@@ -1024,5 +1064,111 @@ mod tests {
     fn test_dispatch_error_is_error() {
         let err: Box<dyn std::error::Error> = Box::new(DispatchError::HandlerNotFound("x".into()));
         assert!(!err.to_string().is_empty());
+    }
+
+    // ── _meta injection tests (PIP-520) ──────────────────────────────
+
+    #[test]
+    fn meta_is_injected_after_validation() {
+        let registry = ToolRegistry::new();
+        registry.register_action(ToolMeta {
+            name: "test_tool".into(),
+            dcc: "maya".into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            }),
+            ..Default::default()
+        });
+        let dispatcher = ToolDispatcher::new(registry.clone());
+        dispatcher.register_handler("test_tool", |params| {
+            let meta = params.get("_meta");
+            assert!(
+                meta.is_some(),
+                "_meta should be injected when meta is provided"
+            );
+            assert_eq!(meta.unwrap()["allowed_key"], "value1");
+            Ok(json!({"status": "ok"}))
+        });
+        let meta = json!({"allowed_key": "value1"});
+        let result = dispatcher
+            .dispatch("test_tool", json!({"name": "test"}), Some(meta))
+            .unwrap();
+        assert_eq!(result.output["status"], "ok");
+    }
+
+    #[test]
+    fn no_meta_no_injection_backward_compatible() {
+        let registry = ToolRegistry::new();
+        registry.register_action(ToolMeta {
+            name: "test_tool".into(),
+            dcc: "maya".into(),
+            input_schema: json!({"type": "object", "properties": {"name": {"type": "string"}}}),
+            ..Default::default()
+        });
+        let dispatcher = ToolDispatcher::new(registry.clone());
+        dispatcher.register_handler("test_tool", |params| {
+            assert!(
+                params.get("_meta").is_none(),
+                "_meta should NOT be present when meta is None"
+            );
+            Ok(json!({"status": "ok"}))
+        });
+        let result = dispatcher
+            .dispatch("test_tool", json!({"name": "test"}), None)
+            .unwrap();
+        assert_eq!(result.output["status"], "ok");
+    }
+
+    #[test]
+    fn additional_properties_false_still_works_with_meta() {
+        let registry = ToolRegistry::new();
+        registry.register_action(ToolMeta {
+            name: "strict_tool".into(),
+            dcc: "maya".into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {"radius": {"type": "number"}},
+                "required": ["radius"],
+                "additionalProperties": false,
+            }),
+            ..Default::default()
+        });
+        let dispatcher = ToolDispatcher::new(registry.clone());
+        dispatcher.register_handler("strict_tool", |params| {
+            // Handler receives _meta injected AFTER validation
+            assert!(params.get("_meta").is_some());
+            // The declared property still works
+            assert_eq!(params["radius"], 2.0);
+            Ok(json!({"created": true}))
+        });
+        let meta = json!({"agent_context": {"session_id": "123"}});
+        // This should pass validation (no _meta during validation), then handler gets _meta
+        let result = dispatcher
+            .dispatch("strict_tool", json!({"radius": 2.0}), Some(meta))
+            .unwrap();
+        assert_eq!(result.output["created"], true);
+    }
+
+    #[test]
+    fn meta_is_not_injected_when_params_is_not_object() {
+        let registry = ToolRegistry::new();
+        registry.register_action(ToolMeta {
+            name: "array_tool".into(),
+            dcc: "maya".into(),
+            input_schema: json!({"type": "array", "items": {"type": "number"}}),
+            ..Default::default()
+        });
+        let dispatcher = ToolDispatcher::new(registry.clone());
+        dispatcher.register_handler("array_tool", |params| {
+            // params is an array, not an object, so _meta is not injected
+            assert!(params.as_array().is_some());
+            Ok(json!({"handled": true}))
+        });
+        let meta = json!({"agent_context": {"session_id": "123"}});
+        let result = dispatcher
+            .dispatch("array_tool", json!([1, 2, 3]), Some(meta))
+            .unwrap();
+        assert_eq!(result.output["handled"], true);
     }
 }

--- a/crates/dcc-mcp-actions/src/pipeline/mod.rs
+++ b/crates/dcc-mcp-actions/src/pipeline/mod.rs
@@ -191,6 +191,16 @@ impl ToolPipeline {
         action_name: &str,
         params: Value,
     ) -> Result<DispatchResult, DispatchError> {
+        self.dispatch_with_meta(action_name, params, None)
+    }
+
+    /// Like [`dispatch`] but also passes request-level `meta` to the handler.
+    pub fn dispatch_with_meta(
+        &self,
+        action_name: &str,
+        params: Value,
+        meta: Option<Value>,
+    ) -> Result<DispatchResult, DispatchError> {
         let mut ctx = MiddlewareContext::new(action_name, params.clone());
 
         // Run before_dispatch in registration order
@@ -200,7 +210,7 @@ impl ToolPipeline {
 
         // Use (possibly mutated) params from context
         let dispatch_params = ctx.params.clone();
-        let result = self.dispatcher.dispatch(action_name, dispatch_params);
+        let result = self.dispatcher.dispatch(action_name, dispatch_params, meta);
 
         // Run after_dispatch in reverse order
         for middleware in self.middlewares.iter().rev() {

--- a/crates/dcc-mcp-actions/src/pipeline/python/pipeline.rs
+++ b/crates/dcc-mcp-actions/src/pipeline/python/pipeline.rs
@@ -218,15 +218,24 @@ impl PyToolPipeline {
     ///     KeyError:     No handler registered for ``action_name``.
     ///     ValueError:   Invalid JSON or schema validation failure.
     ///     RuntimeError: Handler error or rate-limit exceeded.
-    #[pyo3(signature = (action_name, params_json = "null"))]
+    #[pyo3(signature = (action_name, params_json = "null", meta_json = "null"))]
     pub fn dispatch<'py>(
         &self,
         py: Python<'py>,
         action_name: &str,
         params_json: &str,
+        meta_json: &str,
     ) -> PyResult<Bound<'py, PyDict>> {
-        let params: Value = serde_json::from_str(params_json)
+        let mut params: Value = serde_json::from_str(params_json)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("invalid JSON: {e}")))?;
+        // Parse optional meta (request-level context like agent_context)
+        let meta: Option<Value> = if meta_json == "null" {
+            None
+        } else {
+            Some(serde_json::from_str(meta_json).map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!("invalid meta JSON: {e}"))
+            })?)
+        };
 
         // Run Python callable before_fn hooks
         for hook in &self.callable_hooks {
@@ -237,7 +246,7 @@ impl PyToolPipeline {
             }
         }
 
-        // Run through Rust middleware pipeline (stubs return null)
+        // Run through Rust middleware pipeline (stubs return null, validates without _meta)
         let result = self.inner.dispatch(action_name, params.clone());
 
         // Determine success for Python after_fn hooks
@@ -252,6 +261,12 @@ impl PyToolPipeline {
 
         match result {
             Ok(dispatch_result) => {
+                // Inject _meta into params AFTER validation (safe for additionalProperties: false).
+                if let Some(m) = meta {
+                    if let Value::Object(ref mut map) = params {
+                        map.insert("_meta".to_string(), m);
+                    }
+                }
                 // Call the real Python handler
                 let handler = self.handler_map.get(action_name).ok_or_else(|| {
                     pyo3::exceptions::PyKeyError::new_err(format!("no handler for '{action_name}'"))

--- a/crates/dcc-mcp-actions/src/python/mod.rs
+++ b/crates/dcc-mcp-actions/src/python/mod.rs
@@ -315,17 +315,26 @@ impl PyToolDispatcher {
     ///     KeyError:     No handler registered for ``action_name``.
     ///     ValueError:   Invalid JSON or validation failure.
     ///     RuntimeError: Handler raised an exception.
-    #[pyo3(signature = (action_name, params_json = "null"))]
+    #[pyo3(signature = (action_name, params_json = "null", meta_json = "null"))]
     pub fn dispatch<'py>(
         &self,
         py: Python<'py>,
         action_name: &str,
         params_json: &str,
+        meta_json: &str,
     ) -> PyResult<Bound<'py, PyDict>> {
         let started = Instant::now();
         // 1. Parse params
-        let params: Value = serde_json::from_str(params_json)
+        let mut params: Value = serde_json::from_str(params_json)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("invalid JSON: {e}")))?;
+        // 1b. Parse optional meta (request-level context like agent_context)
+        let meta: Option<Value> = if meta_json == "null" {
+            None
+        } else {
+            Some(serde_json::from_str(meta_json).map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!("invalid meta JSON: {e}"))
+            })?)
+        };
 
         // 2. Validate via Rust dispatcher (the stub handler is registered there too)
         let validation_skipped = if !self.handler_map.contains_key(action_name) {
@@ -380,6 +389,13 @@ impl PyToolDispatcher {
                 }
             }
         };
+
+        // 2b. Inject _meta into params AFTER validation (safe for additionalProperties: false).
+        if let Some(m) = meta {
+            if let Value::Object(ref mut map) = params {
+                map.insert("_meta".to_string(), m);
+            }
+        }
 
         // 3. Call the Python handler
         if let Err(veto) = self.emit_vetoable_tool_event(

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -36,6 +36,7 @@ use super::capability::{
     CapabilityIndex, CapabilityRecord, RANKER_VERSION, RefreshReason, SearchHit, SearchQuery,
     parse_slug, refresh_instance, remove_instance, search,
 };
+use super::request_meta::meta_with_agent_context;
 use super::state::GatewayState;
 use dcc_mcp_gateway_core::naming::instance_short;
 
@@ -533,27 +534,6 @@ pub async fn call_service(
             )
             .with_backend(backend_attachment))
         }
-    }
-}
-
-fn meta_with_agent_context(
-    meta: Option<Value>,
-    agent_context: Option<&AgentContext>,
-) -> Option<Value> {
-    let Some(agent_context) = agent_context else {
-        return meta;
-    };
-    let agent_context = serde_json::to_value(agent_context).ok()?;
-    match meta {
-        Some(Value::Object(mut map)) => {
-            map.insert("agent_context".to_string(), agent_context);
-            Some(Value::Object(map))
-        }
-        Some(other) => Some(json!({
-            "agent_context": agent_context,
-            "upstream_meta": other,
-        })),
-        None => Some(json!({ "agent_context": agent_context })),
     }
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -51,6 +51,7 @@ pub mod native_resources;
 pub mod openapi;
 pub mod proxy;
 pub mod relay_registration;
+pub(crate) mod request_meta;
 pub mod resilience;
 pub(crate) mod response_codec;
 pub(crate) mod rest_openapi;

--- a/crates/dcc-mcp-gateway/src/gateway/request_meta.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/request_meta.rs
@@ -1,0 +1,138 @@
+use serde_json::{Value, json};
+
+use super::admin::trace::AgentContext;
+
+/// Allowed top-level keys in client-supplied `_meta` that may be passed
+/// through to adapter tool params. `agent_context` is always server-derived
+/// and is appended separately.
+const DEFAULT_META_ALLOWLIST: &[&str] = &[
+    "credential_profile",
+    "permission_hint",
+    "project_scope",
+    "search_id",
+];
+
+/// Filter a client-supplied `_meta` object to only contain allowlisted keys.
+/// Prevents inline secrets or arbitrary client data from piggybacking on the
+/// meta passthrough channel.
+fn bounded_meta(meta: Value) -> Value {
+    match meta {
+        Value::Object(map) => {
+            let filtered: serde_json::Map<String, Value> = map
+                .into_iter()
+                .filter(|(k, _)| DEFAULT_META_ALLOWLIST.contains(&k.as_str()))
+                .collect();
+            Value::Object(filtered)
+        }
+        _ => Value::Object(serde_json::Map::new()),
+    }
+}
+
+pub(crate) fn meta_with_agent_context(
+    meta: Option<Value>,
+    agent_context: Option<&AgentContext>,
+) -> Option<Value> {
+    let Some(agent_context) = agent_context else {
+        return meta.map(bounded_meta);
+    };
+    let agent_context_value = serde_json::to_value(agent_context).ok()?;
+    match meta {
+        Some(m) => {
+            let mut filtered = bounded_meta(m);
+            if let Value::Object(ref mut map) = filtered {
+                map.insert("agent_context".to_string(), agent_context_value);
+            }
+            Some(filtered)
+        }
+        None => Some(json!({ "agent_context": agent_context_value })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn bounded_meta_strips_unknown_fields() {
+        let filtered = bounded_meta(json!({
+            "credential_profile": "prod",
+            "permission_hint": "read-only",
+            "project_scope": "movie-42",
+            "secret_token": "should-be-stripped",
+            "inline_secret": "also-stripped",
+        }));
+        let obj = filtered.as_object().unwrap();
+        assert!(obj.contains_key("credential_profile"));
+        assert!(obj.contains_key("permission_hint"));
+        assert!(obj.contains_key("project_scope"));
+        assert!(!obj.contains_key("secret_token"));
+        assert!(!obj.contains_key("inline_secret"));
+    }
+
+    #[test]
+    fn bounded_meta_preserves_search_id() {
+        let filtered = bounded_meta(json!({"search_id": "abc-123", "evil": "no"}));
+        let obj = filtered.as_object().unwrap();
+        assert_eq!(obj["search_id"], "abc-123");
+        assert!(!obj.contains_key("evil"));
+    }
+
+    #[test]
+    fn bounded_meta_drops_non_object_meta() {
+        let filtered = bounded_meta(json!(["not", "an", "object"]));
+        let obj = filtered.as_object().unwrap();
+        assert!(obj.is_empty());
+    }
+
+    #[test]
+    fn meta_with_agent_context_client_agent_context_is_replaced_by_server() {
+        let agent_ctx = AgentContext {
+            actor_id: Some("server-artist".to_string()),
+            session_id: Some("s1".into()),
+            ..AgentContext::default()
+        };
+        let merged = meta_with_agent_context(
+            Some(json!({
+                "agent_context": {"actor_id": "fake-client"},
+                "credential_profile": "prod",
+            })),
+            Some(&agent_ctx),
+        )
+        .expect("merged meta");
+
+        assert_eq!(merged["agent_context"]["actor_id"], "server-artist");
+        assert_eq!(merged["agent_context"]["session_id"], "s1");
+        assert_eq!(merged["credential_profile"], "prod");
+    }
+
+    #[test]
+    fn meta_with_agent_context_no_meta_is_backward_compatible() {
+        assert!(meta_with_agent_context(None, None).is_none());
+    }
+
+    #[test]
+    fn meta_with_agent_context_only_agent_context_no_client_meta() {
+        let agent_ctx = AgentContext {
+            actor_id: Some("a1".to_string()),
+            ..AgentContext::default()
+        };
+        let merged = meta_with_agent_context(None, Some(&agent_ctx)).expect("merged");
+        assert_eq!(merged["agent_context"]["actor_id"], "a1");
+        assert!(merged.get("credential_profile").is_none());
+    }
+
+    #[test]
+    fn meta_with_agent_context_drops_non_object_client_meta() {
+        let agent_ctx = AgentContext {
+            actor_id: Some("server-artist".to_string()),
+            ..AgentContext::default()
+        };
+        let merged = meta_with_agent_context(Some(json!("inline-secret")), Some(&agent_ctx))
+            .expect("merged");
+
+        assert_eq!(merged["agent_context"]["actor_id"], "server-artist");
+        assert!(merged.get("upstream_meta").is_none());
+    }
+}

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
@@ -119,7 +119,7 @@ async fn run_async_execution_lane(
             cancel_token.clone(),
             Box::new(move || {
                 match dcc_mcp_actions::with_thread_affinity(ThreadAffinity::Main, || {
-                    dispatch.dispatch(&dispatch_name, dispatch_params)
+                    dispatch.dispatch(&dispatch_name, dispatch_params, None)
                 }) {
                     Ok(result) => encode_dispatch_wire(Ok(result)),
                     Err(err) => encode_dispatch_wire(Err(err)),
@@ -145,10 +145,10 @@ async fn run_async_execution_lane(
             }
             let result = if standalone_main {
                 dcc_mcp_actions::with_thread_affinity(ThreadAffinity::Main, || {
-                    dispatch.dispatch(&dispatch_name, dispatch_params)
+                    dispatch.dispatch(&dispatch_name, dispatch_params, None)
                 })
             } else {
-                dispatch.dispatch(&dispatch_name, dispatch_params)
+                dispatch.dispatch(&dispatch_name, dispatch_params, None)
             };
             result
                 .map(|result| result.output)

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/mod.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/mod.rs
@@ -5,7 +5,7 @@ mod helpers;
 mod thread_route;
 mod wire;
 
-pub use thread_route::dispatch_action_with_thread_routing;
+pub use thread_route::{ThreadRoutingDispatch, dispatch_action_with_thread_routing};
 pub(crate) use wire::{decode_dispatch_output, encode_dispatch_wire, use_main_thread_route};
 
 use serde_json::Value;
@@ -231,6 +231,7 @@ async fn dispatch_registry_tool(
         state,
         &resolved_name,
         call_params.clone(),
+        None,
         action_meta.thread_affinity,
         action_meta.enforce_thread_affinity,
     )

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
@@ -13,11 +13,23 @@ use crate::server_state::ServerState;
 
 use super::wire::{decode_dispatch_wire, encode_dispatch_wire, use_main_thread_route};
 
+pub struct ThreadRoutingDispatch<'a> {
+    pub dispatcher: dcc_mcp_actions::ToolDispatcher,
+    pub executor: Option<&'a DccExecutorHandle>,
+    pub resolved_name: &'a str,
+    pub call_params: Value,
+    pub meta: Option<Value>,
+    pub thread_affinity: ThreadAffinity,
+    pub enforce_thread_affinity: bool,
+    pub standalone_main_thread_execution: bool,
+}
+
 async fn run_on_main_thread(
     executor: &DccExecutorHandle,
     dispatcher: dcc_mcp_actions::ToolDispatcher,
     resolved_name: String,
     call_params: Value,
+    meta: Option<Value>,
     exec_ctx: DispatchExecutionContext,
 ) -> Result<DispatchResult, DispatchError> {
     let json_str = executor
@@ -25,7 +37,7 @@ async fn run_on_main_thread(
             with_execution_context(exec_ctx, || {
                 encode_dispatch_wire(dcc_mcp_actions::with_thread_affinity(
                     ThreadAffinity::Main,
-                    || dispatcher.dispatch(&resolved_name, call_params),
+                    || dispatcher.dispatch(&resolved_name, call_params, meta),
                 ))
             })
         }))
@@ -38,6 +50,7 @@ async fn run_on_worker(
     dispatcher: dcc_mcp_actions::ToolDispatcher,
     resolved_name: String,
     call_params: Value,
+    meta: Option<Value>,
     exec_ctx: DispatchExecutionContext,
     standalone_main_thread_execution: bool,
     thread_affinity: ThreadAffinity,
@@ -46,10 +59,10 @@ async fn run_on_worker(
         with_execution_context(exec_ctx, || {
             if standalone_main_thread_execution && matches!(thread_affinity, ThreadAffinity::Main) {
                 dcc_mcp_actions::with_thread_affinity(ThreadAffinity::Main, || {
-                    dispatcher.dispatch(&resolved_name, call_params)
+                    dispatcher.dispatch(&resolved_name, call_params, meta)
                 })
             } else {
-                dispatcher.dispatch(&resolved_name, call_params)
+                dispatcher.dispatch(&resolved_name, call_params, meta)
             }
         })
     });
@@ -73,14 +86,18 @@ async fn run_on_worker(
 /// Route a tool dispatch through the same main-thread executor path as MCP
 /// `tools/call`. Used by REST `POST /v1/call` via [`crate::ThreadRoutedInvoker`].
 pub async fn dispatch_action_with_thread_routing(
-    dispatcher: dcc_mcp_actions::ToolDispatcher,
-    executor: Option<&DccExecutorHandle>,
-    resolved_name: &str,
-    call_params: Value,
-    thread_affinity: ThreadAffinity,
-    enforce_thread_affinity: bool,
-    standalone_main_thread_execution: bool,
+    request: ThreadRoutingDispatch<'_>,
 ) -> Result<DispatchResult, DispatchError> {
+    let ThreadRoutingDispatch {
+        dispatcher,
+        executor,
+        resolved_name,
+        call_params,
+        meta,
+        thread_affinity,
+        enforce_thread_affinity,
+        standalone_main_thread_execution,
+    } = request;
     let executor_present = executor.is_some();
     let standalone_main =
         standalone_main_thread_execution && matches!(thread_affinity, ThreadAffinity::Main);
@@ -110,6 +127,7 @@ pub async fn dispatch_action_with_thread_routing(
             dispatcher,
             resolved_name.to_string(),
             call_params,
+            meta,
             exec_ctx,
         )
         .await
@@ -118,6 +136,7 @@ pub async fn dispatch_action_with_thread_routing(
             dispatcher,
             resolved_name.to_string(),
             call_params,
+            meta,
             exec_ctx,
             standalone_main,
             thread_affinity,
@@ -130,18 +149,20 @@ pub(super) async fn execute_threaded_dispatch(
     state: &ServerState,
     resolved_name: &str,
     call_params: Value,
+    meta: Option<Value>,
     thread_affinity: ThreadAffinity,
     enforce_thread_affinity: bool,
 ) -> Result<Value, String> {
-    dispatch_action_with_thread_routing(
-        state.dispatcher.as_ref().clone(),
-        state.executor.as_ref(),
+    dispatch_action_with_thread_routing(ThreadRoutingDispatch {
+        dispatcher: state.dispatcher.as_ref().clone(),
+        executor: state.executor.as_ref(),
         resolved_name,
         call_params,
+        meta,
         thread_affinity,
         enforce_thread_affinity,
-        state.standalone_main_thread_execution,
-    )
+        standalone_main_thread_execution: state.standalone_main_thread_execution,
+    })
     .await
     .map(|r| r.output)
     .map_err(|e| e.to_string())

--- a/crates/dcc-mcp-http-server/src/thread_routed_invoker.rs
+++ b/crates/dcc-mcp-http-server/src/thread_routed_invoker.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 use tokio::runtime::Handle;
 
 use crate::executor::DccExecutorHandle;
-use crate::rmcp_tool_call_dispatch::dispatch_action_with_thread_routing;
+use crate::rmcp_tool_call_dispatch::{ThreadRoutingDispatch, dispatch_action_with_thread_routing};
 
 /// Invoke backend actions with main-thread routing when a host executor is wired.
 pub struct ThreadRoutedInvoker {
@@ -47,8 +47,13 @@ impl ThreadRoutedInvoker {
 }
 
 impl ToolInvoker for ThreadRoutedInvoker {
-    fn invoke(&self, action_name: &str, params: Value) -> Result<CallOutcome, ServiceError> {
-        let meta = self
+    fn invoke(
+        &self,
+        action_name: &str,
+        params: Value,
+        meta: Option<Value>,
+    ) -> Result<CallOutcome, ServiceError> {
+        let action_meta = self
             .dispatcher
             .registry()
             .get_action(action_name, None)
@@ -62,8 +67,8 @@ impl ToolInvoker for ThreadRoutedInvoker {
         let dispatcher = Arc::clone(&self.dispatcher);
         let executor = self.executor.clone();
         let action = action_name.to_string();
-        let affinity = meta.thread_affinity;
-        let enforce = meta.enforce_thread_affinity;
+        let affinity = action_meta.thread_affinity;
+        let enforce = action_meta.enforce_thread_affinity;
 
         // `SkillRestService::call` is synchronous on the dedicated HTTP
         // thread's `current_thread` runtime — `Handle::block_on` there
@@ -79,13 +84,16 @@ impl ToolInvoker for ThreadRoutedInvoker {
                     },
                     || {
                         bridge_runtime.block_on(dispatch_action_with_thread_routing(
-                            dispatcher.as_ref().clone(),
-                            Some(&executor),
-                            &action,
-                            params,
-                            affinity,
-                            enforce,
-                            false,
+                            ThreadRoutingDispatch {
+                                dispatcher: dispatcher.as_ref().clone(),
+                                executor: Some(&executor),
+                                resolved_name: &action,
+                                call_params: params,
+                                meta,
+                                thread_affinity: affinity,
+                                enforce_thread_affinity: enforce,
+                                standalone_main_thread_execution: false,
+                            },
                         ))
                     },
                 )
@@ -159,7 +167,7 @@ mod tests {
         // runtime; it calls `invoke` which `block_on`s the bridge runtime.
         let outcome = std::thread::spawn(move || {
             invoker
-                .invoke("thread_probe", json!({}))
+                .invoke("thread_probe", json!({}), None)
                 .expect("main-thread REST invoke")
         })
         .join()

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -240,6 +240,23 @@ pub struct DescribeResponse {
 }
 
 /// Payload for `POST /v1/call`.
+///
+/// The `meta` field carries request-level context forwarded by the Gateway
+/// from the MCP `_meta` block.  It is injected as `params["_meta"]` before
+/// the tool handler runs (after schema validation, so `additionalProperties:
+/// false` tools are safe).
+///
+/// ## `meta` keys (bounded passthrough)
+///
+/// | Key | Source | Purpose |
+/// |-----|--------|---------|
+/// | `agent_context` | Server-derived | Caller identity (actor, agent, session) |
+/// | `credential_profile` | Client | Environment tier (`"prod"`/`"staging"`/`"dev"`) |
+/// | `permission_hint` | Client | `"read-only"` or `"read-write"` |
+/// | `project_scope` | Client | Project identifier for data isolation |
+/// | `search_id` | Client/Gateway | Telemetry correlation id |
+///
+/// See `docs/guide/agents-reference.md#request-level-context-passthrough-_meta----pip-520`.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CallRequest {
     pub tool_slug: ToolSlug,
@@ -249,6 +266,12 @@ pub struct CallRequest {
     #[serde(default, alias = "arguments")]
     #[schema(value_type = Object)]
     pub params: Value,
+    /// Optional request-level metadata forwarded from the gateway/client.
+    /// Contains allowlisted fields such as `agent_context`,
+    /// `credential_profile`, `permission_hint`, `project_scope`.
+    #[serde(default)]
+    #[schema(value_type = Object)]
+    pub meta: Option<Value>,
 }
 
 /// Successful invocation outcome.
@@ -332,7 +355,12 @@ pub struct CatalogAction {
 /// synchronously. Embedders that marshal to a host main thread swap
 /// in their own impl here (e.g. Maya's `DccExecutorHandle`).
 pub trait ToolInvoker: Send + Sync {
-    fn invoke(&self, action_name: &str, params: Value) -> Result<CallOutcome, ServiceError>;
+    fn invoke(
+        &self,
+        action_name: &str,
+        params: Value,
+        meta: Option<Value>,
+    ) -> Result<CallOutcome, ServiceError>;
 }
 
 // ── Resource & prompt providers (#818 phase 1) ───────────────────────
@@ -815,7 +843,12 @@ fn is_host_busy_dispatch_error(message: &str) -> bool {
 }
 
 impl ToolInvoker for DispatcherInvoker {
-    fn invoke(&self, action_name: &str, params: Value) -> Result<CallOutcome, ServiceError> {
+    fn invoke(
+        &self,
+        action_name: &str,
+        params: Value,
+        meta: Option<Value>,
+    ) -> Result<CallOutcome, ServiceError> {
         // Default REST path has no host main-thread bridge — publish that so
         // affinity diagnostics can surface host_dispatcher_attached=false (#1075).
         let exec_ctx = DispatchExecutionContext {
@@ -830,10 +863,10 @@ impl ToolInvoker for DispatcherInvoker {
         with_execution_context(exec_ctx, || {
             let dispatched = if standalone_main {
                 with_thread_affinity(ThreadAffinity::Main, || {
-                    self.dispatcher.dispatch(action_name, params)
+                    self.dispatcher.dispatch(action_name, params, meta.clone())
                 })
             } else {
-                self.dispatcher.dispatch(action_name, params)
+                self.dispatcher.dispatch(action_name, params, meta.clone())
             };
             match dispatched {
                 Ok(r) => Ok(CallOutcome {
@@ -1102,9 +1135,9 @@ impl SkillRestService {
             .with_hint("call load_skill first"));
         }
         // Dispatcher registers under the action name, not the slug.
-        let mut outcome = self
-            .invoker
-            .invoke(&action.action_name, req.params.clone())?;
+        let mut outcome =
+            self.invoker
+                .invoke(&action.action_name, req.params.clone(), req.meta.clone())?;
         // Normalise the outcome to report the slug the caller used.
         outcome.slug = req.tool_slug.clone();
         Ok(outcome)
@@ -1141,7 +1174,7 @@ impl SkillRestService {
             )
             .with_hint("call load_skill first"));
         }
-        let mut outcome = self.invoker.invoke(&action.action_name, params)?;
+        let mut outcome = self.invoker.invoke(&action.action_name, params, None)?;
         outcome.slug = ToolSlug::build(&action.dcc, &action.skill_name, &action.action_name);
         Ok(outcome)
     }

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -62,7 +62,7 @@ impl SkillCatalogSource for FakeCatalog {
 
 #[derive(Default)]
 struct FakeInvoker {
-    calls: Mutex<Vec<(String, Value)>>,
+    calls: Mutex<Vec<(String, Value, Option<Value>)>>,
     next: Mutex<Option<Result<Value, ServiceError>>>,
 }
 
@@ -73,11 +73,16 @@ impl FakeInvoker {
 }
 
 impl ToolInvoker for FakeInvoker {
-    fn invoke(&self, name: &str, params: Value) -> Result<CallOutcome, ServiceError> {
+    fn invoke(
+        &self,
+        name: &str,
+        params: Value,
+        meta: Option<Value>,
+    ) -> Result<CallOutcome, ServiceError> {
         self.calls
             .lock()
             .unwrap()
-            .push((name.to_owned(), params.clone()));
+            .push((name.to_owned(), params.clone(), meta));
         let r = self.next.lock().unwrap().take().unwrap_or(Ok(Value::Null));
         r.map(|v| CallOutcome {
             slug: ToolSlug(name.to_owned()),
@@ -537,6 +542,7 @@ fn call_rejects_unloaded_skill() {
         .call(&CallRequest {
             tool_slug: ToolSlug::build("maya", "spheres", "create_sphere"),
             params: Value::Null,
+            meta: None,
         })
         .unwrap_err();
     assert_eq!(err.kind, ServiceErrorKind::SkillNotLoaded);
@@ -576,6 +582,7 @@ fn call_dispatches_and_normalises_slug() {
         .call(&CallRequest {
             tool_slug: ToolSlug::build("maya", "spheres", "create_sphere"),
             params: serde_json::json!({"radius": 1.5}),
+            meta: None,
         })
         .unwrap();
     assert_eq!(out.slug.0, "maya.spheres.create_sphere");
@@ -593,6 +600,7 @@ fn invalid_slug_format_is_bad_request() {
         .call(&CallRequest {
             tool_slug: ToolSlug("not-a-slug".into()),
             params: Value::Null,
+            meta: None,
         })
         .unwrap_err();
     assert_eq!(err.kind, ServiceErrorKind::BadRequest);

--- a/crates/dcc-mcp-skill-rest/src/tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/tests.rs
@@ -158,6 +158,7 @@ async fn mcp_wrapper_and_rest_agree_on_call_output() {
         .call(&super::service::CallRequest {
             tool_slug: super::service::ToolSlug("maya.spheres.create_sphere".into()),
             params: json!({"radius": 3.0}),
+            meta: None,
         })
         .expect("mcp call ok");
 
@@ -1136,4 +1137,521 @@ async fn call_thread_affinity_violation_includes_context() {
     assert_eq!(ctx["observed_affinity"], "any");
     assert_eq!(ctx["host_dispatcher_attached"], false);
     assert_eq!(ctx["observed_context"], "worker_no_dispatcher");
+}
+
+// ── PIP-520: _meta passthrough business scenario tests ──────────────
+
+/// Fixture that registers tools which consume `_meta` from their params.
+/// Models realistic adapter skills that need request-level context.
+fn fixture_meta_aware_tools() -> (SkillRestService, Arc<ToolRegistry>, Arc<ToolDispatcher>) {
+    let registry = Arc::new(ToolRegistry::new());
+
+    // Tool 1: credential_profile — selects credentials based on profile
+    let cred_schema = json!({
+        "type": "object",
+        "properties": {"service": {"type": "string"}},
+        "required": ["service"]
+    });
+    registry.register_action(ToolMeta {
+        name: "credential_resolver".into(),
+        dcc: "maya".into(),
+        description: "Resolves credentials via _meta.credential_profile".into(),
+        input_schema: cred_schema,
+        skill_name: Some("auth".into()),
+        enabled: true,
+        ..Default::default()
+    });
+
+    // Tool 2: permission_hint — enforces read-only mode
+    let perm_schema = json!({
+        "type": "object",
+        "properties": {"action": {"type": "string"}},
+        "required": ["action"]
+    });
+    registry.register_action(ToolMeta {
+        name: "permission_gate".into(),
+        dcc: "maya".into(),
+        description: "Enforces read-only via _meta.permission_hint".into(),
+        input_schema: perm_schema,
+        skill_name: Some("auth".into()),
+        enabled: true,
+        ..Default::default()
+    });
+
+    // Tool 3: project_scope — filters data by project
+    let scope_schema = json!({
+        "type": "object",
+        "properties": {"asset_name": {"type": "string"}},
+        "required": ["asset_name"]
+    });
+    registry.register_action(ToolMeta {
+        name: "asset_lookup".into(),
+        dcc: "maya".into(),
+        description: "Filters assets by _meta.project_scope".into(),
+        input_schema: scope_schema,
+        skill_name: Some("pipeline".into()),
+        enabled: true,
+        ..Default::default()
+    });
+
+    // Tool 4: agent_context — identifies the calling agent/actor
+    let agent_schema = json!({
+        "type": "object",
+        "properties": {"message": {"type": "string"}},
+        "required": ["message"]
+    });
+    registry.register_action(ToolMeta {
+        name: "agent_greeter".into(),
+        dcc: "maya".into(),
+        description: "Reads _meta.agent_context for caller identity".into(),
+        input_schema: agent_schema,
+        skill_name: Some("telemetry".into()),
+        enabled: true,
+        ..Default::default()
+    });
+
+    // Tool 5: additionalProperties: false — strict schema, must still work
+    let strict_schema = json!({
+        "type": "object",
+        "properties": {"value": {"type": "number"}},
+        "required": ["value"],
+        "additionalProperties": false
+    });
+    registry.register_action(ToolMeta {
+        name: "strict_tool".into(),
+        dcc: "maya".into(),
+        description: "Strict additionalProperties:false schema".into(),
+        input_schema: strict_schema,
+        skill_name: Some("pipeline".into()),
+        enabled: true,
+        ..Default::default()
+    });
+
+    let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+
+    // Handler 1: reads credential_profile from _meta
+    dispatcher.register_handler("credential_resolver", |params: Value| {
+        let profile = params
+            .pointer("/_meta/credential_profile")
+            .and_then(Value::as_str)
+            .unwrap_or("default");
+        let creds = match profile {
+            "prod" => json!({"endpoint": "https://prod.api.example.com", "token": "prod-token"}),
+            "staging" => {
+                json!({"endpoint": "https://staging.api.example.com", "token": "staging-token"})
+            }
+            _ => json!({"endpoint": "https://dev.api.example.com", "token": "dev-token"}),
+        };
+        Ok(json!({
+            "resolved": true,
+            "profile": profile,
+            "credentials": creds,
+            "service": params["service"]
+        }))
+    });
+
+    // Handler 2: enforces read-only via permission_hint
+    dispatcher.register_handler("permission_gate", |params: Value| {
+        let hint = params
+            .pointer("/_meta/permission_hint")
+            .and_then(Value::as_str)
+            .unwrap_or("read-write");
+        let action = params["action"].as_str().unwrap_or("");
+        if hint == "read-only" && action == "delete" {
+            return Ok(json!({
+                "allowed": false,
+                "reason": format!("action '{}' denied: permission_hint is '{}'", action, hint),
+                "hint": hint,
+            }));
+        }
+        Ok(json!({
+            "allowed": true,
+            "action": action,
+            "hint": hint,
+        }))
+    });
+
+    // Handler 3: filters by project_scope from _meta
+    dispatcher.register_handler("asset_lookup", |params: Value| {
+        let scope = params
+            .pointer("/_meta/project_scope")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let asset_name = params["asset_name"].as_str().unwrap_or("");
+        // Simulated asset database — only returns assets in scope
+        let all_assets = vec![
+            json!({"name": "hero_model", "project": "movie-42", "path": "/scenes/movie42/hero.ma"}),
+            json!({"name": "prop_chair", "project": "movie-99", "path": "/scenes/movie99/chair.ma"}),
+            json!({"name": "env_forest", "project": "movie-42", "path": "/scenes/movie42/forest.ma"}),
+        ];
+        let filtered: Vec<_> = if scope.is_empty() {
+            all_assets.clone()
+        } else {
+            all_assets
+                .into_iter()
+                .filter(|a| a["project"] == scope)
+                .collect()
+        };
+        Ok(json!({
+            "scope": scope,
+            "query": asset_name,
+            "results": filtered.len(),
+            "assets": filtered,
+        }))
+    });
+
+    // Handler 4: reads agent_context from _meta for caller identity
+    dispatcher.register_handler("agent_greeter", |params: Value| {
+        let meta = params.get("_meta");
+        let agent_ctx = meta.and_then(|m| m.get("agent_context"));
+        let actor_id = agent_ctx
+            .and_then(|ac| ac.get("actor_id"))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let agent_name = agent_ctx
+            .and_then(|ac| ac.get("agent_name"))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown-agent");
+        let session_id = agent_ctx
+            .and_then(|ac| ac.get("session_id"))
+            .and_then(Value::as_str)
+            .unwrap_or("no-session");
+        Ok(json!({
+            "greeting": format!("Hello {}! I see you're using {}. Session: {}", actor_id, agent_name, session_id),
+            "message": params["message"],
+            "actor_id": actor_id,
+            "agent_name": agent_name,
+            "session_id": session_id,
+        }))
+    });
+
+    // Handler 5: strict schema, just echoes — validates additionalProperties:false still works
+    dispatcher.register_handler("strict_tool", |params: Value| {
+        Ok(json!({
+            "echoed_value": params["value"],
+            "has_meta": params.get("_meta").is_some(),
+        }))
+    });
+
+    let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+        registry.clone(),
+        dispatcher.clone(),
+    ));
+
+    for (skill_name, dcc, desc, tags) in [
+        (
+            "auth",
+            "maya",
+            "Authentication & authorization",
+            vec!["security"],
+        ),
+        ("pipeline", "maya", "Pipeline utilities", vec!["pipeline"]),
+        (
+            "telemetry",
+            "maya",
+            "Telemetry & observability",
+            vec!["observability"],
+        ),
+    ] {
+        let meta = SkillMetadata {
+            name: skill_name.into(),
+            dcc: dcc.into(),
+            description: desc.into(),
+            tags: tags.into_iter().map(String::from).collect(),
+            ..Default::default()
+        };
+        catalog.add_skill(meta);
+        let _ = catalog.load_skill(skill_name);
+    }
+
+    let service = SkillRestService::from_catalog_and_dispatcher(catalog, dispatcher.clone());
+    (service, registry, dispatcher)
+}
+
+// ── Scenario 1: credential_profile resolution ────────────────
+
+#[tokio::test]
+async fn meta_credential_profile_selects_prod_credentials() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+    let (server, _) = build_server(svc);
+
+    let resp = server
+        .post("/v1/call")
+        .json(&json!({
+            "tool_slug": "maya.auth.credential_resolver",
+            "params": {"service": "fpt"},
+            "meta": {
+                "credential_profile": "prod",
+                "agent_context": {"actor_id": "artist-1"}
+            }
+        }))
+        .await;
+    resp.assert_status_ok();
+    let out: Value = resp.json();
+    assert_eq!(out["output"]["profile"], "prod");
+    assert_eq!(out["output"]["resolved"], true);
+    assert_eq!(
+        out["output"]["credentials"]["endpoint"],
+        "https://prod.api.example.com"
+    );
+    assert_eq!(out["output"]["credentials"]["token"], "prod-token");
+    assert_eq!(out["output"]["service"], "fpt");
+}
+
+#[tokio::test]
+async fn meta_credential_profile_defaults_when_absent() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+    let (server, _) = build_server(svc);
+
+    // No meta at all — handler should fall back to "default"
+    let resp = server
+        .post("/v1/call")
+        .json(&json!({
+            "tool_slug": "maya.auth.credential_resolver",
+            "params": {"service": "fpt"}
+        }))
+        .await;
+    resp.assert_status_ok();
+    let out: Value = resp.json();
+    assert_eq!(out["output"]["profile"], "default");
+    assert_eq!(
+        out["output"]["credentials"]["endpoint"],
+        "https://dev.api.example.com"
+    );
+}
+
+// ── Scenario 2: permission_hint enforcement ────────────────
+
+#[tokio::test]
+async fn meta_permission_hint_read_only_blocks_delete() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+    let (server, _) = build_server(svc);
+
+    let resp = server
+        .post("/v1/call")
+        .json(&json!({
+            "tool_slug": "maya.auth.permission_gate",
+            "params": {"action": "delete"},
+            "meta": {"permission_hint": "read-only"}
+        }))
+        .await;
+    resp.assert_status_ok();
+    let out: Value = resp.json();
+    assert_eq!(out["output"]["allowed"], false);
+    assert!(out["output"]["reason"].as_str().unwrap().contains("denied"));
+}
+
+#[tokio::test]
+async fn meta_permission_hint_read_write_allows_delete() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+    let (server, _) = build_server(svc);
+
+    let resp = server
+        .post("/v1/call")
+        .json(&json!({
+            "tool_slug": "maya.auth.permission_gate",
+            "params": {"action": "delete"},
+            "meta": {"permission_hint": "read-write"}
+        }))
+        .await;
+    resp.assert_status_ok();
+    let out: Value = resp.json();
+    assert_eq!(out["output"]["allowed"], true);
+    assert_eq!(out["output"]["hint"], "read-write");
+}
+
+// ── Scenario 3: project_scope isolation ────────────────
+
+#[tokio::test]
+async fn meta_project_scope_filters_assets_to_movie_42() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+    let (server, _) = build_server(svc);
+
+    let resp = server
+        .post("/v1/call")
+        .json(&json!({
+            "tool_slug": "maya.pipeline.asset_lookup",
+            "params": {"asset_name": "hero"},
+            "meta": {"project_scope": "movie-42"}
+        }))
+        .await;
+    resp.assert_status_ok();
+    let out: Value = resp.json();
+    assert_eq!(out["output"]["scope"], "movie-42");
+    assert_eq!(out["output"]["results"], 2); // hero_model + env_forest
+    let assets = out["output"]["assets"].as_array().unwrap();
+    for asset in assets {
+        assert_eq!(asset["project"], "movie-42");
+    }
+}
+
+#[tokio::test]
+async fn meta_project_scope_empty_returns_all_assets() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+    let (server, _) = build_server(svc);
+
+    // No meta — should return all assets (scope is empty string)
+    let resp = server
+        .post("/v1/call")
+        .json(&json!({
+            "tool_slug": "maya.pipeline.asset_lookup",
+            "params": {"asset_name": "hero"}
+        }))
+        .await;
+    resp.assert_status_ok();
+    let out: Value = resp.json();
+    assert_eq!(out["output"]["scope"], "");
+    assert_eq!(out["output"]["results"], 3); // all 3 assets
+}
+
+// ── Scenario 4: agent_context passthrough ────────────────
+
+#[tokio::test]
+async fn meta_agent_context_identifies_caller() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+    let (server, _) = build_server(svc);
+
+    let resp = server
+        .post("/v1/call")
+        .json(&json!({
+            "tool_slug": "maya.telemetry.agent_greeter",
+            "params": {"message": "hello"},
+            "meta": {
+                "agent_context": {
+                    "actor_id": "artist-42",
+                    "agent_name": "claude-code",
+                    "session_id": "sess-abc-123",
+                    "agent_version": "4.6.0"
+                }
+            }
+        }))
+        .await;
+    resp.assert_status_ok();
+    let out: Value = resp.json();
+    assert_eq!(out["output"]["actor_id"], "artist-42");
+    assert_eq!(out["output"]["agent_name"], "claude-code");
+    assert_eq!(out["output"]["session_id"], "sess-abc-123");
+    let greeting = out["output"]["greeting"].as_str().unwrap();
+    assert!(greeting.contains("artist-42"));
+    assert!(greeting.contains("claude-code"));
+}
+
+#[tokio::test]
+async fn meta_agent_context_unknown_when_absent() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+    let (server, _) = build_server(svc);
+
+    // No meta — handler falls back to "unknown"
+    let resp = server
+        .post("/v1/call")
+        .json(&json!({
+            "tool_slug": "maya.telemetry.agent_greeter",
+            "params": {"message": "hi"}
+        }))
+        .await;
+    resp.assert_status_ok();
+    let out: Value = resp.json();
+    assert_eq!(out["output"]["actor_id"], "unknown");
+    assert_eq!(out["output"]["agent_name"], "unknown-agent");
+}
+
+// ── Scenario 5: strict schema (additionalProperties: false) ──
+
+#[tokio::test]
+async fn meta_passthrough_with_strict_schema_additional_properties_false() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+    let (server, _) = build_server(svc);
+
+    // This would fail validation if _meta were injected BEFORE validation
+    let resp = server
+        .post("/v1/call")
+        .json(&json!({
+            "tool_slug": "maya.pipeline.strict_tool",
+            "params": {"value": 42.0},
+            "meta": {
+                "agent_context": {"actor_id": "strict-user"},
+                "credential_profile": "prod",
+                "permission_hint": "read-only",
+                "project_scope": "movie-42",
+            }
+        }))
+        .await;
+    resp.assert_status_ok();
+    let out: Value = resp.json();
+    assert_eq!(out["output"]["echoed_value"], 42.0);
+    // _meta should be present in handler params (injected after validation)
+    assert_eq!(out["output"]["has_meta"], true);
+}
+
+// ── Scenario 6: service-layer meta passthrough ─────────────
+
+#[test]
+fn service_layer_call_passes_meta_through_to_invoker() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+
+    // Service-layer call (bypasses HTTP) — the same path the gateway
+    // MCP wrapper uses via `call_tool` -> `call_service`.
+    let outcome = svc
+        .call(&super::service::CallRequest {
+            tool_slug: super::service::ToolSlug("maya.auth.credential_resolver".into()),
+            params: json!({"service": "fpt"}),
+            meta: Some(json!({
+                "credential_profile": "staging",
+                "agent_context": {"actor_id": "svc-caller"}
+            })),
+        })
+        .expect("service call");
+    let output = &outcome.output;
+    assert_eq!(output["profile"], "staging");
+    assert_eq!(
+        output["credentials"]["endpoint"],
+        "https://staging.api.example.com"
+    );
+}
+
+#[test]
+fn service_layer_call_without_meta_is_backward_compatible() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+
+    let outcome = svc
+        .call(&super::service::CallRequest {
+            tool_slug: super::service::ToolSlug("maya.auth.credential_resolver".into()),
+            params: json!({"service": "fpt"}),
+            meta: None,
+        })
+        .expect("service call");
+    assert_eq!(outcome.output["profile"], "default");
+}
+
+// ── Scenario 7: multi-field passthrough ────────────────────
+
+#[tokio::test]
+async fn meta_multiple_fields_all_passed_through_together() {
+    let (svc, _, _) = fixture_meta_aware_tools();
+    let (server, _) = build_server(svc);
+
+    // Send all allowlisted fields + agent_context at once
+    let resp = server
+        .post("/v1/call")
+        .json(&json!({
+            "tool_slug": "maya.telemetry.agent_greeter",
+            "params": {"message": "multi-test"},
+            "meta": {
+                "agent_context": {
+                    "actor_id": "multi-user",
+                    "agent_name": "test-agent",
+                    "session_id": "multi-session"
+                },
+                "credential_profile": "prod",
+                "permission_hint": "read-write",
+                "project_scope": "movie-42",
+                "search_id": "search-xyz"
+            }
+        }))
+        .await;
+    resp.assert_status_ok();
+    let out: Value = resp.json();
+    assert_eq!(out["output"]["actor_id"], "multi-user");
+    assert_eq!(out["output"]["agent_name"], "test-agent");
+    assert_eq!(out["output"]["session_id"], "multi-session");
 }

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
@@ -345,12 +345,12 @@ fn test_load_skill_propagates_thread_affinity_enforcement() {
     catalog.load_skill("main-thread").unwrap();
 
     let err = dispatcher
-        .dispatch("main_thread__execute_python", serde_json::json!({}))
+        .dispatch("main_thread__execute_python", serde_json::json!({}), None)
         .expect_err("worker-thread dispatch must be rejected");
     assert!(matches!(err, DispatchError::ThreadAffinityViolation { .. }));
 
     let ok = with_thread_affinity(ThreadAffinity::Main, || {
-        dispatcher.dispatch("main_thread__execute_python", serde_json::json!({}))
+        dispatcher.dispatch("main_thread__execute_python", serde_json::json!({}), None)
     })
     .expect("main-thread dispatch should pass enforcement");
     assert_eq!(ok.output, serde_json::json!({"ok": true}));
@@ -400,7 +400,7 @@ fn test_load_skill_object_applies_tool_declaration_overrides() {
     assert!(!meta.enforce_thread_affinity);
 
     let ok = dispatcher
-        .dispatch("mutable_affinity__host_scene", serde_json::json!({}))
+        .dispatch("mutable_affinity__host_scene", serde_json::json!({}), None)
         .expect("worker dispatch should be allowed after override");
     assert_eq!(ok.output, serde_json::json!({"ok": true}));
 }

--- a/crates/dcc-mcp-workflow/src/callers.rs
+++ b/crates/dcc-mcp-workflow/src/callers.rs
@@ -89,7 +89,8 @@ impl ToolCaller for ToolDispatcherCaller {
         let dispatcher = self.dispatcher.clone();
         let name = tool_name.to_string();
         Box::pin(async move {
-            let dispatch = tokio::task::spawn_blocking(move || dispatcher.dispatch(&name, args));
+            let dispatch =
+                tokio::task::spawn_blocking(move || dispatcher.dispatch(&name, args, None));
             tokio::select! {
                 biased;
                 _ = cancel.cancelled() => Err("cancelled".to_string()),

--- a/crates/dcc-mcp-workflow/src/tests.rs
+++ b/crates/dcc-mcp-workflow/src/tests.rs
@@ -209,7 +209,7 @@ async fn register_workflow_handlers_wires_run_and_cancel() {
 
     let yaml = "name: t\nsteps:\n  - id: s1\n    tool: scene_echo\n    args: {x: 1}\n";
     let out = dispatcher
-        .dispatch(tools::names::RUN, json!({"spec": yaml, "inputs": {}}))
+        .dispatch(tools::names::RUN, json!({"spec": yaml, "inputs": {}}), None)
         .unwrap()
         .output;
     let wid = out["workflow_id"].as_str().unwrap();
@@ -217,7 +217,7 @@ async fn register_workflow_handlers_wires_run_and_cancel() {
 
     // Cancel via dispatcher.
     let cancelled = dispatcher
-        .dispatch(tools::names::CANCEL, json!({"workflow_id": wid}))
+        .dispatch(tools::names::CANCEL, json!({"workflow_id": wid}), None)
         .unwrap()
         .output;
     assert_eq!(cancelled["cancelled"], true);

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -760,6 +760,138 @@ Stateless tools are easier to test, retry, and compose into workflows.
 
 ---
 
+## Request-Level Context Passthrough (`_meta`) — PIP-520
+
+When a client (AI agent, CI pipeline, or external service) calls a tool through
+the dcc-mcp Gateway, it can attach **request-level context** via the MCP
+`_meta` block.  The Gateway forwards this context to the backend adapter skill,
+where the tool handler can read it from `params._meta`.
+
+### What Gets Passed Through
+
+The Gateway applies a **bounded passthrough** allowlist — only these fields
+survive the trip from client to tool handler:
+
+| Field | Purpose | Example |
+|-------|---------|---------|
+| `agent_context` | **Server-derived** caller identity (actor, agent name, session, model) | `{"actor_id":"artist-42","agent_name":"claude-code"}` |
+| `credential_profile` | Which credential/profile to use for backend services | `"prod"`, `"staging"` |
+| `permission_hint` | Caller's permission level for enforcement | `"read-only"`, `"read-write"` |
+| `project_scope` | Project context for data isolation | `"movie-42"`, `"game-99"` |
+| `search_id` | Telemetry correlation id (set by gateway) | `"srch-abc123"` |
+
+**Security**: The client's self-reported `agent_context` is **stripped** by the
+Gateway. The `agent_context` the tool sees is **always server-derived** —
+populated from HTTP headers, JWT claims, and network attribution. Never trust
+client-supplied identity fields; always read `_meta.agent_context` from the
+server.
+
+### How Tool Handlers Consume `_meta`
+
+The `_meta` is injected into `params` as a top-level key **after** schema
+validation. This means tools with `"additionalProperties": false` in their
+`input_schema` are safe — the validator never sees `_meta`.
+
+#### Rust Handler
+
+```rust
+dispatcher.register_handler("my_tool", |params: Value| {
+    // Read credential_profile from _meta
+    let profile = params
+        .pointer("/_meta/credential_profile")
+        .and_then(Value::as_str)
+        .unwrap_or("default");
+
+    // Read server-derived agent_context
+    let actor = params
+        .pointer("/_meta/agent_context/actor_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+
+    Ok(json!({"resolved": true, "profile": profile, "actor": actor}))
+});
+```
+
+#### Python Handler
+
+```python
+def my_tool_handler(params: dict) -> dict:
+    meta = params.get("_meta", {})
+
+    # Read credential_profile
+    profile = meta.get("credential_profile", "default")
+
+    # Read server-derived agent_context
+    agent_ctx = meta.get("agent_context", {})
+    actor_id = agent_ctx.get("actor_id", "unknown")
+    agent_name = agent_ctx.get("agent_name", "unknown-agent")
+
+    # Use for credential resolution, permission checks, scope isolation...
+    if profile == "prod":
+        endpoint = "https://prod.api.example.com"
+    else:
+        endpoint = "https://staging.api.example.com"
+
+    return {"resolved": True, "endpoint": endpoint, "actor": actor_id}
+```
+
+### Common Patterns
+
+**Pattern 1: Credential resolution** — select API endpoints/tokens based on
+`credential_profile`:
+```python
+profile = params.get("_meta", {}).get("credential_profile", "default")
+client = get_client_for_profile(profile)
+return client.call(params["service"], **params.get("arguments", {}))
+```
+
+**Pattern 2: Permission enforcement** — reject destructive actions when
+`permission_hint` is `"read-only"`:
+```python
+hint = params.get("_meta", {}).get("permission_hint", "read-write")
+if hint == "read-only" and params.get("action") == "delete":
+    return error_result("action 'delete' denied: permission_hint is 'read-only'")
+```
+
+**Pattern 3: Project-scoped data isolation** — filter results by
+`project_scope`:
+```python
+scope = params.get("_meta", {}).get("project_scope", "")
+results = [a for a in all_assets if not scope or a["project"] == scope]
+```
+
+**Pattern 4: Caller attribution** — log or route based on `agent_context`:
+```python
+actor = params.get("_meta", {}).get("agent_context", {}).get("actor_id", "unknown")
+logger.info(f"Tool call by {actor}", extra={"actor_id": actor, "tool": action_name})
+```
+
+### When to Use Each Field
+
+- **`agent_context`**: telemetry, audit logs, per-user rate limiting, routing.
+- **`credential_profile`**: switching between prod/staging/dev backends.
+- **`permission_hint`**: read-only enforcement, guard destructive operations.
+- **`project_scope`**: multi-project isolation, data filtering, path scoping.
+
+### Backward Compatibility
+
+When `_meta` is absent (no client context sent, or legacy client), the
+`_meta` key is simply not injected into `params`. Tool handlers should always
+use `.get("_meta", {})` with a sensible default. No handler signature changes
+are required — the `_meta` key is transparently present or absent.
+
+### Gateway-Side Filtering
+
+The Gateway's `bounded_meta()` filter (in
+`crates/dcc-mcp-gateway/src/gateway/capability_service.rs`) strips all
+client-supplied `_meta` keys that are not in the allowlist.  If you need a
+new field added to the allowlist, open a PR against
+`DEFAULT_META_ALLOWLIST`.  The same filter removes any client-supplied
+`agent_context` and replaces it with the server-derived one — preventing
+spoofing.
+
+---
+
 ## Adding a New Public Symbol — Checklist
 
 When adding a Rust type/function that needs to be callable from Python:
@@ -821,7 +953,7 @@ When adding a Rust type/function that needs to be callable from Python:
 - PRs must pass: `vx just preflight` + `vx just test` + `vx just lint`
 - CI matrix: Python 3.7, 3.9, 3.11, 3.13 on Linux / macOS / Windows
 - Versioning: Release Please (Conventional Commits) — never manually bump
-- PyPI: Trusted Publishing (no tokens)
+- PyPI: Trusted Publishing (no tokens) — **each** of `dcc-mcp-core`, `dcc-mcp-server`, and `dcc-mcp-core-semantic` needs its own PyPI Trusted Publisher; see [PyPI Trusted Publishers](https://docs.pypi.org/trusted-publishers/)
 - Docs-only changes skip Rust rebuild → CI passes quickly
 - Squash merge convention for PRs
 
@@ -1393,7 +1525,7 @@ either a single `prompts.yaml` (top-level `prompts:` + `workflows:` lists)
 or a `prompts/*.prompt.yaml` glob. Workflows referenced by the spec
 auto-generate a summary prompt.
 
-Template engine is minimal: only `{{arg_name}}` substitution; missing
+Template engine is minimal: only <code v-pre>{{arg_name}}</code> substitution; missing
 required args return JSON-RPC `INVALID_PARAMS`.
 `notifications/prompts/list_changed` fires on skill load / unload.
 

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3099,7 +3099,7 @@ class ToolDispatcher:
         r"""
         Alphabetically sorted list of registered handler names.
         """
-    def dispatch(self, action_name: builtins.str, params_json: builtins.str = 'null') -> dict:
+    def dispatch(self, action_name: builtins.str, params_json: builtins.str = 'null', meta_json: builtins.str = 'null') -> dict:
         r"""
         Dispatch an action call.
 
@@ -3239,7 +3239,7 @@ class ToolPipeline:
             before_fn: Optional callable ``(action_name: str) -> None`` called before dispatch.
             after_fn:  Optional callable ``(action_name: str, success: bool) -> None`` called after.
         """
-    def dispatch(self, action_name: builtins.str, params_json: builtins.str = 'null') -> dict:
+    def dispatch(self, action_name: builtins.str, params_json: builtins.str = 'null', meta_json: builtins.str = 'null') -> dict:
         r"""
         Dispatch an action through the middleware pipeline.
 


### PR DESCRIPTION
## Summary

- Preserves bounded request-level metadata from gateway MCP/REST calls through backend REST invocation into adapter skill params as `params._meta`.
- Adds validation-safe injection after schema validation so `additionalProperties: false` tools keep working.
- Adds realistic credential, permission, project-scope, and caller-context tests, plus agent-facing docs for using `_meta`.
- Keeps this PR scoped to PIP-520; unrelated marketplace admin route changes from the working branch are intentionally excluded.

## Validation

- `vx cargo test -p dcc-mcp-gateway`
- `vx cargo test -p dcc-mcp-actions`
- `vx cargo test -p dcc-mcp-skill-rest`
- `vx cargo test -p dcc-mcp-http-server`
- `vx cargo test -p dcc-mcp-workflow`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo clippy --workspace --all-targets -- -D warnings`

## Skill guidance

PIP-520 affects gateway behavior and agent workflow. The PR updates `AI_AGENT_GUIDE.md` and `docs/guide/agents-reference.md`; no bundled adapter skill package changes are required.
