### PR TITLE
feat(core): extract shared registration phase pipeline

### DIFF
--- a/python/dcc_mcp_core/_registration.py
+++ b/python/dcc_mcp_core/_registration.py
@@ -1,0 +1,96 @@
+"""Registration phase pipeline for DCC MCP builtin-action registration.
+
+Host adapters import the shared base classes and executor from here,
+then define their own phase subclasses in a host-specific
+``_registration`` module.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Sequence
+
+
+@dataclass
+class RegistrationContext:
+    """Input shared by every registration phase."""
+
+    server: Any
+    extra_skill_paths: Optional[List[str]] = None
+    include_bundled: bool = True
+    minimal: Optional[bool] = None
+    strict_scan: Optional[bool] = None
+
+
+@dataclass
+class PhaseOutcome:
+    """Result for one registration phase."""
+
+    name: str
+    success: bool
+    elapsed_secs: float
+    error: Optional[str] = None
+
+
+@dataclass
+class RegistrationReport:
+    """Summary emitted after builtin-action registration completes."""
+
+    outcomes: List[PhaseOutcome] = field(default_factory=list)
+
+    @property
+    def success(self) -> bool:
+        return all(outcome.success for outcome in self.outcomes)
+
+    @property
+    def elapsed_secs(self) -> float:
+        return sum(outcome.elapsed_secs for outcome in self.outcomes)
+
+
+class RegistrationPhase:
+    """Base class for one side-effect in DCC builtin registration."""
+
+    name = "registration"
+    fatal_exceptions: tuple[type[Exception], ...] = ()
+
+    def run(self, context: RegistrationContext) -> None:
+        raise NotImplementedError
+
+
+def run_registration_phases(
+    phases: Sequence[RegistrationPhase], context: RegistrationContext
+) -> RegistrationReport:
+    report = RegistrationReport()
+    for phase in phases:
+        started = time.monotonic()
+        try:
+            phase.run(context)
+        except phase.fatal_exceptions as exc:
+            report.outcomes.append(
+                PhaseOutcome(
+                    name=phase.name,
+                    success=False,
+                    elapsed_secs=time.monotonic() - started,
+                    error=str(exc),
+                )
+            )
+            raise
+        except Exception as exc:  # noqa: BLE001 - phase loop localizes optional integration failures
+            report.outcomes.append(
+                PhaseOutcome(
+                    name=phase.name,
+                    success=False,
+                    elapsed_secs=time.monotonic() - started,
+                    error=str(exc),
+                )
+            )
+        else:
+            report.outcomes.append(
+                PhaseOutcome(
+                    name=phase.name,
+                    success=True,
+                    elapsed_secs=time.monotonic() - started,
+                )
+            )
+    return report

--- a/python/dcc_mcp_core/_registration.py
+++ b/python/dcc_mcp_core/_registration.py
@@ -7,9 +7,11 @@ then define their own phase subclasses in a host-specific
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from dataclasses import field
 import time
-from dataclasses import dataclass, field
-from typing import Any, List, Optional, Sequence
+from typing import Any
+from typing import Sequence
 
 
 @dataclass
@@ -17,10 +19,10 @@ class RegistrationContext:
     """Input shared by every registration phase."""
 
     server: Any
-    extra_skill_paths: Optional[List[str]] = None
+    extra_skill_paths: list[str] | None = None
     include_bundled: bool = True
-    minimal: Optional[bool] = None
-    strict_scan: Optional[bool] = None
+    minimal: bool | None = None
+    strict_scan: bool | None = None
 
 
 @dataclass
@@ -30,14 +32,14 @@ class PhaseOutcome:
     name: str
     success: bool
     elapsed_secs: float
-    error: Optional[str] = None
+    error: str | None = None
 
 
 @dataclass
 class RegistrationReport:
     """Summary emitted after builtin-action registration completes."""
 
-    outcomes: List[PhaseOutcome] = field(default_factory=list)
+    outcomes: list[PhaseOutcome] = field(default_factory=list)
 
     @property
     def success(self) -> bool:
@@ -58,9 +60,7 @@ class RegistrationPhase:
         raise NotImplementedError
 
 
-def run_registration_phases(
-    phases: Sequence[RegistrationPhase], context: RegistrationContext
-) -> RegistrationReport:
+def run_registration_phases(phases: Sequence[RegistrationPhase], context: RegistrationContext) -> RegistrationReport:
     report = RegistrationReport()
     for phase in phases:
         started = time.monotonic()
@@ -76,7 +76,7 @@ def run_registration_phases(
                 )
             )
             raise
-        except Exception as exc:  # noqa: BLE001 - phase loop localizes optional integration failures
+        except Exception as exc:
             report.outcomes.append(
                 PhaseOutcome(
                     name=phase.name,


### PR DESCRIPTION
## Summary
- Add `dcc_mcp_core._registration` module with the shared phase pipeline base classes and executor
- Extracted from `dcc-mcp-maya`'s registration system
- Pure Python — no Rust dependency, importable from any adapter install root

## Changed
- **New**: `python/dcc_mcp_core/_registration.py` — `RegistrationContext`, `RegistrationPhase`, `PhaseOutcome`, `RegistrationReport`, `run_registration_phases`

## Consumer PRs
- Maya adapter: https://github.com/dcc-mcp/dcc-mcp-maya/pull/new/agent/loonghao/pip689-registration-refactor
- 3ds Max adapter: https://github.com/dcc-mcp/dcc-mcp-3dsmax/pull/new/agent/loonghao/pip689-registration-refactor

## Backward compatibility
No breaking changes. Maya adapter's existing `dcc_mcp_maya._registration` re-exports all symbols from core.