### PR TITLE
docs: add marketplace, analytics dashboard, and sentry monitoring docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -92,6 +92,8 @@ export default defineConfig({
               text: 'DCC Integration',
               items: [
                 { text: 'Admin UI', link: '/guide/admin-ui' },
+                { text: 'Analytics Dashboard', link: '/guide/analytics-dashboard' },
+                { text: 'Sentry Error Monitoring', link: '/guide/sentry' },
                 { text: 'App UI Workflows', link: '/guide/app-ui-workflows' },
                 { text: 'Host Adapter', link: '/guide/host-adapter' },
                 { text: 'Adapter Runtime Contracts', link: '/guide/adapter-runtime-contracts' },
@@ -103,6 +105,7 @@ export default defineConfig({
               text: 'Catalog & Skills',
               items: [
                 { text: 'Catalog', link: '/guide/catalog' },
+                { text: 'Marketplace', link: '/guide/marketplace' },
                 { text: 'Skill Maintenance', link: '/guide/skill-maintenance' },
                 { text: 'Rez Skill Packages', link: '/guide/rez-skill-packages' },
                 { text: 'Context Bundles', link: '/guide/context-bundles' },
@@ -274,6 +277,8 @@ export default defineConfig({
               text: 'DCC 集成',
               items: [
                 { text: '管理界面', link: '/zh/guide/admin-ui' },
+                { text: '分析仪表盘', link: '/zh/guide/analytics-dashboard' },
+                { text: 'Sentry 错误监控', link: '/zh/guide/sentry' },
                 { text: 'App UI 工作流', link: '/zh/guide/app-ui-workflows' },
                 { text: '主机适配器', link: '/zh/guide/host-adapter' },
                 { text: '适配器运行时契约', link: '/zh/guide/adapter-runtime-contracts' },
@@ -285,6 +290,7 @@ export default defineConfig({
               text: '目录与技能',
               items: [
                 { text: '技能目录', link: '/zh/guide/catalog' },
+                { text: '市场技能包', link: '/zh/guide/marketplace' },
                 { text: '技能维护', link: '/zh/guide/skill-maintenance' },
                 { text: 'Rez 技能包', link: '/zh/guide/rez-skill-packages' },
                 { text: '上下文束', link: '/zh/guide/context-bundles' },

--- a/docs/guide/INDEX.md
+++ b/docs/guide/INDEX.md
@@ -50,6 +50,9 @@ document without scanning every file.
 | [protocols.md](protocols.md) | MCP protocol types and versioning |
 | [middleware.md](middleware.md) | Pluggable BeforeCall/AfterCall middleware chain: audit, quota, redaction |
 | [admin-ui.md](admin-ui.md) | Built-in embedded `/admin` dashboard (instances, tools, calls, traces, stats, workers, merged logs, health, durable JSONL audit/trace persistence) |
+| [analytics-dashboard.md](analytics-dashboard.md) | Analytics dashboard: KPIs, timeseries, heatmap, top tools, CSV/JSONL export |
+| [sentry.md](sentry.md) | Sentry error monitoring: DSN config, environment tags, sample rate, E2E tests |
+| [marketplace.md](marketplace.md) | Marketplace skill packages: catalog sources, install/update lifecycle, security |
 | [translate.md](translate.md) | `translate` subcommand: bridge any stdio MCP server to HTTP/SSE |
 | [openapi-mount.md](openapi-mount.md) | OpenAPI-to-MCP mount helper: expose any REST API as MCP tools |
 | [catalog.md](catalog.md) | DCC-MCP public adapter catalog: search and describe |

--- a/docs/guide/analytics-dashboard.md
+++ b/docs/guide/analytics-dashboard.md
@@ -1,0 +1,161 @@
+# Analytics Dashboard
+
+The gateway analytics dashboard provides aggregate visibility into gateway
+traffic, performance, and token usage over configurable time ranges. It is
+available as a built-in panel in the `/admin` web UI and through REST API
+endpoints under `/admin/api/analytics/*`.
+
+## Activation
+
+The analytics dashboard is available on any gateway built with the `admin`
+feature (default). There is no separate configuration flag — if `/admin` is
+enabled, the analytics panel is available.
+
+```bash
+# Default: analytics included
+dcc-mcp-server --app maya
+
+# Disable admin (also disables analytics)
+dcc-mcp-server --no-admin
+```
+
+## REST API Endpoints
+
+All endpoints require a `range` query parameter indicating the look-back
+window. Supported values: `7d`, `30d` (default), `90d`, `180d`, `365d`.
+
+### `GET /admin/api/analytics/overview`
+
+Aggregate KPIs for the selected time range.
+
+```json
+{
+  "range_days": 30,
+  "calls_total": 15420,
+  "calls_success": 14803,
+  "calls_failed": 617,
+  "success_rate": 0.96,
+  "tokens_input": 28500000,
+  "tokens_output": 4200000,
+  "tokens_saved": 12300000,
+  "duration_ms_avg": 842,
+  "duration_ms_min": 12,
+  "duration_ms_max": 45000,
+  "llm_prompt_tokens": 15000000,
+  "llm_completion_tokens": 3800000,
+  "llm_total_tokens": 18800000,
+  "unique_instances": 12,
+  "unique_agents": 8,
+  "daily_series": [
+    { "date": "2026-05-06", "calls": 512, "failed": 18, "success": 494,
+      "tokens_input": 950000, "tokens_output": 140000, "tokens_saved": 410000 },
+    ...
+  ],
+  "top_tools": [
+    { "name": "maya_scene__get_session_info", "calls": 3200, "failed": 2,
+      "success": 3198, "success_rate": 0.999, "duration_ms_avg": 45 },
+    ...
+  ]
+}
+```
+
+### `GET /admin/api/analytics/timeseries`
+
+Time-series broken down by DCC type. Supports `granularity=day` (default) or
+`granularity=hour`.
+
+```json
+{
+  "range_days": 30,
+  "granularity": "day",
+  "points": [
+    { "timestamp": "2026-05-06T00:00:00Z", "calls": 512,
+      "dcc_breakdown": { "maya": 320, "blender": 192 } },
+    ...
+  ]
+}
+```
+
+### `GET /admin/api/analytics/heatmap`
+
+Hour-of-day × day-of-week heatmap data.
+
+```json
+{
+  "range_days": 30,
+  "cells": [
+    { "weekday": 1, "hour": 9, "calls": 142, "failed": 3 },
+    { "weekday": 1, "hour": 10, "calls": 189, "failed": 1 },
+    ...
+  ],
+  "max_calls": 234
+}
+```
+
+### `GET /admin/api/analytics/export`
+
+Bulk data export. Accepts `format=csv` (default) or `format=jsonl`.
+
+```text
+GET /admin/api/analytics/export?range=30d&format=csv
+Content-Disposition: attachment; filename="analytics-export-30d.csv"
+```
+
+## Web UI Panel
+
+The analytics panel in `/admin` renders:
+
+- **Range selector**: 7d / 30d / 90d / 180d / 365d
+- **KPI card grid**: total calls, success rate, failure count, input/output/saved
+  tokens, average duration, LLM token breakdown, unique instances, unique agents
+- **Daily trend mini-chart**: bar chart of calls per day; failed days highlighted
+  in red
+- **Heatmap**: 7 (weekday) × 24 (hour) grid with blue intensity gradient; hover
+  for tooltip with call/failure counts
+- **Top tools table**: ranked by call volume with failure count, success rate,
+  and average duration
+- **Export links**: CSV and JSONL download
+
+## Data Source
+
+Analytics are computed from `AdminAuditRecord` entries stored in:
+
+1. **SQLite** (`~/.dcc-mcp/gateway/admin/audit.db`) when durable audit is
+   configured via `DCC_MCP_GATEWAY_AUDIT_DIR`
+2. **In-memory ring buffer** (default, last ~5000 records)
+
+For persistent analytics across gateway restarts, set `DCC_MCP_GATEWAY_AUDIT_DIR`
+to a writable directory.
+
+## Data Aggregation
+
+Aggregation runs on-demand when API endpoints are called. The core
+`aggregate_audits()` function groups audit records by `(date, dcc_type, hour)`
+into `DayAggregate` structs tracking:
+
+| Field               | Source                                      |
+|---------------------|---------------------------------------------|
+| `calls_total`       | Count of audit records                      |
+| `calls_success`     | Records with `success == true`              |
+| `calls_failed`      | Records with `success == false`             |
+| `tokens_input`      | Sum of `llm_usage.input_tokens`             |
+| `tokens_output`     | Sum of `llm_usage.output_tokens`            |
+| `tokens_saved`      | Sum of `context.tokens.total_saved`         |
+| `llm_*`             | Direct LLM token counters                   |
+| `duration_ms_*`     | Min/max/sum of `duration_ms`                |
+| `instance_ids`      | Unique instance set                         |
+| `agent_ids`         | Unique agent set                            |
+
+## Limitations
+
+- Data retention is bounded by the audit store capacity (default ~5000 in-memory
+  records; for SQLite, by `DCC_MCP_GATEWAY_AUDIT_MAX_ROWS` / `MAX_BYTES`)
+- Aggregation is computed on every request; very large time ranges or high-traffic
+  gateways may see slower response times
+- The dashboard refreshes every 5 seconds via React Query polling
+
+## See Also
+
+- [admin-ui.md](admin-ui.md) — full admin dashboard documentation
+- [gateway.md](gateway.md) — gateway architecture and configuration
+- [observability.md](observability.md) — metrics, tracing, and Prometheus export

--- a/docs/guide/marketplace.md
+++ b/docs/guide/marketplace.md
@@ -1,0 +1,210 @@
+# Marketplace: Skill Package Catalog & Installer
+
+The marketplace is a CLI-first discovery and installation system for official and
+community skill packages. It resolves human-readable names from one or more
+catalog sources, downloads or clones the matching package, and registers it so
+the DCC adapter discovers it on the next restart or `reload_skill_paths` call.
+
+## Architecture
+
+```
+┌──────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│  CLI (CLAP)  │ ──▶ │ Application      │ ──▶ │ Domain           │
+│ marketplace  │     │ marketplace.rs   │     │ marketplace.rs   │
+│ subcommand   │     │ (business logic) │     │ (types/sources)  │
+└──────────────┘     └──────────────────┘     └──────────────────┘
+       │                        │                       │
+       │                        ▼                       │
+       │              ┌──────────────────┐              │
+       │              │ dcc-mcp-catalog  │              │
+       └──────────────│ (parse/search)   │──────────────┘
+                      └──────────────────┘
+                              │
+                              ▼
+                     ┌──────────────────┐
+                     │  Gateway         │
+                     │  gateway://catalog│
+                     │  MCP resources   │
+                     └──────────────────┘
+```
+
+The marketplace code lives in three layers:
+
+1. **Domain** (`crates/dcc-mcp-cli/src/domain/marketplace.rs`) — types:
+   `MarketplaceSource`, `MarketplaceHit`, `MarketplaceSearchResult`,
+   `InstalledMarketplacePackage`, `OutdatedMarketplacePackage`, etc.
+
+2. **Application** (`crates/dcc-mcp-cli/src/application/marketplace.rs`) —
+   business logic: source management, search across sources, installation,
+   uninstallation, update checks.
+
+3. **Catalog** (`crates/dcc-mcp-catalog/`) — standalone package that parses
+   `marketplace.json` / `catalog.yml` files, searches entries by keyword and
+   DCC type, and inspects individual entries.
+
+The gateway also exposes catalog data through MCP resources (`gateway://catalog`)
+with a 5-minute cache (see [catalog.md](catalog.md)).
+
+## Sources
+
+A marketplace **source** is a named reference to a catalog file. Sources are
+persisted in `~/.dcc-mcp/marketplace/sources.json`.
+
+| Source type         | Example                                        |
+|---------------------|------------------------------------------------|
+| Official (built-in) | `dcc-mcp/marketplace`                          |
+| GitHub slug         | `my-org/my-skills`                             |
+| Raw JSON URL        | `https://example.com/catalog.json`             |
+| Local file          | `/path/to/local-catalog.yml`                   |
+
+### Source Precedence
+
+1. Built-in official source (`dcc-mcp/marketplace`)
+2. User-configured sources (persisted in `sources.json`)
+3. Environment variable sources (`DCC_MCP_MARKETPLACE_SOURCES`)
+4. Explicit `--source` CLI flag
+
+Set `DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES=1` to disable the built-in source.
+
+## CLI Commands
+
+| Command                                   | Description                                    |
+|-------------------------------------------|------------------------------------------------|
+| `marketplace add <source>`                | Register a marketplace source                  |
+| `marketplace list`                        | List configured sources                        |
+| `marketplace search --query <q>`          | Search entries across all sources              |
+| `marketplace inspect <name>`              | Show full entry metadata                       |
+| `marketplace install <name> --dcc <dcc>`  | Install a skill package                        |
+| `marketplace list-installed --dcc <dcc>`  | List installed packages                        |
+| `marketplace uninstall <name> --dcc <dcc>`| Remove an installed package                    |
+| `marketplace outdated [name] --dcc <dcc>` | Check for newer versions                       |
+| `marketplace update [name] --all`         | Upgrade installed packages                     |
+
+Full argument reference: [cli-reference.md](cli-reference.md#marketplace).
+
+## Installation Types
+
+Three install types are supported, controlled by the catalog entry's
+`install.type` field:
+
+### Git (`install.type: git`)
+
+Clones the repository on install, then uses `git fetch && git checkout <ref>`
+on subsequent updates. Best for actively developed skill packages.
+
+```yaml
+- name: dcc-mcp-maya-skills
+  install:
+    type: git
+    url: "https://github.com/example/dcc-mcp-maya-skills.git"
+    ref: "v1.2.0"
+```
+
+### Zip (`install.type: zip`)
+
+Downloads a ZIP archive (from URL or local path) and extracts it. Supports
+`sha256` verification. The archive root must contain exactly one top-level
+directory, which is flattened automatically.
+
+```yaml
+- name: dcc-asset-hunyuan-download
+  install:
+    type: zip
+    url: "https://example.com/packages/hunyuan-v2.zip"
+    sha256: "a1b2c3d4e5f6..."
+```
+
+### Path (`install.type: path`)
+
+Copies files from a local directory. Useful for development or internal
+tooling.
+
+```yaml
+- name: my-internal-skills
+  install:
+    type: path
+    url: "/share/skills/my-internal-skills"
+```
+
+## Directory Layout
+
+Installed packages land under:
+
+```
+~/.dcc-mcp/marketplace/
+├── sources.json              # registered source list
+├── installed.json            # installed-package state
+├── maya/
+│   ├── dcc-mcp-maya-skills/  # installed git clone
+│   └── my-custom-skill/      # installed path copy
+└── blender/
+    └── dcc-blender-skills/
+```
+
+DCC adapters automatically include `~/.dcc-mcp/marketplace/<dcc>` in their
+skill search paths (see `collect_skill_search_paths()` in `server_base.py`),
+so installed skills appear on adapter startup or `reload_skill_paths`.
+
+## Environment Variables
+
+| Variable                                   | Default                                      | Description                           |
+|--------------------------------------------|----------------------------------------------|---------------------------------------|
+| `DCC_MCP_MARKETPLACE_SOURCES`              | unset                                        | Comma-separated extra sources         |
+| `DCC_MCP_MARKETPLACE_SOURCES_FILE`         | `~/.dcc-mcp/marketplace/sources.json`        | Sources persistence path              |
+| `DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES`   | unset                                        | Disable built-in official source      |
+| `DCC_MCP_MARKETPLACE_INSTALL_ROOT`         | `~/.dcc-mcp/marketplace`                     | Install root directory override       |
+| `DCC_MCP_MARKETPLACE_OFFLINE`              | unset                                        | Force local-only catalog mode         |
+| `DCC_MCP_MARKETPLACE_CATALOG_URL`          | official marketplace URL                     | Override remote catalog URL           |
+
+## Security
+
+- **Path traversal protection**: `marketplace_path_component()` rejects empty
+  components, `.`, `..`, leading dots, and non-ASCII alphanumeric characters.
+- **SHA256 verification**: Zip installs verify `install.sha256` when present
+  and reject mismatches without modifying existing packages.
+- **Archive escape detection**: Zip extraction rejects entries that escape the
+  install root directory.
+- **Force mode**: `--force` re-attempts install on failure but preserves the
+  existing package when the replacement itself fails.
+
+## Gateway Integration
+
+The gateway exposes catalog data through MCP resources:
+
+```python
+# Search all catalog entries
+result = client.resources_read("gateway://catalog?query=physics")
+
+# Single entry by exact name
+result = client.resources_read("gateway://catalog/dcc-mcp-physics-sim")
+```
+
+The gateway fetches the remote `marketplace.json` on a 5-minute cache cycle,
+falling back to the local `dcc-mcp-catalog.yml` when offline. Set
+`DCC_MCP_MARKETPLACE_OFFLINE=1` to force local-only mode.
+
+## Catalog Entry Format
+
+```yaml
+- name: dcc-mcp-maya-skills          # unique kebab-case identifier
+  description: "Official Maya skill pack"
+  dcc: [maya]                        # supported DCC types
+  url: "https://github.com/..."      # project URL
+  tags: [skills, maya, official]     # searchable tags
+  version: "1.2.0"                   # current version
+  min_core_version: ">=0.17.0"       # minimum dcc-mcp-core version
+  install:
+    type: git                        # git | zip | path
+    url: "https://github.com/..."
+    ref: "v1.2.0"                    # tag/branch/commit (git type)
+    sha256: "a1b2c3..."              # content hash (zip type)
+  maintainer: "team@example.com"     # optional contact
+```
+
+## See Also
+
+- [cli-reference.md](cli-reference.md) — CLI command reference with full flag
+  documentation
+- [catalog.md](catalog.md) — DCC-MCP public adapter catalog format
+- [skills.md](skills.md) — how to author a skill pack
+- [admin-ui.md](admin-ui.md) — marketplace panel in the web dashboard

--- a/docs/guide/sentry.md
+++ b/docs/guide/sentry.md
@@ -1,0 +1,84 @@
+# Sentry Error Monitoring
+
+The gateway and server binaries ship with built-in Sentry SDK integration for
+real-time error monitoring. The SDK captures Rust panics, explicit error events,
+and selected span breadcrumbs automatically.
+
+## Activation
+
+Set the `DCC_MCP_SENTRY_DSN` environment variable to your Sentry project DSN.
+The SDK initialises at server startup and captures panics automatically.
+
+```bash
+DCC_MCP_SENTRY_DSN="https://<key>@o<org>.ingest.sentry.io/<project>" \
+  dcc-mcp-server --app maya
+```
+
+## Configuration
+
+| Variable                      | Default              | Description                                |
+|-------------------------------|----------------------|--------------------------------------------|
+| `DCC_MCP_SENTRY_DSN`          | (disabled)           | Sentry project DSN                         |
+| `DCC_MCP_SENTRY_ENVIRONMENT`  | `production`         | Environment tag for source-map filtering   |
+| `DCC_MCP_SENTRY_RELEASE`      | crate version        | Release identifier (commit correlation)    |
+| `DCC_MCP_SENTRY_SAMPLE_RATE`  | `1.0`                | Error event sample rate (`0.0`–`1.0`)      |
+
+When `DCC_MCP_SENTRY_DSN` is absent the SDK skips initialisation entirely,
+so zero-config deployments pay no overhead.
+
+## What Gets Captured
+
+| Event type                 | Automatic? | Notes                            |
+|----------------------------|------------|----------------------------------|
+| Rust panics                | ✅ Yes     | Caught by the Sentry panic hook  |
+| Explicit `sentry::capture_error` | Manual | Use in catch blocks              |
+| Explicit `sentry::capture_message` | Manual | Use for business-logic alerts    |
+| Span breadcrumbs           | ✅ Yes     | When OTLP tracing is also active |
+| Webhook delivery failures  | ✅ Yes     | When webhooks are configured     |
+
+## Python-Side Error Reporting
+
+Python adapters can forward exceptions to Sentry through the Rust bridge.
+Use the `dcc_mcp_core.telemetry` helpers:
+
+```python
+from dcc_mcp_core import capture_exception
+
+try:
+    # … skill execution …
+    pass
+except Exception as exc:
+    capture_exception(exc)
+```
+
+## Disabling Sentry
+
+The Sentry crate is compiled in by default. To exclude it from the binary:
+
+```bash
+# Build without default features, then opt in only what you need
+cargo build --no-default-features -p dcc-mcp-server
+```
+
+The SDK skips initialisation when `DCC_MCP_SENTRY_DSN` is absent, so the
+compiled-in crate adds negligible size unless a DSN is configured.
+
+## E2E Tests
+
+Real-ingest Sentry E2E tests are gated behind the `sentry_e2e` feature and
+require a valid `DCC_MCP_SENTRY_DSN` environment variable:
+
+```bash
+cargo test --features sentry_e2e --test sentry_e2e
+```
+
+These tests send events to your configured Sentry project and verify the
+ingest pipeline end-to-end. They are excluded from CI unless the
+`sentry_e2e` flag is explicitly set.
+
+## See Also
+
+- [gateway.md](gateway.md) — gateway configuration including webhooks and
+  observability
+- [observability.md](observability.md) — metrics, OTLP tracing, Prometheus
+- [production-deployment.md](production-deployment.md) — production checklist

--- a/docs/zh/guide/INDEX.md
+++ b/docs/zh/guide/INDEX.md
@@ -47,6 +47,9 @@
 | [protocols.md](protocols.md) | MCP 协议类型与版本管理 |
 | [middleware.md](middleware.md) | 可插拔 BeforeCall/AfterCall 中间件链：审计、限流、脱敏 |
 | [admin-ui.md](admin-ui.md) | 内置零构建 `/admin` 仪表盘（实例、工具、调用、traces、stats、workers、日志、健康、JSONL 审计/trace 持久化） |
+| [analytics-dashboard.md](analytics-dashboard.md) | 分析仪表盘：KPI、时序、热力图、Top 工具、CSV/JSONL 导出 |
+| [sentry.md](sentry.md) | Sentry 错误监控：DSN 配置、环境标签、采样率、E2E 测试 |
+| [marketplace.md](marketplace.md) | 市场技能包：目录源、安装/更新生命周期、安全机制 |
 | [translate.md](translate.md) | `translate` 子命令：将任意 stdio MCP 服务器桥接到 HTTP/SSE |
 | [openapi-mount.md](openapi-mount.md) | OpenAPI → MCP 挂载助手：将任意 REST API 暴露为 MCP 工具 |
 | [catalog.md](catalog.md) | DCC-MCP 公共适配器目录：搜索与描述 |

--- a/docs/zh/guide/analytics-dashboard.md
+++ b/docs/zh/guide/analytics-dashboard.md
@@ -1,0 +1,155 @@
+# 分析仪表盘
+
+网关分析仪表盘提供网关流量、性能和 Token 使用的聚合可见性，支持可配置的时间范围。
+它作为内置面板在 `/admin` Web UI 中提供，也可通过 `/admin/api/analytics/*` 的
+REST API 端点访问。
+
+## 启用
+
+分析仪表盘在启用了 `admin` 特性（默认）的网关上可用。无需单独的配置标志——
+如果 `/admin` 已启用，分析面板即可使用。
+
+```bash
+# 默认：包含分析功能
+dcc-mcp-server --app maya
+
+# 禁用管理 UI（也会禁用分析）
+dcc-mcp-server --no-admin
+```
+
+## REST API 端点
+
+所有端点都需要 `range` 查询参数来指定回溯窗口。支持的值：
+`7d`、`30d`（默认）、`90d`、`180d`、`365d`。
+
+### `GET /admin/api/analytics/overview`
+
+所选时间范围内的聚合 KPI。
+
+```json
+{
+  "range_days": 30,
+  "calls_total": 15420,
+  "calls_success": 14803,
+  "calls_failed": 617,
+  "success_rate": 0.96,
+  "tokens_input": 28500000,
+  "tokens_output": 4200000,
+  "tokens_saved": 12300000,
+  "duration_ms_avg": 842,
+  "duration_ms_min": 12,
+  "duration_ms_max": 45000,
+  "llm_prompt_tokens": 15000000,
+  "llm_completion_tokens": 3800000,
+  "llm_total_tokens": 18800000,
+  "unique_instances": 12,
+  "unique_agents": 8,
+  "daily_series": [
+    { "date": "2026-05-06", "calls": 512, "failed": 18, "success": 494,
+      "tokens_input": 950000, "tokens_output": 140000, "tokens_saved": 410000 },
+    ...
+  ],
+  "top_tools": [
+    { "name": "maya_scene__get_session_info", "calls": 3200, "failed": 2,
+      "success": 3198, "success_rate": 0.999, "duration_ms_avg": 45 },
+    ...
+  ]
+}
+```
+
+### `GET /admin/api/analytics/timeseries`
+
+按 DCC 类型细分的时间序列。支持 `granularity=day`（默认）或
+`granularity=hour`。
+
+```json
+{
+  "range_days": 30,
+  "granularity": "day",
+  "points": [
+    { "timestamp": "2026-05-06T00:00:00Z", "calls": 512,
+      "dcc_breakdown": { "maya": 320, "blender": 192 } },
+    ...
+  ]
+}
+```
+
+### `GET /admin/api/analytics/heatmap`
+
+小时 × 星期热力图数据。
+
+```json
+{
+  "range_days": 30,
+  "cells": [
+    { "weekday": 1, "hour": 9, "calls": 142, "failed": 3 },
+    { "weekday": 1, "hour": 10, "calls": 189, "failed": 1 },
+    ...
+  ],
+  "max_calls": 234
+}
+```
+
+### `GET /admin/api/analytics/export`
+
+批量数据导出。接受 `format=csv`（默认）或 `format=jsonl`。
+
+```text
+GET /admin/api/analytics/export?range=30d&format=csv
+Content-Disposition: attachment; filename="analytics-export-30d.csv"
+```
+
+## Web UI 面板
+
+`/admin` 中的分析面板会渲染：
+
+- **时间范围选择器**：7天 / 30天 / 90天 / 180天 / 365天
+- **KPI 卡片网格**：总调用数、成功率、失败数、输入/输出/节省 Token、平均耗时、
+  LLM Token 细分、唯一实例数、唯一 Agent 数
+- **每日趋势迷你图**：每日调用量的柱状图；失败日以红色高亮
+- **热力图**：7（星期）× 24（小时）网格，蓝色渐变色阶；悬停提示显示
+  调用/失败计数
+- **Top 工具表格**：按调用量排序，含失败数、成功率、平均耗时
+- **导出链接**：CSV 和 JSONL 下载
+
+## 数据源
+
+分析数据从存储在以下位置的 `AdminAuditRecord` 条目计算：
+
+1. **SQLite**（`~/.dcc-mcp/gateway/admin/audit.db`）— 通过
+   `DCC_MCP_GATEWAY_AUDIT_DIR` 配置持久化审计后可用
+2. **内存环形缓冲区**（默认，约最后 5000 条记录）
+
+要实现跨网关重启的持久化分析，请设置 `DCC_MCP_GATEWAY_AUDIT_DIR` 为
+可写目录。
+
+## 数据聚合
+
+API 端点被调用时按需运行聚合。核心 `aggregate_audits()` 函数将审计记录
+按 `(date, dcc_type, hour)` 分组到 `DayAggregate` 结构中，跟踪：
+
+| 字段               | 来源                                |
+|--------------------|-------------------------------------|
+| `calls_total`      | 审计记录计数                        |
+| `calls_success`    | `success == true` 的记录            |
+| `calls_failed`     | `success == false` 的记录           |
+| `tokens_input`     | `llm_usage.input_tokens` 的总和     |
+| `tokens_output`    | `llm_usage.output_tokens` 的总和    |
+| `tokens_saved`     | `context.tokens.total_saved` 的总和 |
+| `llm_*`            | 直接 LLM Token 计数器               |
+| `duration_ms_*`    | `duration_ms` 的最小/最大/总和      |
+| `instance_ids`     | 唯一实例集合                        |
+| `agent_ids`        | 唯一 Agent 集合                     |
+
+## 限制
+
+- 数据保留受审计存储容量限制（内存模式默认约 5000 条记录；SQLite 模式受
+  `DCC_MCP_GATEWAY_AUDIT_MAX_ROWS` / `MAX_BYTES` 限制）
+- 聚合在每次请求时计算；非常大的时间范围或高流量网关可能响应较慢
+- 仪表盘每 5 秒通过 React Query 轮询刷新
+
+## 参见
+
+- [admin-ui.md](admin-ui.md) — 完整管理仪表盘文档
+- [gateway.md](gateway.md) — 网关架构与配置
+- [observability.md](observability.md) — 指标、追踪与 Prometheus 导出

--- a/docs/zh/guide/marketplace.md
+++ b/docs/zh/guide/marketplace.md
@@ -1,0 +1,198 @@
+# Marketplace：技能包目录与安装器
+
+Marketplace 是一个 CLI 优先的发现和安装系统，用于官方和社区技能包。它将人类可读的名称从一个或多个目录源中解析，下载或克隆匹配的包，并注册到系统中，使得 DCC 适配器能够在下次重启或调用 `reload_skill_paths` 时发现它们。
+
+## 架构
+
+```
+┌──────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│  CLI (CLAP)  │ ──▶ │ 应用层           │ ──▶ │ 领域层           │
+│ marketplace  │     │ marketplace.rs   │     │ marketplace.rs   │
+│ 子命令        │     │ (业务逻辑)       │     │ (类型/源)        │
+└──────────────┘     └──────────────────┘     └──────────────────┘
+       │                        │                       │
+       │                        ▼                       │
+       │              ┌──────────────────┐              │
+       │              │ dcc-mcp-catalog  │              │
+       └──────────────│ (解析/搜索)      │──────────────┘
+                      └──────────────────┘
+                              │
+                              ▼
+                     ┌──────────────────┐
+                     │  Gateway         │
+                     │  gateway://catalog│
+                     │  MCP 资源        │
+                     └──────────────────┘
+```
+
+市场代码分为三层：
+
+1. **领域层**（`crates/dcc-mcp-cli/src/domain/marketplace.rs`）— 类型定义：
+   `MarketplaceSource`、`MarketplaceHit`、`MarketplaceSearchResult`、
+   `InstalledMarketplacePackage`、`OutdatedMarketplacePackage` 等。
+
+2. **应用层**（`crates/dcc-mcp-cli/src/application/marketplace.rs`）—
+   业务逻辑：源管理、跨源搜索、安装、卸载、更新检查。
+
+3. **目录包**（`crates/dcc-mcp-catalog/`）— 独立包，解析 `marketplace.json` /
+   `catalog.yml` 文件，按关键词和 DCC 类型搜索条目，并查看单个条目的详情。
+
+网关还通过 MCP 资源（`gateway://catalog`）暴露目录数据，缓存周期为 5 分钟（参见 [catalog.md](catalog.md)）。
+
+## 源
+
+Marketplace **源**是指向目录文件的命名引用。源持久化存储在 `~/.dcc-mcp/marketplace/sources.json` 中。
+
+| 源类型              | 示例                                          |
+|---------------------|-----------------------------------------------|
+| 官方（内置）        | `dcc-mcp/marketplace`                         |
+| GitHub slug         | `my-org/my-skills`                            |
+| 原始 JSON URL       | `https://example.com/catalog.json`            |
+| 本地文件            | `/path/to/local-catalog.yml`                  |
+
+### 源优先级
+
+1. 内置官方源（`dcc-mcp/marketplace`）
+2. 用户配置的源（持久化在 `sources.json`）
+3. 环境变量源（`DCC_MCP_MARKETPLACE_SOURCES`）
+4. 显式 `--source` CLI 标志
+
+设置 `DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES=1` 可禁用内置源。
+
+## CLI 命令
+
+| 命令                                      | 描述                      |
+|-------------------------------------------|---------------------------|
+| `marketplace add <source>`                | 注册一个市场源            |
+| `marketplace list`                        | 列出已配置的源            |
+| `marketplace search --query <q>`          | 跨源搜索条目              |
+| `marketplace inspect <name>`              | 显示完整条目元数据        |
+| `marketplace install <name> --dcc <dcc>`  | 安装技能包                |
+| `marketplace list-installed --dcc <dcc>`  | 列出已安装的包            |
+| `marketplace uninstall <name> --dcc <dcc>`| 移除已安装的包            |
+| `marketplace outdated [name] --dcc <dcc>` | 检查是否有更新版本        |
+| `marketplace update [name] --all`         | 升级已安装的包            |
+
+完整参数参考：[cli-reference.md](cli-reference.md#marketplace)。
+
+## 安装类型
+
+支持三种安装类型，由目录条目的 `install.type` 字段控制：
+
+### Git（`install.type: git`）
+
+安装时克隆仓库，后续更新时使用 `git fetch && git checkout <ref>`。
+最适合活跃开发的技能包。
+
+```yaml
+- name: dcc-mcp-maya-skills
+  install:
+    type: git
+    url: "https://github.com/example/dcc-mcp-maya-skills.git"
+    ref: "v1.2.0"
+```
+
+### Zip（`install.type: zip`）
+
+下载 ZIP 存档（从 URL 或本地路径）并解压。支持 `sha256` 校验。
+存档根目录必须包含恰好一个顶层目录，该目录会自动展平。
+
+```yaml
+- name: dcc-asset-hunyuan-download
+  install:
+    type: zip
+    url: "https://example.com/packages/hunyuan-v2.zip"
+    sha256: "a1b2c3d4e5f6..."
+```
+
+### Path（`install.type: path`）
+
+从本地目录复制文件。适用于开发或内部工具。
+
+```yaml
+- name: my-internal-skills
+  install:
+    type: path
+    url: "/share/skills/my-internal-skills"
+```
+
+## 目录布局
+
+已安装的包存放于：
+
+```
+~/.dcc-mcp/marketplace/
+├── sources.json              # 注册的源列表
+├── installed.json            # 已安装包的状态
+├── maya/
+│   ├── dcc-mcp-maya-skills/  # 已安装的 git 克隆
+│   └── my-custom-skill/      # 已安装的路径复制
+└── blender/
+    └── dcc-blender-skills/
+```
+
+DCC 适配器会自动将 `~/.dcc-mcp/marketplace/<dcc>` 加入其技能搜索路径
+（参见 `server_base.py` 中的 `collect_skill_search_paths()`），因此
+已安装的技能会在适配器启动或 `reload_skill_paths` 时被发现。
+
+## 环境变量
+
+| 变量                                      | 默认值                                     | 描述                        |
+|-------------------------------------------|--------------------------------------------|-----------------------------|
+| `DCC_MCP_MARKETPLACE_SOURCES`             | 未设置                                     | 逗号分隔的额外源            |
+| `DCC_MCP_MARKETPLACE_SOURCES_FILE`        | `~/.dcc-mcp/marketplace/sources.json`      | 源持久化路径                |
+| `DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES`  | 未设置                                     | 禁用内置官方源              |
+| `DCC_MCP_MARKETPLACE_INSTALL_ROOT`        | `~/.dcc-mcp/marketplace`                   | 安装根目录覆盖              |
+| `DCC_MCP_MARKETPLACE_OFFLINE`             | 未设置                                     | 强制仅本地目录模式          |
+| `DCC_MCP_MARKETPLACE_CATALOG_URL`         | 官方市场 URL                               | 覆盖远程目录 URL            |
+
+## 安全
+
+- **路径遍历保护**：`marketplace_path_component()` 拒绝空组件、`.`、`..`、
+  前导点和非 ASCII 字母数字字符。
+- **SHA256 校验**：ZIP 安装会验证 `install.sha256`（如果存在），在哈希不匹配
+  时拒绝安装，且不会修改已有包。
+- **压缩包逃逸检测**：ZIP 解压会拒绝逃脱安装根目录的条目。
+- **强制模式**：`--force` 会在安装失败时重试，但当替换本身失败时会保留
+  现有包。
+
+## 网关集成
+
+网关通过 MCP 资源暴露目录数据：
+
+```python
+# 搜索所有目录条目
+result = client.resources_read("gateway://catalog?query=physics")
+
+# 按精确名称查看单个条目
+result = client.resources_read("gateway://catalog/dcc-mcp-physics-sim")
+```
+
+网关以 5 分钟缓存周期获取远程 `marketplace.json`，在离线时回退到本地
+`dcc-mcp-catalog.yml`。设置 `DCC_MCP_MARKETPLACE_OFFLINE=1` 可强制
+仅本地模式。
+
+## 目录条目格式
+
+```yaml
+- name: dcc-mcp-maya-skills          # 唯一 kebab-case 标识符
+  description: "Official Maya skill pack"
+  dcc: [maya]                        # 支持的 DCC 类型
+  url: "https://github.com/..."      # 项目 URL
+  tags: [skills, maya, official]     # 可搜索标签
+  version: "1.2.0"                   # 当前版本
+  min_core_version: ">=0.17.0"       # 最低 dcc-mcp-core 版本
+  install:
+    type: git                        # git | zip | path
+    url: "https://github.com/..."
+    ref: "v1.2.0"                    # 标签/分支/提交（git 类型）
+    sha256: "a1b2c3..."              # 内容哈希（zip 类型）
+  maintainer: "team@example.com"     # 可选联系方式
+```
+
+## 参见
+
+- [cli-reference.md](cli-reference.md) — 带完整标志文档的 CLI 命令参考
+- [catalog.md](catalog.md) — DCC-MCP 公共适配器目录格式
+- [skills.md](skills.md) — 如何编写技能包
+- [admin-ui.md](admin-ui.md) — Web 仪表盘中的市场面板

--- a/docs/zh/guide/sentry.md
+++ b/docs/zh/guide/sentry.md
@@ -1,0 +1,81 @@
+# Sentry 错误监控
+
+网关和服务端二进制文件内置了 Sentry SDK 集成，用于实时错误监控。
+SDK 会自动捕获 Rust panics、显式错误事件以及选定的 span breadcrumbs。
+
+## 启用的
+
+设置 `DCC_MCP_SENTRY_DSN` 环境变量为你的 Sentry 项目 DSN。
+SDK 在服务器启动时初始化，并自动捕获 panics。
+
+```bash
+DCC_MCP_SENTRY_DSN="https://<key>@o<org>.ingest.sentry.io/<project>" \
+  dcc-mcp-server --app maya
+```
+
+## 配置
+
+| 变量                            | 默认值              | 描述                              |
+|---------------------------------|---------------------|-----------------------------------|
+| `DCC_MCP_SENTRY_DSN`            | （禁用）            | Sentry 项目 DSN                   |
+| `DCC_MCP_SENTRY_ENVIRONMENT`    | `production`        | 用于 source-map 过滤的环境标签    |
+| `DCC_MCP_SENTRY_RELEASE`        | crate 版本          | 发布标识符（提交关联）            |
+| `DCC_MCP_SENTRY_SAMPLE_RATE`    | `1.0`               | 错误事件采样率（`0.0`–`1.0`）    |
+
+当 `DCC_MCP_SENTRY_DSN` 不存在时，SDK 完全跳过初始化，因此零配置部署
+没有任何开销。
+
+## 会捕获什么
+
+| 事件类型                | 自动？    | 说明                             |
+|-------------------------|-----------|----------------------------------|
+| Rust panics             | ✅ 是     | 由 Sentry panic hook 捕获        |
+| 显式 `sentry::capture_error` | 手动 | 在 catch 块中使用                |
+| 显式 `sentry::capture_message` | 手动 | 用于业务逻辑告警                 |
+| Span breadcrumbs        | ✅ 是     | 当 OTLP 追踪也启用时             |
+| Webhook 投递失败        | ✅ 是     | 当配置了 webhooks 时             |
+
+## Python 端的错误报告
+
+Python 适配器可以通过 Rust 桥接将异常转发到 Sentry。
+使用 `dcc_mcp_core.telemetry` 辅助函数：
+
+```python
+from dcc_mcp_core import capture_exception
+
+try:
+    # … 技能执行 …
+    pass
+except Exception as exc:
+    capture_exception(exc)
+```
+
+## 禁用 Sentry
+
+Sentry crate 默认被编译进二进制文件。要将其从二进制文件中排除：
+
+```bash
+# 不使用默认特性构建，然后仅选择需要的特性
+cargo build --no-default-features -p dcc-mcp-server
+```
+
+当 `DCC_MCP_SENTRY_DSN` 不存在时，SDK 跳过初始化，因此编译进来的 crate
+除非配置了 DSN，否则增加的大小可以忽略不计。
+
+## E2E 测试
+
+真实数据摄入的 Sentry E2E 测试由 `sentry_e2e` 特性门控，需要有效的
+`DCC_MCP_SENTRY_DSN` 环境变量：
+
+```bash
+cargo test --features sentry_e2e --test sentry_e2e
+```
+
+这些测试会向你配置的 Sentry 项目发送事件，并端到端验证摄入管道。
+除非显式设置 `sentry_e2e` 标志，否则 CI 中会排除这些测试。
+
+## 参见
+
+- [gateway.md](gateway.md) — 网关配置，包括 webhooks 和可观测性
+- [observability.md](observability.md) — 指标、OTLP 追踪、Prometheus
+- [production-deployment.md](production-deployment.md) — 生产部署检查清单


### PR DESCRIPTION
## Summary

Adds three missing documentation guides identified during the 7-day documentation audit (PIP-544):

### New documents

1. **Marketplace** (\docs/guide/marketplace.md\) — conceptual guide for the skill package catalog and installer system, covering architecture, sources, install types (git/zip/path), directory layout, security, and gateway integration
2. **Analytics Dashboard** (\docs/guide/analytics-dashboard.md\) — REST API endpoints (overview, timeseries, heatmap, export), web UI panel description, data aggregation, and limitations
3. **Sentry Error Monitoring** (\docs/guide/sentry.md\) — activation, configuration vars, capture scope, Python-side reporting, disablement, and E2E tests

### Chinese translations

All three new documents have corresponding Chinese translations under \docs/zh/guide/\.

### Updated files

- \docs/guide/INDEX.md\ + \docs/zh/guide/INDEX.md\ — added entries for all three new docs
- \docs/.vitepress/config.mts\ — added sidebar navigation entries (EN + ZH)

### Documentation audit context

These three gaps were the highest-severity findings from a comprehensive audit of the past 7 days of merged changes on \main\:

- **Marketplace**: previously only had thin CLI reference coverage in \cli-reference.md\ — no conceptual guide existed
- **Analytics Dashboard**: entirely undocumented beyond a 5-line YAML snippet in \gateway.md\
- **Sentry**: 10-line stub in \gateway.md\ — no dedicated doc or Python-side coverage

Reviewed features with adequate docs (no gap): meta passthrough, gateway lifecycle/idle policy, gateway guardian, admin UI, Autodesk Product Help catalog, daemon mode vocabulary.