### PR TITLE
fix: increase SSE notification budget for prompts watcher on slow CI runners

### DIFF
--- a/tests/test_e2e_gateway_prompts_sse.py
+++ b/tests/test_e2e_gateway_prompts_sse.py
@@ -26,8 +26,12 @@ The flow covered end-to-end:
    symmetric unload path.
 
 Runtime budget: the prompts watcher inherits the same 3-second tick as
-the tools/resources aggregators, so we allow up to 12 s end-to-end for
-each wait.
+the tools/resources aggregators. We allow up to 25 s end-to-end for
+each wait to accommodate slow CI runners (macOS py3.8 in particular,
+where resource contention and Python 3.8's slower asyncio can inflate
+individual ticks past the 3 s nominal interval). With
+MissedTickBehavior::Delay, a single slow HTTP fetch defers the next
+tick, so ~8 ticks is a safe ceiling even under load.
 """
 
 from __future__ import annotations
@@ -53,7 +57,7 @@ FIXTURE_SKILL_PARENT = str(REPO_ROOT / "tests" / "fixtures" / "prompts_skills" /
 
 # The aggregating prompts watcher ticks every 3 s (same cadence as the
 # tools and resources aggregators); add slack for scheduling jitter.
-SSE_NOTIFICATION_BUDGET_S = 12.0
+SSE_NOTIFICATION_BUDGET_S = 25.0
 AGGREGATOR_TICK_S = 3.0
 
 


### PR DESCRIPTION
## Summary

- Increase `SSE_NOTIFICATION_BUDGET_S` from 12.0s to 25.0s in the prompts SSE E2E test
- Add detailed comment explaining the macOS py3.8 CI runner timing constraints

## Root Cause

The gateway's `notifications/prompts/list_changed` relies entirely on a 3s polling watcher (unlike `notifications/tools/list_changed` which is pushed immediately via `skill_mgmt_dispatch`). On macOS py3.8 CI runners, resource contention and Python 3.8's slower asyncio can inflate individual watcher ticks past the nominal 3s interval. With `MissedTickBehavior::Delay`, a single slow HTTP fetch defers subsequent ticks, reducing effective ticks within the 12s window.

This is **not a race condition** — the notification path is correct and will eventually deliver. The old budget was simply too tight for the slowest platform.

## Contract

No API or behavior changes. Test-only timeout adjustment.

## Test Plan

- [x] The only change is a test timeout constant; CI will validate on all platforms
- [x] macOS py3.8 should now have sufficient budget (~8 watcher ticks) even under load