### PR TITLE
fix(gateway): add abort_and_wait to GatewayHandle to prevent SIGABRT on shutdown

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handle.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handle.rs
@@ -70,6 +70,42 @@ impl GatewayHandle {
         self.registry.clone()
     }
 
+    /// Async shutdown: deregister from the file registry, abort all
+    /// background tasks, and wait for the supervisor to join so every
+    /// spawned child is cooperatively cancelled before the tokio
+    /// [`Runtime`] is dropped.
+    ///
+    /// Callers embedded via PyO3 **must** call this inside the runtime
+    /// before letting the process exit, otherwise aborted-but-not-yet-
+    /// cancelled tasks may hold `tokio::sync` primitives that panic or
+    /// abort when the runtime tears down (observed as exit code 134 /
+    /// SIGABRT in CI).
+    ///
+    /// After calling this method the `GatewayHandle::Drop` impl is a
+    /// cheap no-op — all handles have already been taken.
+    pub async fn abort_and_wait(&mut self) {
+        self.deregister_all();
+
+        if let Some(h) = self.heartbeat_abort.take() {
+            h.abort();
+        }
+        if let Some(h) = self.gateway_abort.take() {
+            h.abort();
+        }
+        if let Some(h) = self.challenger_abort.take() {
+            h.abort();
+        }
+
+        // Await the combined supervisor so all child task handles get
+        // a chance to observe cancellation before we detach.
+        if let Some(supervisor) = self.gateway_supervisor.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(5), supervisor).await;
+        }
+
+        // Best-effort detach for dedicated-mode threads (same as Drop).
+        drop(self.gateway_thread.take());
+    }
+
     /// Deregister every pending `ServiceKey` from the `FileRegistry` and
     /// clear the queue. Idempotent and cheap — safe to call from both
     /// async shutdown paths and `Drop`.

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -90,7 +90,7 @@ impl McpServerHandle {
         // correctness safety net for callers who skip `shutdown()`.
         #[cfg(feature = "auto-gateway")]
         if let Some(gw) = self._gateway.as_mut() {
-            gw.deregister_all();
+            gw.abort_and_wait().await;
         }
 
         let _ = self.shutdown_tx.send(true);


### PR DESCRIPTION
Cherry-pick of loonghao's fix from agent/agent/97deb3df.

## Root Cause

When `GatewayHandle::Drop` aborts background tasks synchronously, the tokio Runtime destructor may tear down before aborted tasks observe cancellation, causing double-panic and SIGABRT (exit code 134) in PyO3-embedded hosts.

## Fix

Add `abort_and_wait()` async method that deregisters from the file registry, aborts all background tasks, and awaits the supervisor JoinHandle with a 5s timeout before the gateway handle is dropped. Called from `McpServerHandle::shutdown()`.

## Impact

Fixes CI failures in dcc-mcp-unreal PR#9 where MCP Protocol Conformance job crashes with exit code 134 during shutdown.

## Test Plan

- [ ] dcc-mcp-unreal CI MCP Protocol Conformance job passes
- [ ] Existing dcc-mcp-core test suite passes