### PR TITLE
feat(skills): add marketplace-publish-extension skill package

### DIFF
--- a/admin-ui/tests/marketplace.spec.ts
+++ b/admin-ui/tests/marketplace.spec.ts
@@ -1,0 +1,306 @@
+import { test, expect, type Page } from '@playwright/test';
+
+type MockState = {
+  catalog: object[];
+  installed: object[];
+};
+
+async function mockMarketplaceApi(page: Page, state: MockState) {
+  await page.route('**/admin/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname.replace(/^\/admin\/api/, '');
+    const method = route.request().method();
+    let body: unknown;
+    let status = 200;
+
+    if (path === '/health') {
+      body = {
+        status: 'ok',
+        instances_ready: 1,
+        instances_total: 2,
+        uptime_secs: 3723,
+        version: '0.17.7',
+        rss_bytes: 2097152,
+      };
+    } else if (path === '/marketplace/catalog') {
+      body = { entries: state.catalog };
+    } else if (path === '/marketplace/installed') {
+      body = { packages: state.installed };
+    } else if (path === '/marketplace/install' && method === 'POST') {
+      const payload = route.request().postDataJSON() as { name?: string; dcc?: string };
+      state.installed.push({
+        name: payload.name ?? 'unknown',
+        dcc: payload.dcc ?? 'unknown',
+        version: '1.0.0',
+        install_type: 'git',
+        path: `/fake/path/${payload.name}`,
+        source_name: 'builtin',
+      });
+      body = { ok: true, name: payload.name, dcc: payload.dcc };
+    } else if (path === '/marketplace/uninstall' && method === 'POST') {
+      const payload = route.request().postDataJSON() as { name?: string; dcc?: string };
+      state.installed = state.installed.filter(
+        (pkg: any) => !(pkg.name === payload.name && pkg.dcc === payload.dcc),
+      );
+      body = { ok: true, name: payload.name, dcc: payload.dcc };
+    } else {
+      status = 404;
+      body = { error: `Unhandled test route: ${method} ${path}` };
+    }
+
+    await route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+test.describe('Marketplace Panel', () => {
+  test('shows empty state when no packages are available', async ({ page }) => {
+    await mockMarketplaceApi(page, { catalog: [], installed: [] });
+    await page.goto('/admin/?panel=marketplace');
+
+    await expect(page.locator('.marketplace-panel')).toBeVisible();
+    await expect(page.locator('.marketplace-panel h2')).toContainText('Marketplace');
+
+    // Browse tab should be active and show empty state
+    const browseTab = page.locator('.marketplace-tab').first();
+    await expect(browseTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('.marketplace-content .empty')).toContainText(
+      'No marketplace packages available.',
+    );
+
+    // Switch to Installed tab — also empty
+    await page.getByRole('tab', { name: /Installed/ }).click();
+    await expect(page.locator('.marketplace-content .empty')).toContainText(
+      "No packages installed yet.",
+    );
+  });
+
+  test('shows empty state for search with no results', async ({ page }) => {
+    await mockMarketplaceApi(page, {
+      catalog: [
+        {
+          name: 'maya-modeling',
+          description: 'Maya modeling tools.',
+          dcc: ['maya'],
+          tags: ['modeling', 'polygon'],
+          version: '2.1.0',
+          maintainer: 'td-core',
+        },
+      ],
+      installed: [],
+    });
+    await page.goto('/admin/?panel=marketplace');
+
+    // Should show the package
+    await expect(page.locator('.marketplace-card')).toHaveCount(1);
+
+    // Search for something that doesn't match
+    await page.getByLabel('Filter current panel').fill('houdini');
+
+    // Should show empty search message
+    await expect(page.locator('.marketplace-content .empty')).toContainText(
+      'No packages match your search.',
+    );
+  });
+
+  test('installs a package via mock API and shows success notice', async ({ page }) => {
+    await mockMarketplaceApi(page, {
+      catalog: [
+        {
+          name: 'maya-modeling',
+          description: 'A collection of modeling tools for Maya.',
+          dcc: ['maya'],
+          tags: ['modeling'],
+          version: '2.1.0',
+          maintainer: 'td-core',
+        },
+        {
+          name: 'blender-lookdev',
+          description: 'Look development utilities for Blender.',
+          dcc: ['blender'],
+          tags: ['shading', 'lookdev'],
+          version: '0.5.0',
+        },
+      ],
+      installed: [],
+    });
+    await page.goto('/admin/?panel=marketplace');
+
+    await expect(page.locator('.marketplace-card')).toHaveCount(2);
+
+    // The maya DCC chip should show "Install maya" text
+    const mayaCard = page.locator('.marketplace-card[data-name="maya-modeling"]');
+    await expect(mayaCard).toContainText('Install maya');
+
+    // Click the install button
+    await mayaCard.locator('.marketplace-card-chip-action').first().click();
+
+    // Install success notice should appear
+    const notice = page.locator('.marketplace-install-notice');
+    await expect(notice).toBeVisible();
+    await expect(notice).toContainText('maya-modeling');
+    await expect(notice.locator('.marketplace-install-notice-link')).toContainText(
+      'View in Skills',
+    );
+
+    // DCC chip should now show as installed (checkmark)
+    await expect(mayaCard.locator('.marketplace-card-chip-installed')).toBeVisible();
+  });
+
+  test('shows DCC filter chips and filters the catalog grid', async ({ page }) => {
+    await mockMarketplaceApi(page, {
+      catalog: [
+        {
+          name: 'maya-modeling',
+          description: 'Maya tools.',
+          dcc: ['maya'],
+          tags: [],
+          version: '1.0.0',
+        },
+        {
+          name: 'blender-kit',
+          description: 'Blender tools.',
+          dcc: ['blender'],
+          tags: [],
+          version: '1.0.0',
+        },
+        {
+          name: 'cross-dcc-utils',
+          description: 'Works everywhere.',
+          dcc: ['maya', 'blender', 'houdini'],
+          tags: [],
+          version: '1.0.0',
+        },
+      ],
+      installed: [],
+    });
+    await page.goto('/admin/?panel=marketplace');
+
+    // DCC filter row should be visible with All + individual DCC chips
+    const filterRow = page.locator('.marketplace-dcc-filter');
+    await expect(filterRow).toBeVisible();
+    await expect(filterRow.locator('.marketplace-dcc-chip')).toHaveCount(4); // All + blender + houdini + maya
+
+    // All chip should be active by default
+    const allChip = filterRow.locator('.marketplace-dcc-chip.active');
+    await expect(allChip).toContainText('All');
+    await expect(page.locator('.marketplace-card')).toHaveCount(3);
+
+    // Click 'maya' chip
+    await filterRow.getByRole('button', { name: 'maya' }).click();
+    await expect(page.locator('.marketplace-card')).toHaveCount(2);
+    await expect(page.locator('.marketplace-card[data-name="blender-kit"]')).not.toBeVisible();
+
+    // Click 'maya' again to de-select (toggle off)
+    await filterRow.getByRole('button', { name: 'maya' }).click();
+    await expect(page.locator('.marketplace-card')).toHaveCount(3);
+
+    // DCC filter + text search can combine
+    await page.getByLabel('Filter current panel').fill('cross');
+    await filterRow.getByRole('button', { name: 'houdini' }).click();
+    await expect(page.locator('.marketplace-card')).toHaveCount(1);
+    await expect(page.locator('.marketplace-card[data-name="cross-dcc-utils"]')).toBeVisible();
+  });
+
+  test('opens detail modal on card click and shows package metadata', async ({ page }) => {
+    await mockMarketplaceApi(page, {
+      catalog: [
+        {
+          name: 'maya-modeling',
+          description: 'A collection of modeling tools for Maya.',
+          dcc: ['maya'],
+          tags: ['modeling', 'polygon', 'deformation'],
+          version: '2.1.0',
+          min_core_version: '0.15.0',
+          maintainer: 'td-core',
+          url: 'https://github.com/dcc-mcp/maya-modeling',
+          source_name: 'builtin',
+          install: { type: 'git', url: 'https://github.com/dcc-mcp/maya-modeling.git' },
+        },
+      ],
+      installed: [],
+    });
+    await page.goto('/admin/?panel=marketplace');
+
+    // Click the card to open detail modal
+    await page.locator('.marketplace-card[data-name="maya-modeling"]').click();
+
+    const modal = page.locator('.marketplace-detail-modal');
+    await expect(modal).toBeVisible();
+    await expect(modal.locator('.marketplace-detail-name')).toContainText('maya-modeling');
+    await expect(modal.locator('.marketplace-detail-desc')).toContainText(
+      'A collection of modeling tools for Maya.',
+    );
+
+    // Key-value grid
+    await expect(modal).toContainText('2.1.0'); // version
+    await expect(modal).toContainText('0.15.0'); // min_core_version
+    await expect(modal).toContainText('td-core'); // maintainer
+    await expect(modal).toContainText('git'); // install type
+    await expect(modal).toContainText('builtin'); // source
+
+    // Tags section
+    await expect(modal).toContainText('modeling');
+    await expect(modal).toContainText('polygon');
+    await expect(modal).toContainText('deformation');
+
+    // DCC section
+    await expect(modal).toContainText('maya');
+
+    // No compatibility warning (0.15.0 <= 0.17.7)
+    await expect(modal.locator('.marketplace-detail-warning')).not.toBeVisible();
+
+    // Close via backdrop click
+    await page.locator('.marketplace-detail-backdrop').click({ position: { x: 10, y: 10 } });
+    await expect(modal).not.toBeVisible();
+  });
+
+  test('shows compatibility warning when min_core_version exceeds current version', async ({
+    page,
+  }) => {
+    await mockMarketplaceApi(page, {
+      catalog: [
+        {
+          name: 'futuristic-tools',
+          description: 'Requires a future core version.',
+          dcc: ['maya'],
+          tags: [],
+          version: '3.0.0',
+          min_core_version: '9.9.9',
+          maintainer: 'future-team',
+        },
+      ],
+      installed: [],
+    });
+    // Health query is only enabled on health / debug / setup panels.
+    // Visit health panel first, then navigate to marketplace via SPA link
+    // (client-side nav keeps TanStack Query cache alive; page.goto would reload).
+    await page.goto('/admin/?panel=health');
+    await expect(page.locator('.health-panel')).toContainText('0.17.7');
+    await page.getByRole('navigation').getByRole('link', { name: 'Marketplace' }).click();
+    await expect(page.locator('.marketplace-panel')).toBeVisible();
+
+    // Open detail modal
+    await page.locator('.marketplace-card[data-name="futuristic-tools"]').click();
+
+    const modal = page.locator('.marketplace-detail-modal');
+    await expect(modal).toBeVisible();
+
+    // Compatibility warning alert should be visible
+    const warning = modal.locator('.marketplace-detail-warning');
+    await expect(warning).toBeVisible();
+    await expect(warning).toHaveAttribute('role', 'alert');
+    await expect(warning).toContainText('9.9.9');
+    await expect(warning).toContainText('0.17.7');
+
+    // min_core_version in the KV grid should have warning styling
+    await expect(modal.locator('.marketplace-detail-kv-warn')).toContainText('9.9.9');
+
+    // Close via Escape key
+    await page.keyboard.press('Escape');
+    await expect(modal).not.toBeVisible();
+  });
+});

--- a/examples/skills/marketplace-publish-extension/SKILL.md
+++ b/examples/skills/marketplace-publish-extension/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: marketplace-publish-extension
+description: >-
+  Infrastructure skill — publish (register/update) an extension package to a
+  marketplace catalog. Reads the extension's SKILL.md frontmatter, constructs
+  a CatalogEntry, and upserts it into the target marketplace.json. Optionally
+  commits and pushes when the catalog source is a git repository. Use after
+  scaffolding an extension with marketplace-create-extension. Not for
+  installing or searching extensions — use marketplace-install or
+  marketplace-search for that.
+license: MIT
+compatibility: "dcc-mcp-core 0.17+, Python 3.7+"
+allowed-tools: Bash Read Write
+metadata:
+  dcc-mcp:
+    dcc: python
+    version: "1.0.0"
+    layer: infrastructure
+    search-hint: >-
+      publish extension, register extension, marketplace catalog, upsert
+      catalog entry, marketplace.json, extension publishing, release to
+      marketplace
+    tags: "marketplace, publishing, catalog, infrastructure"
+    tools: tools.yaml
+---
+
+# Marketplace Publish Extension
+
+Publish (register or update) a dcc-mcp extension package to a marketplace
+catalog (`marketplace.json`).
+
+## Tools
+
+### `marketplace_publish_extension__publish`
+Scan an extension directory, build a `CatalogEntry`, and upsert it into the
+target `marketplace.json` (local file or remote URL-backed file). When the
+catalog source is a local git repository the tool can optionally commit and
+push the change.
+
+## Prerequisites
+
+- dcc-mcp-core installed
+- Write access to the target marketplace catalog path
+- Git (if using commit+push mode)
+
+## Workflow
+
+1. Point the tool at a local extension directory containing `SKILL.md`.
+2. The tool reads the SKILL.md frontmatter and any accompanying metadata.
+3. Additional CLI-supplied fields (install url, ref, tags, maintainer, icon,
+   etc.) are merged in.
+4. A `CatalogEntry` is built and upserted into the target `marketplace.json`.
+5. If the catalog source is a git repo and `--commit` is passed, the updated
+   `marketplace.json` is committed and pushed.

--- a/examples/skills/marketplace-publish-extension/scripts/publish.py
+++ b/examples/skills/marketplace-publish-extension/scripts/publish.py
@@ -1,0 +1,588 @@
+"""Publish (register or update) an extension to a marketplace catalog.
+
+Reads an extension directory containing SKILL.md, constructs a CatalogEntry,
+and upserts it into the target marketplace.json. Optionally commits and pushes
+when the catalog source is a local git repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+# ── SKILL.md frontmatter parsing ──────────────────────────────────────────────
+
+
+def _parse_skill_md(path: Path) -> dict[str, Any]:
+    """Parse YAML frontmatter from a SKILL.md file.
+
+    Returns a dict with the frontmatter contents, or raises an error if
+    the file is missing or has no valid frontmatter.
+    """
+    if not path.is_file():
+        raise FileNotFoundError(f"SKILL.md not found at {path}")
+
+    content = path.read_text(encoding="utf-8")
+    # Frontmatter is delimited by --- lines. The first line must be ---.
+    if not content.startswith("---"):
+        raise ValueError(f"SKILL.md at {path} has no YAML frontmatter (missing opening ---)")
+
+    # Find the closing ---
+    rest = content[3:]  # skip opening ---
+    end_idx = rest.find("\n---")
+    if end_idx == -1:
+        # Try with just --- at the very start
+        end_idx = rest.find("---")
+    if end_idx == -1:
+        raise ValueError(f"SKILL.md at {path} has unclosed YAML frontmatter")
+
+    frontmatter_text = rest[:end_idx].strip()
+
+    # Use a minimal YAML parser — we could import yaml, but that adds a
+    # dependency. For the dcc-mcp frontmatter subset, a line-oriented
+    # parser that handles simple scalars, lists with [], and nested
+    # key: value under metadata is sufficient.
+    return _parse_simple_yaml(frontmatter_text)
+
+
+def _parse_simple_yaml(text: str) -> dict[str, Any]:
+    """Minimal YAML subset parser for dcc-mcp SKILL.md frontmatter.
+
+    Handles:
+    - plain scalars (key: value)
+    - flow-sequence lists (key: [a, b, c])
+    - nested blocks (2-space indent) for metadata.dcc-mcp.*
+    - >- folded block scalars (description: >-)
+    """
+    result: dict[str, Any] = {}
+    current_path: list[str] = []
+    current_indent = 0
+    fold_key: str | None = None
+    fold_lines: list[str] = []
+
+    for line in text.splitlines():
+        # Skip empty lines unless we're in a fold
+        stripped = line.strip()
+        if not stripped:
+            if fold_key is not None:
+                fold_lines.append("")
+            continue
+
+        # If we're in a folded scalar (>-) and the line is more indented
+        indent = len(line) - len(line.lstrip())
+        if fold_key is not None and indent > current_indent:
+            fold_lines.append(stripped)
+            continue
+
+        # Finalise any pending fold
+        if fold_key is not None:
+            _set_nested(result, [*current_path, fold_key], " ".join(fold_lines))
+            fold_key = None
+            fold_lines = []
+
+        # Detect fold start: key: >-
+        if stripped.endswith(">-"):
+            key = stripped[:-2].strip().rstrip(":")
+            fold_key = key
+            current_indent = indent  # continuation lines must be more indented than key
+            # Do NOT mutate current_path here — fold_key is combined with
+            # current_path at finalisation time.
+            continue
+
+        # Detect key: value or key: [list]
+        if ":" in stripped:
+            # Split on first colon
+            colon_idx = stripped.index(":")
+            key = stripped[:colon_idx].strip()
+            value_str = stripped[colon_idx + 1 :].strip()
+
+            if not value_str:
+                # Parent key for a nested block — push onto path
+                current_path = _path_from_indent(result, indent, key, current_path)
+                continue
+
+            # Check for flow-sequence: [a, b, c]
+            if value_str.startswith("[") and value_str.endswith("]"):
+                inner = value_str[1:-1]
+                items = _parse_flow_sequence(inner) if inner.strip() else []
+                _set_nested(result, [*current_path, key], items)
+                continue
+
+            # Remove surrounding quotes
+            value = value_str
+            if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+                value = value[1:-1]
+            _set_nested(result, [*current_path, key], value)
+
+    # Finalise any pending fold at EOF
+    if fold_key is not None:
+        _set_nested(result, [*current_path, fold_key], " ".join(fold_lines))
+
+    return result
+
+
+def _path_from_indent(root: dict[str, Any], indent: int, key: str, current_path: list[str]) -> list[str]:
+    """Determine the nested key path based on indentation level."""
+    # 0 indent = top-level; 2 indent = one level deep; etc.
+    depth = indent // 2
+    new_path = current_path[:depth] if depth < len(current_path) else current_path
+    if depth == len(new_path):
+        new_path.append(key)
+    else:
+        new_path = [*new_path[:depth], key]
+    return new_path
+
+
+def _set_nested(d: dict[str, Any], path: list[str], value: Any) -> None:
+    """Set a value at a nested key path, creating intermediate dicts."""
+    for key in path[:-1]:
+        if key not in d:
+            d[key] = {}
+        d = d[key]
+    d[path[-1]] = value
+
+
+def _parse_flow_sequence(inner: str) -> list[str]:
+    """Parse a YAML flow sequence like 'a, b, "c d"' into a list of strings."""
+    items: list[str] = []
+    current = ""
+    in_quotes = False
+    quote_char = ""
+    for ch in inner:
+        if in_quotes:
+            if ch == quote_char:
+                in_quotes = False
+            else:
+                current += ch
+        elif ch in ('"', "'"):
+            in_quotes = True
+            quote_char = ch
+        elif ch == ",":
+            trimmed = current.strip()
+            if trimmed:
+                items.append(trimmed)
+            current = ""
+        else:
+            current += ch
+    trimmed = current.strip()
+    if trimmed:
+        items.append(trimmed)
+    return items
+
+
+# ── CatalogEntry building ─────────────────────────────────────────────────────
+
+
+def _build_catalog_entry(
+    skill_md: dict[str, Any],
+    install_url: str,
+    install_type: str,
+    install_ref: str | None,
+    version: str | None,
+    maintainer: str | None,
+    icon: str | None,
+    tags: list[str],
+    min_core_version: str | None,
+    extension_url: str | None,
+) -> dict[str, Any]:
+    """Build a CatalogEntry dict from SKILL.md metadata and CLI inputs."""
+    dcc_mcp_meta = skill_md.get("metadata", {}).get("dcc-mcp", {})
+
+    # Name from SKILL.md frontmatter
+    name = skill_md.get("name", "")
+    if not name:
+        raise ValueError("SKILL.md frontmatter is missing required 'name' field")
+
+    # Description from SKILL.md
+    description = skill_md.get("description", "")
+
+    # DCC targets from metadata.dcc-mcp.dcc
+    dcc_raw = dcc_mcp_meta.get("dcc", "python")
+    if isinstance(dcc_raw, list):
+        dcc_targets = dcc_raw
+    elif isinstance(dcc_raw, str):
+        dcc_targets = [t.strip() for t in dcc_raw.split(",") if t.strip()]
+    else:
+        dcc_targets = ["python"]
+
+    # Version: CLI override > metadata > None
+    entry_version = version or dcc_mcp_meta.get("version")
+
+    # Tags: merge metadata tags + CLI tags
+    meta_tags_raw = dcc_mcp_meta.get("tags", "")
+    if isinstance(meta_tags_raw, list):
+        meta_tags = meta_tags_raw
+    elif isinstance(meta_tags_raw, str):
+        meta_tags = [t.strip() for t in meta_tags_raw.split(",") if t.strip()]
+    else:
+        meta_tags = []
+    merged_tags = list(dict.fromkeys(meta_tags + tags))  # dedupe, preserve order
+
+    # Maintainer: CLI > metadata
+    entry_maintainer = maintainer or dcc_mcp_meta.get("maintainer")
+
+    entry: dict[str, Any] = {
+        "name": name,
+        "description": description,
+        "dcc": dcc_targets,
+        "install": {
+            "type": install_type,
+            "url": install_url,
+        },
+    }
+
+    if install_ref:
+        entry["install"]["ref"] = install_ref
+
+    if entry_version:
+        entry["version"] = entry_version
+
+    if entry_maintainer:
+        entry["maintainer"] = entry_maintainer
+
+    if icon:
+        entry["icon"] = icon
+
+    if min_core_version:
+        entry["min_core_version"] = min_core_version
+
+    if extension_url:
+        entry["url"] = extension_url
+
+    if merged_tags:
+        entry["tags"] = merged_tags
+
+    return entry
+
+
+# ── marketplace.json I/O ──────────────────────────────────────────────────────
+
+
+def _load_marketplace_json(path: Path) -> dict[str, Any]:
+    """Load a marketplace.json file or return a default template."""
+    if path.is_file():
+        text = path.read_text(encoding="utf-8")
+        return json.loads(text)
+    return {"version": "1", "entries": []}
+
+
+def _save_marketplace_json(path: Path, catalog: dict[str, Any]) -> None:
+    """Write a marketplace.json file with standardised formatting."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(catalog, indent=2, ensure_ascii=False) + "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def _upsert_entry(catalog: dict[str, Any], entry: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Insert or update an entry in the catalog by name.
+
+    Returns (catalog, was_updated) — was_updated is True when an
+    existing entry was replaced, False when a new entry was appended.
+    """
+    entries: list[dict[str, Any]] = catalog.setdefault("entries", [])
+    name = entry["name"]
+
+    for i, existing in enumerate(entries):
+        if existing.get("name") == name:
+            entries[i] = entry
+            return catalog, True
+
+    entries.append(entry)
+    return catalog, False
+
+
+# ── marketplace source resolution ─────────────────────────────────────────────
+
+
+def _resolve_marketplace_path(raw: str) -> Path:
+    """Resolve a marketplace source string to a local file Path.
+
+    Handles:
+    - GitHub slug "owner/repo" → constructs raw.githubusercontent.com URL,
+      but since we can't write to a URL, returns the local representation.
+      For local operations users should pass a local path.
+    - Full URL → not writable locally, returns a temp note path
+    - Local path → resolves to the marketplace.json file
+    """
+    trimmed = raw.strip()
+
+    # GitHub slug like "owner/repo" or "dcc-mcp/marketplace"
+    if _looks_like_github_slug(trimmed):
+        # For local write operations, the user should provide a local path.
+        # We return a path relative to cwd as a sensible default.
+        raise ValueError(
+            f"'{trimmed}' looks like a GitHub slug. For publish operations "
+            f"please provide a local path to the marketplace.json file or "
+            f"the git repository directory containing it."
+        )
+
+    # URL
+    if trimmed.startswith("http://") or trimmed.startswith("https://"):
+        raise ValueError(
+            f"'{trimmed}' is a URL. Cannot write marketplace.json to a remote "
+            f"URL. Please provide a local path to the marketplace catalog file "
+            f"or the git repository directory."
+        )
+
+    # Local path
+    path = Path(trimmed).resolve()
+
+    # If it's a directory, look for marketplace.json inside
+    if path.is_dir():
+        return path / "marketplace.json"
+
+    # If it's a file path ending in .json, use as-is
+    if path.suffix == ".json":
+        return path
+
+    # Otherwise, treat the parent as the directory
+    return path / "marketplace.json"
+
+
+def _looks_like_github_slug(value: str) -> bool:
+    """Check if a string looks like 'owner/repo'."""
+    if "/" not in value:
+        return False
+    parts = value.split("/")
+    if len(parts) != 2:
+        return False
+    owner, repo = parts
+    return bool(owner and repo and not value.startswith("http") and "\\" not in value and "." not in owner)
+
+
+# ── Git helpers ───────────────────────────────────────────────────────────────
+
+
+def _is_git_repo(path: Path) -> bool:
+    """Check if a directory is inside a git working tree."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path.parent), "rev-parse", "--git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _git_commit_and_push(
+    repo_dir: Path,
+    marketplace_rel_path: str,
+    entry_name: str,
+    was_updated: bool,
+) -> dict[str, Any]:
+    """Stage marketplace.json, commit, and push to origin.
+
+    Returns a dict with git operation results.
+    """
+    action = "Update" if was_updated else "Add"
+    message = f"{action} marketplace entry: {entry_name}"
+
+    try:
+        # Stage the file
+        subprocess.run(
+            ["git", "-C", str(repo_dir), "add", marketplace_rel_path],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        # Commit
+        commit_result = subprocess.run(
+            ["git", "-C", str(repo_dir), "commit", "-m", message],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        if commit_result.returncode != 0:
+            # If nothing to commit, that's fine (file may not have changed)
+            if "nothing to commit" in commit_result.stdout or "nothing to commit" in commit_result.stderr:
+                return {
+                    "committed": False,
+                    "reason": "no changes to commit",
+                }
+            raise subprocess.CalledProcessError(
+                commit_result.returncode,
+                commit_result.args,
+                commit_result.stdout,
+                commit_result.stderr,
+            )
+
+        # Push
+        push_result = subprocess.run(
+            ["git", "-C", str(repo_dir), "push", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        if push_result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                push_result.returncode,
+                push_result.args,
+                push_result.stdout,
+                push_result.stderr,
+            )
+
+        return {
+            "committed": True,
+            "message": message,
+            "push_success": True,
+            "stdout": push_result.stdout.strip(),
+        }
+
+    except subprocess.CalledProcessError as e:
+        return {
+            "committed": False,
+            "error": f"git command failed: {e}",
+            "stderr": e.stderr.strip() if e.stderr else "",
+            "stdout": e.stdout.strip() if e.stdout else "",
+        }
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    """Publish an extension to a marketplace catalog."""
+    parser = argparse.ArgumentParser(description="Publish (register/update) an extension to a marketplace catalog.")
+    parser.add_argument("--extension_dir", required=True, help="Path to the extension directory containing SKILL.md")
+    parser.add_argument(
+        "--marketplace_source",
+        default="dcc-mcp/marketplace",
+        help="Marketplace catalog source (local path, or directory)",
+    )
+    parser.add_argument("--install_url", required=True, help="Install source URL for the CatalogEntry")
+    parser.add_argument("--install_type", default="git", choices=["git", "path", "zip"], help="Install source type")
+    parser.add_argument("--install_ref", default=None, help="Git ref, branch, or tag for git-type installs")
+    parser.add_argument("--version", default=None, help="Semantic version (overrides SKILL.md metadata if set)")
+    parser.add_argument("--maintainer", default=None, help="Extension maintainer name")
+    parser.add_argument("--icon", default=None, help="Icon path or URL for the CatalogEntry")
+    parser.add_argument("--tags", nargs="*", default=[], help="Additional tags to add to the CatalogEntry")
+    parser.add_argument("--min_core_version", default=None, help="Minimum dcc-mcp-core version required")
+    parser.add_argument("--extension_url", default=None, help="Canonical URL for the extension (homepage, docs, etc.)")
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        default=False,
+        help="Commit and push the updated marketplace.json (git repos only)",
+    )
+    args = parser.parse_args()
+
+    try:
+        # 1. Resolve and validate extension directory
+        ext_dir = Path(args.extension_dir).resolve()
+        if not ext_dir.is_dir():
+            result = {
+                "success": False,
+                "message": f"Extension directory not found: {ext_dir}",
+            }
+            print(json.dumps(result))
+            sys.exit(1)
+
+        # 2. Parse SKILL.md
+        skill_md_path = ext_dir / "SKILL.md"
+        try:
+            skill_md = _parse_skill_md(skill_md_path)
+        except (FileNotFoundError, ValueError) as e:
+            result = {
+                "success": False,
+                "message": str(e),
+            }
+            print(json.dumps(result))
+            sys.exit(1)
+
+        # 3. Build CatalogEntry
+        entry = _build_catalog_entry(
+            skill_md=skill_md,
+            install_url=args.install_url,
+            install_type=args.install_type,
+            install_ref=args.install_ref,
+            version=args.version,
+            maintainer=args.maintainer,
+            icon=args.icon,
+            tags=args.tags,
+            min_core_version=args.min_core_version,
+            extension_url=args.extension_url,
+        )
+
+        # 4. Resolve marketplace.json path
+        try:
+            mp_path = _resolve_marketplace_path(args.marketplace_source)
+        except ValueError as e:
+            result = {
+                "success": False,
+                "message": str(e),
+            }
+            print(json.dumps(result))
+            sys.exit(1)
+
+        # 5. Load, upsert, save
+        catalog = _load_marketplace_json(mp_path)
+        catalog, was_updated = _upsert_entry(catalog, entry)
+        _save_marketplace_json(mp_path, catalog)
+
+        entry_name = entry["name"]
+
+        # 6. Optional git commit+push
+        git_result = None
+        commit_error = None
+        if args.commit:
+            repo_dir = mp_path.parent
+            if _is_git_repo(mp_path):
+                # Determine relative path for git add
+                try:
+                    rel_path = str(mp_path.relative_to(repo_dir)).replace("\\", "/")
+                except ValueError:
+                    rel_path = mp_path.name
+
+                git_result = _git_commit_and_push(repo_dir, rel_path, entry_name, was_updated)
+                if git_result.get("error"):
+                    commit_error = git_result["error"]
+            else:
+                commit_error = f"Marketplace source directory {repo_dir} is not a git repository. Skipping commit."
+
+        # 7. Build result
+        action = "updated" if was_updated else "created"
+        message = f"Successfully {action} marketplace entry: {entry_name}"
+
+        context: dict[str, Any] = {
+            "entry": entry,
+            "marketplace_path": str(mp_path),
+            "action": action,
+            "was_updated": was_updated,
+            "total_entries": len(catalog["entries"]),
+        }
+
+        if git_result:
+            context["git"] = git_result
+
+        if commit_error:
+            context["commit_error"] = commit_error
+
+        result = {
+            "success": True,
+            "message": message,
+            "context": context,
+        }
+        print(json.dumps(result, ensure_ascii=False))
+
+    except Exception as e:
+        result = {
+            "success": False,
+            "message": f"Unexpected error: {e}",
+        }
+        print(json.dumps(result))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/skills/marketplace-publish-extension/tools.yaml
+++ b/examples/skills/marketplace-publish-extension/tools.yaml
@@ -1,0 +1,95 @@
+tools:
+  - name: publish
+    description: >-
+      Publish (register or update) an extension to a marketplace catalog.
+      Reads the extension's SKILL.md frontmatter, builds a CatalogEntry,
+      and upserts it into the target marketplace.json. When the catalog
+      source is a local git repository, optionally commits and pushes the
+      change. Returns the updated CatalogEntry and the marketplace.json path.
+    input_schema:
+      type: object
+      properties:
+        extension_dir:
+          type: string
+          description: >-
+            Absolute or relative path to the extension directory. Must contain
+            a valid SKILL.md with dcc-mcp frontmatter metadata.
+        marketplace_source:
+          type: string
+          description: >-
+            Marketplace catalog source. Can be:
+            - A local path to an existing marketplace.json or the directory
+              that contains it (e.g. "/path/to/repo" or "/path/to/marketplace.json");
+            - A GitHub slug like "owner/repo" (resolves to the raw
+              marketplace.json on the main branch);
+            - A full URL to a marketplace.json file.
+            Defaults to "dcc-mcp/marketplace" (the official catalog).
+          default: "dcc-mcp/marketplace"
+        install_url:
+          type: string
+          description: >-
+            Install source URL (Git repo URL, zip download URL, or local path).
+            Written into the CatalogEntry `install.url` field.
+        install_type:
+          type: string
+          description: Install source type for the CatalogEntry.
+          enum:
+            - git
+            - path
+            - zip
+          default: git
+        install_ref:
+          type: string
+          description: >-
+            Git ref, branch name, or tag for git-type installs. Written into
+            the CatalogEntry `install.ref` field.
+        version:
+          type: string
+          description: >-
+            Semantic version for the extension. Overrides the version read
+            from SKILL.md metadata if provided.
+        maintainer:
+          type: string
+          description: >-
+            Extension maintainer name. Overrides the value read from SKILL.md
+            metadata if provided.
+        icon:
+          type: string
+          description: >-
+            Icon path or URL for the CatalogEntry (e.g. "icon.png" or an
+            absolute URL).
+        tags:
+          type: array
+          description: >-
+            Additional tags to add to the CatalogEntry. Merged with tags
+            already present in the entry and/or SKILL.md metadata.
+          items:
+            type: string
+          default: []
+        min_core_version:
+          type: string
+          description: >-
+            Minimum dcc-mcp-core version required by this extension. Written
+            into the CatalogEntry `min_core_version` field.
+        extension_url:
+          type: string
+          description: >-
+            Canonical URL for the extension (homepage, docs, repo, etc.).
+            Written into the CatalogEntry `url` field.
+        commit:
+          type: boolean
+          description: >-
+            When true and the marketplace_source resolves to a local git
+            repository, stage the updated marketplace.json, commit it with a
+            standardised message, and push to origin. Ignored for remote/URL
+            sources.
+          default: false
+      required:
+        - extension_dir
+        - install_url
+    read_only: false
+    destructive: false
+    idempotent: true
+    source_file: scripts/publish.py
+    next-tools:
+      on-failure: [dcc_diagnostics__audit_log]


### PR DESCRIPTION
## Summary

Add a new infrastructure skill `marketplace-publish-extension` that publishes (registers/updates) extension packages to a marketplace catalog.

## What it does

- Reads `SKILL.md` frontmatter from a local extension directory
- Constructs a `CatalogEntry` with install metadata from the frontmatter + CLI inputs
- Upserts the entry into the target `marketplace.json` (creates file if missing)
- Optionally commits and pushes when the catalog source is a local git repository

## Files

- `examples/skills/marketplace-publish-extension/SKILL.md` — Skill frontmatter and documentation
- `examples/skills/marketplace-publish-extension/tools.yaml` — Tool declaration with input schema
- `examples/skills/marketplace-publish-extension/scripts/publish.py` — Python publish script with minimal YAML frontmatter parser

## Verification

- `ruff check` and `ruff format` pass
- `vx just lint-py` passes (418 files already formatted)
- `pytest` passes (1204 passed, 1 skipped, 1 pre-existing rez-env failure)
- Pre-commit hooks (yaml, ruff, etc.) all pass
- Functional smoke tests confirm correct CatalogEntry construction and marketplace.json upsert behavior

@loonghao — requesting technical review