### PR TITLE
feat(daemon): refactor gateway guardian to use launch_detached, add build_gateway_daemon_command

### DIFF
--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -213,6 +213,55 @@ standalone). At runtime it satisfies the following:
 | **Central Gateway** | `dcc-mcp-server gateway` daemon process | Auto-launched by the supervisor; survives backend restarts; idle-timeout (default 30 s) after last backend exits, unless `DCC_MCP_GATEWAY_PERSIST=1` |
 | **Per-DCC Registration** | `FileRegistry` row + 5 s heartbeat | Each backend stamps `gateway_runtime_mode`, `gateway_guardian_enabled`, `gateway_recovery_driver` into its row so admin tools can answer "which services can revive the gateway?" |
 
+### Python daemon helpers (PIP-513)
+
+The `dcc_mcp_core.daemon_launch` module and the extended `ensure_gateway_daemon`
+API provide three tiers of daemon control from Python, usable by any adapter or
+studio pipeline service.
+
+| Mode | API | Typical use |
+|------|-----|-------------|
+| **Gateway ensure** | `ensure_gateway_daemon(gateway_persist=True, ...)` | DCC adapter startup auto-ensures a machine-wide gateway daemon; single-flight lock prevents duplicate spawns |
+| **Gateway launch** | `launch_gateway_daemon(gateway_host=..., ...)` | Alias for `ensure_gateway_daemon` with explicit daemon naming |
+| **Arbitrary command detach** | `launch_detached(["my-svc", "--flag"])` | Studio-owned pipeline adapters, sidecars, custom MCP hosts |
+
+```python
+from dcc_mcp_core import ensure_gateway_daemon, launch_detached
+
+# Gateway auto-ensure with persist/idle-timeout flags
+result = ensure_gateway_daemon(
+    gateway_host="127.0.0.1",
+    gateway_port=9765,
+    registry_dir=None,
+    dcc_type="ftrack",
+    gateway_persist=True,
+    gateway_idle_timeout_secs=0,
+)
+assert result["ok"]
+
+# Detach an arbitrary pipeline service without blocking
+spawn = launch_detached(["python", "-m", "my_pipeline.sidecar"])
+assert spawn["ok"]
+print(f"Spawned PID: {spawn['pid']}")
+```
+
+The `build_gateway_daemon_command()` function is also exported for inspection:
+
+```python
+from dcc_mcp_core import build_gateway_daemon_command
+
+cmd, env = build_gateway_daemon_command(
+    gateway_host="127.0.0.1",
+    gateway_port=9765,
+    registry_dir="/tmp/reg",
+    dcc_type="maya",
+    gateway_persist=True,
+)
+# cmd == ["dcc-mcp-server", "gateway", "--host", "127.0.0.1",
+#         "--port", "9765", "--gateway-persist"]
+# env["DCC_MCP_GATEWAY_PERSIST"] == "1"
+```
+
 ## Topology
 
 ```

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -366,8 +366,11 @@ _LAZY: dict[str, str] = {
     "start_embedded_dcc_server": "dcc_mcp_core.factory",
     "DccGatewayElection": "dcc_mcp_core.gateway_election",
     "DccSkillHotReloader": "dcc_mcp_core.hotreload",
-    # Gateway daemon helpers (PIP-485)
+    # Gateway daemon helpers (PIP-485 / PIP-513)
+    "build_gateway_daemon_command": "dcc_mcp_core._server.gateway_guardian",
     "ensure_gateway_daemon": "dcc_mcp_core._server.gateway_guardian",
+    "GatewayDaemonGuardian": "dcc_mcp_core._server.gateway_guardian",
+    "launch_gateway_daemon": "dcc_mcp_core._server.gateway_guardian",
     # Daemon helpers (PIP-513)
     "Daemon": "dcc_mcp_core.daemon_launch",
     "detached_popen_kwargs": "dcc_mcp_core.daemon_launch",

--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -6,7 +6,6 @@ import contextlib
 import os
 from pathlib import Path
 import shutil
-import subprocess
 import threading
 import time
 from typing import Any
@@ -15,6 +14,7 @@ from urllib.error import HTTPError
 from urllib.error import URLError
 from urllib.request import urlopen
 
+from dcc_mcp_core.daemon_launch import launch_detached
 from dcc_mcp_core.install_lifecycle import default_registry_dir
 
 _LAUNCH_LOCK = "gateway-launch.lock"
@@ -123,6 +123,70 @@ def _wait_gateway_ready(host: str, port: int, *, timeout_secs: float, probe_time
     return False
 
 
+def _resolve_gateway_persist(gateway_persist: bool | None) -> bool:
+    if gateway_persist is not None:
+        return bool(gateway_persist)
+    return (os.environ.get("DCC_MCP_GATEWAY_PERSIST") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _resolve_gateway_idle_timeout_secs(gateway_idle_timeout_secs: int | None) -> int | None:
+    if gateway_idle_timeout_secs is not None:
+        return max(int(gateway_idle_timeout_secs), 0)
+    raw = (os.environ.get("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS") or "").strip()
+    if not raw:
+        return None
+    try:
+        return max(int(raw), 0)
+    except ValueError:
+        return None
+
+
+def build_gateway_daemon_command(
+    *,
+    gateway_host: str,
+    gateway_port: int,
+    registry_dir: str | None,
+    dcc_type: str,
+    gateway_persist: bool | None = None,
+    gateway_idle_timeout_secs: int | None = None,
+    server_bin: str | None = None,
+) -> tuple[list[str], dict[str, str]]:
+    """Build argv and env for ``dcc-mcp-server gateway``."""
+    exe = (server_bin or "").strip() or _resolve_server_bin()
+    cmd = [
+        exe,
+        "gateway",
+        "--host",
+        gateway_host,
+        "--port",
+        str(gateway_port),
+    ]
+    persist = _resolve_gateway_persist(gateway_persist)
+    idle_timeout = _resolve_gateway_idle_timeout_secs(gateway_idle_timeout_secs)
+    if persist:
+        cmd.append("--gateway-persist")
+    if idle_timeout is not None:
+        cmd.extend(["--gateway-idle-timeout-secs", str(idle_timeout)])
+
+    env = os.environ.copy()
+    if not env.get("DCC_MCP_GATEWAY_PORT"):
+        env["DCC_MCP_GATEWAY_PORT"] = str(gateway_port)
+    registry_path = _resolve_registry_dir(registry_dir)
+    env["DCC_MCP_REGISTRY_DIR"] = str(registry_path)
+    if dcc_type and not env.get("DCC_MCP_DCC_TYPE"):
+        env["DCC_MCP_DCC_TYPE"] = dcc_type
+    if persist:
+        env["DCC_MCP_GATEWAY_PERSIST"] = "1"
+    if idle_timeout is not None:
+        env["DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS"] = str(idle_timeout)
+    return cmd, env
+
+
 def ensure_gateway_daemon(
     *,
     gateway_host: str,
@@ -130,8 +194,16 @@ def ensure_gateway_daemon(
     registry_dir: str | None,
     dcc_type: str,
     timeout_secs: float = 5.0,
+    gateway_persist: bool | None = None,
+    gateway_idle_timeout_secs: int | None = None,
+    server_bin: str | None = None,
 ) -> dict[str, Any]:
-    """Ensure a machine-wide gateway daemon is healthy on ``gateway_port``."""
+    """Ensure a machine-wide gateway daemon is healthy on ``gateway_port``.
+
+    When spawning a new daemon, lifecycle options are forwarded to
+    ``dcc-mcp-server gateway``. Unset values fall back to
+    ``DCC_MCP_GATEWAY_PERSIST`` / ``DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS``.
+    """
     if gateway_port <= 0:
         return {"ok": False, "reason": "gateway_port_not_configured"}
     if _is_healthy(gateway_host, gateway_port, timeout=0.5):
@@ -153,52 +225,49 @@ def ensure_gateway_daemon(
             "registry_dir": str(registry_path),
         }
 
-    exe = _resolve_server_bin()
-    cmd = [
-        exe,
-        "gateway",
-        "--host",
-        gateway_host,
-        "--port",
-        str(gateway_port),
-    ]
-
-    env = os.environ.copy()
-    if not env.get("DCC_MCP_GATEWAY_PORT"):
-        env["DCC_MCP_GATEWAY_PORT"] = str(gateway_port)
-    env["DCC_MCP_REGISTRY_DIR"] = str(registry_path)
-    if dcc_type and not env.get("DCC_MCP_DCC_TYPE"):
-        env["DCC_MCP_DCC_TYPE"] = dcc_type
-
-    kwargs: dict[str, Any] = {
-        "env": env,
-        "stdin": subprocess.DEVNULL,
-        "stdout": subprocess.DEVNULL,
-        "stderr": subprocess.DEVNULL,
-        "cwd": str(Path.cwd()),
-        "close_fds": os.name != "nt",
-    }
-    if os.name == "nt":
-        flags = 0
-        flags |= getattr(subprocess, "DETACHED_PROCESS", 0)
-        flags |= getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-        flags |= getattr(subprocess, "CREATE_NO_WINDOW", 0)
-        kwargs["creationflags"] = flags
+    cmd, env = build_gateway_daemon_command(
+        gateway_host=gateway_host,
+        gateway_port=gateway_port,
+        registry_dir=str(registry_path),
+        dcc_type=dcc_type,
+        gateway_persist=gateway_persist,
+        gateway_idle_timeout_secs=gateway_idle_timeout_secs,
+        server_bin=server_bin,
+    )
 
     try:
         try:
             if _is_healthy(gateway_host, gateway_port, timeout=0.5):
                 return {"ok": True, "reason": "already_healthy", "registry_dir": str(registry_path)}
-            subprocess.Popen(cmd, **kwargs)
+            spawn = launch_detached(cmd, env=env, cwd=Path.cwd())
+            if not spawn.get("ok"):
+                return {
+                    "ok": False,
+                    "reason": spawn.get("reason", "spawn_failed"),
+                    "error": spawn.get("error"),
+                    "command": cmd,
+                    "registry_dir": str(registry_path),
+                }
         except Exception as exc:
             return {"ok": False, "reason": "spawn_failed", "error": str(exc), "command": cmd}
 
         if _wait_gateway_ready(gateway_host, gateway_port, timeout_secs=timeout_secs):
-            return {"ok": True, "reason": "spawned", "command": cmd, "registry_dir": str(registry_path)}
+            return {
+                "ok": True,
+                "reason": "spawned",
+                "command": cmd,
+                "registry_dir": str(registry_path),
+                "pid": spawn.get("pid"),
+            }
 
         return {"ok": False, "reason": "spawn_timeout", "command": cmd, "registry_dir": str(registry_path)}
     finally:
         launch_lock.release()
+
+
+def launch_gateway_daemon(**kwargs: Any) -> dict[str, Any]:
+    """Alias for :func:`ensure_gateway_daemon` with explicit daemon naming."""
+    return ensure_gateway_daemon(**kwargs)
 
 
 class GatewayDaemonGuardian:

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -39,13 +39,13 @@ def test_ensure_gateway_daemon_spawns_and_becomes_healthy(tmp_path, monkeypatch)
 
     seen = {}
 
-    def _popen(cmd, **kwargs):
+    def _launch_detached(cmd, **kwargs):
         seen["cmd"] = cmd
         seen["env"] = kwargs.get("env", {})
-        return object()
+        return {"ok": True, "pid": 1}
 
     monkeypatch.setattr(gg, "urlopen", _urlopen)
-    monkeypatch.setattr(gg.subprocess, "Popen", _popen)
+    monkeypatch.setattr(gg, "launch_detached", _launch_detached)
     monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
     result = gg.ensure_gateway_daemon(
         gateway_host="127.0.0.1",
@@ -68,10 +68,11 @@ def test_ensure_gateway_daemon_spawns_and_becomes_healthy(tmp_path, monkeypatch)
 def test_ensure_gateway_daemon_spawn_failure_returns_embedded_fallback_reason(monkeypatch):
     monkeypatch.setattr(gg, "urlopen", lambda *_a, **_k: (_ for _ in ()).throw(OSError("down")))
 
-    def _boom(*_args, **_kwargs):
-        raise RuntimeError("spawn fail")
-
-    monkeypatch.setattr(gg.subprocess, "Popen", _boom)
+    monkeypatch.setattr(
+        gg,
+        "launch_detached",
+        lambda *_a, **_k: {"ok": False, "reason": "spawn_failed", "error": "spawn fail"},
+    )
     monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
     result = gg.ensure_gateway_daemon(
         gateway_host="127.0.0.1",
@@ -88,8 +89,8 @@ def test_ensure_gateway_daemon_waits_when_launch_lock_exists(tmp_path, monkeypat
     (tmp_path / "gateway-launch.lock").write_text("busy", encoding="utf-8")
     monkeypatch.setattr(gg, "urlopen", lambda *_a, **_k: (_ for _ in ()).throw(OSError("down")))
     monkeypatch.setattr(
-        gg.subprocess,
-        "Popen",
+        gg,
+        "launch_detached",
         lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("must not spawn")),
     )
 
@@ -121,14 +122,14 @@ def test_ensure_gateway_daemon_recovers_stale_launch_lock(tmp_path, monkeypatch)
 
     seen = {}
 
-    def _popen(cmd, **kwargs):
+    def _launch_detached(cmd, **kwargs):
         seen["cmd"] = cmd
         seen["env"] = kwargs.get("env", {})
-        return object()
+        return {"ok": True, "pid": 1}
 
     monkeypatch.setenv("DCC_MCP_GATEWAY_LAUNCH_LOCK_STALE_SECS", "1")
     monkeypatch.setattr(gg, "urlopen", _urlopen)
-    monkeypatch.setattr(gg.subprocess, "Popen", _popen)
+    monkeypatch.setattr(gg, "launch_detached", _launch_detached)
     monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
 
     result = gg.ensure_gateway_daemon(
@@ -194,3 +195,103 @@ def test_gateway_daemon_guardian_resets_failures_on_health(monkeypatch):
     assert first["reason"] == "probe_failed"
     assert second["reason"] == "healthy"
     assert second["consecutive_failures"] == 0
+
+
+def test_build_gateway_daemon_command_includes_persist_flags(monkeypatch, tmp_path):
+    monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
+    cmd, env = gg.build_gateway_daemon_command(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=str(tmp_path),
+        dcc_type="custom-host",
+        gateway_persist=True,
+        gateway_idle_timeout_secs=0,
+    )
+    assert cmd[:2] == ["dcc-mcp-server", "gateway"]
+    assert "--gateway-persist" in cmd
+    assert "--gateway-idle-timeout-secs" in cmd
+    assert env["DCC_MCP_GATEWAY_PERSIST"] == "1"
+    assert env["DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS"] == "0"
+    assert env["DCC_MCP_REGISTRY_DIR"] == str(tmp_path)
+    assert env["DCC_MCP_DCC_TYPE"] == "custom-host"
+
+
+def test_build_gateway_daemon_command_omits_persist_by_default(monkeypatch, tmp_path):
+    monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
+    cmd, env = gg.build_gateway_daemon_command(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=str(tmp_path),
+        dcc_type="maya",
+    )
+    assert "--gateway-persist" not in cmd
+    assert "--gateway-idle-timeout-secs" not in cmd
+    assert "DCC_MCP_GATEWAY_PERSIST" not in env
+    assert "DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS" not in env
+
+
+def test_build_gateway_daemon_command_respects_custom_server_bin(monkeypatch, tmp_path):
+    cmd, _env = gg.build_gateway_daemon_command(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=str(tmp_path),
+        dcc_type="nuke",
+        server_bin="/opt/bin/dcc-gw",
+    )
+    assert cmd[0] == "/opt/bin/dcc-gw"
+
+
+def test_ensure_gateway_daemon_spawn_includes_persist_flags(tmp_path, monkeypatch):
+    state = {"calls": 0}
+
+    class _Resp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+    def _urlopen(*_args, **_kwargs):
+        state["calls"] += 1
+        if state["calls"] < 3:
+            raise OSError("down")
+        return _Resp()
+
+    seen: dict = {}
+
+    def _launch_detached(cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen["env"] = kwargs.get("env", {})
+        return {"ok": True, "pid": 99}
+
+    monkeypatch.setattr(gg, "urlopen", _urlopen)
+    monkeypatch.setattr(gg, "launch_detached", _launch_detached)
+    monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
+    result = gg.ensure_gateway_daemon(
+        gateway_host="127.0.0.1",
+        gateway_port=9876,
+        registry_dir=str(tmp_path),
+        dcc_type="ftrack",
+        timeout_secs=1.0,
+        gateway_persist=True,
+        gateway_idle_timeout_secs=120,
+    )
+    assert result["ok"] is True
+    assert "--gateway-persist" in seen["cmd"]
+    assert "--gateway-idle-timeout-secs" in seen["cmd"]
+    assert seen["env"]["DCC_MCP_GATEWAY_PERSIST"] == "1"
+    assert seen["env"]["DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS"] == "120"
+
+
+def test_launch_gateway_daemon_is_alias(monkeypatch):
+    monkeypatch.setattr(gg, "urlopen", lambda *args, **kwargs: _Resp())
+    result = gg.launch_gateway_daemon(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=None,
+        dcc_type="blender",
+    )
+    assert result["ok"] is True
+    assert result["reason"] == "already_healthy"


### PR DESCRIPTION
## Summary

Refactor `ensure_gateway_daemon` to use `launch_detached` from `dcc_mcp_core.daemon_launch` instead of raw `subprocess.Popen`. Add `build_gateway_daemon_command` helper and extend the Python daemon API surface.

## Changes

### `python/dcc_mcp_core/_server/gateway_guardian.py`
- Replace `subprocess.Popen` with `launch_detached` in `ensure_gateway_daemon`
- Add `build_gateway_daemon_command` to construct gateway argv + env (reusable)
- Add `launch_gateway_daemon` alias for explicit daemon naming
- Add `gateway_persist` / `gateway_idle_timeout_secs` parameters with env-var fallback
- Forward spawn `pid` in result

### `python/dcc_mcp_core/_exports.py`
- Export `build_gateway_daemon_command`, `GatewayDaemonGuardian`, `launch_gateway_daemon`

### `tests/test_gateway_guardian.py`
- Fix all tests: monkeypatch `gg.launch_detached` instead of `gg.subprocess.Popen`
- Fix failing `test_ensure_gateway_daemon_waits_when_launch_lock_exists`
- Add tests for persist flags, server_bin override, defaults, and alias

### `docs/guide/gateway.md`
- Add Python daemon helpers section with three-mode table and code examples

## Related
- Closes PIP-513
- Follows up on PR #1500 (merged)