### PR TITLE
fix: tolerate versioned ClawHub duplicate errors

### DIFF
--- a/scripts/clawhub_sync.py
+++ b/scripts/clawhub_sync.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 from typing import Any
@@ -16,7 +17,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
 DEFAULT_CLI = os.environ.get("CLAWHUB_CLI_PACKAGE", "clawhub@0.17.0")
 CLAWHUB_LICENSE = "MIT-0"
-VERSION_EXISTS_MARKER = "Version already exists"
+VERSION_EXISTS_RE = re.compile(r"\bVersion(?:\s+\S+)?\s+already exists\b")
 
 
 def parse_args() -> argparse.Namespace:
@@ -92,7 +93,7 @@ def print_completed_process_output(proc: subprocess.CompletedProcess[str]) -> No
 def version_already_exists(proc: subprocess.CompletedProcess[str]) -> bool:
     """Return True when ClawHub reports that the immutable version exists."""
     output = "\n".join(part for part in (proc.stdout, proc.stderr) if part)
-    return VERSION_EXISTS_MARKER in output
+    return VERSION_EXISTS_RE.search(output) is not None
 
 
 def publish_one(

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -70,7 +70,7 @@ class TestClawhubSync:
                 cmd,
                 1,
                 stdout="- Preparing example@1.2.3\n",
-                stderr="Error: Uncaught ConvexError: Version already exists\n",
+                stderr="Error: Uncaught ConvexError: Version 1.2.3 already exists\n",
             )
 
         monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
@@ -87,7 +87,7 @@ class TestClawhubSync:
 
         captured = capsys.readouterr()
         assert rc == 0
-        assert "Version already exists" in captured.err
+        assert "Version 1.2.3 already exists" in captured.err
         assert "example@1.2.3 already exists on ClawHub; skipping." in captured.out
 
     def test_clawhub_skill_versions_follow_release_please(self) -> None:


### PR DESCRIPTION
## Summary
- Treat ClawHub duplicate-version errors with an embedded version number as idempotent
- Update the ClawHub sync regression test to match the live CLI error text

## Validation
- vx python -m pytest -q tests/test_clawhub_sync.py tests/test_release_workflow.py

## Skill guidance
- No update needed; this only changes release automation idempotency for ClawHub publishing.
