### PR TITLE
fix: make publish-clawhub-skills non-blocking in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,6 +477,7 @@ jobs:
   publish-clawhub-skills:
     needs: [release-please]
     if: needs.release-please.outputs.release_created == 'true'
+    continue-on-error: true
     uses: ./.github/workflows/clawhub.yml
     with:
       checkout-ref: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the `publish-clawhub-skills` job in the Release workflow so a ClawHub publish failure does not fail the entire Release workflow
- The `clawhub_sync.py` script already handles pre-existing ClawHub versions gracefully (regex-based version-exists detection added in b3483ade / a44f7c2e) — this workflow-level change adds defense-in-depth for any other ClawHub failure mode

## Context
Three Release runs hit `Version already exists` errors today (v0.18.8, v0.18.9) because the Release workflow re-checked-out the old tag code without the regex fix. Future releases will include the fix via the tag, but `continue-on-error` ensures ClawHub is best-effort and never blocks PyPI / GitHub Release uploads.

## Test plan
- [x] `tests/test_clawhub_sync.py` all 6 tests pass
- [ ] CI (release workflow will validate on next release)