### PR TITLE
docs(release): document 0.18.0 minor rationale

### DIFF
--- a/docs/guide/release-0.18-adapter-checklist.md
+++ b/docs/guide/release-0.18-adapter-checklist.md
@@ -20,6 +20,10 @@ behaviour changed in ways that are larger than a patch:
 Adapter repositories should set their minimum core dependency to
 `dcc-mcp-core>=0.18.0` when they adopt this checklist.
 
+Release notes should call this out as: minor release for daemon-backed gateway
+startup, bounded gateway request metadata, Sentry server monitoring, and the
+adapter dependency floor of `dcc-mcp-core>=0.18.0`.
+
 ## Required adapter changes
 
 | Area | What changed | Adapter action |


### PR DESCRIPTION
## Summary
- clarify the 0.18 release-note wording in the adapter checklist
- pin the adapter dependency floor language to dcc-mcp-core>=0.18.0
- include a real Release-As: 0.18.0 commit footer for release-please

## Validation
- vx npx markdownlint-cli2 docs/guide/release-0.18-adapter-checklist.md
- npm run docs:build