### PR TITLE
fix(ci): install Windows Python 3.7 for release wheels

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -44,9 +44,14 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Python
+      if: runner.os != 'Windows' || inputs.python-version != '3.7'
       uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
+
+    - name: Setup Windows Python 3.7
+      if: runner.os == 'Windows' && inputs.python-version == '3.7'
+      uses: ./.github/actions/setup-windows-python37
 
     - name: Remove pre-installed cargo-clippy (conflict workaround)
       # GitHub-hosted runners (macOS aarch64 AND ubuntu-latest) pre-install Rust

--- a/.github/actions/setup-windows-python37/action.yml
+++ b/.github/actions/setup-windows-python37/action.yml
@@ -1,0 +1,41 @@
+name: Setup Windows Python 3.7
+description: Install Python 3.7 on Windows runners after setup-python dropped it.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Python 3.7.9
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+
+        $version = "3.7.9"
+        $target = Join-Path $env:RUNNER_TEMP "python-$version-x64"
+        $installer = Join-Path $env:RUNNER_TEMP "python-$version-amd64.exe"
+        $url = "https://www.python.org/ftp/python/$version/python-$version-amd64.exe"
+
+        Invoke-WebRequest -Uri $url -OutFile $installer
+
+        $arguments = @(
+          "/quiet",
+          "InstallAllUsers=0",
+          "PrependPath=0",
+          "Include_launcher=0",
+          "Include_test=0",
+          "TargetDir=$target"
+        )
+        $process = Start-Process -FilePath $installer -ArgumentList $arguments -Wait -PassThru
+        if ($process.ExitCode -ne 0) {
+          throw "Python $version installer failed with exit code $($process.ExitCode)"
+        }
+
+        $python = Join-Path $target "python.exe"
+        Copy-Item -Path $python -Destination (Join-Path $target "python3.7.exe") -Force
+
+        & $python -m pip install --upgrade "pip<24.1" "setuptools<69" "wheel<0.43"
+
+        Add-Content -Path $env:GITHUB_PATH -Value $target
+        Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $target "Scripts")
+
+        & $python --version
+        & $python -m pip --version

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -92,7 +92,7 @@ jobs:
           use-sccache: 'false'
 
   windows-py37:
-    runs-on: windows-2022  # Python 3.7 not available on newer Windows runners
+    runs-on: windows-2022  # Installs Python 3.7 from python.org.
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,8 @@ jobs:
   # `just build-py37` directly, which hid a pyo3-stub-gen Python<3.10 compat
   # bug (PyEncodingWarning missing on py37) that only surfaced in the release
   # build-wheels workflow. Now both paths go through the same composite action.
-  # Note: Must use older OS runners where Python 3.7 is still available via setup-python
+  # Windows runners no longer expose Python 3.7 via setup-python, so the
+  # composite action installs the python.org build there.
   build-wheel-py37:
     name: Build wheel (py3.7, ${{ matrix.os }})
     needs: [admin-ui-bundle]
@@ -408,7 +409,7 @@ jobs:
         include:
           - os: ubuntu-22.04  # Ubuntu 24.04 dropped Python 3.7 support
             target: x86_64
-          - os: windows-2022  # Use Windows 2022 for Python 3.7 availability
+          - os: windows-2022
             target: x64
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,9 +392,7 @@ jobs:
 
       - name: Setup Python (py37 build)
         if: matrix.target == 'windows-py37'
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.7'
+        uses: ./.github/actions/setup-windows-python37
 
       - name: Install maturin
         if: matrix.target != 'linux-abi3' && matrix.target != 'linux-py37'


### PR DESCRIPTION
## Summary

- add a reusable Windows Python 3.7 setup action for GitHub-hosted runners
- route release semantic cp37 and shared wheel cp37 builds through that action
- keep PR CI's Windows py37 wheel job on the same path as release

## Validation

- `vx actionlint .github/workflows/release.yml .github/workflows/ci.yml .github/workflows/build-wheels.yml`
- pre-commit on commit, including `check yaml` and `actionlint`

## Agent-facing skill sync

- Not needed: this only changes GitHub Actions release/CI packaging setup.
