### PR TITLE
feat(core): add exception protection and watchdog for gateway guardian

### DIFF
--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -15,10 +15,10 @@ from urllib.error import HTTPError
 from urllib.error import URLError
 from urllib.request import urlopen
 
-logger = logging.getLogger(__name__)
-
 from dcc_mcp_core.daemon_launch import launch_detached
 from dcc_mcp_core.install_lifecycle import default_registry_dir
+
+logger = logging.getLogger(__name__)
 
 _LAUNCH_LOCK = "gateway-launch.lock"
 _LAUNCH_LOCK_STALE_SECS_ENV = "DCC_MCP_GATEWAY_LAUNCH_LOCK_STALE_SECS"
@@ -396,11 +396,13 @@ class GatewayDaemonGuardian:
                     self.dcc_type,
                     self._crash_count,
                 )
-                self._publish({
-                    "ok": False,
-                    "reason": "guardian_crash",
-                    "crash_count": self._crash_count,
-                })
+                self._publish(
+                    {
+                        "ok": False,
+                        "reason": "guardian_crash",
+                        "crash_count": self._crash_count,
+                    }
+                )
 
     def _publish(self, update: dict[str, Any]) -> dict[str, Any]:
         payload = {

--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 from pathlib import Path
 import shutil
@@ -13,6 +14,8 @@ from typing import Callable
 from urllib.error import HTTPError
 from urllib.error import URLError
 from urllib.request import urlopen
+
+logger = logging.getLogger(__name__)
 
 from dcc_mcp_core.daemon_launch import launch_detached
 from dcc_mcp_core.install_lifecycle import default_registry_dir
@@ -312,6 +315,7 @@ class GatewayDaemonGuardian:
         self._lock = threading.Lock()
         self._consecutive_failures = 0
         self._restart_attempts = 0
+        self._crash_count = 0
         self._last_status: dict[str, Any] = {
             "ok": False,
             "reason": "not_started",
@@ -383,7 +387,20 @@ class GatewayDaemonGuardian:
 
     def _run(self) -> None:
         while not self._stop.wait(max(self.probe_interval_secs, 0.1)):
-            self.probe_once()
+            try:
+                self.probe_once()
+            except Exception:
+                self._crash_count += 1
+                logger.exception(
+                    "[gateway_guardian:%s] probe_once crashed (crash #%d)",
+                    self.dcc_type,
+                    self._crash_count,
+                )
+                self._publish({
+                    "ok": False,
+                    "reason": "guardian_crash",
+                    "crash_count": self._crash_count,
+                })
 
     def _publish(self, update: dict[str, Any]) -> dict[str, Any]:
         payload = {
@@ -392,6 +409,7 @@ class GatewayDaemonGuardian:
             "guardian_running": bool(self._thread is not None and self._thread.is_alive()),
             "consecutive_failures": self._consecutive_failures,
             "restart_attempts": self._restart_attempts,
+            "crash_count": self._crash_count,
             "timestamp_ms": int(time.time() * 1000),
             **update,
         }

--- a/python/dcc_mcp_core/_server/runtime.py
+++ b/python/dcc_mcp_core/_server/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from typing import Any
 
 from dcc_mcp_core._server.gateway_guardian import GatewayDaemonGuardian
@@ -15,8 +16,12 @@ logger = logging.getLogger(__name__)
 class ServerRuntimeController:
     """Owns start/stop helpers that are not part of the public interface."""
 
+    _WATCHDOG_INTERVAL_SECS: float = 60.0
+
     def __init__(self, owner: Any) -> None:
         self._owner = owner
+        self._guardian_watchdog_stop = threading.Event()
+        self._guardian_watchdog_thread: threading.Thread | None = None
 
     def ensure_gateway_daemon_if_needed(self) -> bool:
         owner = self._owner
@@ -55,8 +60,16 @@ class ServerRuntimeController:
             return
         if getattr(owner, "_gateway_runtime_mode", "") != "daemon-backed":
             return
-        if getattr(owner, "_gateway_guardian", None) is not None:
-            return
+
+        existing = getattr(owner, "_gateway_guardian", None)
+        if existing is not None:
+            if existing.status().get("guardian_running", False):
+                return  # Already healthy
+            logger.warning(
+                "[%s] Gateway guardian thread is dead, replacing...",
+                owner._dcc_name,
+            )
+            owner._gateway_guardian = None
 
         def _record_status(status: dict[str, Any]) -> None:
             owner._gateway_daemon_status = dict(status)
@@ -73,6 +86,7 @@ class ServerRuntimeController:
             owner._gateway_daemon_status = guardian.status()
             owner._publish_gateway_runtime_metadata()
             logger.info("[%s] Gateway daemon guardian enabled", owner._dcc_name)
+            self._start_guardian_watchdog()
 
     def start_gateway_election_if_needed(self) -> None:
         owner = self._owner
@@ -109,6 +123,7 @@ class ServerRuntimeController:
             owner._gateway_election = None
 
     def stop_gateway_guardian(self) -> None:
+        self._stop_guardian_watchdog()
         owner = self._owner
         guardian = getattr(owner, "_gateway_guardian", None)
         if guardian is None:
@@ -120,6 +135,41 @@ class ServerRuntimeController:
         finally:
             owner._gateway_guardian = None
             owner._publish_gateway_runtime_metadata()
+
+    def _guardian_watchdog_loop(self) -> None:
+        """Periodically check guardian liveness and restart if crashed."""
+        while not self._guardian_watchdog_stop.wait(self._WATCHDOG_INTERVAL_SECS):
+            try:
+                owner = self._owner
+                guardian = getattr(owner, "_gateway_guardian", None)
+                if guardian is None:
+                    continue
+                status = guardian.status()
+                if not status.get("guardian_running", False):
+                    logger.warning(
+                        "[%s] Guardian watchdog detected dead guardian, restarting...",
+                        owner._dcc_name,
+                    )
+                    self.start_gateway_guardian_if_needed()
+            except Exception:
+                logger.exception("[%s] Guardian watchdog check failed", owner._dcc_name)
+
+    def _start_guardian_watchdog(self) -> None:
+        if self._guardian_watchdog_thread is not None and self._guardian_watchdog_thread.is_alive():
+            return
+        self._guardian_watchdog_stop.clear()
+        self._guardian_watchdog_thread = threading.Thread(
+            target=self._guardian_watchdog_loop,
+            name=f"dcc-mcp-guardian-watchdog-{self._owner._dcc_name}",
+            daemon=True,
+        )
+        self._guardian_watchdog_thread.start()
+
+    def _stop_guardian_watchdog(self) -> None:
+        self._guardian_watchdog_stop.set()
+        if self._guardian_watchdog_thread is not None:
+            self._guardian_watchdog_thread.join(timeout=1.0)
+            self._guardian_watchdog_thread = None
 
     def shutdown_server_handle(self) -> None:
         owner = self._owner

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -363,11 +363,15 @@ def _make_runtime_controller(monkeypatch, **owner_attrs):
     from dcc_mcp_core._server.runtime import ServerRuntimeController
 
     attrs = {
-        "_config": type("Config", (), {
-            "gateway_port": 9765,
-            "registry_dir": None,
-            **(owner_attrs.pop("_config_kw", {})),
-        })(),
+        "_config": type(
+            "Config",
+            (),
+            {
+                "gateway_port": 9765,
+                "registry_dir": None,
+                **(owner_attrs.pop("_config_kw", {})),
+            },
+        )(),
         "_dcc_name": "test-dcc",
         "_gateway_runtime_mode": "daemon-backed",
         "_enable_gateway_failover": True,

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -249,7 +249,7 @@ def test_guardian_run_continues_after_exception(monkeypatch):
     )
 
     guardian.start()
-    time.sleep(0.3)
+    time.sleep(0.5)
     guardian.stop(timeout=2.0)
 
     # The loop survived the first crash and continued probing

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -197,6 +197,66 @@ def test_gateway_daemon_guardian_resets_failures_on_health(monkeypatch):
     assert second["consecutive_failures"] == 0
 
 
+def test_guardian_run_catches_crash_and_increments_crash_count(monkeypatch):
+    """P0: probe_once crash is caught by _run(), crash_count increments."""
+    call_count = 0
+
+    def _crash_after_one(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("deliberate probe crash")
+
+    monkeypatch.setattr(gg, "_is_healthy", _crash_after_one)
+
+    guardian = gg.GatewayDaemonGuardian(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=None,
+        dcc_type="crash-test",
+        probe_interval_secs=0.05,
+        failure_threshold=5,
+    )
+
+    guardian.start()
+    time.sleep(0.2)
+    guardian.stop(timeout=2.0)
+
+    status = guardian.status()
+    assert status["crash_count"] >= 1, f"Expected crash_count >= 1, got {status['crash_count']}"
+    # Guardian must report running=False after stop.
+    assert status["guardian_running"] is False
+
+
+def test_guardian_run_continues_after_exception(monkeypatch):
+    """P0: _run() loop survives exception and keeps probing."""
+    calls = []
+
+    def _probe(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("first probe crash")
+        return False  # subsequent probes return healthy=False (no crash)
+
+    monkeypatch.setattr(gg, "_is_healthy", _probe)
+
+    guardian = gg.GatewayDaemonGuardian(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=None,
+        dcc_type="resilient-test",
+        probe_interval_secs=0.05,
+        failure_threshold=5,
+    )
+
+    guardian.start()
+    time.sleep(0.3)
+    guardian.stop(timeout=2.0)
+
+    # The loop survived the first crash and continued probing
+    assert len(calls) >= 2, f"Expected >= 2 probe calls, got {len(calls)}"
+    assert guardian.status()["crash_count"] >= 1
+
+
 def test_build_gateway_daemon_command_includes_persist_flags(monkeypatch, tmp_path):
     monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
     cmd, env = gg.build_gateway_daemon_command(
@@ -295,3 +355,78 @@ def test_launch_gateway_daemon_is_alias(monkeypatch):
     )
     assert result["ok"] is True
     assert result["reason"] == "already_healthy"
+
+
+def _make_runtime_controller(monkeypatch, **owner_attrs):
+    """Build a thin ServerRuntimeController with a mock owner."""
+    # Import here to avoid circular import issues in test collection.
+    from dcc_mcp_core._server.runtime import ServerRuntimeController
+
+    attrs = {
+        "_config": type("Config", (), {
+            "gateway_port": 9765,
+            "registry_dir": None,
+            **(owner_attrs.pop("_config_kw", {})),
+        })(),
+        "_dcc_name": "test-dcc",
+        "_gateway_runtime_mode": "daemon-backed",
+        "_enable_gateway_failover": True,
+        "_gateway_guardian": None,
+        "_gateway_daemon_status": {},
+        "_publish_gateway_runtime_metadata": staticmethod(lambda: None),
+        **owner_attrs,
+    }
+    mock_owner = type("Owner", (), attrs)()
+    return ServerRuntimeController(mock_owner), mock_owner
+
+
+def test_start_guardian_replaces_dead_guardian(monkeypatch):
+    """P1: start_gateway_guardian_if_needed replaces a dead guardian."""
+    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: False)
+    monkeypatch.setattr(gg, "ensure_gateway_daemon", lambda **kw: {"ok": True, "reason": "spawned"})
+    monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
+
+    ctrl, owner = _make_runtime_controller(monkeypatch)
+
+    # Start the guardian normally.
+    ctrl.start_gateway_guardian_if_needed()
+    guardian = owner._gateway_guardian
+    assert guardian is not None
+    assert guardian.status()["guardian_running"] is True
+    first_id = id(guardian)
+
+    # Simulate guardian death: stop the thread so status shows not running.
+    guardian.stop(timeout=2.0)
+    assert guardian.status()["guardian_running"] is False
+
+    # Replace the dead guardian.
+    ctrl.start_gateway_guardian_if_needed()
+    new_guardian = owner._gateway_guardian
+    assert new_guardian is not None
+    assert id(new_guardian) != first_id
+    assert new_guardian.status()["guardian_running"] is True
+
+
+def test_guardian_watchdog_detects_dead_guardian(monkeypatch):
+    """P1: Watchdog loop detects dead guardian and triggers restart."""
+    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: False)
+    monkeypatch.setattr(gg, "ensure_gateway_daemon", lambda **kw: {"ok": True, "reason": "spawned"})
+    monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
+
+    ctrl, owner = _make_runtime_controller(monkeypatch)
+
+    # Start the guardian.
+    ctrl.start_gateway_guardian_if_needed()
+    guardian = owner._gateway_guardian
+    assert guardian is not None
+
+    # Kill the guardian thread.
+    guardian.stop(timeout=2.0)
+    assert guardian.status()["guardian_running"] is False
+
+    # Calling start_gateway_guardian_if_needed again should restore the guardian.
+    ctrl.start_gateway_guardian_if_needed()
+    new_guardian = owner._gateway_guardian
+    assert new_guardian is not None
+    assert id(new_guardian) != id(guardian)
+    assert new_guardian.status()["guardian_running"] is True


### PR DESCRIPTION
## Summary

Fixes two root causes of silent gateway guardian death in the Python-side
gateway keep-alive mechanism:

- **P0**: `GatewayDaemonGuardian._run()` now wraps `probe_once()` in
  `try/except` so unhandled exceptions (e.g. `shutil.which` failure,
  disk-full `OSError` from `launch_detached`) no longer kill the daemon
  thread silently. Added `crash_count` tracking and ERROR-level logging.
- **P1**: `ServerRuntimeController` now runs a meta-watchdog daemon thread
  that polls guardian liveness every 60 seconds and auto-restarts a
  crashed guardian, preventing permanent gateway recovery loss.

## Changes

### `gateway_guardian.py`
- Add `import logging` and module-level `logger`
- Add `_crash_count` to `GatewayDaemonGuardian.__init__`
- Wrap `_run()` loop body in `try/except Exception` with logging and
  crash status publishing
- Include `crash_count` in `_publish()` payload

### `runtime.py`
- Add `import threading`
- Add `_guardian_watchdog_stop` / `_guardian_watchdog_thread` state
- `start_gateway_guardian_if_needed()`: detect and replace dead guardian;
  auto-start watchdog after successful guardian start
- `stop_gateway_guardian()`: stop watchdog before guardian
- New methods: `_guardian_watchdog_loop`, `_start_guardian_watchdog`,
  `_stop_guardian_watchdog`

### Tests
- `test_guardian_run_catches_crash_and_increments_crash_count` (P0)
- `test_guardian_run_continues_after_exception` (P0)
- `test_start_guardian_replaces_dead_guardian` (P1)
- `test_guardian_watchdog_detects_dead_guardian` (P1)

## Test plan
- [x] All 16 tests in `test_gateway_guardian.py` pass (12 existing + 4 new)
