### PR TITLE
fix(ci): isolate workflow_dispatch from push concurrency in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}${{ inputs.release_tag && format('-{0}', inputs.release_tag) || '' }}
   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 permissions:


### PR DESCRIPTION
## Summary

Change `cancel-in-progress` from `false` to `true` in the Release workflow concurrency group.

## Problem

When multiple pushes land on `main` in quick succession (e.g., Renovate PR merges within seconds of each other), the concurrency queue can overflow. With `cancel-in-progress: false`, GitHub Actions queues up to N runs. When the queue limit is exceeded, new runs are silently cancelled with zero jobs created, and some runs can get stuck in pending state indefinitely.

## Fix

`cancel-in-progress: true` ensures that only the latest push to `main` runs — previous queued or in-progress runs are cancelled. This is the standard pattern already used by dcc-mcp-houdini, dcc-mcp-photoshop, dcc-mcp-maya, dcc-mcp-blender, and dcc-mcp-3dsmax.

## Why this is safe

- `release-please-action` is idempotent — it only creates a release when release-worthy commits are detected
- If a release build is cancelled mid-flight by a newer push, the next run re-evaluates and re-triggers the release if needed
- PyPI publish uses `skip-existing: true` (safe to re-run)
- Renovate `chore(deps)` commits do not trigger release-please, so cancelled non-release runs are harmless