### PR TITLE
fix: remove OpenSSL from server binary graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,16 @@ jobs:
       - name: cargo deny check
         run: cargo deny --all-features check
 
+  server-binary-dependency-policy:
+    name: Server binary dependency policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Forbid OpenSSL in release server graph
+        shell: bash
+        run: bash scripts/ci/check_server_binary_tls_graph.sh
+
 
   # ── Build ABI3 wheel (one per OS, reused by python-test) ──
   # Intentionally does NOT `needs: [rust-check]` — maturin runs its own compile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,11 @@ jobs:
         shell: bash
         run: echo "DCC_MCP_ADMIN_UI_PREBUILT=1" >> "$GITHUB_ENV"
 
+      - name: Forbid OpenSSL in Linux server binary graph
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: bash scripts/ci/check_server_binary_tls_graph.sh
+
       - name: Build raw binary (macOS universal2)
         if: matrix.os == 'macos-latest'
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,21 +2355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,22 +2827,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -3633,23 +3602,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4133,47 +4085,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -5267,11 +5182,9 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5282,7 +5195,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -5843,7 +5755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eb7daabbc631b13f48e991f4d828f12ec43e2acd3fb2972b445bdc138231ee2"
 dependencies = [
  "httpdate",
- "native-tls",
  "reqwest 0.12.28",
  "rustls",
  "sentry-backtrace",
@@ -5851,7 +5762,6 @@ dependencies = [
  "sentry-core",
  "sentry-panic",
  "sentry-tracing",
- "tokio",
  "ureq 2.12.1",
  "webpki-roots 0.26.11",
 ]
@@ -6520,16 +6430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7082,7 +6982,6 @@ checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64 0.22.1",
  "log",
- "native-tls",
  "once_cell",
  "rustls",
  "rustls-pki-types",
@@ -7897,7 +7796,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "httparse",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "image",
  "indexmap",
@@ -7929,7 +7827,6 @@ dependencies = [
  "regex-syntax",
  "reqwest 0.13.4",
  "rustls",
- "rustls-pki-types",
  "rustls-webpki",
  "serde",
  "serde_core",
@@ -7943,7 +7840,6 @@ dependencies = [
  "sync_wrapper",
  "time",
  "tokio",
- "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "toml_datetime",

--- a/crates/dcc-mcp-server/Cargo.toml
+++ b/crates/dcc-mcp-server/Cargo.toml
@@ -59,9 +59,8 @@ sentry = { version = "0.39", default-features = false, features = [
     "backtrace",
     "contexts",
     "panic",
-    "reqwest",
     "rustls",
-    "transport",
+    "ureq",
 ], optional = true }
 
 [features]

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -65,9 +65,6 @@ rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls", "stream"] }
-rustls = { version = "0.23.40", default-features = false, features = ["logging", "ring", "std", "tls12"] }
-rustls-pki-types = { version = "1.14.1", features = ["std"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["ring", "std"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
 serde_json = { version = "1.0.150", features = ["alloc", "preserve_order", "raw_value"] }
@@ -146,9 +143,6 @@ rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls", "stream"] }
-rustls = { version = "0.23.40", default-features = false, features = ["logging", "ring", "std", "tls12"] }
-rustls-pki-types = { version = "1.14.1", features = ["std"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["ring", "std"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
 serde_json = { version = "1.0.150", features = ["alloc", "preserve_order", "raw_value"] }
@@ -178,12 +172,10 @@ zeroize = { version = "1.8.2", features = ["derive"] }
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -191,24 +183,20 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -216,12 +204,10 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -229,12 +215,10 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -243,12 +227,10 @@ bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -256,12 +238,10 @@ tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
@@ -270,42 +250,36 @@ bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl", "winsock2"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60.2", features = ["Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 cc = { version = "1.2.62", default-features = false, features = ["parallel"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
-rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "ring", "tls12"] }
+rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.11", features = ["cors", "follow-redirect", "limit", "trace"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl", "winsock2"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60.2", features = ["Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 ### END HAKARI SECTION

--- a/scripts/ci/check_server_binary_tls_graph.sh
+++ b/scripts/ci/check_server_binary_tls_graph.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep dcc-mcp-server release binaries free of OpenSSL-linked TLS stacks.
+# The release job builds this crate on ubuntu-latest before packaging the
+# PyPI binary wheel and GitHub Release assets, so this graph must stay aligned
+# with the default Linux binary build.
+target="${1:-x86_64-unknown-linux-gnu}"
+
+check_absent() {
+  local dep="$1"
+  local output
+  output="$(mktemp)"
+
+  if cargo tree \
+    -p dcc-mcp-server \
+    -e normal \
+    --target "$target" \
+    -i "$dep" >"$output" 2>&1; then
+    cat "$output"
+    echo "::error::$dep is present in the dcc-mcp-server Linux release dependency graph"
+    exit 1
+  fi
+
+  if ! grep -Eq "did not match any packages|nothing to print" "$output"; then
+    cat "$output"
+    echo "::error::cargo tree failed unexpectedly while checking $dep"
+    exit 1
+  fi
+
+  echo "$dep is absent from the dcc-mcp-server Linux release dependency graph"
+}
+
+check_absent native-tls
+check_absent openssl-sys


### PR DESCRIPTION
## Summary

- Switch `dcc-mcp-server` Sentry transport from `reqwest`/`native-tls` to `ureq`/`rustls`.
- Remove the now-unreachable OpenSSL/native-tls packages from `Cargo.lock` and regenerate `workspace-hack`.
- Add a reusable CI script that fails if `native-tls` or `openssl-sys` re-enters the Linux `dcc-mcp-server` release graph.
- Run the same guard in PR CI and early in release `build-binaries` before the expensive Ubuntu binary build.

## Root Cause

`dcc-mcp-server` default features enable Sentry. Sentry 0.39's `transport` feature expands to `reqwest + native-tls`, which pulls in `openssl-sys`. The release `build-binaries` Ubuntu job builds the raw server binary before packaging wheels/assets, so the missing OpenSSL development headers blocked `dcc-mcp-server` and then skipped release assets.

## Validation

- `vx bash scripts/ci/check_server_binary_tls_graph.sh`
- `vx cargo check -p dcc-mcp-server`
- `vx cargo check -p dcc-mcp-server --release`
- `vx actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `vx cargo deny --all-features check bans` (passes; existing duplicate warnings remain)
- `vx cargo hakari verify`

Skill guidance update: not needed. This changes release CI/dependency policy only; it does not affect public APIs, adapter/server wiring contracts, gateway behavior, skill authoring rules, or agent-facing workflows.
