### PR TITLE
feat(models): PIP-577 add call_examples to describe responses

### DIFF
--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -16,11 +16,11 @@ pub use dcc_name::DccName;
 pub use error::DccMcpError;
 pub use registry::{DefaultRegistry, Registry, RegistryEntry, SearchQuery};
 pub use skill_metadata::{
-    ExecutionMode, NextTools, Precondition, RecallContext, RiskLevel, SideEffects, SkillBranding,
-    SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup, SkillLinks, SkillMetadata,
-    SkillPolicy, SkillRuntimeDescriptor, SkillRuntimeKind, SkillRuntimeReport, SkillRuntimeState,
-    SkillRuntimeSummary, SuccessMetrics, ThreadAffinity, ToolAnnotations, ToolDeclaration,
-    ToolRole, resolve_runtime_reports, summarize_runtime_reports,
+    CallExample, ExecutionMode, NextTools, Precondition, RecallContext, RiskLevel, SideEffects,
+    SkillBranding, SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup, SkillLinks,
+    SkillMetadata, SkillPolicy, SkillRuntimeDescriptor, SkillRuntimeKind, SkillRuntimeReport,
+    SkillRuntimeState, SkillRuntimeSummary, SuccessMetrics, ThreadAffinity, ToolAnnotations,
+    ToolDeclaration, ToolRole, resolve_runtime_reports, summarize_runtime_reports,
 };
 pub use skill_scope::SkillScope;
 

--- a/crates/dcc-mcp-models/src/python/tool_declaration.rs
+++ b/crates/dcc-mcp-models/src/python/tool_declaration.rs
@@ -94,6 +94,7 @@ impl ToolDeclaration {
             side_effects: None,
             produces: Vec::new(),
             requires: Vec::new(),
+            call_examples: None,
         })
     }
 

--- a/crates/dcc-mcp-models/src/skill_metadata/tests.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tests.rs
@@ -80,6 +80,31 @@ fn test_tool_declaration_parses_required_capabilities() {
 }
 
 #[test]
+fn test_tool_declaration_parses_call_examples() {
+    let json = r#"{
+            "name": "export_fbx",
+            "call_examples": [
+                {
+                    "arguments": {
+                        "path": "C:/exports/scene.fbx",
+                        "selected_only": true
+                    },
+                    "note": "Export selected objects to FBX"
+                }
+            ]
+        }"#;
+    let decl: ToolDeclaration = serde_json::from_str(json).unwrap();
+    let examples = decl.call_examples.expect("call_examples should parse");
+    assert_eq!(examples.len(), 1);
+    assert_eq!(examples[0].arguments["path"], "C:/exports/scene.fbx");
+    assert_eq!(examples[0].arguments["selected_only"], true);
+    assert_eq!(
+        examples[0].note.as_deref(),
+        Some("Export selected objects to FBX")
+    );
+}
+
+#[test]
 fn test_skill_and_tool_search_aliases_parse() {
     let json = r#"{
             "name": "export-skill",

--- a/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
@@ -407,6 +407,34 @@ pub struct ToolDeclaration {
     /// `required_capabilities`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requires: Vec<String>,
+
+    /// Ready-to-copy call examples that help agents construct correct
+    /// arguments on the first attempt.
+    ///
+    /// YAML key is `call_examples` (snake_case).
+    ///
+    /// ```yaml
+    /// call_examples:
+    ///   - arguments: {path: "C:/scenes/export.fbx", selected_only: true}
+    ///     note: "Export current selection to FBX"
+    /// ```
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "call_examples"
+    )]
+    pub call_examples: Option<Vec<CallExample>>,
+}
+
+/// A single call example — argument payload and optional human-readable note.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CallExample {
+    /// JSON object matching the tool's `input_schema.properties`.
+    pub arguments: serde_json::Value,
+
+    /// Short description of what this example demonstrates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
 }
 
 // ── ToolDeclaration custom deserializer (issue #344) ──────────────────────
@@ -530,6 +558,10 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
             produces: Vec<String>,
             #[serde(default)]
             requires: Vec<String>,
+
+            // ── Call examples (PIP-577) ─────────────────────────────
+            #[serde(default, rename = "call_examples")]
+            call_examples: Option<Vec<CallExample>>,
         }
 
         let w = Wire::deserialize(deserializer)?;
@@ -586,6 +618,7 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
             side_effects: w.side_effects,
             produces: w.produces,
             requires: w.requires,
+            call_examples: w.call_examples,
         })
     }
 }

--- a/crates/dcc-mcp-skill-rest/src/search_index.rs
+++ b/crates/dcc-mcp-skill-rest/src/search_index.rs
@@ -35,6 +35,9 @@ pub(crate) fn action_metadata(action: &CatalogAction) -> Value {
         "risk".to_string(),
         Value::String(action_risk(&action.annotations).to_string()),
     );
+    if let Some(ref examples) = action.call_examples {
+        dcc.insert("call_examples".to_string(), serde_json::json!(examples));
+    }
 
     let mut out = serde_json::Map::new();
     out.insert("dcc".to_string(), Value::Object(dcc));

--- a/crates/dcc-mcp-skill-rest/src/search_index.rs
+++ b/crates/dcc-mcp-skill-rest/src/search_index.rs
@@ -9,6 +9,10 @@ use crate::service::CatalogAction;
 use dcc_mcp_models::ToolAnnotations;
 
 pub(crate) fn action_metadata(action: &CatalogAction) -> Value {
+    action_metadata_with_options(action, true)
+}
+
+fn action_metadata_with_options(action: &CatalogAction, include_call_examples: bool) -> Value {
     let mut dcc = serde_json::Map::new();
     dcc.insert(
         "affinity".to_string(),
@@ -35,7 +39,7 @@ pub(crate) fn action_metadata(action: &CatalogAction) -> Value {
         "risk".to_string(),
         Value::String(action_risk(&action.annotations).to_string()),
     );
-    if let Some(ref examples) = action.call_examples {
+    if include_call_examples && let Some(ref examples) = action.call_examples {
         dcc.insert("call_examples".to_string(), serde_json::json!(examples));
     }
 
@@ -63,7 +67,7 @@ pub(crate) fn search_metadata(action: &CatalogAction) -> Option<Value> {
     }
 
     let mut metadata = if has_non_default_execution {
-        action_metadata(action)
+        action_metadata_with_options(action, false)
     } else {
         serde_json::json!({"dcc": {}})
     };

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -26,7 +26,7 @@ use dcc_mcp_actions::{
     DispatchExecutionContext, current_execution_context, with_execution_context,
 };
 use dcc_mcp_models::{
-    ExecutionMode, NextTools, SkillRuntimeSummary, ThreadAffinity, ToolAnnotations,
+    CallExample, ExecutionMode, NextTools, SkillRuntimeSummary, ThreadAffinity, ToolAnnotations,
 };
 use dcc_mcp_skills::SkillCatalog;
 
@@ -347,6 +347,9 @@ pub struct CatalogAction {
     /// Suggested follow-up tools (`on-success` / `on-failure`). Surfaced at
     /// describe-time so agents can pre-plan recovery steps (issue #1408).
     pub next_tools: NextTools,
+    /// Ready-to-copy call examples from `tools.yaml`. Surfaced in
+    /// `metadata.dcc.call_examples` at describe-time (PIP-577).
+    pub call_examples: Option<Vec<CallExample>>,
 }
 
 /// Anything that can invoke a tool by name and return its output.
@@ -614,6 +617,13 @@ impl SkillCatalogSource for CatalogSource {
                 });
             seen.insert(meta.name.clone());
             let search_tokens = schema_search_tokens(&meta.input_schema);
+            let call_examples = self.catalog.get_skill_info(&skill_name).and_then(|detail| {
+                detail
+                    .tools
+                    .iter()
+                    .find(|t| t.name == meta.name)
+                    .and_then(|t| t.call_examples.clone())
+            });
             out.push(CatalogAction {
                 action_name: meta.name,
                 skill_name: skill_name.clone(),
@@ -636,6 +646,7 @@ impl SkillCatalogSource for CatalogSource {
                     .unwrap_or_default(),
                 runtime,
                 next_tools: meta.next_tools,
+                call_examples,
             });
         }
 
@@ -710,6 +721,7 @@ impl SkillCatalogSource for CatalogSource {
                         .unwrap_or_default(),
                     runtime: detail.runtime.clone(),
                     next_tools: tool_decl.next_tools.clone(),
+                    call_examples: tool_decl.call_examples.clone(),
                 });
             }
         }

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -290,6 +290,34 @@ fn describe_omits_next_tools_when_none_declared() {
 }
 
 #[test]
+fn describe_surfaces_call_examples_in_dcc_metadata() {
+    let mut action = sphere_action(true);
+    action.call_examples = Some(vec![dcc_mcp_models::CallExample {
+        arguments: serde_json::json!({
+            "radius": 5.0,
+            "subdivisionsX": 32,
+            "subdivisionsY": 32
+        }),
+        note: Some("Create a high-res sphere".into()),
+    }]);
+    let (svc, _) = build_service(vec![action]);
+
+    let desc = svc
+        .describe(&DescribeRequest {
+            tool_slug: ToolSlug::build("maya", "spheres", "create_sphere"),
+            include_schema: false,
+        })
+        .expect("describe");
+    let examples = &desc.metadata.as_ref().expect("metadata")["dcc"]["call_examples"];
+    assert_eq!(examples[0]["arguments"]["radius"], serde_json::json!(5.0));
+    assert_eq!(
+        examples[0]["arguments"]["subdivisionsX"],
+        serde_json::json!(32)
+    );
+    assert_eq!(examples[0]["note"], "Create a high-res sphere");
+}
+
+#[test]
 fn load_skill_then_search_makes_action_callable() {
     let (svc, _) = build_service(vec![sphere_action(false)]);
 

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -318,6 +318,25 @@ fn describe_surfaces_call_examples_in_dcc_metadata() {
 }
 
 #[test]
+fn search_metadata_keeps_call_examples_behind_describe() {
+    let mut action = sphere_action(true);
+    action.timeout_hint_secs = Some(5);
+    action.call_examples = Some(vec![dcc_mcp_models::CallExample {
+        arguments: serde_json::json!({"radius": 5.0}),
+        note: Some("Create a sphere".into()),
+    }]);
+    let (svc, _) = build_service(vec![action]);
+
+    let search = svc.search(&SearchRequest {
+        query: Some("sphere".into()),
+        ..Default::default()
+    });
+    let metadata = search.hits[0].metadata.as_ref().expect("metadata");
+    assert_eq!(metadata["dcc"]["timeoutHintSecs"], serde_json::json!(5));
+    assert!(metadata["dcc"].get("call_examples").is_none());
+}
+
+#[test]
 fn load_skill_then_search_makes_action_callable() {
     let (svc, _) = build_service(vec![sphere_action(false)]);
 

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -112,6 +112,7 @@ fn sphere_action(loaded: bool) -> CatalogAction {
         available_groups: Vec::new(),
         runtime: None,
         next_tools: Default::default(),
+        call_examples: None,
     }
 }
 
@@ -362,6 +363,7 @@ fn search_matches_aliases_and_schema_tokens_without_schema_expansion() {
         available_groups: Vec::new(),
         runtime: None,
         next_tools: Default::default(),
+        call_examples: None,
     };
 
     let (svc, _) = build_service(vec![maya, photoshop]);

--- a/examples/skills/maya-geometry/tools.yaml
+++ b/examples/skills/maya-geometry/tools.yaml
@@ -21,6 +21,12 @@ tools:
     destructive: false
     idempotent: false
     source_file: scripts/create_sphere.py
+    call_examples:
+      - arguments:
+          radius: 5.0
+          subdivisionsX: 32
+          subdivisionsY: 32
+        note: "Create a high-res sphere with 32x32 subdivisions"
     next-tools:
       on-success: [maya_geometry__bevel_edges, maya_pipeline__export_usd]
       on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -121,6 +121,7 @@ Generated `tools.yaml` entries follow the modern contract:
 - `affinity` is explicit. Use `main` for host API or scene mutation work and `any` for pure work.
 - `enforce_thread_affinity: true` is emitted so adapter dispatch stays honest.
 - `annotations` use MCP hints: read-only, destructive, idempotent, open-world, and deferred.
+- `call_examples`: optional list of ready-to-copy argument payloads. Each entry has `arguments` (JSON object matching `input_schema.properties`) and an optional `note`. Surfaced in describe responses at `metadata.dcc.call_examples` so agents can construct correct arguments on the first attempt.
 
 ## Authoring Workflow
 
@@ -128,7 +129,7 @@ Generated `tools.yaml` entries follow the modern contract:
 2. Give the skill a kebab-case name and each local tool a snake_case name.
 3. Keep host API calls inside scripts, with lazy imports so discovery works without the host running.
 4. Import dependency-light runtime helpers from `dcc_mcp_core.skills_helper` first: JSON/YAML codecs, bounded HTTP helpers, safe file/path helpers, validation, cancellation checks, and result helpers.
-5. Declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`.
+5. Declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`. For high-frequency tools, add `call_examples` so agents can copy argument payloads without trial-and-error.
 6. Put long examples, recipes, and host-specific notes under `references/`.
 7. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before loading it in an adapter.
 8. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.

--- a/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
+++ b/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
@@ -21,6 +21,37 @@ diagnostic or observation tools, such as screenshots, audit logs, or scene
 snapshots. Infrastructure tools can omit failure chains when they are already
 the recovery target.
 
+## Call Examples
+
+For high-frequency or parameter-rich tools, add `call_examples` so agents can
+construct valid arguments on the first attempt without trial-and-error describe
+retries. Each example is a ready-to-copy payload.
+
+```yaml
+tools:
+  - name: export_fbx
+    # ... other fields ...
+    call_examples:
+      - arguments:
+          path: "C:/exports/scene.fbx"
+          selected_only: true
+        note: "Export selected objects to FBX with default settings"
+      - arguments:
+          path: "C:/exports/animation.fbx"
+          bake_animation: true
+          start_frame: 1
+          end_frame: 120
+```
+
+Guidelines:
+- Each entry must have an `arguments` object matching `input_schema.properties`.
+- Optional `note` describes what the example demonstrates.
+- List at most 3 examples; one well-chosen example beats three generic ones.
+- Server passes examples through to describe responses at
+  `metadata.dcc.call_examples` — agents see them without extra round trips.
+- This is an optional field. Tools with simple schemas (≤2 properties) or that
+  are always called with different arguments can omit it.
+
 ## Core Boundary
 
 Keep configuration in `SKILL.md` frontmatter under `metadata.dcc-mcp.*`, and


### PR DESCRIPTION
## Summary

PIP-577 P0: tools.yaml optional call_examples → describe passes through to metadata.dcc.call_examples

## Changes

### Model layer
- **dcc-mcp-models**: add struct ( + optional )
- **ToolDeclaration**: add field
- Wire deserializer synchronously supports YAML key

### Backend passthrough
- **CatalogAction**: add field
- Both construction points are populated: loaded skills look up ToolDeclaration from catalog, unloaded use tool_decl directly
- **action_metadata()**: inject when value is present
- describe response automatically includes it, no additional gateway changes needed (gateway's mcp_meta_from_rest_metadata already passes through metadata)

### Documentation
- **skills-creator SKILL.md**: add call_examples field description
- **DCC_TOOL_CONTRACTS.md**: add Call Examples section
- **examples/skills/maya-geometry**: add example to create_sphere

### Verification
- dcc-mcp-models: 78 passed
- dcc-mcp-skill-rest: 85 passed
- Total: 9507 passed (20 pre-existing failures unrelated)
- fmt + clippy: green

## Usage

```yaml
tools:
  - name: export_fbx
    call_examples:
      - arguments:
          path: "C:/exports/scene.fbx"
          selected_only: true
        note: "Export selected objects to FBX"
```

The `metadata.dcc.call_examples` in describe responses contains the above array; agents can directly copy the arguments to construct parameters.
