### PR TITLE
fix(ci): use any() in release asset pattern matching to fix false timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -773,7 +773,7 @@ jobs:
             release_json="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json tagName,name,url,isPrerelease,isDraft,publishedAt,targetCommitish,assets)"
             missing=""
             for pattern in "${required_patterns[@]}"; do
-              if ! jq -e --arg pattern "$pattern" '.assets[].name | test($pattern)' <<<"$release_json" >/dev/null; then
+              if ! jq -e --arg pattern "$pattern" 'any(.assets[].name; test($pattern))' <<<"$release_json" >/dev/null; then
                 missing="${missing}${pattern}"$'\n'
               fi
             done


### PR DESCRIPTION
## Summary

Fixes the "Notify Multica release-ready autopilot" step timing out despite
all release assets being present (21/21).

**Root cause:** `jq -e` with `.assets[].name | test($pattern)` only checks
the **last** asset in the iteration. When `dcc_mcp_server-*.whl` happens to
be last, 5/6 patterns fail to match and the step exhausts all 20 retries.

**Fix:** Replace with `any(.assets[].name; test($pattern))` which correctly
returns true if ANY asset matches the pattern, regardless of ordering.

## Test plan

- [x] Verify all 6 required patterns match with `any()` against the actual
  asset list from the failed run (v0.18.15)
- [x] Confirm the buggy code does NOT match (last asset is non-core)
- [x] Validate a simulated release run completes the notification step
