### PR TITLE
fix(release): upload dcc_mcp_core wheels to GitHub Release per-platform

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: ""
+      release-tag-name:
+        description: "Release tag to upload wheels to GitHub Release (e.g. v0.18.11). Empty means skip upload."
+        required: false
+        type: string
+        default: ""
   workflow_call:
     inputs:
       test-wheel:
@@ -18,8 +23,8 @@ on:
         required: false
         type: string
         default: ""
-      release-tag:
-        description: "Release tag to upload wheels to (for direct release upload)"
+      release-tag-name:
+        description: "Release tag to upload wheels to GitHub Release (e.g. v0.18.11). Empty means skip upload."
         required: false
         type: string
         default: ""
@@ -32,7 +37,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   # ── ABI3 builds (Python 3.8+) — one wheel works for all 3.8+ ──
@@ -50,11 +55,11 @@ jobs:
           target: x86_64
           python-version: '3.11'
           artifact-name: wheels-linux-x86_64
-      - name: Upload to GitHub Release
-        if: inputs.release-tag != ''
+      - name: Upload wheel to GitHub Release
+        if: inputs.release-tag-name != ''
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ inputs.release-tag }}
+          tag_name: ${{ inputs.release-tag-name }}
           files: dist/*.whl
 
   windows:
@@ -70,11 +75,11 @@ jobs:
           target: x64
           python-version: '3.11'
           artifact-name: wheels-windows-x64
-      - name: Upload to GitHub Release
-        if: inputs.release-tag != ''
+      - name: Upload wheel to GitHub Release
+        if: inputs.release-tag-name != ''
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ inputs.release-tag }}
+          tag_name: ${{ inputs.release-tag-name }}
           files: dist/*.whl
 
   macos:
@@ -91,11 +96,11 @@ jobs:
           python-version: '3.11'
           maturin-extra-args: '--sdist --find-interpreter'
           artifact-name: wheels-macos-universal2
-      - name: Upload to GitHub Release
-        if: inputs.release-tag != ''
+      - name: Upload wheel to GitHub Release
+        if: inputs.release-tag-name != ''
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ inputs.release-tag }}
+          tag_name: ${{ inputs.release-tag-name }}
           files: dist/*.whl
 
   # ── Python 3.7 builds (non-abi3) — separate wheel for Python 3.7 only ──
@@ -121,11 +126,11 @@ jobs:
           test-wheel: ${{ inputs.test-wheel || 'true' }}
           artifact-name: wheels-linux-x86_64-py37
           use-sccache: 'false'
-      - name: Upload to GitHub Release
-        if: inputs.release-tag != ''
+      - name: Upload wheel to GitHub Release
+        if: inputs.release-tag-name != ''
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ inputs.release-tag }}
+          tag_name: ${{ inputs.release-tag-name }}
           files: dist/*.whl
 
   windows-py37:
@@ -146,11 +151,11 @@ jobs:
           test-wheel: ${{ inputs.test-wheel || 'true' }}
           artifact-name: wheels-windows-x64-py37
           use-sccache: 'false'
-      - name: Upload to GitHub Release
-        if: inputs.release-tag != ''
+      - name: Upload wheel to GitHub Release
+        if: inputs.release-tag-name != ''
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ inputs.release-tag }}
+          tag_name: ${{ inputs.release-tag-name }}
           files: dist/*.whl
 
   macos-py37:
@@ -250,9 +255,9 @@ jobs:
           path: dist/
           retention-days: 30
 
-      - name: Upload to GitHub Release
-        if: inputs.release-tag != ''
+      - name: Upload wheel to GitHub Release
+        if: inputs.release-tag-name != ''
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ inputs.release-tag }}
+          tag_name: ${{ inputs.release-tag-name }}
           files: dist/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,7 +473,7 @@ jobs:
       # every wheel/binary is produced successfully.
       test-wheel: ${{ 'false' }}
       checkout-ref: ${{ needs.release-please.outputs.tag_name }}
-      release-tag: ${{ needs.release-please.outputs.tag_name }}
+      release-tag-name: ${{ needs.release-please.outputs.tag_name }}
 
   publish-clawhub-skills:
     needs: [release-please]
@@ -696,9 +696,9 @@ jobs:
 
       # Always attempt the GitHub Release upload, even if PyPI failed; this is
       # the user-visible artefact set and must be complete per release tag.
-      # Note: build-binaries / build-semantic-wheels already upload each
-      # per-platform wheel directly to the Release. This step is the safety
-      # net for the (unlikely) case where the per-platform upload was skipped.
+      # Note: build-binaries / build-semantic-wheels / build-wheels already
+      # upload each per-platform wheel directly to the Release. This step
+      # is the safety net for the (unlikely) case where upload was skipped.
       - name: Upload wheels to GitHub Release (safety net)
         uses: softprops/action-gh-release@v3
         with:


### PR DESCRIPTION
## Summary

Each per-platform `build-wheels` job now uploads its `dcc_mcp_core-*` wheel
directly to the GitHub Release via `softprops/action-gh-release`, matching
the pattern already used by `build-binaries` and `build-semantic-wheels`.

## Problem

The `publish-github-release-assets` job was the only path for
`dcc_mcp_core-*` wheels to reach the GitHub Release. When
`concurrency.cancel-in-progress: true` interrupted the push-triggered
workflow, the safety net job was cancelled before it could upload the
core wheels, leaving the release incomplete.

## Changes

- Added `release-tag-name` input to `build-wheels.yml` (both
  `workflow_dispatch` and `workflow_call`)
- Each platform job now conditionally uploads its wheel to the GitHub
  Release when `release-tag-name` is provided
- Updated `release.yml` to pass the tag name to `build-wheels`
- Updated the safety net comment to reflect that all three build paths
  upload directly now

## Test plan

- [ ] Next release on push to main — all wheel variants appear as
      Release assets without relying on the safety net job
- [ ] `workflow_dispatch` backfill — same assertion