### PR TITLE
refactor(capability): consolidate dual compute_fingerprint into gateway-core

### DIFF
--- a/crates/dcc-mcp-gateway-core/src/capability/index.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/index.rs
@@ -17,8 +17,8 @@
 //! without depending on the gateway crate's tokio / axum / parking_lot
 //! footprint.
 
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 

--- a/crates/dcc-mcp-gateway-core/src/capability/index.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/index.rs
@@ -17,7 +17,9 @@
 //! without depending on the gateway crate's tokio / axum / parking_lot
 //! footprint.
 
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use uuid::Uuid;
@@ -36,6 +38,44 @@ use super::record::CapabilityRecord;
 /// that hash so comparisons are O(1).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct InstanceFingerprint(pub u64);
+
+/// Compute a stable content fingerprint over every identity-relevant
+/// field of `records`.
+///
+/// The union of fields hashed here is the canonical set — every field
+/// whose change should cause the refresh loop to rebuild the instance
+/// slice. The two historical private implementations in
+/// `dcc-mcp-gateway`'s `builder.rs` and `refresh.rs` hashed different
+/// subsets; this function is the single source of truth.
+///
+/// Callers that already hold a `BuildOutcome` may use its pre-computed
+/// `fingerprint` field instead of calling this again.
+#[must_use]
+pub fn compute_fingerprint(records: &[CapabilityRecord]) -> InstanceFingerprint {
+    let mut hasher = DefaultHasher::new();
+    for r in records {
+        r.tool_slug.hash(&mut hasher);
+        r.skill_name.hash(&mut hasher);
+        r.has_schema.hash(&mut hasher);
+        r.summary.hash(&mut hasher);
+        r.loaded.hash(&mut hasher);
+        r.tool_group.hash(&mut hasher);
+        r.annotations.hash(&mut hasher);
+        r.metadata.hash(&mut hasher);
+        for group in &r.available_groups {
+            group.name.hash(&mut hasher);
+            group.default_active.hash(&mut hasher);
+            group.active.hash(&mut hasher);
+        }
+        for t in &r.tags {
+            t.hash(&mut hasher);
+        }
+        for t in &r.search_tokens {
+            t.hash(&mut hasher);
+        }
+    }
+    InstanceFingerprint(hasher.finish())
+}
 
 /// Owned snapshot of the capability index returned to REST / MCP
 /// callers.
@@ -105,6 +145,68 @@ mod tests {
         // rebuilds via `==`; pin the structural-equality contract.
         assert_eq!(InstanceFingerprint(42), InstanceFingerprint(42));
         assert_ne!(InstanceFingerprint(42), InstanceFingerprint(43));
+    }
+
+    #[test]
+    fn compute_fingerprint_is_deterministic() {
+        let rec = make_record("maya.abcdef01.create_sphere");
+        let fp_a = compute_fingerprint(&[rec.clone()]);
+        let fp_b = compute_fingerprint(&[rec]);
+        assert_eq!(fp_a, fp_b);
+    }
+
+    #[test]
+    fn compute_fingerprint_changes_on_tool_slug() {
+        let a = make_record("maya.abcdef01.create_sphere");
+        let mut b = a.clone();
+        b.tool_slug = "maya.abcdef01.create_cube".into();
+        assert_ne!(compute_fingerprint(&[a]), compute_fingerprint(&[b]));
+    }
+
+    #[test]
+    fn compute_fingerprint_changes_on_loaded() {
+        let mut a = make_record("maya.abcdef01.t");
+        a.loaded = true;
+        let mut b = a.clone();
+        b.loaded = false;
+        assert_ne!(compute_fingerprint(&[a]), compute_fingerprint(&[b]));
+    }
+
+    #[test]
+    fn compute_fingerprint_changes_on_annotations() {
+        use crate::capability::record::CapabilityAnnotations;
+        let a = make_record("maya.abcdef01.t");
+        let mut b = a.clone();
+        b.annotations = Some(CapabilityAnnotations {
+            title: Some("Test".into()),
+            read_only_hint: Some(true),
+            destructive_hint: None,
+            idempotent_hint: None,
+            open_world_hint: None,
+        });
+        assert_ne!(compute_fingerprint(&[a]), compute_fingerprint(&[b]));
+    }
+
+    #[test]
+    fn compute_fingerprint_changes_on_metadata() {
+        use crate::capability::record::CapabilityMetadata;
+        let a = make_record("maya.abcdef01.t");
+        let mut b = a.clone();
+        b.metadata = Some(CapabilityMetadata {
+            affinity: None,
+            execution: None,
+            timeout_hint_secs: None,
+            enforce_thread_affinity: None,
+            risk: Some("mutation".into()),
+            tool_role: None,
+        });
+        assert_ne!(compute_fingerprint(&[a]), compute_fingerprint(&[b]));
+    }
+
+    #[test]
+    fn compute_fingerprint_empty_list_is_stable() {
+        let fp = compute_fingerprint(&[]);
+        assert_eq!(fp, compute_fingerprint(&[]));
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway-core/src/capability/mod.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/mod.rs
@@ -37,7 +37,7 @@ pub mod search_ranking;
 // facade so historical paths (`dcc_mcp_gateway_core::capability::
 // CapabilityRecord` etc.) keep working verbatim.
 pub use builder::BuildOutcome;
-pub use index::{IndexSnapshot, InstanceFingerprint};
+pub use index::{IndexSnapshot, InstanceFingerprint, compute_fingerprint};
 pub use record::{
     CapabilityAnnotations, CapabilityGroupInfo, CapabilityMetadata, CapabilityRecord,
     SCHEMA_AVAILABLE, is_valid_dcc_bucket, parse_slug, tool_slug,

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -17,18 +17,15 @@
 //! `&[dcc_mcp_jsonrpc::McpTool]` — the type contract belongs in the
 //! crate that already depends on `dcc-mcp-jsonrpc`.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-
 use serde_json::Value;
 use uuid::Uuid;
 
+use dcc_mcp_gateway_core::capability::compute_fingerprint;
 use dcc_mcp_gateway_core::naming::{
     decode_skill_tool_name, extract_bare_tool_name, is_core_tool, is_local_tool,
 };
 use dcc_mcp_jsonrpc::McpTool;
 
-use super::index::InstanceFingerprint;
 use super::record::{
     CapabilityAnnotations, CapabilityGroupInfo, CapabilityMetadata, CapabilityRecord,
     SCHEMA_AVAILABLE, is_valid_dcc_bucket, tool_slug,
@@ -257,25 +254,6 @@ fn meta_declares_schema(meta: Option<&serde_json::Map<String, Value>>) -> bool {
         .and_then(|dcc| dcc.get("has_schema"))
         .and_then(Value::as_bool)
         .unwrap_or(false)
-}
-
-fn compute_fingerprint(records: &[CapabilityRecord]) -> InstanceFingerprint {
-    let mut hasher = DefaultHasher::new();
-    for r in records {
-        r.tool_slug.hash(&mut hasher);
-        r.skill_name.hash(&mut hasher);
-        r.has_schema.hash(&mut hasher);
-        r.summary.hash(&mut hasher);
-        r.annotations.hash(&mut hasher);
-        r.metadata.hash(&mut hasher);
-        for t in &r.tags {
-            t.hash(&mut hasher);
-        }
-        for t in &r.search_tokens {
-            t.hash(&mut hasher);
-        }
-    }
-    InstanceFingerprint(hasher.finish())
 }
 
 fn extract_search_tokens(tool: &McpTool) -> Vec<String> {

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -17,17 +17,17 @@
 //! `crate::gateway::capability::refresh::RefreshReason` path working
 //! unchanged.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::Duration;
 
 use uuid::Uuid;
 
+use dcc_mcp_gateway_core::capability::compute_fingerprint;
+
 use crate::gateway::backend_client::{UnloadedCapabilityHint, fetch_tools};
 
 use super::builder::{BuildInput, build_records_from_backend};
-use super::index::{CapabilityIndex, InstanceFingerprint};
+use super::index::CapabilityIndex;
 use super::record::{CapabilityRecord, tool_slug};
 
 pub use dcc_mcp_gateway_core::capability::refresh::RefreshReason;
@@ -129,29 +129,6 @@ fn build_unloaded_records(
         .collect()
 }
 
-fn compute_fingerprint(records: &[CapabilityRecord]) -> InstanceFingerprint {
-    let mut hasher = DefaultHasher::new();
-    for r in records {
-        r.tool_slug.hash(&mut hasher);
-        r.has_schema.hash(&mut hasher);
-        r.summary.hash(&mut hasher);
-        r.loaded.hash(&mut hasher);
-        r.tool_group.hash(&mut hasher);
-        for group in &r.available_groups {
-            group.name.hash(&mut hasher);
-            group.default_active.hash(&mut hasher);
-            group.active.hash(&mut hasher);
-        }
-        for t in &r.tags {
-            t.hash(&mut hasher);
-        }
-        for t in &r.search_tokens {
-            t.hash(&mut hasher);
-        }
-    }
-    InstanceFingerprint(hasher.finish())
-}
-
 /// Drop every record for `instance_id`. Safe to call even if the
 /// instance was never indexed.
 pub fn remove_instance(index: &Arc<CapabilityIndex>, instance_id: Uuid) -> bool {
@@ -168,6 +145,7 @@ pub fn remove_instance(index: &Arc<CapabilityIndex>, instance_id: Uuid) -> bool 
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+    use dcc_mcp_gateway_core::capability::index::InstanceFingerprint;
 
     #[test]
     fn refresh_reason_label_is_stable() {


### PR DESCRIPTION
## Summary
- Move two divergent private `compute_fingerprint` implementations from `builder.rs` and `refresh.rs` into a single canonical public function in `gateway-core`
- Union hashes all 11 identity fields: `tool_slug`, `skill_name`, `has_schema`, `summary`, `loaded`, `tool_group`, `available_groups`, `annotations`, `metadata`, `tags`, `search_tokens`
- Add 6 unit tests for deterministic fingerprint behavior

## Test plan
- [x] gateway-core: 99 passed
- [x] gateway (lib): 463 passed
- [x] 0 regressions