### PR TITLE
docs(skills-creator): correct tags_any/dcc_types as planned fields, not current

### DIFF
--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -156,9 +156,11 @@ appropriate tags under `metadata.dcc-mcp.tags`:
 | `destructive` | Mutating or irreversible operations. Also set MCP `destructiveHint` (`annotations.destructive_hint: true` in `tools.yaml`); the tag is for search, not policy. |
 
 Current `tags` semantics are **AND**: a request containing both `pipeline` and
-`production-tracking` returns records that carry both tags. To match any of
-several tags, issue separate searches or omit the tag filter.
-`dcc_type` is a singular filter — pass one DCC family per request.
+`production-tracking` returns records that carry both tags. Planned search
+fields will add `tags_any` for OR-style matching and `dcc_types[]` for
+multi-host filtering; until those fields land, send separate
+`POST /v1/search` requests for alternatives and use singular `dcc_type` for one
+backend family.
 
 **Vendor tags** can be added when they sharpen routing without replacing the
 canonical tags. For example, Autodesk Product Help should use `docs`,

--- a/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
+++ b/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
@@ -45,9 +45,11 @@ across hosts. The canonical tag vocabulary:
 | `destructive` | Mutating or irreversible operations. Also set MCP `destructiveHint` (`annotations.destructive_hint: true` in `tools.yaml`); the tag is for search, not policy. |
 
 Current `tags` semantics are **AND**: a search containing both `pipeline` and
-`production-tracking` returns records that carry both tags. To match any of
-several tags, issue separate searches or omit the tag filter.
-`dcc_type` is a singular filter — pass one DCC family per request.
+`production-tracking` returns records that carry both tags. Planned search
+fields will add `tags_any` for OR-style matching and `dcc_types[]` for
+multi-host filtering; until those fields land, send separate
+`POST /v1/search` requests for alternatives and use singular `dcc_type` for one
+backend family.
 
 **Vendor tags** can be added when they sharpen routing without replacing the
 canonical tags. For example, Autodesk Product Help should use `docs`,


### PR DESCRIPTION
## Summary

Aligns the Gateway-Facing Tag Taxonomy section in skills-creator docs with the authoritative gateway source (\crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md\).

## Changes

- \skills/dcc-mcp-skills-creator/SKILL.md\: Added **Gateway-Facing Tag Taxonomy** section
- \skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md\: Added **Gateway-Facing Tags** subsection

## Key correction vs original PR #1525

Original wording treated \	ags_any\ and \dcc_types\ as currently usable fields. This version aligns with the authoritative source:

> \	ags\ currently uses AND semantics; \	ags_any\ and \dcc_types[]\ are **planned** additions. Until those fields land, send separate \POST /v1/search\ requests for alternatives and use singular \dcc_type\ for one backend family.

## Context

- Original PR https://github.com/dcc-mcp/dcc-mcp-core/pull/1525 added the same section with incorrect field availability
- Authoritative source: \crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md\
- Search schema: \crates/dcc-mcp-gateway-search/src/query.rs\ does not yet expose \	ags_any\ or \dcc_types\
- Fixes the review finding from loonghao in PR #1525