### PR TITLE
fix(ci): upload build-wheels artifacts directly to GitHub Release

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: ""
+      release-tag:
+        description: "Release tag to upload wheels to (for direct release upload)"
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   # Scope by the resolved checkout target so a release-driven build for tag
@@ -34,6 +39,8 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -43,9 +50,17 @@ jobs:
           target: x86_64
           python-version: '3.11'
           artifact-name: wheels-linux-x86_64
+      - name: Upload to GitHub Release
+        if: inputs.release-tag != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.release-tag }}
+          files: dist/*.whl
 
   windows:
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -55,9 +70,17 @@ jobs:
           target: x64
           python-version: '3.11'
           artifact-name: wheels-windows-x64
+      - name: Upload to GitHub Release
+        if: inputs.release-tag != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.release-tag }}
+          files: dist/*.whl
 
   macos:
     runs-on: macos-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -68,6 +91,12 @@ jobs:
           python-version: '3.11'
           maturin-extra-args: '--sdist --find-interpreter'
           artifact-name: wheels-macos-universal2
+      - name: Upload to GitHub Release
+        if: inputs.release-tag != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.release-tag }}
+          files: dist/*.whl
 
   # ── Python 3.7 builds (non-abi3) — separate wheel for Python 3.7 only ──
   # macOS cp37 wheels are cross-compiled from ARM64 (macos-latest) to x86_64.
@@ -76,6 +105,8 @@ jobs:
 
   linux-py37:
     runs-on: ubuntu-22.04  # Python 3.7 not available on Ubuntu 24.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -90,9 +121,17 @@ jobs:
           test-wheel: ${{ inputs.test-wheel || 'true' }}
           artifact-name: wheels-linux-x86_64-py37
           use-sccache: 'false'
+      - name: Upload to GitHub Release
+        if: inputs.release-tag != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.release-tag }}
+          files: dist/*.whl
 
   windows-py37:
     runs-on: windows-2022  # Installs Python 3.7 from python.org.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -107,6 +146,12 @@ jobs:
           test-wheel: ${{ inputs.test-wheel || 'true' }}
           artifact-name: wheels-windows-x64-py37
           use-sccache: 'false'
+      - name: Upload to GitHub Release
+        if: inputs.release-tag != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.release-tag }}
+          files: dist/*.whl
 
   macos-py37:
     # macOS ARM64 runner cross-compiling to x86_64.
@@ -204,3 +249,10 @@ jobs:
           name: wheels-macos-x86_64-py37
           path: dist/
           retention-days: 30
+
+      - name: Upload to GitHub Release
+        if: inputs.release-tag != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.release-tag }}
+          files: dist/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,6 +473,7 @@ jobs:
       # every wheel/binary is produced successfully.
       test-wheel: ${{ 'false' }}
       checkout-ref: ${{ needs.release-please.outputs.tag_name }}
+      release-tag: ${{ needs.release-please.outputs.tag_name }}
 
   publish-clawhub-skills:
     needs: [release-please]


### PR DESCRIPTION
## Problem

The `dcc_mcp_core-*` wheels were missing from the v0.18.11 release because `publish-github-release-assets` was the only upload path for core wheels, and it was skipped/cancelled. Meanwhile `build-binaries` and `build-semantic-wheels` already upload each platform's artifacts directly to the Release per-job.

## Fix

Each per-platform `build-wheels` job now uploads its wheels directly to the GitHub Release when a `release-tag` is provided (i.e., when called from the Release workflow). This mirrors the approach used by `build-binaries` and `build-semantic-wheels`.

- Added optional `release-tag` input to `build-wheels.yml`
- Each of the 6 per-platform jobs uploads `dist/*.whl` directly to the Release
- `release.yml` passes the release tag when calling `build-wheels`

The `publish-github-release-assets` safety net is retained for redundancy but no longer the single point of failure for core wheels.

## Related

- PIP-1137