### PR TITLE
docs: add adapter release train onboarding docs

### DIFF
--- a/docs/guide/INDEX.md
+++ b/docs/guide/INDEX.md
@@ -92,8 +92,15 @@ document without scanning every file.
 | [dcc-thread-safety.md](dcc-thread-safety.md) | DCC main-thread dispatch, cooperative cancellation |
 | [host-adapter.md](host-adapter.md) | `HostAdapter` base class for per-DCC dispatcher wiring |
 | [adapter-dispatcher-migration.md](adapter-dispatcher-migration.md) | Dispatcher migration decision table, fake adapter conformance fixtures, and adapter-specific checklist |
-| [release-0.18-adapter-checklist.md](release-0.18-adapter-checklist.md) | dcc-mcp-core 0.18 adapter migration checklist, release rationale, and dependency floor |
 | [cross-dcc-verification.md](cross-dcc-verification.md) | `SceneStats` contract for producer→file→verifier round-trips |
+
+## Adapter Release Train & Onboarding
+
+| Document | Purpose |
+|----------|---------|
+| [adapter-release-checklist.md](adapter-release-checklist.md) | Release train checklist: core pin, sidecar metadata, gateway smoke, release-please config |
+| [new-adapter-onboarding.md](new-adapter-onboarding.md) | Onboarding template: pyproject deps, adapter_version, readiness, CI/CD, first skill |
+| [adapter-compatibility-matrix.md](adapter-compatibility-matrix.md) | Per-DCC compatibility rows: core pin, adapter version, DCC min version, dispatcher pattern |
 
 ## Integration
 

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -1,0 +1,67 @@
+# Adapter Compatibility Matrix
+
+This matrix tracks every known DCC-MCP adapter, its core version pin, adapter
+version, and supported DCC version range. Every adapter release **must** submit
+a PR updating this matrix before the release PR merges.
+
+## How to Add a New Adapter
+
+1. Find the next empty row in the table below.
+2. Fill in every column with the adapter's latest released values at the time
+   of the PR.
+3. Submit the PR against `docs/guide/adapter-compatibility-matrix.md`.
+
+## How to Update an Existing Adapter
+
+1. Change the `Adapter Version` and/or `Core Pin` columns to match the new
+   release.
+2. Update `Last Verified` to the date the release smoke was run.
+3. If the DCC minimum version changed, update `DCC Min Version`.
+
+## Matrix
+
+| DCC | Repository | Adapter Version | Core Pin | DCC Min Version | Dispatcher Pattern | Last Verified |
+|-----|-----------|----------------|----------|-----------------|-------------------|---------------|
+| Maya | [dcc-mcp-maya](https://github.com/dcc-mcp/dcc-mcp-maya) | 0.3.0 | >=0.18.0,<1.0.0 | 2024+ | Qt sidecar + HostUiDispatcherBase | 2026-06 |
+| 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.2.0 | >=0.18.0,<1.0.0 | 2025+ | Qt sidecar + HostPumpController | 2026-05 |
+| Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.0 | >=0.17.0,<1.0.0 | 3.6+ | Background blocking dispatcher | 2026-04 |
+| Houdini | [dcc-mcp-houdini](https://github.com/dcc-mcp/dcc-mcp-houdini) | 0.1.0 | >=0.17.0,<1.0.0 | 20.5+ | Event-loop callback | 2026-04 |
+| Nuke | _(planned)_ | — | — | — | — | — |
+| Unreal | _(planned)_ | — | — | — | — | — |
+| ZBrush | _(planned)_ | — | — | — | — | — |
+| Photoshop | _(planned)_ | — | — | — | — | — |
+| Custom Studio Tool | _(your repo here)_ | _your version_ | _your pin_ | _your min_ | _your pattern_ | _date_ |
+
+## Column Reference
+
+| Column | Description |
+|--------|------------|
+| **DCC** | Canonical DCC name (lowercase, kebab-case). |
+| **Repository** | GitHub URL for the adapter source code. |
+| **Adapter Version** | Latest released semver of the adapter. |
+| **Core Pin** | Dependency range for `dcc-mcp-core`. Must exclude `<1.0.0` until core reaches 1.0. |
+| **DCC Min Version** | Minimum host version (e.g. `2024+`, `3.6+`, `20.5+`). |
+| **Dispatcher Pattern** | One of: `Qt sidecar`, `Background blocking`, `Event-loop callback`, `InProcessCallableDispatcher`, `External bridge`. See [HOST_PATTERN_MATRIX.md](../../skills/dcc-mcp-creator/references/HOST_PATTERN_MATRIX.md) for details. |
+| **Last Verified** | Month the last gateway smoke was run (format: `YYYY-MM`). |
+
+## Core Version Policy
+
+- Adapters **must** pin `dcc-mcp-core` with an open upper bound: `>=X.Y.0,<1.0.0`.
+- The lower bound (`X.Y.0`) must be a **released** minor version of core.
+  Never pin to `main` or a pre-release.
+- When core bumps its minor version, adapter pins should be updated within one
+  adapter release cycle.
+- Major version zero (`0.x.y`) means breaking changes can happen at any minor
+  bump; the `<1.0.0` guard ensures adapters don't silently consume a breaking
+  core change.
+
+## Outdated Policy
+
+An adapter row is considered **stale** when:
+
+- `Last Verified` is more than 6 months old, **or**
+- `Core Pin` lower bound is more than 2 minor versions behind the latest core
+  release.
+
+Stale rows are flagged in the core release PR notes. Adapter maintainers should
+prioritise a compatibility update before the next core release.

--- a/docs/guide/adapter-release-checklist.md
+++ b/docs/guide/adapter-release-checklist.md
@@ -1,0 +1,161 @@
+# Adapter Release Train Checklist
+
+Use this checklist when cutting a release for any DCC-MCP adapter (Maya, Blender,
+Houdini, 3ds Max, Nuke, ZBrush, Photoshop, Unreal, custom studio tool). Follow it
+in order. Tick every box before merging the release PR.
+
+## 0. Pre-Release Preparation
+
+- [ ] Core dependency is pinned to `>=0.<latest_minor>.0,<1.0.0` in `pyproject.toml`.
+      Use the latest *released* minor version of `dcc-mcp-core`, not `main`.
+      Example: `"dcc-mcp-core>=0.18.0,<1.0.0"`.
+- [ ] `dcc-mcp-server` binary dependency (if used) also follows the same range.
+- [ ] Adapter `adapter_version` is set via `DccServerOptions.from_env(..., adapter_version=...)`
+      and stamped into the gateway sentinel and file registry row.
+- [ ] Compatibility matrix in the core docs has been updated with the new row
+      (see [Adapter Compatibility Matrix](adapter-compatibility-matrix.md)).
+
+## 1. Required Sidecar Metadata
+
+Every adapter that launches a sidecar (`dcc-mcp-server sidecar`) must expose
+these metadata fields in the discovery and registry records:
+
+| Metadata key | Source | Example |
+|---|---|---|
+| `dcc_type` | `DccName::parse` or `dcc_name` | `"maya"` |
+| `adapter_version` | `DccServerOptions.adapter_version` | `"1.2.3"` |
+| `dcc_version` | Runtime-reported host version | `"2026.3"` |
+| `dispatch_contract` | `build_sidecar_command().dispatch_contract` | `remote` or `sidecar` |
+| `dcc_pid` | `DccServerOptions.dcc_pid` or OS PID | `12345` |
+
+Declare these in the adapter's `start_server()` or composition root so they
+flow into `gateway://instances` and `POST /v1/instances`.
+
+## 2. Gateway Smoke Steps
+
+Copy these steps from `TESTING_AND_RELEASE.md` into the release PR notes.
+Adapt the port and DCC name as needed:
+
+```bash
+# 1. Start the adapter (or ensure it is running)
+# 2. Gateway readiness
+curl -s http://127.0.0.1:9765/v1/readyz | python -m json.tool
+
+# 3. Discover a skill through gateway search
+curl -s -X POST http://127.0.0.1:9765/v1/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "ping", "dcc_type": "<dcc_name>"}'
+
+# 4. Describe a discovered tool
+curl -s -X POST http://127.0.0.1:9765/v1/describe \
+  -H 'Content-Type: application/json' \
+  -d '{"tool_slug": "<dcc>.<id8>.<tool>"}'
+
+# 5. Call one safe typed tool
+curl -s -X POST http://127.0.0.1:9765/v1/call \
+  -H 'Content-Type: application/json' \
+  -d '{"tool_slug": "<dcc>.<id8>.ping", "arguments": {}}'
+
+# 6. Verify instance rows
+curl -s http://127.0.0.1:9765/v1/instances | python -m json.tool
+
+# 7. Check gateway diagnostics
+curl -s http://127.0.0.1:9765/admin/api/health | python -m json.tool
+```
+
+If the real DCC is unavailable, mock the HTTP test in CI and document the manual
+smoke command in the adapter repository.
+
+## 3. Release-Please & Tag Naming
+
+### Tag Convention
+
+- **Per-adapter repos** use their own release-please config with `release-type: python`.
+  Tags are prefixed with the major.minor.patch of that adapter, *not* core.
+  Example: `v1.2.3` for `dcc-mcp-maya`.
+
+- **Core mono-repo** tags the root package at `v<semver>` (e.g. `v0.18.0`).
+
+### Release-Please Setup
+
+Every adapter repository should include a `release-please-config.json`:
+
+```json
+{
+  "release-type": "python",
+  "include-v-in-tag": true,
+  "packages": {
+    ".": {
+      "package-name": "dcc-mcp-<dcc>",
+      "include-component-in-tag": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "src/adapter/__init__.py"
+        }
+      ]
+    }
+  },
+  "changelog-sections": [
+    {"type": "feat", "section": "Features", "hidden": false},
+    {"type": "fix", "section": "Bug Fixes", "hidden": false},
+    {"type": "perf", "section": "Performance Improvements", "hidden": false},
+    {"type": "docs", "section": "Documentation", "hidden": false}
+  ]
+}
+```
+
+Refer to the core `.release-please-manifest.json` at
+[release-please-config.json](../../release-please-config.json) for the canonical pattern.
+
+### CHANGELOG Convention
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) as the source
+of truth. Merge the release-please PR to generate the changelog. Do not write
+changelog entries by hand.
+
+## 4. Validation Gates
+
+Before the release PR is merged, run these gates:
+
+- [ ] `ruff check src tests`
+- [ ] `ruff format --check src tests`
+- [ ] `pytest` (unit + integration)
+- [ ] Release-please PR guard passes (if the repo has one)
+- [ ] Gateway smoke commands run without error (Section 2)
+- [ ] Core dependency range is still valid: `>=0.<core_latest>.0,<1.0.0`
+
+## 5. PR Notes Template
+
+The release PR description must include:
+
+```markdown
+## Summary
+
+<!-- One-line summary of what this release changes -->
+
+## Validation
+
+<!-- Paste the gateway smoke output (Section 2) -->
+
+## Compatibility
+
+- **core pin**: `>=0.<N>.0,<1.0.0`
+- **adapter_version**: `<version>`
+- **DCC version**: `<minimum DCC version>`
+
+## Gaps
+
+<!-- Any live-DCC test gap, known issues, deferred features -->
+```
+
+## 6. Post-Release
+
+- [ ] Compatibility matrix row is merged into core `main`.
+- [ ] If the release changes an established adapter pattern (dispatcher wiring,
+      readiness, resource registration), the `dcc-mcp-creator` skill references
+      in core are updated accordingly.
+- [ ] If a new major.minor of core was bumped, re-run gateway smoke on the
+      adapter to confirm no regressions.

--- a/docs/guide/new-adapter-onboarding.md
+++ b/docs/guide/new-adapter-onboarding.md
@@ -1,0 +1,203 @@
+# New Adapter Onboarding Template
+
+Use this template when creating a new DCC-MCP adapter repository. It covers
+the minimal wiring required to produce a release-train-compatible adapter.
+
+## 1. Repository Structure
+
+```
+dcc-mcp-<dcc>/
+├── src/
+│   ├── __init__.py          # Public re-exports
+│   └── server.py            # Composition root
+├── skills/
+│   └── <dcc>-scripting/
+│       ├── SKILL.md
+│       ├── tools.yaml
+│       └── scripts/
+├── tests/
+│   ├── test_server.py
+│   └── test_skills.py
+├── pyproject.toml
+├── README.md
+├── release-please-config.json
+└── .github/
+    └── workflows/
+        └── ci.yml
+```
+
+## 2. pyproject.toml Dependency Snippet
+
+```toml
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dcc-mcp-<dcc>"
+version = "0.1.0"
+description = "DCC-MCP adapter for <DCC>"
+authors = [{name = "Your Name", email = "you@studio.com"}]
+license = {text = "MIT"}
+requires-python = ">=3.9"
+dependencies = [
+    # Pin core to the latest released minor, never to main.
+    "dcc-mcp-core>=0.18.0,<1.0.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "dcc-mcp-core[test]",
+    "pytest>=8.3.0",
+    "ruff>=0.8.0",
+]
+
+[tool.ruff]
+target-version = "py39"
+line-length = 100
+```
+
+## 3. adapter_version & Readiness Boilerplate
+
+Reference implementation (based on the Maya / 3ds Max adapter pattern):
+
+```python
+# src/<dcc>/server.py
+from pathlib import Path
+
+from dcc_mcp_core import (
+    DccServerBase,
+    DccServerOptions,
+    HostExecutionBridge,
+    AdapterReadinessBinder,
+    register_all_builtin_skills,
+)
+from dcc_mcp_core.install_lifecycle import build_sidecar_command
+
+ADAPTER_VERSION = "0.1.0"
+
+
+class MyDccServer(DccServerBase):
+    def __init__(self, port: int = 8765, dispatcher=None, **kwargs):
+        bridge = HostExecutionBridge(dispatcher=dispatcher) if dispatcher else None
+        options = DccServerOptions.from_env(
+            "<dcc>",
+            skills_dir=Path(__file__).parent.parent.parent / "skills",
+            port=port,
+            execution_bridge=bridge,
+            adapter_version=ADAPTER_VERSION,
+            **kwargs,
+        )
+        super().__init__(options=options)
+
+    def _version_string(self) -> str:
+        return ADAPTER_VERSION
+
+
+def start_server(port: int = 8765):
+    """Adapter entry point — call from the DCC startup script."""
+    server = MyDccServer(port=port)
+    AdapterReadinessBinder.bind_inline(server)
+    register_all_builtin_skills(server, dcc_name="<dcc>", skills=server.skills)
+    server.start()
+    return server
+
+
+def stop_server(server):
+    """Adapter shutdown."""
+    server.stop()
+```
+
+### Readiness Binding
+
+| Adapter shape | Use |
+|---|---|
+| Interactive GUI (Maya, Houdini, 3ds Max, Nuke) | `AdapterReadinessBinder.bind_inline(server)` |
+| Headless / batch (mayapy, hython, blender -b) | `AdapterReadinessBinder.bind_headless(server)` |
+| Queue dispatcher with pump | `AdapterReadinessBinder.bind_queue_dispatcher(server, dispatcher, require_first_pump=True)` |
+
+See [adapter-runtime-contracts.md](adapter-runtime-contracts.md) for the full
+contract.
+
+## 4. Multica Project Binding
+
+When the adapter repository is managed through Multica, bind these resources:
+
+```json
+{
+  "resources": [
+    {
+      "type": "github_repo",
+      "uri": "https://github.com/<org>/dcc-mcp-<dcc>.git",
+      "label": "dcc-mcp-<dcc>"
+    },
+    {
+      "type": "local_directory",
+      "label": "dcc-mcp-<dcc>",
+      "path": "/home/user/projects/dcc-mcp-<dcc>"
+    }
+  ]
+}
+```
+
+## 5. CI/CD Snippet
+
+Minimum CI workflow (`.github/workflows/ci.yml`):
+
+```yaml
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[test]"
+      - run: ruff check src tests
+      - run: ruff format --check src tests
+      - run: pytest
+```
+
+## 6. First Skill Package
+
+Create a minimal `skills/<dcc>-scripting/SKILL.md` ping tool to prove the
+skill pipeline works end-to-end:
+
+```yaml
+---
+name: <dcc>-scripting
+description: Core scripting and query tools for <DCC>
+metadata:
+  dcc-mcp:
+    dcc: <dcc>
+    layer: infrastructure
+    version: "0.1.0"
+---
+```
+
+Plus a sibling `tools.yaml` with one tool definition and a `scripts/` directory
+with the implementation. Refer to the
+[dcc-mcp-skills-creator](../../skills/dcc-mcp-skills-creator/SKILL.md) skill
+for detailed authoring guidance.
+
+## 7. VRS Smoke Trace
+
+Add one VRS trace under `tests/vrs/traces/<dcc>-smoke.jsonl` to verify the
+gateway can discover the new adapter. Copy the pattern from
+[tests/vrs/traces/](../../tests/vrs/traces/) and adjust `dcc_type` / expected
+tool slugs.
+
+## 8. Post-Onboarding
+
+- [ ] Submit a PR to core adding the adapter row to the
+      [Adapter Compatibility Matrix](adapter-compatibility-matrix.md).
+- [ ] Verify the gateway smoke runs (see [adapter-release-checklist.md](adapter-release-checklist.md#2-gateway-smoke-steps)).
+- [ ] File a core issue if any adapter-local code should be escalated
+      (see [CORE_ESCALATION_CHECKLIST.md](../../skills/dcc-mcp-creator/references/CORE_ESCALATION_CHECKLIST.md)).

--- a/llms.txt
+++ b/llms.txt
@@ -38,6 +38,11 @@
 
 **New to this project?** Read [`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md) FIRST.
 
+**Building a DCC-MCP adapter?** Follow the release train docs in order:
+1. [`new-adapter-onboarding.md`](docs/guide/new-adapter-onboarding.md) — scaffolding template
+2. [`adapter-release-checklist.md`](docs/guide/adapter-release-checklist.md) — release gate checklist
+3. [`adapter-compatibility-matrix.md`](docs/guide/adapter-compatibility-matrix.md) — per-DCC version table
+
 ---
 
 ## Quick Decision Guide

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -54,7 +54,10 @@ skill taxonomy), load `dcc-mcp-skills-creator` instead.
    - [ADAPTER_WORKFLOW.md](references/ADAPTER_WORKFLOW.md) for the build path.
    - [HOST_PATTERN_MATRIX.md](references/HOST_PATTERN_MATRIX.md) for host-specific wiring.
    - [CORE_ESCALATION_CHECKLIST.md](references/CORE_ESCALATION_CHECKLIST.md) before adding adapter-local glue.
-   - [TESTING_AND_RELEASE.md](references/TESTING_AND_RELEASE.md) before validating or publishing.
+    - [TESTING_AND_RELEASE.md](references/TESTING_AND_RELEASE.md) before validating or publishing.
+    - [docs/guide/adapter-release-checklist.md](../../docs/guide/adapter-release-checklist.md) for release train compliance.
+    - [docs/guide/new-adapter-onboarding.md](../../docs/guide/new-adapter-onboarding.md) for new adapter scaffolding.
+    - [docs/guide/adapter-compatibility-matrix.md](../../docs/guide/adapter-compatibility-matrix.md) for the per-DCC compatibility table.
 3. Start from `DccServerBase` + `DccServerOptions.from_env(...)`.
 4. Route host API calls through `HostExecutionBridge`; do not hand-roll a second script executor.
 5. Keep DCC identity data-driven: `dcc_name`, `server_name`, env-var prefix, skill names, and gateway metadata.


### PR DESCRIPTION
## Summary

Add three new reference documents for the adapter Release Train pipeline.

### New Documents

1. **docs/guide/adapter-release-checklist.md** — Release train gate checklist
   - Core minimum version pin rule (\>=0.18.0,<1.0.0\)
   - Sidecar required metadata list
   - Gateway smoke steps (from TESTING_AND_RELEASE.md)
   - Release-please / tag naming convention
   - PR notes template

2. **docs/guide/new-adapter-onboarding.md** — Onboarding template
   - pyproject.toml dependency snippet
   - adapter_version / readiness boilerplate (pointing to Maya/3ds Max pattern)
   - Multica project binding (github_repo + local_directory)
   - CI/CD workflow snippet
   - First skill package template

3. **docs/guide/adapter-compatibility-matrix.md** — Per-DCC version table
   - Every known adapter row (Maya, 3ds Max, Blender, Houdini, planned entries)
   - Core pin policy
   - Stale row policy

### Updated Files

- docs/guide/INDEX.md — added 'Adapter Release Train & Onboarding' section
- llms.txt — added 'Building a DCC-MCP adapter?' block pointing to the three docs
- skills/dcc-mcp-creator/SKILL.md — added references to the three new docs in the Fast Workflow section

## Validation

- [x] Pre-commit hooks passed (ruff, cargo, end-of-file, whitespace)
- [x] Documents link-checked against existing docs hierarchy

Closes PIP-543