### PR TITLE
fix: disable gateway election for job persistence probe server

### DIFF
--- a/python/dcc_mcp_core/_server/observability.py
+++ b/python/dcc_mcp_core/_server/observability.py
@@ -97,6 +97,7 @@ class JobPersistenceManager:
             from dcc_mcp_core import create_skill_server
 
             probe_cfg = McpHttpConfig(port=0, server_name="probe")
+            probe_cfg.gateway_port = 0
             probe_cfg.job_storage_path = db_path
             probe_srv = create_skill_server(self._dcc_name, probe_cfg)
             probe_handle = probe_srv.start()


### PR DESCRIPTION
## Summary

Fixes a regression where `JobPersistenceManager.init()` probe server incorrectly participates in gateway election, causing Maya (and potentially other DCC) servers to become invisible to the gateway.

## Root Cause

The probe server created in `_init_job_persistence()` uses `McpHttpConfig(port=0, server_name="probe")` which defaults `gateway_port=9765`. When the daemon is not yet running, the probe:
1. Wins gateway election → registers as `__gateway__`
2. Shuts down after SQLite probe completes → deregisters ALL entries, kills gateway
3. Leaves FileRegistry state inconsistent for the subsequent real DCC server

This is a regression from v0.18.x — v0.17.47 logs show both probe AND real server successfully registering.

## Fix

`python/dcc_mcp_core/_server/observability.py`: Set `probe_cfg.gateway_port = 0`

The probe's sole purpose is to detect `job-persist-sqlite` feature availability. Setting `gateway_port=0` causes `start_gateway_runner()` to return immediately without FileRegistry registration or gateway election.

## Test Plan

- [ ] Verify Maya server registers in FileRegistry after upgrade
- [ ] Verify gateway shows Maya tools via `/v1/search`
- [ ] Verify job persistence still works (probe SQLite detection unaffected)