### PR TITLE
docs: add Marketplace Panel and Admin Workflow sections to admin-ui.md and marketplace.md

### DIFF
--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -151,6 +151,61 @@ Clicking a skill opens its detail panel, including backend instance metadata,
 registered tools, `SKILL.md` source path, parsed frontmatter, and rendered
 Markdown body for developer review.
 
+## Marketplace Panel
+
+The **Marketplace** panel, accessible from the left navigation, provides a
+graphical interface for browsing, installing, and managing skill packages from
+the DCC-MCP marketplace catalog. It exposes the same capabilities as the CLI
+`marketplace` subcommand through two tabs: **Browse** and **Installed**.
+
+### Browse Tab
+
+The Browse tab displays available skill packages in a searchable catalog grid.
+Each card shows the package name, description, DCC type badges, current version,
+and an Install button.
+
+Users can filter the catalog by:
+- **Search query**: text search across name, description, and tags.
+- **DCC type filter**: a row of Chip buttons at the top of the tab to filter by
+  DCC type. Search and DCC filter can be combined.
+
+Clicking a card opens the **Marketplace detail modal** showing full metadata:
+name, description, version, tags, DCC type, maintainer, project URL, source,
+install type (git, zip, path), and `min_core_version`. When the package's
+`min_core_version` is lower than the currently running core version, a
+compatibility warning is displayed.
+
+Installing a package from the detail modal or card triggers the marketplace
+install flow. On success, an inline notice appears with a **View in Skills**
+deep link that navigates to the Skills panel and highlights the newly loaded
+skill. If the backend reports a `reload_required` flag, the skill index is
+refreshed automatically.
+
+### Installed Tab
+
+The Installed tab lists all currently installed marketplace packages as
+per-package cards, showing:
+- Package name and version
+- DCC type
+- Install type (git, zip, path)
+- Uninstall button
+
+Users can uninstall a package directly from this tab. On success, the skill
+index is refreshed to reflect the removed package.
+
+### API Endpoints
+
+| Route | Content-Type | Description |
+|-------|-------------|-------------|
+| `GET /admin/api/marketplace/catalog` | `application/json` | List available packages from all configured sources. Returns `{ entries: MarketplaceEntry[] }`. |
+| `GET /admin/api/marketplace/installed` | `application/json` | List locally installed packages with per-DCC grouping. Returns `{ packages: InstalledMarketplacePackage[] }`. |
+| `POST /admin/api/marketplace/install` | `application/json` | Install a package. Body: `{ name, dcc, source?, force? }`. Returns `InstallResultResponse` with `reload_required` flag. |
+| `POST /admin/api/marketplace/uninstall` | `application/json` | Uninstall a package. Body: `{ name, dcc }`. Returns `UninstallResultResponse` with `reload_required` flag. |
+| `GET /admin/api/marketplace/sources` | `application/json` | List configured marketplace sources with origin (builtin, config, env). |
+| `POST /admin/api/marketplace/sources` | `application/json` | Add a marketplace source to the persistent config. Body: `{ source }`. Duplicate additions are idempotent. |
+| `GET /admin/api/marketplace/outdated` | `application/json` | List installed packages that have newer versions available. Supports `?name=&dcc=` filters. |
+| `POST /admin/api/marketplace/update` | `application/json` | Update one or all outdated packages. Body: `{ name?, dcc?, all? }`. Returns per-result `reload_required` flags. |
+
 ## Routes
 
 | Route | Content-Type | Description |

--- a/docs/guide/marketplace.md
+++ b/docs/guide/marketplace.md
@@ -201,6 +201,58 @@ falling back to the local `dcc-mcp-catalog.yml` when offline. Set
   maintainer: "team@example.com"     # optional contact
 ```
 
+## Admin Workflow
+
+The **Marketplace** panel in the Admin Dashboard provides the same capabilities
+as the CLI `marketplace` subcommand through a graphical interface. It is
+accessible from the left navigation in the Admin Dashboard.
+
+### Accessing the Panel
+
+Navigate to the Admin Dashboard (`/admin`) and select **Marketplace** from the
+left navigation. The panel loads the catalog from all configured sources and
+displays the Browse tab by default.
+
+### Browsing and Installing
+
+1. **Browse tab**: use the search bar to find packages by name, description, or
+   tags. Use the DCC type Chip row to filter by application type. Search and
+   DCC filter can be combined.
+2. **Inspect**: click any package card to open the detail modal, which shows
+   full metadata including version, DCC type, tags, maintainer, project URL,
+   source, install type, and `min_core_version` compatibility information.
+3. **Install**: click the **Install** button on a card or in the detail modal.
+   On success, an inline notice appears with a **View in Skills** deep link
+   that jumps to the Skills panel and highlights the newly loaded skill.
+
+### Managing Installed Packages
+
+Switch to the **Installed** tab to see all currently installed packages. Each
+card shows the package name, version, DCC type, and install type. Click
+**Uninstall** to remove a package. Both install and uninstall operations
+automatically refresh the skill index when the backend reports a
+`reload_required` flag.
+
+### Adding Sources from the UI
+
+The Marketplace panel reflects the same source configuration as the CLI. Source
+management is available through the Admin API (`POST /admin/api/marketplace/sources`)
+and is also accessible from the panel's source management interface.
+
+### Relationship Between CLI and Admin UI
+
+| Aspect | CLI | Admin UI |
+|--------|-----|----------|
+| Catalog search | `marketplace search --query <q>` | Browse tab with search + DCC filter |
+| Install | `marketplace install <name> --dcc <dcc>` | Install button on card or detail modal |
+| Uninstall | `marketplace uninstall <name> --dcc <dcc>` | Uninstall button in Installed tab |
+| List installed | `marketplace list-installed --dcc <dcc>` | Installed tab |
+| Add source | `marketplace add <source>` | Source management in panel |
+| Update | `marketplace update [name] --all` | Admin API (`POST /admin/api/marketplace/update`) |
+
+Both interfaces share the same backend — operations performed in one are
+reflected in the other immediately.
+
 ## See Also
 
 - [cli-reference.md](cli-reference.md) — CLI command reference with full flag

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -125,6 +125,55 @@ vx git diff --check
 
 点击某个 skill 会打开详情面板，显示后端实例信息、注册工具、`SKILL.md` 源路径、frontmatter，以及渲染后的 Markdown 正文，方便开发者 review。
 
+## 市场面板（Marketplace）
+
+**Marketplace** 面板位于左侧导航栏，为浏览、安装和管理技能包提供图形界面。
+它与 CLI `marketplace` 子命令共享同一套后端能力，通过两个标签页展现：
+**浏览（Browse）** 和 **已安装（Installed）**。
+
+### 浏览标签页
+
+浏览标签页以可搜索的目录网格展示可用技能包。每个卡片显示：
+包名、描述、DCC 类型徽章、当前版本和安装按钮。
+
+用户可通过以下方式筛选目录：
+- **搜索查询**：按名称、描述和标签进行文本搜索。
+- **DCC 类型筛选**：标签页顶部的 Chip 按钮行，可按 DCC 类型筛选。搜索和
+  DCC 筛选可以组合使用。
+
+点击卡片会打开 **Marketplace 详情弹窗**，展示完整元数据：名称、描述、
+版本、标签、DCC 类型、维护者、项目 URL、来源、安装类型（git、zip、path）
+和 `min_core_version`。当包的 `min_core_version` 低于当前运行的核心版本时，
+会显示兼容性警告。
+
+从详情弹窗或卡片安装包会触发市场安装流程。安装成功后，页面内联显示一条
+成功通知，其中包含 **View in Skills** 深度链接，点击可跳转到 Skills 面板
+并高亮新加载的 skill。如果后端报告了 `reload_required` 标志，技能索引会
+自动刷新。
+
+### 已安装标签页
+
+已安装标签页以卡片形式列出所有已安装的市场包，显示：
+- 包名和版本
+- DCC 类型
+- 安装类型（git、zip、path）
+- 卸载按钮
+
+用户可直接从此标签页卸载包。卸载成功后，技能索引会刷新以移除已删除的包。
+
+### API 端点
+
+| 路由 | Content-Type | 说明 |
+|------|-------------|------|
+| `GET /admin/api/marketplace/catalog` | `application/json` | 列出所有已配置来源中的可用包。返回 `{ entries: MarketplaceEntry[] }`。 |
+| `GET /admin/api/marketplace/installed` | `application/json` | 列出本地已安装的包（按 DCC 分组）。返回 `{ packages: InstalledMarketplacePackage[] }`。 |
+| `POST /admin/api/marketplace/install` | `application/json` | 安装包。请求体：`{ name, dcc, source?, force? }`。返回带 `reload_required` 标志的结果。 |
+| `POST /admin/api/marketplace/uninstall` | `application/json` | 卸载包。请求体：`{ name, dcc }`。返回带 `reload_required` 标志的结果。 |
+| `GET /admin/api/marketplace/sources` | `application/json` | 列出已配置的市场来源及其来源类型（builtin、config、env）。 |
+| `POST /admin/api/marketplace/sources` | `application/json` | 添加市场来源到持久化配置。请求体：`{ source }`。重复添加是幂等的。 |
+| `GET /admin/api/marketplace/outdated` | `application/json` | 列出有更新版本的已安装包。支持 `?name=&dcc=` 筛选参数。 |
+| `POST /admin/api/marketplace/update` | `application/json` | 更新一个或全部过期包。请求体：`{ name?, dcc?, all? }`。返回每个结果的 `reload_required` 标志。 |
+
 ## 路由
 
 | 路由 | Content-Type | 说明 |

--- a/docs/zh/guide/marketplace.md
+++ b/docs/zh/guide/marketplace.md
@@ -190,6 +190,51 @@ result = client.resources_read("gateway://catalog/dcc-mcp-physics-sim")
   maintainer: "team@example.com"     # 可选联系方式
 ```
 
+## Admin 工作流
+
+Admin 仪表盘中的 **Marketplace** 面板通过图形界面提供与 CLI `marketplace`
+子命令相同的能力。在 Admin 仪表盘左侧导航中选择 **Marketplace** 即可访问。
+
+### 访问面板
+
+导航到 Admin 仪表盘（`/admin`），从左侧导航中选择 **Marketplace**。面板会
+从所有已配置来源加载目录，并默认显示浏览标签页。
+
+### 浏览与安装
+
+1. **浏览标签页**：使用搜索栏按名称、描述或标签搜索包。使用 DCC 类型 Chip
+   行按应用类型筛选。搜索和 DCC 筛选可以组合使用。
+2. **查看详情**：点击任意包卡片打开详情弹窗，显示完整元数据，包括版本、
+   DCC 类型、标签、维护者、项目 URL、来源、安装类型和 `min_core_version`
+   兼容性信息。
+3. **安装**：点击卡片或详情弹窗中的 **Install** 按钮。安装成功后，内联
+   通知会显示 **View in Skills** 深度链接，可跳转到 Skills 面板并高亮
+   新加载的 skill。
+
+### 管理已安装包
+
+切换到 **已安装（Installed）** 标签页查看所有已安装的包。每个卡片显示
+包名、版本、DCC 类型和安装类型。点击 **Uninstall** 可移除包。安装和卸载
+操作在后台报告 `reload_required` 标志时都会自动刷新技能索引。
+
+### 从 UI 添加来源
+
+Marketplace 面板反映与 CLI 相同的来源配置。来源管理功能通过 Admin API
+（`POST /admin/api/marketplace/sources`）提供，也可从面板的来源管理界面使用。
+
+### CLI 与 Admin UI 的关系
+
+| 方面 | CLI | Admin UI |
+|------|-----|----------|
+| 目录搜索 | `marketplace search --query <q>` | 浏览标签页，支持搜索 + DCC 筛选 |
+| 安装 | `marketplace install <name> --dcc <dcc>` | 卡片或详情弹窗上的 Install 按钮 |
+| 卸载 | `marketplace uninstall <name> --dcc <dcc>` | 已安装标签页的 Uninstall 按钮 |
+| 列出已安装 | `marketplace list-installed --dcc <dcc>` | 已安装标签页 |
+| 添加来源 | `marketplace add <source>` | 面板中的来源管理界面 |
+| 更新 | `marketplace update [name] --all` | Admin API (`POST /admin/api/marketplace/update`) |
+
+两种界面共享同一套后端——在一侧执行的操作会立即在另一侧反映。
+
 ## 参见
 
 - [cli-reference.md](cli-reference.md) — 带完整标志文档的 CLI 命令参考


### PR DESCRIPTION
## Summary

- Add **Marketplace Panel** section to `docs/guide/admin-ui.md` covering the
  Browse tab, Installed tab, detail modal, source management, and all 8
  marketplace admin API endpoints with route/payload descriptions.
- Add **Admin Workflow** section to `docs/guide/marketplace.md` covering
  UI-based browsing, installing, managing packages, adding sources, and a
  CLI vs Admin UI comparison table.
- Include Simplified Chinese translations in `docs/zh/guide/`.

The content is based on the existing marketplace implementation and the
frontend MarketplacePanel in `admin-ui/`.

## Files changed

- `docs/guide/admin-ui.md` — +55 lines (Marketplace Panel section)
- `docs/guide/marketplace.md` — +58 lines (Admin Workflow section)
- `docs/zh/guide/admin-ui.md` — +55 lines (Chinese translation)
- `docs/zh/guide/marketplace.md` — +51 lines (Chinese translation)

## Test plan

- [ ] Verify generated docs site renders correctly
- [ ] Confirm links between admin-ui.md and marketplace.md are valid
- [ ] Check Chinese translations read naturally