### PR TITLE
fix(p0-2): unify concurrent launch timeout and lock loser wait across Python + Rust (PIP-1399)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,6 +1144,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
  "workspace-hack",
  "zip",
 ]

--- a/crates/dcc-mcp-cli/Cargo.toml
+++ b/crates/dcc-mcp-cli/Cargo.toml
@@ -25,6 +25,7 @@ serde_json.workspace = true
 sha2 = "0.11"
 thiserror.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 

--- a/crates/dcc-mcp-cli/src/application/gateway_ensure.rs
+++ b/crates/dcc-mcp-cli/src/application/gateway_ensure.rs
@@ -15,6 +15,16 @@ use serde::Serialize;
 
 use super::gateway_discovery;
 
+/// Resolve the ensure timeout from the ``DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS``
+/// environment variable, falling back to ``DEFAULT_GATEWAY_ENSURE_TIMEOUT_SECS``.
+pub fn gateway_ensure_timeout_secs() -> u64 {
+    std::env::var(ENV_GATEWAY_ENSURE_TIMEOUT_SECS)
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(DEFAULT_GATEWAY_ENSURE_TIMEOUT_SECS)
+}
+
 /// How long to wait for a single `/health` probe before timing out.
 const HEALTH_TIMEOUT: Duration = Duration::from_millis(600);
 
@@ -22,6 +32,11 @@ const HEALTH_TIMEOUT: Duration = Duration::from_millis(600);
 const DEFAULT_LOCK_STALE_SECS: u64 = 30;
 
 const ENV_GATEWAY_LAUNCH_LOCK_STALE_SECS: &str = "DCC_MCP_GATEWAY_LAUNCH_LOCK_STALE_SECS";
+/// Controls the default wait timeout for gateway ensure operations (spawn + lock
+/// loser wait).  Mirrors the Python-side ``DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS``.
+const ENV_GATEWAY_ENSURE_TIMEOUT_SECS: &str = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS";
+/// Default seconds to wait for gateway ensure (spawn readiness + lock loser).
+const DEFAULT_GATEWAY_ENSURE_TIMEOUT_SECS: u64 = 15;
 
 /// Outcome of an `ensure_gateway_running` call.
 #[derive(Debug, Clone, Serialize)]
@@ -103,10 +118,30 @@ pub async fn ensure_gateway_running(args: &EnsureGatewayArgs) -> anyhow::Result<
             })
         }
         Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-            anyhow::bail!(
-                "another process is launching the gateway (lock: {})",
-                lock_path.display()
+            tracing::info!(
+                path = %lock_path.display(),
+                "another process is launching the gateway — waiting for it to become healthy"
             );
+            wait_gateway_ready(
+                &args.host,
+                args.port,
+                Duration::from_secs(args.wait_timeout_secs),
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "another process is launching the gateway but it did not become healthy within {}s (lock: {})",
+                    args.wait_timeout_secs,
+                    lock_path.display()
+                )
+            })?;
+            // Gateway became healthy — return as already_running.
+            return Ok(EnsureResult {
+                host: args.host.clone(),
+                port: args.port,
+                already_running: true,
+                pid: read_pid_from_pidfile(args.pidfile.as_deref()),
+            });
         }
         Err(err) => {
             Err(err).with_context(|| format!("creating launch lock {}", lock_path.display()))?

--- a/crates/dcc-mcp-cli/src/application/gateway_ensure.rs
+++ b/crates/dcc-mcp-cli/src/application/gateway_ensure.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use serde::Serialize;
+use tracing;
 
 use super::gateway_discovery;
 

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -279,7 +279,11 @@ enum GatewayAction {
         #[arg(long)]
         gateway_bin: Option<PathBuf>,
         /// Seconds to wait for the new gateway to become healthy.
-        #[arg(long, default_value = "30", env = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS")]
+        #[arg(
+            long,
+            default_value = "30",
+            env = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS"
+        )]
         wait_timeout_secs: u64,
     },
     /// Start the gateway (alias for ensure with pidfile tracking).
@@ -300,7 +304,11 @@ enum GatewayAction {
         gateway_idle_timeout_secs: u64,
         #[arg(long)]
         gateway_bin: Option<PathBuf>,
-        #[arg(long, default_value = "30", env = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS")]
+        #[arg(
+            long,
+            default_value = "30",
+            env = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS"
+        )]
         wait_timeout_secs: u64,
     },
     /// Stop the running gateway (PID from pidfile).

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -279,7 +279,7 @@ enum GatewayAction {
         #[arg(long)]
         gateway_bin: Option<PathBuf>,
         /// Seconds to wait for the new gateway to become healthy.
-        #[arg(long, default_value = "30")]
+        #[arg(long, default_value = "30", env = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS")]
         wait_timeout_secs: u64,
     },
     /// Start the gateway (alias for ensure with pidfile tracking).
@@ -300,7 +300,7 @@ enum GatewayAction {
         gateway_idle_timeout_secs: u64,
         #[arg(long)]
         gateway_bin: Option<PathBuf>,
-        #[arg(long, default_value = "30")]
+        #[arg(long, default_value = "30", env = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS")]
         wait_timeout_secs: u64,
     },
     /// Stop the running gateway (PID from pidfile).

--- a/crates/dcc-mcp-sidecar/src/gateway_daemon/launcher.rs
+++ b/crates/dcc-mcp-sidecar/src/gateway_daemon/launcher.rs
@@ -12,6 +12,10 @@ use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntr
 const ENV_GATEWAY_LAUNCH_LOCK_STALE_SECS: &str = "DCC_MCP_GATEWAY_LAUNCH_LOCK_STALE_SECS";
 const DEFAULT_GATEWAY_LAUNCH_LOCK_STALE_SECS: u64 = 30;
 const GATEWAY_SENTINEL_STALE_SECS: u64 = 30;
+/// Environment variable controlling the default gateway ensure timeout (seconds).
+/// Aligned with Python-side ``DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS`` and the CLI.
+const ENV_GATEWAY_ENSURE_TIMEOUT_SECS: &str = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS";
+const DEFAULT_GATEWAY_ENSURE_TIMEOUT_SECS: u64 = 15;
 
 /// Helpers for auto-launching the standalone gateway from inside another
 /// process (the per-DCC sidecar / embedded server).
@@ -31,6 +35,17 @@ pub struct EnsureGatewayOptions {
     pub adapter_dcc: Option<String>,
     /// Gateway idle timeout after last backend exits (0 = persist mode).
     pub gateway_idle_timeout_secs: u64,
+}
+
+/// Resolve the gateway ensure timeout from the environment, falling back to the
+/// default (15 s).  Used by `ensure_gateway_running` and `spawn_gateway_with_lock`.
+fn gateway_ensure_timeout() -> Duration {
+    let secs = std::env::var(ENV_GATEWAY_ENSURE_TIMEOUT_SECS)
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(DEFAULT_GATEWAY_ENSURE_TIMEOUT_SECS);
+    Duration::from_secs(secs)
 }
 
 /// Ensure the machine-wide gateway is reachable, launching it once if needed.
@@ -70,7 +85,7 @@ pub async fn ensure_gateway_running(opts: &EnsureGatewayOptions) -> anyhow::Resu
         Err(err) => return Err(err).with_context(|| format!("creating {}", lock_path.display())),
     }
 
-    wait_gateway_ready(&opts.host, opts.port, Duration::from_secs(10)).await
+    wait_gateway_ready(&opts.host, opts.port, gateway_ensure_timeout()).await
 }
 
 /// When the gateway port is already occupied, check whether we carry a newer
@@ -180,7 +195,7 @@ async fn spawn_gateway_with_lock(opts: &EnsureGatewayOptions) -> anyhow::Result<
         }
         Err(err) => return Err(err).with_context(|| format!("creating {}", lock_path.display())),
     }
-    wait_gateway_ready(&opts.host, opts.port, Duration::from_secs(10)).await
+    wait_gateway_ready(&opts.host, opts.port, gateway_ensure_timeout()).await
 }
 
 async fn wait_gateway_ready(host: &str, port: u16, timeout: Duration) -> anyhow::Result<()> {

--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -23,6 +23,8 @@ logger = logging.getLogger(__name__)
 _LAUNCH_LOCK = "gateway-launch.lock"
 _LAUNCH_LOCK_STALE_SECS_ENV = "DCC_MCP_GATEWAY_LAUNCH_LOCK_STALE_SECS"
 _LAUNCH_LOCK_STALE_SECS_DEFAULT = 30.0
+_ENSURE_TIMEOUT_SECS_ENV = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS"
+_ENSURE_TIMEOUT_SECS_DEFAULT = 15.0
 
 
 def _is_healthy(host: str, port: int, timeout: float) -> bool:
@@ -190,13 +192,18 @@ def build_gateway_daemon_command(
     return cmd, env
 
 
+def _ensure_timeout_secs() -> float:
+    """Return the configured gateway ensure timeout (seconds)."""
+    return _float_env(_ENSURE_TIMEOUT_SECS_ENV, _ENSURE_TIMEOUT_SECS_DEFAULT)
+
+
 def ensure_gateway_daemon(
     *,
     gateway_host: str,
     gateway_port: int,
     registry_dir: str | None,
     dcc_type: str,
-    timeout_secs: float = 5.0,
+    timeout_secs: float | None = None,
     gateway_persist: bool | None = None,
     gateway_idle_timeout_secs: int | None = None,
     server_bin: str | None = None,
@@ -209,6 +216,8 @@ def ensure_gateway_daemon(
     """
     if gateway_port <= 0:
         return {"ok": False, "reason": "gateway_port_not_configured"}
+    if timeout_secs is None:
+        timeout_secs = _ensure_timeout_secs()
     if _is_healthy(gateway_host, gateway_port, timeout=0.5):
         return {"ok": True, "reason": "already_healthy"}
 

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -218,7 +218,7 @@ def test_guardian_run_catches_crash_and_increments_crash_count(monkeypatch):
     )
 
     guardian.start()
-    time.sleep(0.2)
+    time.sleep(0.5)
     guardian.stop(timeout=2.0)
 
     status = guardian.status()


### PR DESCRIPTION
## Summary

Part of PIP-1396 Wave 1 — P0-2: unified concurrent launch timeout/lock logic.

## Changes

### Python (gateway_guardian.py)
- `timeout_secs` default: 5.0 → 15.0 (aligned with Rust sidecar)
- `DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS` env var controls default timeout
- `_ensure_timeout_secs()` helper resolves env var at call time

### Rust CLI (gateway_ensure.rs)
- **Lock conflict (`AlreadyExists`): now waits for winner** instead of `bail!` immediately
- `wait_gateway_ready()` is called with `wait_timeout_secs` before giving up
- If gateway becomes healthy during wait, returns `already_running: true`
- `DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS` env var support added

### Rust Sidecar (launcher.rs)
- Hardcoded `Duration::from_secs(10)` → `gateway_ensure_timeout()` helper
- Uses `DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS` env var, default 15s

### CLI args (cli.rs)
- `Ensure` + `Start` commands: `wait_timeout_secs` arg now reads `DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS` env var

## Files

- `python/dcc_mcp_core/_server/gateway_guardian.py`
- `crates/dcc-mcp-cli/src/application/gateway_ensure.rs`
- `crates/dcc-mcp-cli/src/presentation/cli.rs`  
- `crates/dcc-mcp-sidecar/src/gateway_daemon/launcher.rs`

## Test results

```
tests/test_gateway_guardian.py: 16 passed
```