### PR TITLE
feat(server): add Sentry real-ingest E2E tests and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,6 +558,36 @@ jobs:
               --base-url http://127.0.0.1:1 --dry-run --trace "$f"
           done
 
+  # -- Sentry E2E: real ingest through dcc-mcp-server init_sentry() --
+  # Requires DCC_MCP_SENTRY_DSN GitHub Actions secret. Skips cleanly when
+  # the secret is absent so forks / local clones do not fail the workflow.
+  sentry-e2e:
+    name: Sentry E2E
+    needs: [rust-check]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: loonghao/vx@v0.9.11
+        with:
+          version: "0.9.11"
+          cache: "false"
+
+      - name: Run Sentry real-ingest E2E
+        env:
+          DCC_MCP_SENTRY_DSN: ${{ secrets.DCC_MCP_SENTRY_DSN }}
+          DCC_MCP_SENTRY_ENVIRONMENT: ci-e2e
+          DCC_MCP_SENTRY_SAMPLE_RATE: "1.0"
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${DCC_MCP_SENTRY_DSN:-}" ]; then
+            echo "DCC_MCP_SENTRY_DSN secret not configured; skipping Sentry E2E"
+            exit 0
+          fi
+          vx cargo test -p dcc-mcp-server --features sentry sentry_real_ingest_e2e \
+            -- --exact --test-threads=1 --nocapture
+
   # -- mcpcall e2e: real MCP client vs live MCP servers/gateway --
   # Exercises the full HTTP stack from outside the process:
   #   tools/list, tools/call, find_skills, load_skill, unload_skill,

--- a/crates/dcc-mcp-server/src/sentry_init.rs
+++ b/crates/dcc-mcp-server/src/sentry_init.rs
@@ -86,9 +86,12 @@ mod tests {
         fn set(key: &'static str, value: Option<&str>) -> Self {
             let lock = ENV_LOCK.lock().expect("env lock poisoned");
             let previous = std::env::var(key).ok();
-            match value {
-                Some(v) => std::env::set_var(key, v),
-                None => std::env::remove_var(key),
+            // SAFETY: serialized by ENV_LOCK; tests restore previous values on drop.
+            unsafe {
+                match value {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
             }
             Self {
                 key,
@@ -100,9 +103,12 @@ mod tests {
 
     impl Drop for EnvVarGuard {
         fn drop(&mut self) {
-            match &self.previous {
-                Some(v) => std::env::set_var(self.key, v),
-                None => std::env::remove_var(self.key),
+            // SAFETY: serialized by ENV_LOCK held for the guard lifetime.
+            unsafe {
+                match &self.previous {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
             }
         }
     }
@@ -141,9 +147,12 @@ mod tests {
         };
 
         let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        std::env::set_var("DCC_MCP_SENTRY_DSN", &dsn);
-        std::env::set_var("DCC_MCP_SENTRY_ENVIRONMENT", "ci-e2e");
-        std::env::set_var("DCC_MCP_SENTRY_SAMPLE_RATE", "1.0");
+        // SAFETY: serialized by ENV_LOCK; e2e probe restores env when the lock drops.
+        unsafe {
+            std::env::set_var("DCC_MCP_SENTRY_DSN", &dsn);
+            std::env::set_var("DCC_MCP_SENTRY_ENVIRONMENT", "ci-e2e");
+            std::env::set_var("DCC_MCP_SENTRY_SAMPLE_RATE", "1.0");
+        }
 
         let guard = init_sentry().expect("valid DCC_MCP_SENTRY_DSN should initialise Sentry");
         let probe = format!("dcc-mcp-core sentry e2e probe {}", uuid::Uuid::new_v4());

--- a/crates/dcc-mcp-server/src/sentry_init.rs
+++ b/crates/dcc-mcp-server/src/sentry_init.rs
@@ -67,3 +67,96 @@ pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
 
     Some(guard)
 }
+
+#[cfg(all(test, feature = "sentry"))]
+mod tests {
+    use super::init_sentry;
+    use std::sync::{Mutex, MutexGuard};
+    use std::time::Duration;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let lock = ENV_LOCK.lock().expect("env lock poisoned");
+            let previous = std::env::var(key).ok();
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+            Self {
+                key,
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn init_sentry_absent_dsn_returns_none() {
+        let _guard = EnvVarGuard::set("DCC_MCP_SENTRY_DSN", None);
+        assert!(init_sentry().is_none());
+    }
+
+    #[test]
+    fn init_sentry_blank_dsn_returns_none() {
+        let _guard = EnvVarGuard::set("DCC_MCP_SENTRY_DSN", Some("   "));
+        assert!(init_sentry().is_none());
+    }
+
+    #[test]
+    fn init_sentry_invalid_dsn_returns_none() {
+        let _guard = EnvVarGuard::set("DCC_MCP_SENTRY_DSN", Some("not-a-valid-dsn"));
+        assert!(init_sentry().is_none());
+    }
+
+    /// Real Sentry ingest E2E — posts a probe event and flushes the transport.
+    ///
+    /// Skips when `DCC_MCP_SENTRY_DSN` is unset (local dev / PR CI without the
+    /// secret). The dedicated `sentry-e2e` workflow job sets the secret from
+    /// GitHub Actions and runs this test with `--test-threads=1`.
+    #[test]
+    fn sentry_real_ingest_e2e() {
+        let dsn = match std::env::var("DCC_MCP_SENTRY_DSN") {
+            Ok(v) if !v.trim().is_empty() => v,
+            _ => {
+                eprintln!("SKIP sentry_real_ingest_e2e: DCC_MCP_SENTRY_DSN not set");
+                return;
+            }
+        };
+
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        std::env::set_var("DCC_MCP_SENTRY_DSN", &dsn);
+        std::env::set_var("DCC_MCP_SENTRY_ENVIRONMENT", "ci-e2e");
+        std::env::set_var("DCC_MCP_SENTRY_SAMPLE_RATE", "1.0");
+
+        let guard = init_sentry().expect("valid DCC_MCP_SENTRY_DSN should initialise Sentry");
+        let probe = format!("dcc-mcp-core sentry e2e probe {}", uuid::Uuid::new_v4());
+        let event_id = sentry::capture_message(&probe, sentry::Level::Info);
+        assert!(
+            !event_id.is_nil(),
+            "Sentry SDK should assign an event id for captured messages"
+        );
+
+        let flushed = guard.flush(Some(Duration::from_secs(15)));
+        assert!(
+            flushed,
+            "Sentry transport flush should succeed for real ingest (dsn host reachable)"
+        );
+    }
+}

--- a/docs/guide/INDEX.md
+++ b/docs/guide/INDEX.md
@@ -89,6 +89,7 @@ document without scanning every file.
 | [dcc-thread-safety.md](dcc-thread-safety.md) | DCC main-thread dispatch, cooperative cancellation |
 | [host-adapter.md](host-adapter.md) | `HostAdapter` base class for per-DCC dispatcher wiring |
 | [adapter-dispatcher-migration.md](adapter-dispatcher-migration.md) | Dispatcher migration decision table, fake adapter conformance fixtures, and adapter-specific checklist |
+| [release-0.18-adapter-checklist.md](release-0.18-adapter-checklist.md) | dcc-mcp-core 0.18 adapter migration checklist, release rationale, and dependency floor |
 | [cross-dcc-verification.md](cross-dcc-verification.md) | `SceneStats` contract for producer→file→verifier round-trips |
 
 ## Integration

--- a/docs/guide/release-0.18-adapter-checklist.md
+++ b/docs/guide/release-0.18-adapter-checklist.md
@@ -1,0 +1,143 @@
+# dcc-mcp-core 0.18 Adapter Checklist
+
+Use this checklist before publishing or certifying a DCC adapter against
+`dcc-mcp-core` 0.18.x.
+
+## Release classification
+
+`0.18.0` is a minor release because adapter-visible gateway and runtime
+behaviour changed in ways that are larger than a patch:
+
+- the daemon-backed gateway guardian is now the default path for Python
+  adapters and server modes that auto-start a gateway;
+- gateway request metadata is forwarded only through the bounded allowlist,
+  which changes how clients should pass `_meta` through the gateway;
+- Sentry error monitoring can be enabled in `dcc-mcp-server` deployments and
+  should be configured deliberately by operators;
+- recent gateway REST and MCP surface changes remain the compatibility floor
+  for adapters moving onto this release train.
+
+Adapter repositories should set their minimum core dependency to
+`dcc-mcp-core>=0.18.0` when they adopt this checklist.
+
+## Required adapter changes
+
+| Area | What changed | Adapter action |
+|---|---|---|
+| Gateway daemon guardian | `dcc-mcp-server` and Python `DccServerBase` startup paths use the daemon-backed guardian by default. | Remove local first-wins gateway election workarounds, stop spawning a competing gateway process, and let core own daemon launch/recovery unless the adapter has an explicit legacy-mode requirement. |
+| Request metadata | Gateway search/describe/call only forwards bounded `_meta` keys. Unknown client metadata is dropped, and server-derived agent context cannot be spoofed by clients. | Put backend tool inputs in `arguments`, keep trace/correlation data under allowed `_meta` keys, and do not depend on arbitrary `_meta` echoing across the gateway boundary. |
+| Sentry monitoring | `dcc-mcp-server` can initialize Sentry from environment configuration. | Decide whether the adapter distribution should document or set Sentry env vars. Never bake a DSN into adapter code or skill packages. |
+| Gateway REST output | REST discovery/call endpoints default to compact TOON unless the request asks for JSON. | Update HTTP clients that parse JSON by sending `Accept: application/json` or `response_format: "json"`. |
+| Gateway MCP surface | The gateway exposes bounded discovery/invocation tools instead of fanning out backend tools through `tools/list`. | Use `search` -> `describe` -> `call`, or REST `/v1/search` -> `/v1/describe` -> `/v1/call`. Do not expect backend tools to appear directly in gateway `tools/list`. |
+
+## Migration snippets
+
+### Pin the adapter dependency floor
+
+```toml
+[project]
+dependencies = [
+    "dcc-mcp-core>=0.18.0",
+]
+```
+
+If the adapter ships a companion server wheel, keep it on the same release
+train:
+
+```toml
+[project]
+dependencies = [
+    "dcc-mcp-core>=0.18.0",
+    "dcc-mcp-server>=0.18.0",
+]
+```
+
+### Use core-owned gateway startup
+
+Prefer the standard `DccServerBase` startup path and let core manage the
+gateway daemon:
+
+```python
+from pathlib import Path
+
+from dcc_mcp_core import DccServerBase, DccServerOptions
+
+
+opts = DccServerOptions.from_env(
+    "maya",
+    Path(__file__).parent / "skills",
+    port=8765,
+)
+server = DccServerBase(options=opts)
+server.register_builtin_actions()
+handle = server.start()
+```
+
+Only keep legacy gateway election or custom process supervision when a host
+integration cannot run the daemon-backed mode. Document that exception in the
+adapter release notes.
+
+### Pass bounded gateway metadata
+
+Use wrapper fields only for gateway routing, and place backend tool inputs
+inside `arguments`:
+
+```json
+{
+  "tool_slug": "maya.ab12cd34.create_sphere",
+  "arguments": {
+    "radius": 2.0,
+    "name": "preview_sphere"
+  },
+  "meta": {
+    "progressToken": "job-42",
+    "dcc": {
+      "async": true
+    }
+  }
+}
+```
+
+Do not pass backend arguments such as `radius`, `code`, or `file_path` at the
+gateway wrapper top level.
+
+### Keep REST clients JSON-compatible
+
+```bash
+curl -sS \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{"kind":"tool","query":"create sphere","dcc_type":"maya","limit":5}' \
+  http://127.0.0.1:8765/v1/search
+```
+
+Clients that can consume TOON should keep the default compact response.
+
+### Configure Sentry outside code
+
+```bash
+set DCC_MCP_SENTRY_DSN=https://public@example.ingest.sentry.io/project
+set DCC_MCP_SENTRY_ENVIRONMENT=studio-smoke
+set DCC_MCP_SENTRY_TRACES_SAMPLE_RATE=0.0
+dcc-mcp-server serve --dcc maya --port 8765
+```
+
+Use environment or deployment configuration only. Adapter source, packaged
+skills, and checked-in examples must not contain real DSNs.
+
+## Release validation
+
+Before marking an adapter compatible with `0.18.0`, run at least one of these
+paths:
+
+1. Launch the adapter with `dcc-mcp-core>=0.18.0` and confirm `/v1/readyz`
+   reports the expected gateway/backend readiness.
+2. Through the gateway, call `search`, `describe`, and `call` for one adapter
+   tool. Use REST JSON mode if the adapter test harness parses JSON.
+3. Verify one direct per-DCC MCP path still works: `search_tools`,
+   `get_skill_info`, `load_skill`, then the selected backend tool.
+4. If Sentry is enabled in the deployment, run a non-production DSN smoke and
+   confirm adapter errors are reported without leaking secrets.
+
+Record any host that cannot run a live DCC smoke in the adapter PR validation
+notes, along with the fake-server or conformance test that covered the gap.

--- a/tests/test_sentry_e2e.py
+++ b/tests/test_sentry_e2e.py
@@ -1,0 +1,68 @@
+"""E2E test for real Sentry ingest through dcc-mcp-server.
+
+Exercises the Rust `init_sentry()` path compiled into `dcc-mcp-server`:
+initialise from ``DCC_MCP_SENTRY_DSN``, capture a probe message, and flush
+the transport to the configured Sentry project.
+
+Requirements:
+    ``DCC_MCP_SENTRY_DSN`` — Sentry project DSN (GitHub Actions secret in CI)
+
+The test is skipped automatically when the DSN is absent so local ``pytest
+tests/`` runs stay zero-config.
+
+CI status: dedicated ``sentry-e2e`` job in ``.github/workflows/ci.yml`` sets
+the secret and runs ``pytest tests/test_sentry_e2e.py``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SENTRY_DSN = os.environ.get("DCC_MCP_SENTRY_DSN", "").strip()
+
+
+def _vx_cmd() -> tuple[str, ...]:
+    cmd = os.environ.get("VX_CMD", "vx")
+    return tuple(shlex.split(cmd, posix=sys.platform != "win32"))
+
+
+@pytest.mark.skipif(not SENTRY_DSN, reason="DCC_MCP_SENTRY_DSN not set")
+def test_sentry_real_ingest_via_rust_probe() -> None:
+    """Run the Rust sentry_real_ingest_e2e probe (single-threaded)."""
+    env = os.environ.copy()
+    env.setdefault("DCC_MCP_SENTRY_ENVIRONMENT", "ci-e2e")
+    env.setdefault("DCC_MCP_SENTRY_SAMPLE_RATE", "1.0")
+
+    cmd = (
+        *_vx_cmd(),
+        "cargo",
+        "test",
+        "-p",
+        "dcc-mcp-server",
+        "--features",
+        "sentry",
+        "sentry_real_ingest_e2e",
+        "--",
+        "--exact",
+        "--test-threads=1",
+        "--nocapture",
+    )
+    result = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=int(os.environ.get("SENTRY_E2E_TIMEOUT", "300")),
+    )
+    if result.returncode != 0:
+        combined = f"{result.stdout}\n{result.stderr}".strip()
+        pytest.fail(f"sentry_real_ingest_e2e failed (exit {result.returncode}):\n{combined}")


### PR DESCRIPTION
## Summary

- Added Rust unit tests for `sentry_init` DSN validation (absent/blank/invalid DSN)
- Added `sentry_real_ingest_e2e` Rust probe that posts a real event to Sentry and flushes the transport
- Added Python pytest wrapper `tests/test_sentry_e2e.py` consistent with existing E2E test style
- Added `sentry-e2e` CI job that reads `DCC_MCP_SENTRY_DSN` from GitHub Actions secrets; gracefully skips when secret is absent

## Test plan

- [ ] Rust unit tests pass locally: `cargo test -p dcc-mcp-server sentry`
- [ ] Python E2E test skips cleanly without DSN: `pytest tests/test_sentry_e2e.py`
- [ ] `sentry-e2e` CI job runs and passes with the configured secret