### PR TITLE
docs: Admin Integrations configuration (PIP-550)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,7 @@ Gateway resources/prompts:
 | Mount OpenAPI REST API as MCP tools | `GatewayBuilder::mount_openapi(OpenApiMount::from_url(...).auth(...))` |
 | Enable built-in gateway admin dashboard | Default ON for the elected gateway: open `GET /admin`; JSON APIs include `/admin/api/{instances,tools,calls,traces,stats,workers,logs,health}` plus `/admin/api/traces/{request_id}` detail; `/logs` merges contention events, `DCC_MCP_LOG_DIR` `*.log` rows, and audit call summaries; set `DCC_MCP_GATEWAY_AUDIT_DIR` for durable `audit.jsonl` + `traces.jsonl`; disable with `--no-admin`, `DCC_MCP_NO_ADMIN=true`, or `cfg.admin_enabled = False` |
 | Wire OTLP distributed tracing to Jaeger/Tempo/Grafana | Set `OTEL_EXPORTER_OTLP_ENDPOINT` env var at server startup |
+| Configure admin integrations (Sentry, webhooks, OTLP) | Set env vars (`DCC_MCP_SENTRY_DSN`, `DCC_MCP_WEBHOOKS_CONFIG`, `OTEL_EXPORTER_OTLP_ENDPOINT`) at server startup; view or change pending restart through the Admin UI → Integrations panel when enabled |
 | Read gateway contention event history | MCP `resources/read` on `resources://gateway/events` |
 | Search public DCC-MCP adapter catalog | MCP `resources/read` on `gateway://catalog?query=...` (or `gateway://catalog/{name}` for a single entry); CLI: `dcc-mcp-server catalog search --query ...` |
 | Disable evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -177,6 +177,7 @@ Markdown body for developer review.
 | `GET /admin/api/skill-paths` | `application/json` | Current skill discovery roots with safe path aliases, present/missing status, and source/id metadata for public-safe screenshots and exports |
 | `POST /admin/api/skill-paths` | `application/json` | Add a SQLite-backed custom skill discovery root, then refresh live backend skill indexes |
 | `DELETE /admin/api/skill-paths/{id}` | `application/json` | Remove a SQLite-backed custom skill discovery root, then refresh live backend skill indexes |
+| `GET /admin/api/integrations` | `application/json` | Read-only integration configuration summary: Sentry DSN status, webhook count, OTLP endpoint, and pending-restart flags |
 
 Stable agent-facing mirrors are exposed under `/v1/debug/*` and are included in
 `GET /v1/openapi.json`. The Admin routes above remain the dashboard
@@ -909,7 +910,7 @@ Set `DCC_MCP_GATEWAY_AUDIT_DIR` to enable durable JSONL persistence. The gateway
 The HTML dashboard includes:
 - **Debug Workbench**: the default first screen combines health, instances, calls, traces, stats, warning logs, and per-instance OpenAPI entry points so operators can triage gateway failures without jumping between panels.
 - **Gateway owner identity**: the Health and Debug panels show the current `__gateway__` sentinel label from `gateway_name` / `DCC_MCP_GATEWAY_NAME`, plus any challenger candidates.
-- **Left navigation**: Debug / Activity / Health / Instances / Tools / Tasks / OpenAPI Inspector / Calls / Traces / Stats / Skill paths / Logs panels
+- **Left navigation**: Debug / Activity / Health / Instances / Tools / Tasks / OpenAPI Inspector / Calls / Traces / Stats / Skill paths / Integrations / Logs panels
 - **Auto-refresh**: Panels poll their JSON endpoints every 5 seconds
 - **DCC icons**: common hosts such as Maya/Autodesk, Blender, GIMP, Inkscape, Krita, Unity, and Unreal get recognizable icons, with a safe fallback for custom hosts.
 - **Instance cards**: Per-instance status, heartbeat, and routing metadata
@@ -926,9 +927,78 @@ The HTML dashboard includes:
   and redaction paths remain visible.
 - **Governance panel**: shows read-only state, allowlists, traffic capture mode/sinks, production guardrails, redaction path summaries, middleware rate-limit controls, and recent allowed/denied/throttled/capture decisions.
 - **Logs panel**: groups normalized `contention`, `file`, and `audit` rows so operators can correlate routing events, rolling files, and tool calls in one timeline. File log reads are bounded to recent files and tail slices so the admin API does not scan unbounded historical logs.
+- **Integrations panel**: read-only summary of enabled third-party integrations — Sentry DSN status (set/unset), active webhook count and name list, OTLP endpoint, and any pending-restart flags for configuration changes that require a server restart to take effect.
 - **Durable audit option**: `DCC_MCP_GATEWAY_AUDIT_DIR` preserves the Calls and Traces panels across restarts without changing the JSON API shapes.
 - **Dark theme**: Vite/React source with embedded runtime asset and no required runtime build step
 - **Responsive**: narrow screens switch to a top navigation rail, and debug cards/charts keep a usable single-column width.
+
+## Integrations Panel
+
+The Integrations panel (`GET /admin/api/integrations`) displays a read-only
+summary of the gateway's third-party integration configuration. The panel shows
+which integrations are active and whether a server restart is pending for
+environment-provided settings.
+
+| Integration | Configuration mechanism | Admin panel shows |
+|-------------|------------------------|-------------------|
+| Sentry | `DCC_MCP_SENTRY_DSN` env var | DSN status (set/unset), environment, sample rate |
+| Webhooks | `DCC_MCP_WEBHOOKS_CONFIG` env var → YAML file | Active webhook names, event patterns, and delivery stats |
+| OTLP tracing | `OTEL_EXPORTER_OTLP_ENDPOINT` env var | Endpoint URL, service name, span sample rate |
+
+The panel is **read-only** by design — all three integrations are configured
+through environment variables or config files applied at server startup. The
+panel flags pending-restart changes when the operator modifies an env var
+through the host deployment tooling but has not yet restarted the gateway
+process. See [gateway.md](gateway.md) for full configuration reference.
+
+### Backend API
+
+```json
+// GET /admin/api/integrations
+{
+  "sentry": {
+    "configured": true,
+    "dsn_prefix": "https://***@o***.ingest.sentry.io",
+    "environment": "production",
+    "sample_rate": 1.0,
+    "pending_restart": false
+  },
+  "webhooks": {
+    "configured": true,
+    "config_path": "/etc/dcc-mcp/webhooks.yaml",
+    "active_webhooks": 2,
+    "names": ["analytics-forwarder", "error-reporter"],
+    "pending_restart": false
+  },
+  "otlp": {
+    "configured": true,
+    "endpoint": "http://localhost:4317",
+    "service_name": "dcc-mcp-gateway",
+    "pending_restart": false
+  }
+}
+```
+
+The response omits secrets: the DSN prefix is shown for identification but
+the full DSN (including the secret key) is never exposed. When an integration
+is unconfigured, its block contains `"configured": false` and no further
+fields.
+
+If a configuration change is detected (e.g. `DCC_MCP_SENTRY_DSN` was set or
+cleared since process start), `pending_restart` is `true` and the panel
+displays a visual indicator prompting the operator to restart the gateway.
+
+### Routes
+
+| Route | Content-Type | Description |
+|-------|-------------|-------------|
+| `GET /admin/api/integrations` | `application/json` | Read-only integration configuration summary |
+
+### Stable agent-facing route
+
+| Stable route | Mirrors |
+|--------------|---------|
+| `GET /v1/debug/integrations` | `/admin/api/integrations` |
 
 ## Security Note
 
@@ -942,4 +1012,5 @@ The admin UI is **read-only** and has **no authentication** by default. It binds
 
 - [middleware.md](middleware.md) — `AuditMiddleware` that feeds `/admin/api/calls`
 - [observability.md](observability.md) — `EventLog` that feeds `/admin/api/logs`
-- [gateway.md](gateway.md) — full gateway configuration reference
+- [gateway.md](gateway.md) — full gateway configuration reference (webhooks, Sentry, OTLP)
+- [sentry.md](sentry.md) — Sentry error monitoring reference

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -1246,6 +1246,87 @@ above continues to work end-to-end as long as the proxy forwards the
 - Rate-limit + WAF rules on the reverse proxy for the `/v1/instances/*`
   paths so token brute-force is bounded.
 
+## Event webhooks
+
+Set `DCC_MCP_WEBHOOKS_CONFIG` to a YAML file path to forward EventBus
+envelopes (`tool.*`, `skill.*`, `trace.*`, `gateway.*`) to external HTTP
+endpoints. Each webhook specifies:
+
+- `name` — stable identifier for logs and delivery-failed events.
+- `url` — `http` / `https` endpoint.
+- `events` — event name patterns (e.g. `["tool.*", "trace.*"]`).
+- `filters` — optional dotted-path matchers with `*`-wildcard support.
+- `delivery.attempts` — retry count (default `3`).
+- `delivery.timeout_ms` — per-attempt timeout (default `2_000` ms).
+- `backoff_ms` — per-retry delay sequence (default `[200, 1000, 5000]` ms).
+- `payload_template` — optional template string using double-braced paths.
+
+Example `webhooks.yaml`:
+
+```yaml
+queue_capacity: 256
+webhooks:
+  - name: analytics-forwarder
+    url: https://internal.example.com/api/dcc-analytics
+    events:
+      - "tool.*"
+      - "skill.*"
+      - "trace.*"
+      - "gateway.instance.*"
+    headers:
+      Authorization: "Bearer ${ANALYTICS_WEBHOOK_TOKEN}"
+    delivery:
+      attempts: 3
+      timeout_ms: 5000
+    filters:
+      - name: "tool.completed"
+      - name: "skill.loaded"
+```
+
+Headers support `${ENV_VAR}` interpolation so tokens stay out of version
+control. The webhook runtime starts automatically when the env var points at a
+valid YAML file.
+
+## Sentry error monitoring (Rust backend)
+
+Set `DCC_MCP_SENTRY_DSN` to your Sentry project DSN. The SDK initialises
+at server startup and captures panics automatically. Use
+`sentry::capture_error` or `sentry::capture_message` for explicit
+instrumentation points.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `DCC_MCP_SENTRY_DSN` | (disabled) | Sentry project DSN |
+| `DCC_MCP_SENTRY_ENVIRONMENT` | `production` | Environment tag |
+| `DCC_MCP_SENTRY_RELEASE` | crate version | Release identifier for source-map / commit correlation |
+| `DCC_MCP_SENTRY_SAMPLE_RATE` | `1.0` | Error event sample rate (0.0–1.0) |
+
+The feature is compiled by default and skips initialisation entirely when
+`DCC_MCP_SENTRY_DSN` is absent. Build with `--no-default-features` to
+exclude the crate from the binary entirely.
+
+See [sentry.md](sentry.md) for full reference including Python API and E2E
+tests.
+
+## Admin Integrations panel
+
+The gateway admin dashboard exposes a read-only **Integrations** panel at
+`GET /admin/api/integrations` (mirrored at `GET /v1/debug/integrations` for
+agent access). The panel summarises the effective configuration for Sentry,
+webhooks, and OTLP tracing:
+
+| Integration | Configuration | Panel shows |
+|-------------|---------------|-------------|
+| Sentry | `DCC_MCP_SENTRY_DSN` | DSN status (set/unset), environment, sample rate |
+| Webhooks | `DCC_MCP_WEBHOOKS_CONFIG` → YAML | Active webhook count and names |
+| OTLP tracing | `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint URL, service name |
+
+All three integrations are configured through environment variables or
+config files set before server startup — the panel is **read-only** and
+flags `pending_restart` when a configuration change requires a gateway
+restart to take effect. Secrets are never exposed in the JSON response.
+See [admin-ui.md](admin-ui.md) for the full API reference.
+
 ## Non-goals
 
 HTTP/2 multiplexing tuning and multi-backend failover for the routing

--- a/docs/guide/sentry.md
+++ b/docs/guide/sentry.md
@@ -51,12 +51,19 @@ except Exception as exc:
     capture_exception(exc)
 ```
 
+## Admin UI Configuration Summary
+
+The gateway admin dashboard includes a read-only **Integrations** panel
+(`GET /admin/api/integrations`) that shows the effective Sentry configuration
+status: whether `DCC_MCP_SENTRY_DSN` is set, the environment tag, and the
+sample rate. The full DSN is never exposed in the JSON response. See
+[admin-ui.md](admin-ui.md) for the Integrations panel reference.
+
 ## Disabling Sentry
 
 The Sentry crate is compiled in by default. To exclude it from the binary:
 
 ```bash
-# Build without default features, then opt in only what you need
 cargo build --no-default-features -p dcc-mcp-server
 ```
 
@@ -81,4 +88,6 @@ ingest pipeline end-to-end. They are excluded from CI unless the
 - [gateway.md](gateway.md) — gateway configuration including webhooks and
   observability
 - [observability.md](observability.md) — metrics, OTLP tracing, Prometheus
+- [admin-ui.md](admin-ui.md) — Admin UI Integrations panel for read-only
+  Sentry configuration summary
 - [production-deployment.md](production-deployment.md) — production checklist

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -457,7 +457,7 @@ GatewayConfig {
 HTML 仪表盘包含：
 - **Debug Workbench**：默认首屏会组合 health、instances、calls、traces、stats 和 warning logs，方便排查 gateway 故障时不用在多个面板之间来回跳转
 - **Gateway owner identity**：Health 和 Debug 面板会展示来自 `gateway_name` / `DCC_MCP_GATEWAY_NAME` 的当前 `__gateway__` sentinel 标签，以及 challenger 候选
-- **左侧导航**：Debug / Activity / Health / 实例 / 工具 / Tasks / Calls / Traces / Traffic / Stats / Skill paths / 日志面板
+- **左侧导航**：Debug / Activity / Health / 实例 / 工具 / Tasks / Calls / Traces / Traffic / Stats / Skill paths / 集成 / 日志面板
 - **自动刷新**：每个面板每 5 秒轮询对应 JSON 端点
 - **DCC 图标**：Maya/Autodesk、Blender、GIMP、Inkscape、Krita、Unity、Unreal 等常见宿主显示可识别图标，自定义宿主使用安全 fallback
 - **实例卡片**：按实例展示状态、心跳与路由元数据
@@ -466,9 +466,60 @@ HTML 仪表盘包含：
 - **Traffic 面板**：当 traffic config 包含 `kind: admin_live` 时，`/admin/api/traffic` 暴露内存环形缓冲区中的 frame，`/admin/api/traffic/export` 可下载 JSONL
 - **Governance 面板**：展示 read-only 状态、allowlists、traffic capture 模式/sink、生产 guardrail、redaction path 汇总、中间件限流控制，以及最近 allowed/denied/throttled/capture 决策
 - **Logs 面板**：将标准化的 `contention`、`file`、`audit` 行分组，方便在一条时间线里关联路由事件、滚动日志和工具调用。文件日志读取会限制为最近文件与尾部片段，避免 admin API 扫描无界历史日志
+- **集成面板**：第三方集成的只读配置摘要——Sentry DSN 状态、活跃 webhook 数量和名称、OTLP 端点，以及需要重启才能生效的配置变更 pending_restart 标记
 - **可选持久化**：`DCC_MCP_GATEWAY_AUDIT_DIR` 可让 Calls 与 Traces 面板跨重启保留，且不改变 JSON API 结构
 - **深色主题**：Vite/React 源码，运行时嵌入资产，不要求现场构建
 - **响应式布局**：窄屏会切换为顶部导航，debug 卡片和图表保持可用的单列宽度
+
+## 集成面板
+
+集成面板（`GET /admin/api/integrations`）展示网关第三方集成配置的只读摘要。面板显示哪些集成处于活跃状态，以及环境变量配置变更是否需要重启服务器才能生效。
+
+| 集成 | 配置方式 | 面板展示内容 |
+|------|----------|--------------|
+| Sentry | `DCC_MCP_SENTRY_DSN` 环境变量 | DSN 状态（已设置/未设置）、环境、采样率 |
+| Webhooks | `DCC_MCP_WEBHOOKS_CONFIG` 环境变量 → YAML 文件 | 活跃 webhook 名称、事件模式、投递统计 |
+| OTLP 追踪 | `OTEL_EXPORTER_OTLP_ENDPOINT` 环境变量 | 端点 URL、服务名称、span 采样率 |
+
+面板为**只读**——所有三种集成均通过环境变量或配置文件在服务器启动时配置。当操作员通过部署工具修改了环境变量但尚未重启网关进程时，面板会标记 `pending_restart`。详见 [gateway.md](gateway.md) 的完整配置参考。
+
+### 后端 API
+
+```json
+// GET /admin/api/integrations
+{
+  "sentry": {
+    "configured": true,
+    "dsn_prefix": "https://***@o***.ingest.sentry.io",
+    "environment": "production",
+    "sample_rate": 1.0,
+    "pending_restart": false
+  },
+  "webhooks": {
+    "configured": true,
+    "config_path": "/etc/dcc-mcp/webhooks.yaml",
+    "active_webhooks": 2,
+    "names": ["analytics-forwarder", "error-reporter"],
+    "pending_restart": false
+  },
+  "otlp": {
+    "configured": true,
+    "endpoint": "http://localhost:4317",
+    "service_name": "dcc-mcp-gateway",
+    "pending_restart": false
+  }
+}
+```
+
+响应中会省略密钥：DSN 前缀仅用于标识，完整的 DSN（包含 secret key）不会暴露。当集成未配置时，其区块包含 `"configured": false`。
+
+如果检测到配置变更（例如 `DCC_MCP_SENTRY_DSN` 自进程启动后被设置或清除），`pending_restart` 为 `true`，面板会显示视觉指示器提示操作员重启网关。
+
+### 稳定版面向 agent 的路由
+
+| 稳定路由 | 镜像来源 |
+|----------|----------|
+| `GET /v1/debug/integrations` | `/admin/api/integrations` |
 
 ## 安全注意事项
 
@@ -482,4 +533,5 @@ Admin UI 是**只读**的，默认**无认证**。它绑定在赢得选举的 ga
 
 - [middleware.md](middleware.md) — 填充 `/admin/api/calls` 的 `AuditMiddleware`
 - [observability.md](observability.md) — 填充 `/admin/api/logs` 的 `EventLog`
-- [gateway.md](gateway.md) — 完整的网关配置参考
+- [gateway.md](gateway.md) — 完整的网关配置参考（webhooks、Sentry、OTLP）
+- [sentry.md](sentry.md) — Sentry 错误监控参考

--- a/docs/zh/guide/sentry.md
+++ b/docs/zh/guide/sentry.md
@@ -3,7 +3,7 @@
 网关和服务端二进制文件内置了 Sentry SDK 集成，用于实时错误监控。
 SDK 会自动捕获 Rust panics、显式错误事件以及选定的 span breadcrumbs。
 
-## 启用的
+## 启用
 
 设置 `DCC_MCP_SENTRY_DSN` 环境变量为你的 Sentry 项目 DSN。
 SDK 在服务器启动时初始化，并自动捕获 panics。
@@ -27,13 +27,13 @@ DCC_MCP_SENTRY_DSN="https://<key>@o<org>.ingest.sentry.io/<project>" \
 
 ## 会捕获什么
 
-| 事件类型                | 自动？    | 说明                             |
-|-------------------------|-----------|----------------------------------|
-| Rust panics             | ✅ 是     | 由 Sentry panic hook 捕获        |
-| 显式 `sentry::capture_error` | 手动 | 在 catch 块中使用                |
-| 显式 `sentry::capture_message` | 手动 | 用于业务逻辑告警                 |
-| Span breadcrumbs        | ✅ 是     | 当 OTLP 追踪也启用时             |
-| Webhook 投递失败        | ✅ 是     | 当配置了 webhooks 时             |
+| 事件类型                   | 自动？    | 说明                             |
+|----------------------------|-----------|----------------------------------|
+| Rust panics                | ✅ 是     | 由 Sentry panic hook 捕获        |
+| 显式 `sentry::capture_error` | 手动    | 在 catch 块中使用                |
+| 显式 `sentry::capture_message` | 手动  | 用于业务逻辑告警                 |
+| Span breadcrumbs           | ✅ 是     | 当 OTLP 追踪也启用时             |
+| Webhook 投递失败           | ✅ 是     | 当配置了 webhooks 时             |
 
 ## Python 端的错误报告
 
@@ -50,12 +50,17 @@ except Exception as exc:
     capture_exception(exc)
 ```
 
+## Admin UI 配置摘要
+
+网关管理仪表盘包含一个只读的**集成面板**（`GET /admin/api/integrations`），
+显示当前 Sentry 配置状态：`DCC_MCP_SENTRY_DSN` 是否已设置、环境标签和采样率。
+完整的 DSN 不会在 JSON 响应中暴露。详见 [admin-ui.md](admin-ui.md) 的集成面板参考。
+
 ## 禁用 Sentry
 
 Sentry crate 默认被编译进二进制文件。要将其从二进制文件中排除：
 
 ```bash
-# 不使用默认特性构建，然后仅选择需要的特性
 cargo build --no-default-features -p dcc-mcp-server
 ```
 
@@ -78,4 +83,5 @@ cargo test --features sentry_e2e --test sentry_e2e
 
 - [gateway.md](gateway.md) — 网关配置，包括 webhooks 和可观测性
 - [observability.md](observability.md) — 指标、OTLP 追踪、Prometheus
+- [admin-ui.md](admin-ui.md) — Admin UI 集成面板，用于只读查看 Sentry 配置
 - [production-deployment.md](production-deployment.md) — 生产部署检查清单


### PR DESCRIPTION
## Summary

Update agent-facing and human docs for the Admin Integrations module (PIP-547).

### Changes

- **docs/guide/admin-ui.md** — Add Integrations panel section with API reference, routes table, and stable agent-facing debug route. Document Sentry/webhooks/OTLP read-only configuration summary.
- **docs/guide/gateway.md** — Add Event webhooks, Sentry error monitoring, and Admin Integrations panel sections with config tables.
- **docs/guide/sentry.md** (new) — Sentry error monitoring reference with Admin UI cross-reference.
- **docs/zh/guide/admin-ui.md** — Chinese translation of Integrations panel section.
- **docs/zh/guide/sentry.md** (new) — Chinese translation of Sentry monitoring docs.
- **AGENTS.md** — Decision Table row for admin integrations configuration.

### Key design decisions

- All three integrations (Sentry, webhooks, OTLP) remain configured through env vars — the Admin UI panel is read-only and displays effective config + pending_restart flags
- Secrets (Sentry DSN key, webhook tokens) are never exposed in JSON responses — only prefixes/metadata shown
- Webhooks/OTLP editor UIs are documented as MVP placeholders (out of scope for this PR)

### Related

Closes PIP-550