### PR TITLE
docs: add gateway ensure lifecycle commands, marketplace source management, AGENTS marketplace skill refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,9 @@
 | Skill authoring | [`skills/dcc-mcp-skills-creator/SKILL.md`](skills/dcc-mcp-skills-creator/SKILL.md) + `examples/skills/` | Creating or modifying skills |
 | Adapter developer guidance | [`skills/dcc-mcp-creator/SKILL.md`](skills/dcc-mcp-creator/SKILL.md) | Before creating or changing DCC adapter server/runtime wiring, dispatcher bridges, readiness, resources, gateway behavior, or core-escalation plans |
 | Skill creator guidance | [`skills/dcc-mcp-skills-creator/SKILL.md`](skills/dcc-mcp-skills-creator/SKILL.md) | Before creating or changing adapter skill authoring, tool schemas, scripts, skill taxonomy, testing, or agent-facing workflows |
+| CLI + marketplace operations | [`skills/dcc-cli-gateway/SKILL.md`](skills/dcc-cli-gateway/SKILL.md) | Agents doing DCC control via `dcc-mcp-cli` — gateway ensure, inventory, search, describe, call, marketplace install/update |
+| Marketplace extension publishing | [`skills/marketplace-publish-extension/SKILL.md`](skills/marketplace-publish-extension/SKILL.md) | Before publishing a new skill package to the DCC-MCP marketplace |
+| Marketplace extension creation | [`skills/marketplace-create-extension/SKILL.md`](skills/marketplace-create-extension/SKILL.md) | Before creating a new marketplace extension package |
 | Gateway REST regressions (VRS) | [`tests/vrs/README.md`](tests/vrs/README.md) + `scripts/vrs_replay.py` | After gateway `/v1/*` or live-adapter bugs — add a JSONL trace per regression |
 
 ---

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -193,6 +193,58 @@ per-package cards, showing:
 Users can uninstall a package directly from this tab. On success, the skill
 index is refreshed to reflect the removed package.
 
+### Source Management Tab
+
+A **Sources** management interface is accessible from the Marketplace panel,
+letting operators view, add, and remove marketplace sources without the CLI:
+
+- **Source list**: displays each configured source with its origin label
+  (`builtin`, `config`, `env`) and the raw URL.
+- **Add source**: an inline form to enter a new marketplace source URL.
+  Duplicate additions are idempotent — adding an already-registered source
+  is a no-op rather than a hard error.
+- **Remove source**: removes a user-configured source from the persistent
+  config. Built-in and environment-provided sources cannot be removed from
+  the UI.
+
+Source changes take effect immediately for subsequent catalog queries, and
+the Browse tab refreshes on the next interaction.
+
+### Update Flow
+
+When newer versions are available for installed packages, the **Installed** tab
+shows an **Update** button on each outdated card. The button triggers a
+marketplace update for that single package. A bulk **Update All** action is also
+available at the top of the Installed tab, upgrading every outdated package in
+one operation.
+
+The update flow uses the `force` install flag internally, allowing the new
+version to overwrite the existing installation. After update completes, the
+backend triggers a skill index reload if needed (`reload_required: true`).
+For `git`-type installs, the update fetches the new ref in place rather than
+re-cloning; other install types re-install from the catalog.
+
+### Force Install
+
+The **Install** button supports a force install mode that overwrites an
+existing installation without prompting. This is exposed through the
+`force: true` parameter in the install API. In the UI, force install is
+used automatically during the update flow; manual force install is
+available through the detail modal when a package appears already
+installed.
+
+### Structured Error Display
+
+Install, update, and uninstall operations return structured error responses
+displayed as inline notification banners rather than raw JSON. Each error
+includes:
+
+- **Error code**: a machine-readable identifier (e.g. `source_not_found`,
+  `install_failed`, `network_error`).
+- **Human-readable message**: a localized description of what went wrong.
+- **Recovery hint** (when available): a suggestion for how to resolve the
+  issue (e.g. "check the source URL is reachable", "verify disk space").
+
 ### API Endpoints
 
 | Route | Content-Type | Description |

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -59,6 +59,9 @@ dcc-mcp-cli marketplace list-installed --dcc maya
 dcc-mcp-cli marketplace outdated --dcc maya
 dcc-mcp-cli marketplace update dcc-mcp-maya-skills --dcc maya
 dcc-mcp-cli marketplace update --all
+dcc-mcp-cli gateway ensure
+dcc-mcp-cli gateway status
+dcc-mcp-cli gateway stop
 dcc-mcp-cli lint path/to/skills
 ```
 
@@ -85,6 +88,10 @@ dcc-mcp-cli lint path/to/skills
 | `marketplace uninstall <name> --dcc <dcc>` | local installed-state file + filesystem | Remove an installed marketplace package. |
 | `marketplace outdated [NAME...] [--dcc <dcc>]` | marketplace catalog + local installed state | Compare installed versions against latest catalog entries and list packages with newer versions available. |
 | `marketplace update [<name>] [--all] [--dcc <dcc>]` | marketplace catalog + git/filesystem + local installed state | Upgrade installed packages to the latest catalog version. For `git` installs, fetches the new ref in place; for other types, re-installs from the catalog. Use `--all` to update every outdated package. |
+| `gateway ensure [--port <port>]` | local process | Check gateway health via `GET /health` on the configured port (default 9765). If unreachable, acquire a launch lock and spawn the gateway daemon in the background. Reports `already_running: true` or `started: true` with process PID. |
+| `gateway start [--port <port>] [--idle-timeout <secs>]` | local process | Force-start a new gateway daemon. Wraps `gateway ensure` logic and accepts additional startup options: `--name <name>`, `--remote-host <host>`, `--gateway-bin <path>`, `--wait-timeout <secs>`. |
+| `gateway stop [--port <port>]` | local process | Stop a running gateway daemon by PID file. Sends SIGTERM (Unix) or TerminateProcess (Windows), verifies the process has exited, and cleans up the PID file. |
+| `gateway status [--port <port>]` | local process | Report gateway daemon status: host, port, health check result, PID, and whether the process is alive. JSON output for agent consumption. |
 | `lint [PATH ...]` | local filesystem validator | Recursively validate SKILL.md packages two levels below each path by default. |
 
 `install` intentionally starts as a planning contract: it resolves catalog

--- a/skills/dcc-cli-gateway/SKILL.md
+++ b/skills/dcc-cli-gateway/SKILL.md
@@ -73,11 +73,62 @@ agents without maintaining per-host MCP server lists.
 
 ---
 
+## Gateway Ensure - Mandatory Precondition
+
+**Before any DCC interaction, ensure the gateway is running.** `dcc-mcp-cli gateway ensure`
+checks gateway health at `DCC_MCP_BASE_URL` (default `http://127.0.0.1:9765`) and
+auto-starts the gateway daemon in the background if needed. This is the very first
+command an agent should run — do not skip it.
+
+### What gateway ensure does
+
+1. **Probe** `GET /health` on the gateway port (default 9765).
+2. If healthy -> report `already_running: true` and continue.
+3. If unreachable -> acquire a launch lock, spawn the gateway daemon in the background, wait for health check to pass, report `started: true` with process PID.
+
+### Gateway ensure output (JSON)
+
+```json
+{
+  "host": "127.0.0.1",
+  "port": 9765,
+  "already_running": false,
+  "started": true,
+  "pid": 12345
+}
+```
+
+The launch lock prevents duplicate daemon starts. A stale lock file from a
+previous crash is automatically reclaimed after a timeout.
+
+### When gateway ensure fails
+
+| Symptom | Action |
+|---------|--------|
+| Health unreachable and launch fails | Report gateway unreachable; ask user to start `dcc-mcp-server` or verify DCC_MCP_BASE_URL |
+| Port conflict | Report the conflicting process; suggest `--port <alt>` or ask user to free the port |
+| Launch lock stuck | Reclaim automatically after timeout; retry once; if still stuck, report and ask user |
+
+### Lifecycle commands
+
+After `gateway ensure`, additional lifecycle commands are available:
+
+| Command | Purpose |
+|---------|---------|
+| `dcc-mcp-cli gateway start` | Force-start a new gateway daemon with startup options |
+| `dcc-mcp-cli gateway stop` | Stop the running gateway daemon by PID file |
+| `dcc-mcp-cli gateway status` | Report gateway daemon health, PID, and alive status |
+
+These commands are documented in detail in the [CLI reference](../../docs/guide/cli-reference.md).
+
+---
+
 ## Connection Order
 
-1. Use `dcc-mcp-cli` when it is already on `PATH`.
-2. If missing, ask user permission, then download `dcc-mcp-cli` from GitHub Releases.
-3. If the download fails, use the bundled Python stdlib REST fallback.
+1. Run `dcc-mcp-cli gateway ensure` (or `python scripts/dcc_gateway.py gateway ensure`).
+2. If gateway is up, use `dcc-mcp-cli` when it is already on `PATH`.
+3. If missing, ask user permission, then download `dcc-mcp-cli` from GitHub Releases.
+4. If the download fails, use the bundled Python stdlib REST fallback.
 
 Install via OpenClaw/ClawHub, or point your agent at this `SKILL.md` after cloning
 [`dcc-mcp-core/skills/dcc-cli-gateway/`](https://github.com/dcc-mcp/dcc-mcp-core/tree/main/skills/dcc-cli-gateway).
@@ -88,13 +139,14 @@ Install via OpenClaw/ClawHub, or point your agent at this `SKILL.md` after cloni
 
 | Situation | You MUST |
 |-----------|----------|
-| Starting any DCC task | Run `dcc-mcp-cli health` and `dcc-mcp-cli list` first (or `python scripts/dcc_gateway.py health` / `python scripts/dcc_gateway.py list` as fallback) |
+| Starting any DCC task | Run `dcc-mcp-cli gateway ensure` first, then `dcc-mcp-cli health` and `dcc-mcp-cli list` (or `python scripts/dcc_gateway.py gateway ensure` / `python scripts/dcc_gateway.py health` / `python scripts/dcc_gateway.py list` as fallback) |
 | `dcc-mcp-cli` missing | Ask permission before `--ensure-cli`; fallback Python REST is allowed if download fails |
 | Inventory returns `total == 0` | Stop; do not run `search`, `describe`, or `call` |
-| Gateway unreachable | Stop; explain; ask user permission before troubleshooting |
+| Gateway unreachable after ensure | Stop; explain; ask user permission before troubleshooting |
+| Gateway ensure fails | See Gateway Ensure section above for symptom-specific actions |
 | User has not agreed to setup | Do not install packages, edit env files, launch GUI apps, or write configs |
 | User approved setup | Follow [`references/ZERO_INSTANCES_CLI.md`](references/ZERO_INSTANCES_CLI.md) |
-| After DCC crash/restart | Re-run `list` and `search`; old slugs may be invalid |
+| After DCC crash/restart | Re-run `gateway ensure`, `list` and `search`; old slugs may be invalid |
 
 ---
 
@@ -104,7 +156,16 @@ Install via OpenClaw/ClawHub, or point your agent at this `SKILL.md` after cloni
 
 ```bash
 export DCC_MCP_BASE_URL="${DCC_MCP_BASE_URL:-http://127.0.0.1:9765}"
+
+# Gateway ensure — mandatory first step
+dcc-mcp-cli gateway ensure
+
+# After gateway is running
 dcc-mcp-cli health
+dcc-mcp-cli list
+
+# Python fallback
+python scripts/dcc_gateway.py gateway ensure
 python scripts/dcc_gateway.py health
 ```
 
@@ -122,6 +183,9 @@ py -3 scripts\check_cli.py
 ```
 
 Flags: `--base-url URL`, `--cli dcc-mcp-cli`, `--ensure-cli`, `--install-dir DIR`, `--pretty`.
+Flags for `gateway ensure/start`: `--port PORT`, `--idle-timeout SECS`.
+Flags for `gateway start` only: `--name NAME`, `--remote-host HOST`,
+`--gateway-bin PATH`, `--wait-timeout SECS`.
 
 When the user approves downloading the CLI:
 
@@ -156,16 +220,19 @@ powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps
 
 ---
 
-## Step 0 — Mandatory Instance Inventory
+## Step 0 — Gateway Ensure + Mandatory Instance Inventory
 
-Run this every time you begin work or after the user starts/stops a DCC host:
+**Run `gateway ensure` first**, then inventory. Execute this sequence every
+time you begin work or after the user starts/stops a DCC host:
 
 ```bash
 # CLI (primary)
+dcc-mcp-cli gateway ensure
 dcc-mcp-cli health
 dcc-mcp-cli list
 
 # Python fallback (when CLI is unavailable)
+python scripts/dcc_gateway.py gateway ensure
 python scripts/dcc_gateway.py health
 python scripts/dcc_gateway.py list
 ```

--- a/skills/dcc-cli-gateway/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-cli-gateway/references/CLI_CHEATSHEET.md
@@ -30,6 +30,15 @@ curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
 powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
 ```
 
+## Gateway lifecycle
+
+| Command | Purpose |
+|---------|---------|
+| `dcc-mcp-cli gateway ensure` | Probe gateway health, auto-start if unreachable (mandatory first command) |
+| `dcc-mcp-cli gateway start` | Force-start a new gateway daemon |
+| `dcc-mcp-cli gateway stop` | Stop the gateway daemon by PID file |
+| `dcc-mcp-cli gateway status` | Report daemon health, PID, alive status |
+
 ## Discovery and health
 
 | Command | Purpose |
@@ -51,11 +60,13 @@ powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps
 ```bash
 export DCC_MCP_BASE_URL="${DCC_MCP_BASE_URL:-http://127.0.0.1:9765}"
 
-# CLI (primary)
+# CLI (primary) — gateway ensure first
+dcc-mcp-cli gateway ensure
 dcc-mcp-cli health
 dcc-mcp-cli list
 
 # Python fallback (when CLI is unavailable)
+python scripts/dcc_gateway.py gateway ensure
 python scripts/dcc_gateway.py health
 python scripts/dcc_gateway.py list
 ```

--- a/skills/dcc-cli-gateway/references/ZERO_INSTANCES_CLI.md
+++ b/skills/dcc-cli-gateway/references/ZERO_INSTANCES_CLI.md
@@ -2,11 +2,12 @@
 
 Use this document only when:
 
+- `dcc-mcp-cli gateway ensure` (or `python scripts/dcc_gateway.py gateway ensure`) succeeds,
 - `dcc-mcp-cli health` (or `python scripts/dcc_gateway.py health`) succeeds,
 - `dcc-mcp-cli list` (or `python scripts/dcc_gateway.py list`) returns `"total": 0`, and
 - the user has explicitly approved setup guidance.
 
-Until all three are true, do not run install commands, edit environment files,
+Until all four are true, do not run install commands, edit environment files,
 launch GUI applications, or modify MCP host configuration.
 
 ---
@@ -26,7 +27,7 @@ Before any setup step, confirm:
 
 | Check | Meaning | Next step |
 |-------|---------|-----------|
-| `dcc-mcp-cli health` fails | Gateway is not reachable | Ask user to start a gateway-capable DCC adapter or `dcc-mcp-server` |
+| `dcc-mcp-cli gateway ensure` fails | Gateway is not reachable or cannot be auto-started | Ask user to start a gateway-capable DCC adapter or `dcc-mcp-server` |
 | `dcc-mcp-cli health` succeeds and `list.total == 0` | Gateway is up, no DCC registered | Start a DCC adapter |
 
 Gateway election defaults to port `9765`. The first DCC-MCP process that binds


### PR DESCRIPTION
## Summary

This PR closes the documentation gaps identified in the weekly docs audit (2026-06-02 ~ 2026-06-09):

- **CLI reference**: add `gateway ensure|start|stop|status` subcommands to docs/guide/cli-reference.md
- **dcc-cli-gateway skill**: add Gateway Ensure mandatory precondition section, update Critical Rules, Configuration, and Step 0
- **CLI cheatsheet**: add gateway lifecycle commands table, update examples for gateway ensure
- **Zero instances guide**: add gateway ensure as prerequisite
- **AGENTS.md**: add dcc-cli-gateway, marketplace-publish-extension, marketplace-create-extension to Document Hierarchy
- **Admin UI docs**: add marketplace Source Management Tab, Update Flow, Force Install, and Structured Error Display sections

## Test plan

- Markdown syntax clean
- All links reference existing files
- CLI commands verified against actual implementation
