### PR TITLE
fix(ci): add npm ci retry to build-wheel action

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -131,7 +131,18 @@ runs:
       shell: bash
       run: |
         set -eux
-        vx npm --prefix admin-ui ci --ignore-scripts
+        # npm registry can return ECONNRESET; retry like release.yml's build-admin-ui job
+        for attempt in 1 2 3; do
+          if vx npm --prefix admin-ui ci --ignore-scripts; then
+            break
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            echo "::error::npm ci failed after 3 attempts"
+            exit 1
+          fi
+          echo "::warning::npm ci attempt ${attempt}/3 failed; retrying in 15s..."
+          sleep 15
+        done
         vx npm --prefix admin-ui run build
         test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
 


### PR DESCRIPTION
## Summary
- v0.18.7 release was incomplete because `build-wheels / macos` failed due to an intermittent `ECONNRESET` during `npm ci`
- The `build-admin-ui` job in `release.yml` already has a 3-attempt retry for npm, but the `build-wheel` action's "Pre-build admin UI for manylinux Docker" step did not
- Added the same retry pattern to `build-wheel` action

## Root cause
GitHub Release v0.18.7 only has Linux binaries + semantic wheels. Missing:
- macOS/Windows binaries (stuck build-binaries jobs)
- dcc-mcp-core wheels for all platforms (cascaded from build-wheels failure)

## Fix
Added 3-attempt npm ci retry with 15s delay to `.github/actions/build-wheel/action.yml`, matching the pattern in `release.yml`'s `build-admin-ui` job.

## Test plan
- [ ] Trigger workflow_dispatch backfill for v0.18.7 after merge to verify full release
- [ ] Confirm all platforms produce binaries + wheels in the backfill