### PR TITLE
fix(sidecar): abort old guardian before replacing in watchdog restart

### DIFF
--- a/crates/dcc-mcp-sidecar/src/sidecar.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar.rs
@@ -191,7 +191,11 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
                                 opts.clone(),
                                 crate::gateway_daemon::GatewayGuardianSettings::from_env(),
                             );
-                            *shared_handle.lock().await = Some(new_guardian);
+                            let mut locked = shared_handle.lock().await;
+                            if let Some(old) = locked.take() {
+                                old.abort();
+                            }
+                            *locked = Some(new_guardian);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Fix a resource leak discovered during review of #1589.

## Problem

The watchdog in `crates/dcc-mcp-sidecar/src/sidecar.rs` restarts a dead
guardian by overwriting `*shared_handle.lock().await = Some(new_guardian)`.
`GatewayGuardianHandle` has no `Drop` impl that calls `.abort()`, so the
old guardian's tokio task leaks on every restart cycle, accumulating
orphaned health-check loops that all compete for the same gateway process.

## Fix

Take the old handle and abort it before installing the new one:

```rust
let mut locked = shared_handle.lock().await;
if let Some(old) = locked.take() {
    old.abort();
}
*locked = Some(new_guardian);
```

## Test plan
- [x] `cargo check -p dcc-mcp-sidecar`
- [x] `cargo test -p dcc-mcp-sidecar` — 42 passed