### PR TITLE
PIP-521: reload skill paths after marketplace install/uninstall

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -16,6 +16,7 @@ use super::debug_response::{DebugListQuery, debug_response};
 use super::html::ADMIN_HTML;
 use super::issue_report::{IssueReportMode, issue_report_filename, issue_report_json};
 use super::links::AdminLinkBuilder;
+use super::skill_reload::reload_skill_paths_and_refresh_backends;
 use super::state::{AdminAuditRecord, AdminState};
 use super::trace::{AgentContext, DispatchTrace};
 use crate::gateway::capability::RefreshReason;
@@ -1132,13 +1133,6 @@ fn push_admin_operator_note(state: &AdminState, msg: String) {
         "gateway",
         Some(msg),
     ));
-}
-
-async fn reload_skill_paths_and_refresh_backends(state: &AdminState, reason: RefreshReason) {
-    if let Some(cb) = state.skill_paths_reload.clone() {
-        cb();
-    }
-    refresh_all_live_backends(&state.gateway, reason).await;
 }
 
 /// `GET /admin/api/skill-paths` — skill search paths (snapshot + SQLite custom).

--- a/crates/dcc-mcp-gateway/src/gateway/admin/marketplace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/marketplace.rs
@@ -293,6 +293,9 @@ fn resolve_source_url(raw: &str) -> String {
     if trimmed.eq_ignore_ascii_case("dcc-mcp/marketplace") {
         return OFFICIAL_MARKETPLACE_SOURCE.to_string();
     }
+    if trimmed.starts_with('/') || Path::new(trimmed).is_absolute() {
+        return trimmed.to_string();
+    }
     let looks_like_slug =
         trimmed.contains('/') && !trimmed.contains("://") && !trimmed.contains('\\');
     if looks_like_slug {
@@ -669,6 +672,12 @@ mod tests {
     fn resolve_source_url_passes_through_urls() {
         let url = resolve_source_url("https://example.com/catalog.json");
         assert_eq!(url, "https://example.com/catalog.json");
+    }
+
+    #[test]
+    fn resolve_source_url_passes_through_absolute_paths() {
+        let url = resolve_source_url("/tmp/catalog.json");
+        assert_eq!(url, "/tmp/catalog.json");
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/marketplace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/marketplace.rs
@@ -18,7 +18,9 @@ use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
+use super::skill_reload::reload_skill_paths_and_refresh_backends;
 use super::state::AdminState;
+use crate::gateway::capability::RefreshReason;
 
 /// Official marketplace catalog URL.
 const OFFICIAL_MARKETPLACE_SOURCE: &str =
@@ -207,7 +209,12 @@ pub async fn handle_marketplace_install(
     )
     .await
     {
-        Ok(result) => Json(result).into_response(),
+        Ok(result) => {
+            if result.reload_required {
+                reload_skill_paths_and_refresh_backends(&s, RefreshReason::ToolsListChanged).await;
+            }
+            Json(result).into_response()
+        }
         Err(err) => (StatusCode::BAD_REQUEST, Json(json!({ "error": err }))).into_response(),
     }
 }
@@ -216,11 +223,16 @@ pub async fn handle_marketplace_install(
 ///
 /// Body: `{ "name": "...", "dcc": "..." }`
 pub async fn handle_marketplace_uninstall(
-    State(_s): State<AdminState>,
+    State(s): State<AdminState>,
     Json(body): Json<UninstallRequestBody>,
 ) -> impl IntoResponse {
     match uninstall_package(&body.name, &body.dcc) {
-        Ok(result) => Json(result).into_response(),
+        Ok(result) => {
+            if result.reload_required {
+                reload_skill_paths_and_refresh_backends(&s, RefreshReason::ToolsListChanged).await;
+            }
+            Json(result).into_response()
+        }
         Err(err) => (StatusCode::BAD_REQUEST, Json(json!({ "error": err }))).into_response(),
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -56,6 +56,7 @@ mod issue_report;
 mod links;
 pub mod marketplace;
 mod skill_health;
+mod skill_reload;
 pub mod sqlite_lane;
 pub mod state;
 pub mod stats;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/skill_reload.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/skill_reload.rs
@@ -1,0 +1,13 @@
+//! Shared skill-catalog reload hook used by admin handlers that mutate skill paths.
+
+use super::state::AdminState;
+use crate::gateway::capability::RefreshReason;
+use crate::gateway::capability_service::refresh_all_live_backends;
+
+/// Run the optional disk-catalog reload callback, then refresh live backends.
+pub async fn reload_skill_paths_and_refresh_backends(state: &AdminState, reason: RefreshReason) {
+    if let Some(cb) = state.skill_paths_reload.clone() {
+        cb();
+    }
+    refresh_all_live_backends(&state.gateway, reason).await;
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -29,6 +29,9 @@ mod admin_tests {
     /// point at a non-existent directory for the duration of the request.
     static API_LOGS_ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    /// Marketplace install/uninstall tests mutate `DCC_MCP_MARKETPLACE_INSTALL_ROOT`.
+    static MARKETPLACE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
     struct ScopedNoDiskLogsDir {
         previous: Option<String>,
     }
@@ -90,6 +93,36 @@ mod admin_tests {
                 match &self.previous {
                     Some(v) => std::env::set_var("DCC_MCP_LOG_DIR", v),
                     None => std::env::remove_var("DCC_MCP_LOG_DIR"),
+                }
+            }
+        }
+    }
+
+    struct ScopedMarketplaceInstallRoot {
+        previous: Option<String>,
+    }
+
+    impl ScopedMarketplaceInstallRoot {
+        fn new(root: &std::path::Path) -> Self {
+            let previous = std::env::var("DCC_MCP_MARKETPLACE_INSTALL_ROOT").ok();
+            // SAFETY: tests are serialized with `MARKETPLACE_ENV_LOCK`.
+            unsafe {
+                std::env::set_var(
+                    "DCC_MCP_MARKETPLACE_INSTALL_ROOT",
+                    root.to_string_lossy().as_ref(),
+                );
+            }
+            Self { previous }
+        }
+    }
+
+    impl Drop for ScopedMarketplaceInstallRoot {
+        fn drop(&mut self) {
+            // SAFETY: same as `new` — guarded by the test mutex.
+            unsafe {
+                match &self.previous {
+                    Some(v) => std::env::set_var("DCC_MCP_MARKETPLACE_INSTALL_ROOT", v),
+                    None => std::env::remove_var("DCC_MCP_MARKETPLACE_INSTALL_ROOT"),
                 }
             }
         }
@@ -3203,5 +3236,124 @@ filters:
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn test_marketplace_install_triggers_skill_paths_reload_hook() {
+        let _env_guard = MARKETPLACE_ENV_LOCK.lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let marketplace_root = tmp.path().join("marketplace");
+        let _scoped_root = ScopedMarketplaceInstallRoot::new(&marketplace_root);
+
+        let skill_src = tmp.path().join("skill-src");
+        std::fs::create_dir_all(&skill_src).unwrap();
+        std::fs::write(skill_src.join("SKILL.md"), "---\nname: test-skill\n---\n").unwrap();
+
+        let catalog_path = tmp.path().join("catalog.json");
+        let skill_src_str = skill_src.display().to_string();
+        let catalog = serde_json::json!({
+            "version": "1",
+            "entries": [{
+                "name": "test-skill",
+                "description": "test",
+                "dcc": ["maya"],
+                "tags": [],
+                "install": {
+                    "type": "path",
+                    "url": skill_src_str
+                }
+            }]
+        });
+        std::fs::write(
+            &catalog_path,
+            serde_json::to_string_pretty(&catalog).unwrap(),
+        )
+        .unwrap();
+
+        let reload_calls = Arc::new(AtomicUsize::new(0));
+        let reload_calls_for_hook = reload_calls.clone();
+        let state = make_admin_state().with_skill_paths_reload(Some(Arc::new(move || {
+            reload_calls_for_hook.fetch_add(1, Ordering::SeqCst);
+        })));
+        let router = build_admin_router(state);
+
+        let source_path = catalog_path.display().to_string();
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/marketplace/install")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(
+                        serde_json::to_vec(&serde_json::json!({
+                            "name": "test-skill",
+                            "dcc": "maya",
+                            "source": source_path
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(reload_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_marketplace_uninstall_triggers_skill_paths_reload_hook() {
+        let _env_guard = MARKETPLACE_ENV_LOCK.lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let marketplace_root = tmp.path().join("marketplace");
+        let _scoped_root = ScopedMarketplaceInstallRoot::new(&marketplace_root);
+
+        let dcc_root = marketplace_root.join("maya");
+        let pkg_root = dcc_root.join("test-skill");
+        std::fs::create_dir_all(&pkg_root).unwrap();
+        std::fs::write(pkg_root.join("SKILL.md"), "---\nname: test-skill\n---\n").unwrap();
+        std::fs::write(
+            marketplace_root.join("installed.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "packages": [{
+                    "name": "test-skill",
+                    "dcc": "maya",
+                    "version": "0.1.0",
+                    "path": pkg_root.display().to_string(),
+                    "source_name": "test",
+                    "source_url": "file://test",
+                    "install_type": "path",
+                    "installed_at_ms": 1
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let reload_calls = Arc::new(AtomicUsize::new(0));
+        let reload_calls_for_hook = reload_calls.clone();
+        let state = make_admin_state().with_skill_paths_reload(Some(Arc::new(move || {
+            reload_calls_for_hook.fetch_add(1, Ordering::SeqCst);
+        })));
+        let router = build_admin_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/marketplace/uninstall")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(
+                        serde_json::to_vec(&serde_json::json!({
+                            "name": "test-skill",
+                            "dcc": "maya"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(reload_calls.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
## Summary

- Extract `reload_skill_paths_and_refresh_backends` into shared `skill_reload.rs`
- Call it from marketplace `install` / `uninstall` handlers when `reload_required` is true (same `RefreshReason::ToolsListChanged` as skill-path mutations)
- Add regression tests asserting the skill-paths reload hook fires on successful marketplace install and uninstall

Closes PIP-521

## Test plan

- [x] `cargo test -p dcc-mcp-gateway admin_tests::test_marketplace --features admin` (2 passed)
- [ ] CI green on merge
