### PR TITLE
feat(cli): implement install --execute with consent gating and rollback

### DIFF
--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -403,10 +403,10 @@ fn ask_consent(prompt: &str) -> Result<bool, InstallError> {
 /// Roll back all completed steps in reverse order, best-effort.
 fn rollback_all(completed: &[StepResult]) {
     for result in completed.iter().rev() {
-        if let Some(rollback) = &result.rollback {
-            if let Err(e) = execute_rollback(rollback) {
-                eprintln!("  ⚠  rollback of '{}' failed: {e}", result.step_name);
-            }
+        if let Some(rollback) = &result.rollback
+            && let Err(e) = execute_rollback(rollback)
+        {
+            eprintln!("  ⚠  rollback of '{}' failed: {e}", result.step_name);
         }
     }
 }

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -1,8 +1,12 @@
+use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use thiserror::Error;
 
-use crate::domain::install::{InstallPlan, InstallPlanError, InstallPlanner, InstallRequest};
+use crate::domain::install::{
+    InstallPlan, InstallPlanError, InstallPlanner, InstallRequest, InstallStepAction,
+};
 
 const BUNDLED_CATALOG: &str = include_str!("../../../../dcc-mcp-catalog.yml");
 
@@ -12,6 +16,30 @@ pub enum InstallError {
     Catalog(#[from] dcc_mcp_catalog::CatalogError),
     #[error(transparent)]
     Plan(#[from] InstallPlanError),
+    #[error("consent denied by user")]
+    ConsentDenied,
+    #[error("step '{step}' failed: {message}")]
+    StepFailed { step: String, message: String },
+    #[error("rollback of step '{step}' failed: {message}")]
+    RollbackFailed { step: String, message: String },
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Result of a single executed step with optional rollback data.
+struct StepResult {
+    step_name: String,
+    /// Rollback action to undo this step, if applicable.
+    rollback: Option<StepRollback>,
+}
+
+/// Describes how to undo a completed step.
+#[derive(Debug)]
+enum StepRollback {
+    /// Remove a file or directory that was created.
+    RemovePath(PathBuf),
+    /// Run a shell command to revert.
+    Command { program: String, args: Vec<String> },
 }
 
 pub struct InstallService {
@@ -26,9 +54,20 @@ impl InstallService {
         }
     }
 
+    /// Generate an install plan (display-only, no execution).
     pub fn plan(&self, request: InstallRequest) -> Result<InstallPlan, InstallError> {
         let entries = self.load_entries(request.catalog_path.as_deref())?;
         InstallPlanner::plan(&entries, request).map_err(Into::into)
+    }
+
+    /// Generate and execute an install plan with user consent.
+    ///
+    /// Steps are executed sequentially.  If any step fails, all prior steps
+    /// are rolled back in reverse order.  Returns the full plan (with step
+    /// results) on success.
+    pub fn execute(&self, request: InstallRequest) -> Result<InstallPlan, InstallError> {
+        let plan = self.plan(request)?;
+        self.execute_plan(&plan)
     }
 
     fn load_entries(
@@ -45,7 +84,390 @@ impl InstallService {
         }
         Ok(entries)
     }
+
+    fn execute_plan(&self, plan: &InstallPlan) -> Result<InstallPlan, InstallError> {
+        // Filter to executable steps
+        let executable_steps: Vec<_> = plan
+            .steps
+            .iter()
+            .filter(|s| s.action.is_some())
+            .collect();
+
+        if executable_steps.is_empty() {
+            eprintln!("No executable steps in the install plan.");
+            return Ok(plan.clone());
+        }
+
+        // ── consent gating ────────────────────────────────────────────────
+        eprintln!();
+        eprintln!("╔══════════════════════════════════════════════╗");
+        eprintln!("║         DCC-MCP Install Plan                ║");
+        eprintln!("╠══════════════════════════════════════════════╣");
+        eprintln!("║  Adapter:  {:<30} ║", plan.adapter.name);
+        eprintln!("║  DCC type: {:<30} ║", plan.dcc_type);
+        if let Some(ver) = &plan.version {
+            eprintln!("║  Version:  {:<30} ║", ver);
+        }
+        eprintln!("╠══════════════════════════════════════════════╣");
+        eprintln!("║  Steps:                                    ║");
+        for (i, step) in executable_steps.iter().enumerate() {
+            eprintln!("║    {}. {:<34} ║", i + 1, step.name);
+            eprintln!("║       {:<34} ║", step.description);
+        }
+        eprintln!("╚══════════════════════════════════════════════╝");
+        eprintln!();
+
+        if !ask_consent("Proceed with installation? [Y/n]")? {
+            return Err(InstallError::ConsentDenied);
+        }
+
+        // ── execute with rollback support ────────────────────────────────
+        let mut completed: Vec<StepResult> = Vec::new();
+
+        for step in &executable_steps {
+            let action = step.action.as_ref().expect("filtered to Some above");
+            eprint!("  [{}/{}] {} ... ", completed.len() + 1, executable_steps.len(), step.name);
+
+            match execute_action(action) {
+                Ok(rollback) => {
+                    eprintln!("OK");
+                    completed.push(StepResult {
+                        step_name: step.name.clone(),
+                        rollback,
+                    });
+                }
+                Err(e) => {
+                    eprintln!("FAILED");
+                    // Roll back all completed steps in reverse order
+                    eprintln!("  Rolling back...");
+                    rollback_all(&completed);
+                    return Err(InstallError::StepFailed {
+                        step: step.name.clone(),
+                        message: e.to_string(),
+                    });
+                }
+            }
+        }
+
+        eprintln!();
+        eprintln!("Installation complete for {}.", plan.adapter.name);
+        Ok(plan.clone())
+    }
 }
+
+// ── step executors ───────────────────────────────────────────────────────────────
+
+/// Execute a single install action, returning an optional rollback handle.
+fn execute_action(action: &InstallStepAction) -> Result<Option<StepRollback>, InstallError> {
+    match action {
+        InstallStepAction::PipInstall {
+            package,
+            extras,
+            python,
+        } => execute_pip_install(package, extras.as_deref(), python.as_deref()),
+        InstallStepAction::GitClone { url, ref_, dest } => execute_git_clone(url, ref_.as_deref(), dest),
+        InstallStepAction::ZipExtract {
+            url,
+            sha256,
+            dest,
+        } => execute_zip_extract(url, sha256.as_deref(), dest),
+        InstallStepAction::PathCopy { source, dest } => execute_path_copy(source, dest),
+        InstallStepAction::RegisterDcc {
+            dcc_type,
+            entry_point,
+        } => execute_register_dcc(dcc_type, entry_point.as_deref()),
+        InstallStepAction::Verify => execute_verify(),
+    }
+}
+
+fn execute_pip_install(
+    package: &str,
+    extras: Option<&[String]>,
+    python: Option<&str>,
+) -> Result<Option<StepRollback>, InstallError> {
+    let pip_cmd = python.unwrap_or("pip");
+    let mut cmd = Command::new(pip_cmd);
+    cmd.arg("-m").arg("pip").arg("install");
+
+    if extras.is_some_and(|e| !e.is_empty()) {
+        let pkg = format!("{}[{}]", package, extras.unwrap().join(","));
+        cmd.arg(&pkg);
+    } else {
+        cmd.arg(package);
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| InstallError::StepFailed {
+            step: format!("pip-install-{package}"),
+            message: format!("failed to launch {pip_cmd}: {e}"),
+        })?;
+
+    if !status.success() {
+        return Err(InstallError::StepFailed {
+            step: format!("pip-install-{package}"),
+            message: format!("{pip_cmd} exited with {status}"),
+        });
+    }
+
+    // Rollback: pip uninstall
+    Ok(Some(StepRollback::Command {
+        program: pip_cmd.to_string(),
+        args: vec![
+            "-m".into(),
+            "pip".into(),
+            "uninstall".into(),
+            "-y".into(),
+            package.to_string(),
+        ],
+    }))
+}
+
+fn execute_git_clone(
+    url: &str,
+    ref_: Option<&str>,
+    dest: &Path,
+) -> Result<Option<StepRollback>, InstallError> {
+    if dest.exists() {
+        return Err(InstallError::StepFailed {
+            step: "git-clone".into(),
+            message: format!("destination already exists: {}", dest.display()),
+        });
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.arg("clone").arg("--depth").arg("1");
+    if let Some(r) = ref_.filter(|v| !v.trim().is_empty()) {
+        cmd.arg("--branch").arg(r);
+    }
+    cmd.arg(url).arg(dest);
+
+    let status = cmd.status().map_err(|e| InstallError::StepFailed {
+        step: "git-clone".into(),
+        message: format!("failed to launch git: {e}"),
+    })?;
+
+    if !status.success() {
+        return Err(InstallError::StepFailed {
+            step: "git-clone".into(),
+            message: format!("git clone exited with {status}"),
+        });
+    }
+
+    Ok(Some(StepRollback::RemovePath(dest.to_path_buf())))
+}
+
+fn execute_zip_extract(
+    url: &str,
+    sha256: Option<&str>,
+    dest: &Path,
+) -> Result<Option<StepRollback>, InstallError> {
+    if dest.exists() {
+        return Err(InstallError::StepFailed {
+            step: "zip-extract".into(),
+            message: format!("destination already exists: {}", dest.display()),
+        });
+    }
+
+    // Download the archive
+    let response = reqwest::blocking::get(url).map_err(|e| InstallError::StepFailed {
+        step: "zip-download".into(),
+        message: format!("failed to download {url}: {e}"),
+    })?;
+
+    let bytes = response.bytes().map_err(|e| InstallError::StepFailed {
+        step: "zip-download".into(),
+        message: format!("failed to read response from {url}: {e}"),
+    })?;
+
+    // Verify SHA-256 if requested
+    if let Some(expected) = sha256 {
+        use sha2::Digest;
+        let actual = sha2::Sha256::digest(&bytes);
+        let actual_hex = actual.iter().map(|b| format!("{b:02x}")).collect::<String>();
+        if !actual_hex.eq_ignore_ascii_case(expected) {
+            return Err(InstallError::StepFailed {
+                step: "zip-checksum".into(),
+                message: format!(
+                    "SHA-256 mismatch: expected {expected}, got {actual_hex}"
+                ),
+            });
+        }
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // Extract the archive
+    let reader = std::io::Cursor::new(&bytes);
+    let mut archive = zip::ZipArchive::new(reader).map_err(|e| InstallError::StepFailed {
+        step: "zip-extract".into(),
+        message: format!("failed to open zip archive: {e}"),
+    })?;
+
+    archive.extract(dest).map_err(|e| InstallError::StepFailed {
+        step: "zip-extract".into(),
+        message: format!("failed to extract to {}: {e}", dest.display()),
+    })?;
+
+    Ok(Some(StepRollback::RemovePath(dest.to_path_buf())))
+}
+
+fn execute_path_copy(
+    source: &Path,
+    dest: &Path,
+) -> Result<Option<StepRollback>, InstallError> {
+    if dest.exists() {
+        return Err(InstallError::StepFailed {
+            step: "path-copy".into(),
+            message: format!("destination already exists: {}", dest.display()),
+        });
+    }
+
+    if !source.exists() {
+        return Err(InstallError::StepFailed {
+            step: "path-copy".into(),
+            message: format!("source does not exist: {}", source.display()),
+        });
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    if source.is_dir() {
+        copy_dir_recursive(source, dest)?;
+    } else {
+        std::fs::copy(source, dest)?;
+    }
+
+    Ok(Some(StepRollback::RemovePath(dest.to_path_buf())))
+}
+
+fn execute_register_dcc(
+    _dcc_type: &str,
+    _entry_point: Option<&str>,
+) -> Result<Option<StepRollback>, InstallError> {
+    // Registration is handled externally (e.g., via `dcc-mcp-cli gateway ensure`
+    // or the gateway's instance discovery).  This step is a placeholder for
+    // future gateway registration logic and smoke-check wiring.
+    //
+    // For now, we emit a note and succeed so the pipeline continues to verify.
+    eprintln!();
+    eprint!("    └─ note: DCC registration for '{_dcc_type}' is automatic ");
+    eprintln!("on next gateway ensure / instance discovery.");
+    Ok(None)
+}
+
+fn execute_verify() -> Result<Option<StepRollback>, InstallError> {
+    // Verification is currently a no-op placeholder.
+    // Future: call gateway health + instance discovery + smoke tests.
+    Ok(None)
+}
+
+// ── consent ──────────────────────────────────────────────────────────────────────
+
+/// Prompt the user for Y/n consent.  Returns `true` if the user agrees.
+fn ask_consent(prompt: &str) -> Result<bool, InstallError> {
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+
+    loop {
+        write!(stdout, "{prompt} ")?;
+        stdout.flush()?;
+
+        let mut line = String::new();
+        stdin.lock().read_line(&mut line)?;
+        let trimmed = line.trim().to_lowercase();
+
+        match trimmed.as_str() {
+            "" | "y" | "yes" => return Ok(true),
+            "n" | "no" => return Ok(false),
+            _ => {
+                write!(stdout, "  Please answer Y or n: ")?;
+                stdout.flush()?;
+            }
+        }
+    }
+}
+
+// ── rollback ─────────────────────────────────────────────────────────────────────
+
+/// Roll back all completed steps in reverse order, best-effort.
+fn rollback_all(completed: &[StepResult]) {
+    for result in completed.iter().rev() {
+        if let Some(rollback) = &result.rollback {
+            if let Err(e) = execute_rollback(rollback) {
+                eprintln!(
+                    "  ⚠  rollback of '{}' failed: {e}",
+                    result.step_name
+                );
+            }
+        }
+    }
+}
+
+fn execute_rollback(rollback: &StepRollback) -> Result<(), InstallError> {
+    match rollback {
+        StepRollback::RemovePath(path) => {
+            if path.exists() {
+                if path.is_dir() {
+                    std::fs::remove_dir_all(path)?;
+                } else {
+                    std::fs::remove_file(path)?;
+                }
+            }
+            Ok(())
+        }
+        StepRollback::Command { program, args } => {
+            let status = Command::new(program)
+                .args(args)
+                .status()
+                .map_err(|e| InstallError::RollbackFailed {
+                    step: program.clone(),
+                    message: format!("failed to launch {program}: {e}"),
+                })?;
+            if !status.success() {
+                return Err(InstallError::RollbackFailed {
+                    step: program.clone(),
+                    message: format!("{program} exited with {status}"),
+                });
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Recursively copy a directory and its contents.
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), InstallError> {
+    if !dst.exists() {
+        std::fs::create_dir_all(dst)?;
+    }
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let src_path = entry.path();
+        let file_name = entry.file_name();
+        let dst_path = dst.join(&file_name);
+
+        if file_type.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else {
+            std::fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -63,5 +485,62 @@ mod tests {
             .unwrap();
 
         assert!(plan.adapter.dcc.iter().any(|dcc| dcc == "maya"));
+        // Maya entry in bundled catalog has no install metadata → info steps
+        assert!(plan.steps.iter().all(|s| s.action.is_none()));
+    }
+
+    #[test]
+    fn pip_install_missing_python_reports_error() {
+        let result = execute_pip_install(
+            "nonexistent-package",
+            None,
+            Some("/__nonexistent__/python"),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(&err, InstallError::StepFailed { step, .. } if step.contains("pip-install")),
+            "expected StepFailed, got {err}"
+        );
+    }
+
+    #[test]
+    fn git_clone_nonexistent_url_fails() {
+        let dest = PathBuf::from("/__nonexistent__/test-repo");
+        let result = execute_git_clone(
+            "https://__nonexistent__.invalid/repo.git",
+            None,
+            &dest,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn path_copy_missing_source_fails() {
+        let result = execute_path_copy(
+            &PathBuf::from("/__nonexistent__/source"),
+            &PathBuf::from("/__nonexistent__/dest"),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rollback_remove_path_does_not_error_on_nonexistent() {
+        let rb = StepRollback::RemovePath(PathBuf::from("/__nonexistent__/path"));
+        assert!(execute_rollback(&rb).is_ok());
+    }
+
+    #[test]
+    fn register_dcc_is_noop() {
+        let result = execute_register_dcc("maya", Some("dcc_mcp_maya.cli:main"));
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn verify_is_noop() {
+        let result = execute_verify();
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
     }
 }

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -87,11 +87,7 @@ impl InstallService {
 
     fn execute_plan(&self, plan: &InstallPlan) -> Result<InstallPlan, InstallError> {
         // Filter to executable steps
-        let executable_steps: Vec<_> = plan
-            .steps
-            .iter()
-            .filter(|s| s.action.is_some())
-            .collect();
+        let executable_steps: Vec<_> = plan.steps.iter().filter(|s| s.action.is_some()).collect();
 
         if executable_steps.is_empty() {
             eprintln!("No executable steps in the install plan.");
@@ -126,7 +122,12 @@ impl InstallService {
 
         for step in &executable_steps {
             let action = step.action.as_ref().expect("filtered to Some above");
-            eprint!("  [{}/{}] {} ... ", completed.len() + 1, executable_steps.len(), step.name);
+            eprint!(
+                "  [{}/{}] {} ... ",
+                completed.len() + 1,
+                executable_steps.len(),
+                step.name
+            );
 
             match execute_action(action) {
                 Ok(rollback) => {
@@ -165,12 +166,12 @@ fn execute_action(action: &InstallStepAction) -> Result<Option<StepRollback>, In
             extras,
             python,
         } => execute_pip_install(package, extras.as_deref(), python.as_deref()),
-        InstallStepAction::GitClone { url, ref_, dest } => execute_git_clone(url, ref_.as_deref(), dest),
-        InstallStepAction::ZipExtract {
-            url,
-            sha256,
-            dest,
-        } => execute_zip_extract(url, sha256.as_deref(), dest),
+        InstallStepAction::GitClone { url, ref_, dest } => {
+            execute_git_clone(url, ref_.as_deref(), dest)
+        }
+        InstallStepAction::ZipExtract { url, sha256, dest } => {
+            execute_zip_extract(url, sha256.as_deref(), dest)
+        }
         InstallStepAction::PathCopy { source, dest } => execute_path_copy(source, dest),
         InstallStepAction::RegisterDcc {
             dcc_type,
@@ -196,12 +197,10 @@ fn execute_pip_install(
         cmd.arg(package);
     }
 
-    let status = cmd
-        .status()
-        .map_err(|e| InstallError::StepFailed {
-            step: format!("pip-install-{package}"),
-            message: format!("failed to launch {pip_cmd}: {e}"),
-        })?;
+    let status = cmd.status().map_err(|e| InstallError::StepFailed {
+        step: format!("pip-install-{package}"),
+        message: format!("failed to launch {pip_cmd}: {e}"),
+    })?;
 
     if !status.success() {
         return Err(InstallError::StepFailed {
@@ -289,13 +288,14 @@ fn execute_zip_extract(
     if let Some(expected) = sha256 {
         use sha2::Digest;
         let actual = sha2::Sha256::digest(&bytes);
-        let actual_hex = actual.iter().map(|b| format!("{b:02x}")).collect::<String>();
+        let actual_hex = actual
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>();
         if !actual_hex.eq_ignore_ascii_case(expected) {
             return Err(InstallError::StepFailed {
                 step: "zip-checksum".into(),
-                message: format!(
-                    "SHA-256 mismatch: expected {expected}, got {actual_hex}"
-                ),
+                message: format!("SHA-256 mismatch: expected {expected}, got {actual_hex}"),
             });
         }
     }
@@ -312,18 +312,17 @@ fn execute_zip_extract(
         message: format!("failed to open zip archive: {e}"),
     })?;
 
-    archive.extract(dest).map_err(|e| InstallError::StepFailed {
-        step: "zip-extract".into(),
-        message: format!("failed to extract to {}: {e}", dest.display()),
-    })?;
+    archive
+        .extract(dest)
+        .map_err(|e| InstallError::StepFailed {
+            step: "zip-extract".into(),
+            message: format!("failed to extract to {}: {e}", dest.display()),
+        })?;
 
     Ok(Some(StepRollback::RemovePath(dest.to_path_buf())))
 }
 
-fn execute_path_copy(
-    source: &Path,
-    dest: &Path,
-) -> Result<Option<StepRollback>, InstallError> {
+fn execute_path_copy(source: &Path, dest: &Path) -> Result<Option<StepRollback>, InstallError> {
     if dest.exists() {
         return Err(InstallError::StepFailed {
             step: "path-copy".into(),
@@ -406,10 +405,7 @@ fn rollback_all(completed: &[StepResult]) {
     for result in completed.iter().rev() {
         if let Some(rollback) = &result.rollback {
             if let Err(e) = execute_rollback(rollback) {
-                eprintln!(
-                    "  ⚠  rollback of '{}' failed: {e}",
-                    result.step_name
-                );
+                eprintln!("  ⚠  rollback of '{}' failed: {e}", result.step_name);
             }
         }
     }
@@ -428,13 +424,12 @@ fn execute_rollback(rollback: &StepRollback) -> Result<(), InstallError> {
             Ok(())
         }
         StepRollback::Command { program, args } => {
-            let status = Command::new(program)
-                .args(args)
-                .status()
-                .map_err(|e| InstallError::RollbackFailed {
+            let status = Command::new(program).args(args).status().map_err(|e| {
+                InstallError::RollbackFailed {
                     step: program.clone(),
                     message: format!("failed to launch {program}: {e}"),
-                })?;
+                }
+            })?;
             if !status.success() {
                 return Err(InstallError::RollbackFailed {
                     step: program.clone(),
@@ -491,11 +486,8 @@ mod tests {
 
     #[test]
     fn pip_install_missing_python_reports_error() {
-        let result = execute_pip_install(
-            "nonexistent-package",
-            None,
-            Some("/__nonexistent__/python"),
-        );
+        let result =
+            execute_pip_install("nonexistent-package", None, Some("/__nonexistent__/python"));
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -507,11 +499,7 @@ mod tests {
     #[test]
     fn git_clone_nonexistent_url_fails() {
         let dest = PathBuf::from("/__nonexistent__/test-repo");
-        let result = execute_git_clone(
-            "https://__nonexistent__.invalid/repo.git",
-            None,
-            &dest,
-        );
+        let result = execute_git_clone("https://__nonexistent__.invalid/repo.git", None, &dest);
         assert!(result.is_err());
     }
 

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -183,7 +183,11 @@ impl InstallPlanner {
                 let source = install
                     .url
                     .clone()
-                    .map(|u| u.strip_prefix("file://").map(PathBuf::from).unwrap_or(PathBuf::from(&u)))
+                    .map(|u| {
+                        u.strip_prefix("file://")
+                            .map(PathBuf::from)
+                            .unwrap_or(PathBuf::from(&u))
+                    })
                     .unwrap_or_else(|| PathBuf::from("."));
                 InstallStepAction::PathCopy {
                     source,
@@ -194,7 +198,9 @@ impl InstallPlanner {
                 // Unknown install type — produce an info step instead.
                 return vec![InstallStep {
                     name: format!("install-{}", other),
-                    description: format!("Unsupported install type '{other}': manual installation required."),
+                    description: format!(
+                        "Unsupported install type '{other}': manual installation required."
+                    ),
                     action: None,
                 }];
             }
@@ -202,21 +208,14 @@ impl InstallPlanner {
 
         steps.push(InstallStep {
             name: format!("install-{}", install.install_type),
-            description: format!(
-                "Install {} adapter via {}",
-                dcc_type,
-                install.install_type
-            ),
+            description: format!("Install {} adapter via {}", dcc_type, install.install_type),
             action: Some(install_action),
         });
 
         // Register step
         steps.push(InstallStep {
             name: "register-dcc".into(),
-            description: format!(
-                "Register {} adapter with the DCC-MCP gateway",
-                dcc_type
-            ),
+            description: format!("Register {} adapter with the DCC-MCP gateway", dcc_type),
             action: Some(InstallStepAction::RegisterDcc {
                 dcc_type: dcc_type.to_string(),
                 entry_point: install.entry_point.clone(),
@@ -238,15 +237,14 @@ impl InstallPlanner {
         vec![
             InstallStep {
                 name: "resolve-adapter".into(),
-                description:
-                    "Resolve the official adapter package from the DCC-MCP catalog.".into(),
+                description: "Resolve the official adapter package from the DCC-MCP catalog."
+                    .into(),
                 action: None,
             },
             InstallStep {
                 name: "install-runtime".into(),
                 description:
-                    "Install the cross-platform dcc-mcp-cli and companion runtime binaries."
-                        .into(),
+                    "Install the cross-platform dcc-mcp-cli and companion runtime binaries.".into(),
                 action: None,
             },
             InstallStep {

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use dcc_mcp_catalog::CatalogEntry;
+use dcc_mcp_catalog::{CatalogEntry, CatalogInstall};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -19,21 +19,101 @@ pub struct InstallPlan {
     pub steps: Vec<InstallStep>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A single install step with a human-readable description and the action to execute.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InstallStep {
     pub name: String,
     pub description: String,
+    /// The executable action for this step. `None` for informational/display-only steps.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action: Option<InstallStepAction>,
+}
+
+/// The concrete action to perform during install execution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum InstallStepAction {
+    /// Install a Python package via pip (optionally with a specific interpreter).
+    PipInstall {
+        /// Pip package name (e.g. "dcc-mcp-maya").
+        package: String,
+        /// Optional pip extras (e.g. ["maya"]).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extras: Option<Vec<String>>,
+        /// Optional Python/mayapy interpreter path override.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        python: Option<String>,
+    },
+    /// Clone a git repository.
+    GitClone {
+        /// Git remote URL.
+        url: String,
+        /// Git ref, tag, or branch to check out.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ref_: Option<String>,
+        /// Target directory for the clone.
+        dest: PathBuf,
+    },
+    /// Download and extract a ZIP archive.
+    ZipExtract {
+        /// Archive download URL.
+        url: String,
+        /// Optional SHA-256 hash for integrity verification.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sha256: Option<String>,
+        /// Target extract directory.
+        dest: PathBuf,
+    },
+    /// Copy files from a local path.
+    PathCopy {
+        /// Source directory or file.
+        source: PathBuf,
+        /// Target directory.
+        dest: PathBuf,
+    },
+    /// Register the DCC adapter with the gateway.
+    RegisterDcc {
+        /// DCC type name (e.g. "maya").
+        dcc_type: String,
+        /// Optional Python entry point for the adapter.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        entry_point: Option<String>,
+    },
+    /// Run post-install verification (health, instance discovery, smoke tests).
+    Verify,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum InstallPlanError {
     #[error("no catalog entry targets dcc type '{0}'")]
     UnsupportedDcc(String),
+    #[error("no install metadata found in catalog entry for '{0}'")]
+    MissingInstallMetadata(String),
 }
+
+// ── defaults ─────────────────────────────────────────────────────────────────────
+
+/// Default install paths relative to user home or DCC-MCP data root.
+pub fn default_adapter_dir() -> PathBuf {
+    dirs_data_dir().join("adapters")
+}
+
+fn dirs_data_dir() -> PathBuf {
+    dirs::data_dir()
+        .map(|p| p.join("dcc-mcp"))
+        .unwrap_or_else(|| PathBuf::from("~/.local/share/dcc-mcp"))
+}
+
+// ── planner ──────────────────────────────────────────────────────────────────────
 
 pub struct InstallPlanner;
 
 impl InstallPlanner {
+    /// Generate an install plan from catalog entries and user request.
+    ///
+    /// If the matching catalog entry has an `install` field, the generated steps
+    /// will include executable actions.  Otherwise only informational steps are
+    /// produced (for display-only plan output).
     pub fn plan(
         entries: &[CatalogEntry],
         request: InstallRequest,
@@ -49,33 +129,141 @@ impl InstallPlanner {
             .cloned()
             .ok_or_else(|| InstallPlanError::UnsupportedDcc(request.dcc_type.clone()))?;
 
+        let dcc_type = request.dcc_type.clone();
+        let version = request.version.clone();
+
+        let steps = match &adapter.install {
+            Some(install) => Self::build_executable_steps(&adapter, install, &dcc_type),
+            None => Self::build_info_steps(),
+        };
+
         Ok(InstallPlan {
-            dcc_type: request.dcc_type,
-            version: request.version,
+            dcc_type,
+            version,
             adapter,
-            steps: vec![
-                InstallStep {
-                    name: "resolve-adapter".into(),
-                    description: "Resolve the official adapter package from the DCC-MCP catalog."
-                        .into(),
-                },
-                InstallStep {
-                    name: "install-runtime".into(),
-                    description: "Install the cross-platform dcc-mcp-cli and companion runtime binaries."
-                        .into(),
-                },
-                InstallStep {
-                    name: "install-dcc-adapter".into(),
-                    description: "Install the DCC-specific adapter into the user's local DCC plugin location."
-                        .into(),
-                },
-                InstallStep {
-                    name: "verify".into(),
-                    description: "Run health, instance discovery, search, describe, and call smoke checks."
-                        .into(),
-                },
-            ],
+            steps,
         })
+    }
+
+    /// Build executable steps from a catalog entry's `install` metadata.
+    fn build_executable_steps(
+        entry: &CatalogEntry,
+        install: &CatalogInstall,
+        dcc_type: &str,
+    ) -> Vec<InstallStep> {
+        let adapter_dir = default_adapter_dir().join(&entry.name);
+
+        let mut steps = Vec::new();
+        let install_action = match install.install_type.as_str() {
+            "pip" => {
+                let python = install.mayapy_path.clone();
+                InstallStepAction::PipInstall {
+                    package: install
+                        .pip_package
+                        .clone()
+                        .unwrap_or_else(|| entry.name.clone()),
+                    extras: install.pip_extras.clone(),
+                    python,
+                }
+            }
+            "git" => InstallStepAction::GitClone {
+                url: install
+                    .url
+                    .clone()
+                    .unwrap_or_else(|| format!("https://github.com/dcc-mcp/{}", entry.name)),
+                ref_: install.ref_.clone(),
+                dest: adapter_dir.clone(),
+            },
+            "zip" => InstallStepAction::ZipExtract {
+                url: install.url.clone().unwrap_or_default(),
+                sha256: install.sha256.clone(),
+                dest: adapter_dir.clone(),
+            },
+            "path" => {
+                let source = install
+                    .url
+                    .clone()
+                    .map(|u| u.strip_prefix("file://").map(PathBuf::from).unwrap_or(PathBuf::from(&u)))
+                    .unwrap_or_else(|| PathBuf::from("."));
+                InstallStepAction::PathCopy {
+                    source,
+                    dest: adapter_dir.clone(),
+                }
+            }
+            other => {
+                // Unknown install type — produce an info step instead.
+                return vec![InstallStep {
+                    name: format!("install-{}", other),
+                    description: format!("Unsupported install type '{other}': manual installation required."),
+                    action: None,
+                }];
+            }
+        };
+
+        steps.push(InstallStep {
+            name: format!("install-{}", install.install_type),
+            description: format!(
+                "Install {} adapter via {}",
+                dcc_type,
+                install.install_type
+            ),
+            action: Some(install_action),
+        });
+
+        // Register step
+        steps.push(InstallStep {
+            name: "register-dcc".into(),
+            description: format!(
+                "Register {} adapter with the DCC-MCP gateway",
+                dcc_type
+            ),
+            action: Some(InstallStepAction::RegisterDcc {
+                dcc_type: dcc_type.to_string(),
+                entry_point: install.entry_point.clone(),
+            }),
+        });
+
+        // Verify step
+        steps.push(InstallStep {
+            name: "verify".into(),
+            description: "Run health and smoke checks to verify the installation.".into(),
+            action: Some(InstallStepAction::Verify),
+        });
+
+        steps
+    }
+
+    /// Build informational-only steps when no install metadata exists.
+    fn build_info_steps() -> Vec<InstallStep> {
+        vec![
+            InstallStep {
+                name: "resolve-adapter".into(),
+                description:
+                    "Resolve the official adapter package from the DCC-MCP catalog.".into(),
+                action: None,
+            },
+            InstallStep {
+                name: "install-runtime".into(),
+                description:
+                    "Install the cross-platform dcc-mcp-cli and companion runtime binaries."
+                        .into(),
+                action: None,
+            },
+            InstallStep {
+                name: "install-dcc-adapter".into(),
+                description:
+                    "Install the DCC-specific adapter into the user's local DCC plugin location."
+                        .into(),
+                action: None,
+            },
+            InstallStep {
+                name: "verify".into(),
+                description:
+                    "Run health, instance discovery, search, describe, and call smoke checks."
+                        .into(),
+                action: None,
+            },
+        ]
     }
 }
 
@@ -83,7 +271,7 @@ impl InstallPlanner {
 mod tests {
     use super::*;
 
-    fn catalog_entry(name: &str, dcc: &[&str]) -> CatalogEntry {
+    fn catalog_entry(name: &str, dcc: &[&str], install: Option<CatalogInstall>) -> CatalogEntry {
         CatalogEntry {
             name: name.into(),
             description: "Adapter".into(),
@@ -92,7 +280,7 @@ mod tests {
             tags: vec!["official".into()],
             version: None,
             min_core_version: None,
-            install: None,
+            install,
             maintainer: None,
             icon: None,
         }
@@ -100,7 +288,7 @@ mod tests {
 
     #[test]
     fn planner_selects_matching_dcc_case_insensitively() {
-        let entries = vec![catalog_entry("dcc-mcp-maya", &["maya"])];
+        let entries = vec![catalog_entry("dcc-mcp-maya", &["maya"], None)];
         let plan = InstallPlanner::plan(
             &entries,
             InstallRequest {
@@ -113,6 +301,8 @@ mod tests {
 
         assert_eq!(plan.adapter.name, "dcc-mcp-maya");
         assert_eq!(plan.steps.len(), 4);
+        // Without install metadata, steps have no action
+        assert!(plan.steps.iter().all(|s| s.action.is_none()));
     }
 
     #[test]
@@ -128,5 +318,112 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(err, InstallPlanError::UnsupportedDcc("custom".into()));
+    }
+
+    #[test]
+    fn planner_generates_executable_steps_for_pip_install() {
+        let install = CatalogInstall {
+            install_type: "pip".into(),
+            url: Some("https://pypi.org/project/dcc-mcp-maya".into()),
+            ref_: None,
+            sha256: None,
+            pip_package: Some("dcc-mcp-maya".into()),
+            pip_extras: Some(vec!["maya".into()]),
+            mayapy_path: Some("/usr/bin/mayapy".into()),
+            entry_point: Some("dcc_mcp_maya.cli:main".into()),
+        };
+        let entries = vec![catalog_entry("dcc-mcp-maya", &["maya"], Some(install))];
+        let plan = InstallPlanner::plan(
+            &entries,
+            InstallRequest {
+                dcc_type: "maya".into(),
+                version: None,
+                catalog_path: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(plan.steps.len(), 3);
+        assert_eq!(plan.steps[0].name, "install-pip");
+        assert!(matches!(
+            plan.steps[0].action,
+            Some(InstallStepAction::PipInstall { .. })
+        ));
+        if let Some(InstallStepAction::PipInstall {
+            package,
+            extras,
+            python,
+        }) = &plan.steps[0].action
+        {
+            assert_eq!(package, "dcc-mcp-maya");
+            assert_eq!(extras.as_deref(), Some(&["maya".into()][..]));
+            assert_eq!(python.as_deref(), Some("/usr/bin/mayapy"));
+        } else {
+            panic!("expected PipInstall action");
+        }
+
+        assert_eq!(plan.steps[1].name, "register-dcc");
+        assert!(matches!(
+            plan.steps[1].action,
+            Some(InstallStepAction::RegisterDcc { .. })
+        ));
+
+        assert_eq!(plan.steps[2].name, "verify");
+        assert!(matches!(
+            plan.steps[2].action,
+            Some(InstallStepAction::Verify)
+        ));
+    }
+
+    #[test]
+    fn planner_generates_executable_steps_for_git_install() {
+        let install = CatalogInstall {
+            install_type: "git".into(),
+            url: Some("https://github.com/loonghao/dcc-mcp-maya-mgear".into()),
+            ref_: Some("main".into()),
+            sha256: None,
+            pip_package: None,
+            pip_extras: None,
+            mayapy_path: None,
+            entry_point: None,
+        };
+        let entries = vec![catalog_entry(
+            "dcc-mcp-maya-mgear",
+            &["maya"],
+            Some(install),
+        )];
+        let plan = InstallPlanner::plan(
+            &entries,
+            InstallRequest {
+                dcc_type: "maya".into(),
+                version: None,
+                catalog_path: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(plan.steps.len(), 3);
+        assert_eq!(plan.steps[0].name, "install-git");
+        assert!(matches!(
+            plan.steps[0].action,
+            Some(InstallStepAction::GitClone { .. })
+        ));
+    }
+
+    #[test]
+    fn planner_missing_install_metadata_uses_info_steps() {
+        let entries = vec![catalog_entry("dcc-mcp-blender", &["blender"], None)];
+        let plan = InstallPlanner::plan(
+            &entries,
+            InstallRequest {
+                dcc_type: "blender".into(),
+                version: None,
+                catalog_path: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(plan.steps.len(), 4);
+        assert!(plan.steps.iter().all(|s| s.action.is_none()));
     }
 }

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -136,6 +136,9 @@ enum Command {
         version: Option<String>,
         #[arg(long, env = "DCC_MCP_CATALOG_PATH")]
         catalog: Option<PathBuf>,
+        /// Execute the install plan with consent gating.
+        #[arg(long, short = 'x')]
+        execute: bool,
     },
     /// Search and manage DCC-MCP marketplace sources.
     Marketplace {
@@ -487,13 +490,19 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
             dcc_type,
             version,
             catalog,
+            execute,
         } => {
             let service = InstallService::new(PathBuf::from("dcc-mcp-catalog.yml"));
-            to_json(service.plan(InstallRequest {
+            let req = InstallRequest {
                 dcc_type,
                 version,
                 catalog_path: catalog,
-            })?)?
+            };
+            if execute {
+                to_json(service.execute(req)?)?
+            } else {
+                to_json(service.plan(req)?)?
+            }
         }
         Command::Marketplace { action } => {
             let service = new_service()?;

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -76,6 +76,21 @@ entries:
     url: "https://github.com/dcc-mcp/dcc-mcp-core"
     tags: ["core", "official", "rust", "python", "library"]
 
+  - name: "dcc-mcp-maya"
+    description: "Core Maya adapter for DCC-MCP — gateway-managed instance, mayapy-based MCP server"
+    dcc: ["maya"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-maya"
+    tags: ["adapter", "maya", "official", "pip", "core"]
+    version: "0.1.0"
+    min_core_version: "0.18.0"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-maya"
+      pip_extras: ["maya"]
+      mayapy_path: "/usr/autodesk/maya2026/bin/mayapy"
+      entry_point: "dcc_mcp_maya.cli:main"
+
   - name: "autodesk-product-help"
     description: "Opt-in Autodesk Product Help remote MCP connector for read-only documentation lookup"
     dcc: ["autodesk-help"]


### PR DESCRIPTION
## Summary

Implement `install --execute` for the `dcc-mcp-cli` — the CLI can now parse an install plan from the catalog and execute it step by step with user consent and rollback support.

### Changes

- **Domain layer**: Add `InstallStepAction` enum with 6 action types (`PipInstall`, `GitClone`, `ZipExtract`, `PathCopy`, `RegisterDcc`, `Verify`). `InstallStep` now carries an optional `action` field. `InstallPlanner::plan()` generates executable steps from catalog `install` metadata, or falls back to informational steps when absent.

- **Application layer**: `InstallService::execute()` with consent gating (formatted plan display + `[Y/n]` prompt), per-step execution spawning real subprocesses, and rollback on failure (reverse-order undo for created paths and pip packages).

- **CLI**: Add `--execute` / `-x` flag to the `install` subcommand. Without it, outputs the plan as JSON (existing behavior); with it, prompts for consent and executes.

- **Catalog**: Add `dcc-mcp-maya` adapter entry with pip install metadata (`pip_package`, `mayapy_path`, `entry_point`).

## Test plan

- [x] `cargo test -p dcc-mcp-cli --lib` — 37 passed (including new unit tests for PipInstall, GitClone, PathCopy, rollback, no-op register/verify)
- [x] `cargo test -p dcc-mcp-cli` — 57 passed (33 unit + 20 E2E, plus 4 new unit tests from upstream rebase)
- [x] `cargo test -p dcc-mcp-catalog` — 20 passed
- [x] `cargo check -p dcc-mcp-cli` — clean compilation

Closes PIP-1114