### PR TITLE
feat(catalog): add dcc-mcp-maya-mgear marketplace entry

### DIFF
--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -22,6 +22,20 @@ entries:
     url: "https://github.com/loonghao/dcc-mcp-maya-skills"
     tags: ["skills", "maya", "official", "rigging", "render"]
 
+  - name: "dcc-mcp-maya-mgear"
+    description: "mGear Shifter rigging integration for DCC-MCP — inspect, list, create guides, build rigs, export templates"
+    dcc: ["maya"]
+    url: "https://github.com/loonghao/dcc-mcp-maya-mgear"
+    tags: ["skills", "maya", "rigging", "mgear", "shifter"]
+    version: "0.1.0"
+    min_core_version: "0.17.0"
+    maintainer: "dcc-mcp"
+    icon: "icon.png"
+    install:
+      type: git
+      url: "https://github.com/loonghao/dcc-mcp-maya-mgear"
+      ref: "main"
+
   - name: "dcc-mcp-blender-skills"
     description: "Official Blender skill pack for DCC-MCP — modeling, shading, and render tools"
     dcc: ["blender"]


### PR DESCRIPTION
## Summary

Add dcc-mcp-maya-mgear to the public DCC-MCP catalog for marketplace discovery and CLI-driven installation.

## Changes

- Add `dcc-mcp-maya-mgear` entry to `dcc-mcp-catalog.yml` with full install metadata (git type, loonghao/dcc-mcp-maya-mgear repo, main ref)
- The dcc-mcp-maya-mgear repo has also been updated with a marketplace-compatible root layout (SKILL.md, tools.yaml, scripts/, metadata/) in a separate branch `feature/marketplace-layout`

## Related

- PIP-826
- dcc-mcp-maya-mgear PR: https://github.com/dcc-mcp/dcc-mcp-maya-mgear/pull/new/feature/marketplace-layout