### PR TITLE
fix(p0-1): add retry, strict-gateway mode, and metadata visibility for embedded fallback (PIP-1398)

### DIFF
--- a/python/dcc_mcp_core/_server/lifecycle_controller.py
+++ b/python/dcc_mcp_core/_server/lifecycle_controller.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import json
 import logging
 from typing import Any
 import weakref
@@ -132,12 +133,28 @@ class LifecycleController:
             gateway_recovery_driver = "daemon_guardian"
         elif runtime_mode == "embedded-fallback":
             gateway_recovery_driver = "embedded_election"
-        return {
+        meta: dict[str, str] = {
             "gateway_runtime_mode": runtime_mode,
             "gateway_guardian_enabled": str(bool(guardian_running)).lower(),
             "gateway_recovery_driver": gateway_recovery_driver,
             "registration_refresh_mode": "file_registry_heartbeat",
         }
+        # Surface gateway_daemon_status reason for embedded-fallback visibility.
+        if runtime_mode == "embedded-fallback":
+            daemon_status = getattr(owner, "_gateway_daemon_status", None)
+            if daemon_status:
+                meta["gateway_daemon_status_reason"] = str(
+                    daemon_status.get("reason", "unknown")
+                )
+                meta["gateway_daemon_status_ok"] = str(
+                    bool(daemon_status.get("ok", False))
+                ).lower()
+                # Include full status as JSON for debugging.
+                with contextlib.suppress(TypeError, ValueError):
+                    meta["gateway_daemon_status"] = json.dumps(
+                        daemon_status, default=str
+                    )
+        return meta
 
     def _stage_gateway_runtime_metadata(self) -> None:
         owner = self._owner

--- a/python/dcc_mcp_core/_server/lifecycle_controller.py
+++ b/python/dcc_mcp_core/_server/lifecycle_controller.py
@@ -143,17 +143,11 @@ class LifecycleController:
         if runtime_mode == "embedded-fallback":
             daemon_status = getattr(owner, "_gateway_daemon_status", None)
             if daemon_status:
-                meta["gateway_daemon_status_reason"] = str(
-                    daemon_status.get("reason", "unknown")
-                )
-                meta["gateway_daemon_status_ok"] = str(
-                    bool(daemon_status.get("ok", False))
-                ).lower()
+                meta["gateway_daemon_status_reason"] = str(daemon_status.get("reason", "unknown"))
+                meta["gateway_daemon_status_ok"] = str(bool(daemon_status.get("ok", False))).lower()
                 # Include full status as JSON for debugging.
                 with contextlib.suppress(TypeError, ValueError):
-                    meta["gateway_daemon_status"] = json.dumps(
-                        daemon_status, default=str
-                    )
+                    meta["gateway_daemon_status"] = json.dumps(daemon_status, default=str)
         return meta
 
     def _stage_gateway_runtime_metadata(self) -> None:

--- a/python/dcc_mcp_core/_server/runtime.py
+++ b/python/dcc_mcp_core/_server/runtime.py
@@ -35,10 +35,7 @@ class ServerRuntimeController:
             owner._gateway_runtime_mode = "failover_disabled_by_adapter"
             return False
 
-        strict_gateway = (
-            os.environ.get("DCC_MCP_STRICT_GATEWAY", "").strip().lower()
-            in {"1", "true", "yes", "on"}
-        )
+        strict_gateway = os.environ.get("DCC_MCP_STRICT_GATEWAY", "").strip().lower() in {"1", "true", "yes", "on"}
 
         dcc_type = str(getattr(owner, "_dcc_name", "dcc"))
         registry_dir = getattr(owner._config, "registry_dir", None)

--- a/python/dcc_mcp_core/_server/runtime.py
+++ b/python/dcc_mcp_core/_server/runtime.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
+import time
 from typing import Any
 
 from dcc_mcp_core._server.gateway_guardian import GatewayDaemonGuardian
@@ -33,21 +35,64 @@ class ServerRuntimeController:
             owner._gateway_runtime_mode = "failover_disabled_by_adapter"
             return False
 
-        result = ensure_gateway_daemon(
-            gateway_host="127.0.0.1",
-            gateway_port=gateway_port,
-            registry_dir=getattr(owner._config, "registry_dir", None),
-            dcc_type=str(getattr(owner, "_dcc_name", "dcc")),
+        strict_gateway = (
+            os.environ.get("DCC_MCP_STRICT_GATEWAY", "").strip().lower()
+            in {"1", "true", "yes", "on"}
         )
-        owner._gateway_daemon_status = dict(result)
-        if result.get("ok"):
-            owner._gateway_runtime_mode = "daemon-backed"
-            return True
+
+        dcc_type = str(getattr(owner, "_dcc_name", "dcc"))
+        registry_dir = getattr(owner._config, "registry_dir", None)
+        retry_count = 2  # additional retries after first attempt
+        retry_interval_secs = 2.0
+
+        result: dict[str, Any] = {}
+        for attempt in range(1 + retry_count):
+            result = ensure_gateway_daemon(
+                gateway_host="127.0.0.1",
+                gateway_port=gateway_port,
+                registry_dir=registry_dir,
+                dcc_type=dcc_type,
+            )
+            owner._gateway_daemon_status = dict(result)
+            if result.get("ok"):
+                owner._gateway_runtime_mode = "daemon-backed"
+                if attempt > 0:
+                    logger.info(
+                        "[%s] Gateway daemon ensure succeeded on retry %d/%d",
+                        owner._dcc_name,
+                        attempt,
+                        retry_count,
+                    )
+                return True
+            if attempt < retry_count:
+                logger.warning(
+                    "[%s] Gateway daemon ensure attempt %d/%d failed (%s), retrying in %.1fs...",
+                    owner._dcc_name,
+                    attempt + 1,
+                    1 + retry_count,
+                    result.get("reason", "unknown"),
+                    retry_interval_secs,
+                )
+                time.sleep(retry_interval_secs)
+
+        # All attempts failed.
+        reason = result.get("reason", "unknown") if result else "unknown"
+        gateway_daemon_status = dict(result) if result else {}
+
+        if strict_gateway:
+            raise RuntimeError(
+                f"[{owner._dcc_name}] DCC_MCP_STRICT_GATEWAY is enabled and "
+                f"gateway daemon ensure failed after {1 + retry_count} attempts: "
+                f"{reason}. gateway_daemon_status={gateway_daemon_status!r}"
+            )
+
         owner._gateway_runtime_mode = "embedded-fallback"
+        owner._gateway_daemon_status = gateway_daemon_status
         logger.warning(
-            "[%s] Gateway daemon ensure failed (%s), falling back to embedded election",
+            "[%s] Gateway daemon ensure failed after %d attempts (%s), falling back to embedded election",
             owner._dcc_name,
-            result.get("reason", "unknown"),
+            1 + retry_count,
+            reason,
         )
         return False
 

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -434,3 +434,135 @@ def test_guardian_watchdog_detects_dead_guardian(monkeypatch):
     assert new_guardian is not None
     assert id(new_guardian) != id(guardian)
     assert new_guardian.status()["guardian_running"] is True
+
+
+# ---------------------------------------------------------------------------
+# P0-1: embedded fallback retry / strict gateway / metadata visibility tests
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_gateway_daemon_if_needed_retries_and_succeeds(monkeypatch):
+    """P0-1: ensure_gateway_daemon_if_needed retries on failure and succeeds."""
+    call_count = 0
+
+    def _mock_ensure(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            return {"ok": False, "reason": "launch_in_progress_timeout"}
+        return {"ok": True, "reason": "spawned"}
+
+    # ServerRuntimeController does `from dcc_mcp_core._server.gateway_guardian
+    # import ensure_gateway_daemon` — patch the _server.runtime namespace.
+    import dcc_mcp_core._server.runtime as rt
+    monkeypatch.setattr(rt, "ensure_gateway_daemon", _mock_ensure)
+
+    ctrl, owner = _make_runtime_controller(monkeypatch)
+    owner._dcc_name = "retry-test"
+
+    result = ctrl.ensure_gateway_daemon_if_needed()
+    assert result is True
+    assert call_count == 3
+    assert owner._gateway_runtime_mode == "daemon-backed"
+
+
+def test_ensure_gateway_daemon_if_needed_fallback_after_exhausted_retries(monkeypatch):
+    """P0-1: Non-strict mode falls back to embedded after all retries fail."""
+    failures = []
+
+    def _mock_ensure(**kwargs):
+        failures.append(1)
+        return {"ok": False, "reason": "spawn_failed", "error": "test error"}
+
+    import dcc_mcp_core._server.runtime as rt
+    monkeypatch.setattr(rt, "ensure_gateway_daemon", _mock_ensure)
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+    ctrl, owner = _make_runtime_controller(monkeypatch)
+    owner._dcc_name = "fallback-test"
+
+    result = ctrl.ensure_gateway_daemon_if_needed()
+    assert result is False
+    assert len(failures) == 3  # 1 initial + 2 retries
+    assert owner._gateway_runtime_mode == "embedded-fallback"
+    assert owner._gateway_daemon_status["reason"] == "spawn_failed"
+
+
+def test_ensure_gateway_daemon_if_needed_strict_gateway_raises(monkeypatch):
+    """P0-1: DCC_MCP_STRICT_GATEWAY=1 raises RuntimeError on ensure failure."""
+    def _mock_ensure(**kwargs):
+        return {"ok": False, "reason": "spawn_failed", "error": "test error"}
+
+    import dcc_mcp_core._server.runtime as rt
+    monkeypatch.setattr(rt, "ensure_gateway_daemon", _mock_ensure)
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    monkeypatch.setenv("DCC_MCP_STRICT_GATEWAY", "1")
+
+    ctrl, owner = _make_runtime_controller(monkeypatch)
+    owner._dcc_name = "strict-test"
+
+    raised = False
+    try:
+        ctrl.ensure_gateway_daemon_if_needed()
+    except RuntimeError as exc:
+        raised = True
+        assert "DCC_MCP_STRICT_GATEWAY" in str(exc)
+        assert "spawn_failed" in str(exc)
+
+    assert raised, "Expected RuntimeError in strict gateway mode"
+    # Fallback must NOT be set in strict mode.
+    assert owner._gateway_runtime_mode != "embedded-fallback"
+
+
+def test_gateway_runtime_metadata_includes_daemon_status_on_fallback(monkeypatch):
+    """P0-1: _gateway_runtime_metadata includes daemon_status on embedded-fallback."""
+    from dcc_mcp_core._server.lifecycle_controller import LifecycleController
+
+    ctrl = LifecycleController.__new__(LifecycleController)
+    owner = type(
+        "Owner",
+        (),
+        {
+            "_gateway_runtime_mode": "embedded-fallback",
+            "_gateway_guardian": None,
+            "_gateway_daemon_status": {
+                "ok": False,
+                "reason": "spawn_timeout",
+                "command": ["dcc-mcp-server", "gateway"],
+            },
+            "_enable_gateway_failover": True,
+        },
+    )()
+    ctrl._owner = owner
+
+    meta = ctrl._gateway_runtime_metadata()
+    assert meta["gateway_runtime_mode"] == "embedded-fallback"
+    assert meta["gateway_recovery_driver"] == "embedded_election"
+    assert meta["gateway_daemon_status_ok"] == "false"
+    assert meta["gateway_daemon_status_reason"] == "spawn_timeout"
+    assert "gateway_daemon_status" in meta
+    # JSON blob contains the reason.
+    assert "spawn_timeout" in meta["gateway_daemon_status"]
+
+
+def test_gateway_runtime_metadata_omits_daemon_status_for_daemon_backed(monkeypatch):
+    """P0-1: _gateway_runtime_metadata does NOT include daemon_status for daemon-backed."""
+    from dcc_mcp_core._server.lifecycle_controller import LifecycleController
+
+    ctrl = LifecycleController.__new__(LifecycleController)
+    owner = type(
+        "Owner",
+        (),
+        {
+            "_gateway_runtime_mode": "daemon-backed",
+            "_gateway_guardian": None,
+            "_gateway_daemon_status": {"ok": True, "reason": "already_healthy"},
+            "_enable_gateway_failover": True,
+        },
+    )()
+    ctrl._owner = owner
+
+    meta = ctrl._gateway_runtime_metadata()
+    assert meta["gateway_runtime_mode"] == "daemon-backed"
+    assert "gateway_daemon_status_reason" not in meta
+    assert "gateway_daemon_status_ok" not in meta

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -455,6 +455,7 @@ def test_ensure_gateway_daemon_if_needed_retries_and_succeeds(monkeypatch):
     # ServerRuntimeController does `from dcc_mcp_core._server.gateway_guardian
     # import ensure_gateway_daemon` — patch the _server.runtime namespace.
     import dcc_mcp_core._server.runtime as rt
+
     monkeypatch.setattr(rt, "ensure_gateway_daemon", _mock_ensure)
 
     ctrl, owner = _make_runtime_controller(monkeypatch)
@@ -475,6 +476,7 @@ def test_ensure_gateway_daemon_if_needed_fallback_after_exhausted_retries(monkey
         return {"ok": False, "reason": "spawn_failed", "error": "test error"}
 
     import dcc_mcp_core._server.runtime as rt
+
     monkeypatch.setattr(rt, "ensure_gateway_daemon", _mock_ensure)
     monkeypatch.setattr("time.sleep", lambda _s: None)
 
@@ -490,10 +492,12 @@ def test_ensure_gateway_daemon_if_needed_fallback_after_exhausted_retries(monkey
 
 def test_ensure_gateway_daemon_if_needed_strict_gateway_raises(monkeypatch):
     """P0-1: DCC_MCP_STRICT_GATEWAY=1 raises RuntimeError on ensure failure."""
+
     def _mock_ensure(**kwargs):
         return {"ok": False, "reason": "spawn_failed", "error": "test error"}
 
     import dcc_mcp_core._server.runtime as rt
+
     monkeypatch.setattr(rt, "ensure_gateway_daemon", _mock_ensure)
     monkeypatch.setattr("time.sleep", lambda _s: None)
     monkeypatch.setenv("DCC_MCP_STRICT_GATEWAY", "1")


### PR DESCRIPTION
## Summary

Part of [PIP-1396](https://github.com/dcc-mcp/dcc-mcp-core/issues) Wave 1 — P0-1: silent embedded fallback fix.

## Changes

1. **Retry on  failure** —  now retries up to 2 additional times (2s interval) before falling back to embedded gateway.

2. **Strict gateway mode** —  env var support: when enabled, ensure failure raises  instead of silently falling back to embedded.

3. **Metadata visibility** —  now surfaces , , and a JSON status blob when , making the fallback state visible in the registry.

## Files

-  — retry loop + strict-gateway support
-  — metadata staging
-  — 5 new unit tests

## Test results

```
tests/test_gateway_guardian.py: 21 passed
```