### PR TITLE
fix(ci): increase release asset verification retries to 20 and add diagnostic logging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -769,7 +769,7 @@ jobs:
 
           release_json=""
           missing=""
-          for attempt in {1..10}; do
+          for attempt in {1..20}; do
             release_json="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json tagName,name,url,isPrerelease,isDraft,publishedAt,targetCommitish,assets)"
             missing=""
             for pattern in "${required_patterns[@]}"; do
@@ -783,9 +783,11 @@ jobs:
             fi
 
             assets_count="$(jq '.assets | length' <<<"$release_json")"
-            echo "::warning::Release assets not complete yet (attempt ${attempt}/10, assets=${assets_count}); missing patterns:"
+            current_assets="$(jq -r '[.assets[].name] | join(", ")' <<<"$release_json")"
+            echo "::warning::Release assets not complete yet (attempt ${attempt}/20, assets=${assets_count}); missing patterns:"
             printf '%s' "$missing"
-            if [ "$attempt" -lt 10 ]; then
+            echo "::warning::Current asset names: ${current_assets}"
+            if [ "$attempt" -lt 20 ]; then
               sleep 30
             fi
           done


### PR DESCRIPTION
## Summary

Hardens the "Notify Multica release-ready autopilot" step in `release.yml` to handle GitHub API eventual consistency delays.

- Increase retries: 10×30s → 20×30s (10 min total polling window)
- Add current asset names to each warning log for immediate debugging visibility
- Keep `sleep 30` interval unchanged

## Root Cause

`gh release view` in CI returned incomplete asset data despite successful uploads. The 5-minute polling window was insufficient for GitHub API propagation.

## Test Plan

- [ ] Verify on next release tag that the verification step passes green
- [ ] If verification initially fails, warning logs now include explicit asset names for debugging

Fixes PIP-1287