### PR TITLE
fix(ci): remove continue-on-error from reusable workflow job in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,7 +477,6 @@ jobs:
   publish-clawhub-skills:
     needs: [release-please]
     if: needs.release-please.outputs.release_created == 'true'
-    continue-on-error: true
     uses: ./.github/workflows/clawhub.yml
     with:
       checkout-ref: ${{ needs.release-please.outputs.tag_name }}

--- a/tests/test_gateway_election_scenarios.py
+++ b/tests/test_gateway_election_scenarios.py
@@ -332,6 +332,12 @@ def test_crash_recovery_loop() -> None:
     promotion_count = {"n": 0}
 
     srv = _make_server()
+
+    def _on_promote() -> bool:
+        promotion_count["n"] += 1
+        srv.is_gateway = True
+        return True
+
     election = DccGatewayElection(
         dcc_name="crash-recover",
         server=srv,
@@ -339,7 +345,7 @@ def test_crash_recovery_loop() -> None:
         probe_interval=0.05,
         probe_timeout=0.5,
         probe_failures=2,
-        on_promote=lambda: promotion_count.update(n=promotion_count["n"] + 1) or True,
+        on_promote=_on_promote,
     )
     try:
         election.start()


### PR DESCRIPTION
## Summary

- **release.yml fix:** GitHub Actions rejects `continue-on-error: true` before `uses:` on a reusable workflow job, causing the workflow to fail with 0 jobs parsed. Since `publish-clawhub-skills` is already non-blocking (no other job depends on it), removing `continue-on-error` restores parsing without changing semantics.
- **test fix:** Updated `test_crash_recovery_loop`'s `on_promote` callback to also set `srv.is_gateway = True`, preventing re-election after successful promotion which caused flaky failures on macOS ARM64.

## Changelog

- fix(ci): remove continue-on-error from reusable workflow job in release.yml
- fix(test): set is_gateway=True in crash_recovery_loop on_promote callback

## Test plan

- [ ] Verify the release.yml workflow parses correctly after merge
- [ ] Monitor the next push-to-main CI run, confirming test_crash_recovery_loop passes on macOS ARM64