### PR TITLE
feat(gateway): add version-aware takeover to Python ensure_gateway_daemon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,10 +339,10 @@ jobs:
           # Windows + macOS — cover oldest + newest only. Middle versions
           # are exercised on ubuntu and rarely surface OS-specific Python
           # bugs; python-matrix-full.yml runs the full matrix weekly.
-          # Python 3.8 is not available in the windows-latest hosted-tool cache.
-          # Reuse the ABI3 Windows wheel, but run the oldest-version test on
-          # windows-2022 where actions/setup-python still provides 3.8.
-          - { os: windows-2022,   python-version: "3.8",  wheel_os: windows-latest }
+          # Python 3.8 is not available in the windows-latest or windows-2022
+          # hosted-tool cache. Reuse the ABI3 Windows wheel, but run the
+          # oldest-version test on windows-2019 which still provides 3.8.
+          - { os: windows-2019,   python-version: "3.8",  wheel_os: windows-latest }
           - { os: windows-latest, python-version: "3.13", wheel_os: windows-latest }
           - { os: macos-latest,   python-version: "3.8",  wheel_os: macos-latest }
           - { os: macos-latest,   python-version: "3.13", wheel_os: macos-latest }

--- a/.github/workflows/python-matrix-full.yml
+++ b/.github/workflows/python-matrix-full.yml
@@ -26,12 +26,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
-          # Python 3.8 is no longer present in the windows-latest hosted-tool
-          # cache; keep the oldest Windows cell on windows-2022.
+          # Python 3.8 is no longer present in the windows-latest or
+          # windows-2022 hosted-tool cache; keep the oldest Windows cell
+          # on windows-2019.
           - os: windows-latest
             python-version: "3.8"
         include:
-          - os: windows-2022
+          - os: windows-2019
             python-version: "3.8"
     runs-on: ${{ matrix.os }}
     steps:

--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import os
 from pathlib import Path
 import shutil
 import threading
 import time
+import uuid
 from typing import Any
 from typing import Callable
 from urllib.error import HTTPError
@@ -23,6 +25,14 @@ logger = logging.getLogger(__name__)
 _LAUNCH_LOCK = "gateway-launch.lock"
 _LAUNCH_LOCK_STALE_SECS_ENV = "DCC_MCP_GATEWAY_LAUNCH_LOCK_STALE_SECS"
 _LAUNCH_LOCK_STALE_SECS_DEFAULT = 30.0
+
+# ── Version-aware takeover constants ────────────────────────────────────────
+# Matches Rust dcc_mcp_transport::discovery::types::GATEWAY_SENTINEL_DCC_TYPE
+_GATEWAY_SENTINEL_DCC_TYPE = "__gateway__"
+_GATEWAY_SENTINEL_STALE_SECS = 30.0
+_VERSION_TAKEOVER_WAIT_SECS = 20.0
+_VERSION_TAKEOVER_POLL_INTERVAL = 0.5
+_SERVICES_JSON = "services.json"
 
 
 def _is_healthy(host: str, port: int, timeout: float) -> bool:
@@ -200,19 +210,43 @@ def ensure_gateway_daemon(
     gateway_persist: bool | None = None,
     gateway_idle_timeout_secs: int | None = None,
     server_bin: str | None = None,
+    adapter_version: str | None = None,
+    enable_version_takeover: bool = True,
 ) -> dict[str, Any]:
     """Ensure a machine-wide gateway daemon is healthy on ``gateway_port``.
 
     When spawning a new daemon, lifecycle options are forwarded to
     ``dcc-mcp-server gateway``. Unset values fall back to
     ``DCC_MCP_GATEWAY_PERSIST`` / ``DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS``.
+
+    When *enable_version_takeover* is ``True`` (the default) and the gateway
+    port is already occupied by a healthy gateway, this function checks whether
+    the current ``dcc_mcp_core`` version is newer than the running gateway.  If
+    it is, a ``__gateway__`` sentinel entry is written to ``services.json`` so
+    the running gateway's 15-second cleanup loop detects a newer challenger and
+    voluntarily yields.  This function then waits for the old gateway to exit
+    and spawns the replacement.
     """
     if gateway_port <= 0:
         return {"ok": False, "reason": "gateway_port_not_configured"}
-    if _is_healthy(gateway_host, gateway_port, timeout=0.5):
-        return {"ok": True, "reason": "already_healthy"}
 
     registry_path = _resolve_registry_dir(registry_dir)
+
+    if _is_healthy(gateway_host, gateway_port, timeout=0.5):
+        if enable_version_takeover:
+            takeover = _try_version_takeover(
+                gateway_host=gateway_host,
+                gateway_port=gateway_port,
+                registry_dir=str(registry_path),
+                dcc_type=dcc_type,
+                timeout_secs=timeout_secs,
+                server_bin=server_bin,
+                adapter_version=adapter_version,
+            )
+            if takeover.get("reason") != "already_healthy":
+                return takeover
+        return {"ok": True, "reason": "already_healthy"}
+
     launch_lock = _LaunchLock(registry_path / _LAUNCH_LOCK)
     try:
         acquired = launch_lock.acquire()
@@ -421,6 +455,332 @@ class GatewayDaemonGuardian:
             with contextlib.suppress(Exception):
                 self.status_callback(dict(payload))
         return payload
+
+
+# ── Version-aware takeover helpers ──────────────────────────────────────────
+
+
+def _get_core_version() -> str | None:
+    """Resolve ``dcc_mcp_core`` version without importing the native extension.
+
+    Resolution order:
+    1. ``DCC_MCP_CORE_VERSION`` environment variable
+    2. ``importlib.metadata.version("dcc-mcp-core")``
+    3. ``dcc_mcp_core.__version__`` attribute
+    """
+    env_version = (os.environ.get("DCC_MCP_CORE_VERSION") or "").strip()
+    if env_version:
+        return env_version
+
+    try:
+        from importlib.metadata import version as pkg_version
+
+        return pkg_version("dcc-mcp-core")
+    except Exception:
+        pass
+
+    try:
+        import dcc_mcp_core
+
+        return getattr(dcc_mcp_core, "__version__", None) or None
+    except Exception:
+        pass
+
+    return None
+
+
+def _parse_semver(v: str) -> tuple[int, int, int]:
+    """Parse a semver string to a numeric triple, matching Rust :func:`parse_semver`.
+
+    Leading ``v`` / ``V`` stripped; pre-release suffixes (``-rc1``) ignored;
+    missing components default to ``0``.
+    """
+    text = str(v).strip().lstrip("vV")
+    text = text.split("-", 1)[0]
+    parts = text.split(".")
+    nums: list[int] = []
+    for part in parts[:3]:
+        try:
+            nums.append(int(part))
+        except ValueError:
+            nums.append(0)
+    while len(nums) < 3:
+        nums.append(0)
+    return (nums[0], nums[1], nums[2])
+
+
+def _is_newer_version(candidate: str, current: str) -> bool:
+    """Return ``True`` when *candidate* is strictly newer than *current*."""
+    return _parse_semver(candidate) > _parse_semver(current)
+
+
+def _system_time_now_json() -> dict[str, int]:
+    """Return the current time in serde ``SystemTime`` JSON format.
+
+    serde serializes ``std::time::SystemTime`` as a struct with two fields:
+    ``secs_since_epoch`` (u64) and ``nanos_since_epoch`` (u32).
+    """
+    now = time.time()
+    secs = int(now)
+    nanos = int((now - secs) * 1_000_000_000)
+    return {"secs_since_epoch": secs, "nanos_since_epoch": nanos}
+
+
+def _read_services_json(registry_dir: Path) -> list[dict[str, Any]]:
+    """Read ``services.json`` entries from *registry_dir*."""
+    path = registry_dir / _SERVICES_JSON
+    if not path.exists():
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return []
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def _write_services_json(registry_dir: Path, entries: list[dict[str, Any]]) -> bool:
+    """Atomically write *entries* to ``services.json``."""
+    path = registry_dir / _SERVICES_JSON
+    tmp = path.with_suffix(".tmp")
+    try:
+        registry_dir.mkdir(parents=True, exist_ok=True)
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(entries, fh, indent=2, ensure_ascii=False)
+        os.replace(tmp, path)
+        return True
+    except OSError:
+        return False
+
+
+def _write_takeover_sentinel(
+    registry_dir: Path,
+    host: str,
+    port: int,
+    version: str,
+    adapter_version: str | None = None,
+    adapter_dcc: str | None = None,
+) -> bool:
+    """Write a ``__gateway__`` sentinel entry to trigger the running gateway to yield.
+
+    Removes any existing sentinel for the same (host, port) first, then appends
+    the new entry.  Uses the serde ``SystemTime`` JSON format for
+    ``last_heartbeat`` and ``registered_at`` so the Rust ``FileRegistry`` can
+    deserialise the entry correctly.
+    """
+    entries = _read_services_json(registry_dir)
+
+    # Remove existing sentinel entries for this (host, port)
+    filtered: list[dict[str, Any]] = []
+    for entry in entries:
+        if (
+            entry.get("dcc_type") == _GATEWAY_SENTINEL_DCC_TYPE
+            and entry.get("host") == host
+            and entry.get("port") == port
+        ):
+            continue
+        filtered.append(entry)
+
+    now_ts = _system_time_now_json()
+    sentinel: dict[str, Any] = {
+        "dcc_type": _GATEWAY_SENTINEL_DCC_TYPE,
+        "instance_id": str(uuid.uuid4()),
+        "host": host,
+        "port": port,
+        "version": version,
+        "status": "available",
+        "last_heartbeat": dict(now_ts),
+        "registered_at": dict(now_ts),
+    }
+    if adapter_version:
+        sentinel["adapter_version"] = adapter_version
+    if adapter_dcc:
+        sentinel["adapter_dcc"] = adapter_dcc
+
+    filtered.append(sentinel)
+    return _write_services_json(registry_dir, filtered)
+
+
+def _cleanup_takeover_sentinel(
+    registry_dir: Path,
+    host: str,
+    port: int,
+) -> bool:
+    """Remove our ``__gateway__`` sentinel from ``services.json``."""
+    entries = _read_services_json(registry_dir)
+    filtered: list[dict[str, Any]] = []
+    removed = False
+    for entry in entries:
+        if (
+            entry.get("dcc_type") == _GATEWAY_SENTINEL_DCC_TYPE
+            and entry.get("host") == host
+            and entry.get("port") == port
+        ):
+            removed = True
+            continue
+        filtered.append(entry)
+    if not removed:
+        return True
+    return _write_services_json(registry_dir, filtered)
+
+
+def _sentry_stale(entry: dict[str, Any], stale_timeout: float) -> bool:
+    """Check if a services.json entry is stale based on ``last_heartbeat``.
+
+    The Rust ``ServiceEntry::is_stale`` compares ``SystemTime::elapsed()``
+    against a timeout.  We match this by reading the serde-serialised
+    ``last_heartbeat`` field.
+    """
+    hb = entry.get("last_heartbeat")
+    if not isinstance(hb, dict):
+        return True
+    secs = hb.get("secs_since_epoch")
+    if not isinstance(secs, (int, float)):
+        return True
+    nanos = hb.get("nanos_since_epoch", 0)
+    if not isinstance(nanos, (int, float)):
+        nanos = 0
+    ts = float(secs) + float(nanos) / 1_000_000_000
+    return (time.time() - ts) > stale_timeout
+
+
+def _try_version_takeover(
+    *,
+    gateway_host: str,
+    gateway_port: int,
+    registry_dir: str,
+    dcc_type: str,
+    timeout_secs: float,
+    server_bin: str | None = None,
+    adapter_version: str | None = None,
+) -> dict[str, Any]:
+    """Check if we carry a newer version and trigger a version-aware gateway takeover.
+
+    Returns a result dict; ``{"ok": True, "reason": "already_healthy"}`` when
+    no takeover was needed, ``{"ok": True, "reason": "version_takeover_spawned"}``
+    on successful takeover, or ``{"ok": False, ...}`` on failure.
+    """
+    our_version = _get_core_version()
+    if not our_version:
+        logger.debug("[gateway_guardian] no core version resolved; skipping version takeover")
+        return {"ok": True, "reason": "already_healthy"}
+
+    registry_path = Path(registry_dir).expanduser()
+    entries = _read_services_json(registry_path)
+
+    # Check if any sentinel entry is already newer than us (another sidecar
+    # already requested a newer takeover).
+    for entry in entries:
+        if entry.get("dcc_type") != _GATEWAY_SENTINEL_DCC_TYPE:
+            continue
+        if _sentry_stale(entry, _GATEWAY_SENTINEL_STALE_SECS):
+            continue
+        their_version = entry.get("version")
+        if not their_version:
+            continue
+        if _is_newer_version(their_version, our_version):
+            logger.debug(
+                "[gateway_guardian] running gateway sentinel (%s) is newer than us (%s); no takeover",
+                their_version,
+                our_version,
+            )
+            return {"ok": True, "reason": "already_healthy"}
+
+    # Determine if we are newer than any existing sentinel.
+    should_takeover = False
+    for entry in entries:
+        if entry.get("dcc_type") != _GATEWAY_SENTINEL_DCC_TYPE:
+            continue
+        if _sentry_stale(entry, _GATEWAY_SENTINEL_STALE_SECS):
+            continue
+        their_version = entry.get("version")
+        if not their_version:
+            continue
+        if _is_newer_version(our_version, their_version):
+            should_takeover = True
+            break
+
+    if not should_takeover:
+        # No sentinel exists or we're not newer — no action.
+        return {"ok": True, "reason": "already_healthy"}
+
+    logger.info(
+        "[gateway_guardian] version %s > running gateway; triggering takeover for %s:%d",
+        our_version,
+        gateway_host,
+        gateway_port,
+    )
+
+    # Write our sentinel so the running gateway detects a newer challenger
+    # in its 15 s cleanup loop and voluntarily yields.
+    if not _write_takeover_sentinel(
+        registry_path,
+        gateway_host,
+        gateway_port,
+        our_version,
+        adapter_version=adapter_version,
+        adapter_dcc=dcc_type,
+    ):
+        return {
+            "ok": False,
+            "reason": "version_takeover_sentinel_write_failed",
+            "registry_dir": str(registry_path),
+        }
+
+    # Wait for old gateway to yield (polling /health).
+    deadline = time.time() + _VERSION_TAKEOVER_WAIT_SECS
+    old_gateway_yielded = False
+    while time.time() < deadline:
+        if not _is_healthy(gateway_host, gateway_port, timeout=_VERSION_TAKEOVER_POLL_INTERVAL):
+            old_gateway_yielded = True
+            break
+        time.sleep(_VERSION_TAKEOVER_POLL_INTERVAL)
+
+    if not old_gateway_yielded:
+        logger.warning("[gateway_guardian] old gateway did not yield within %s s", _VERSION_TAKEOVER_WAIT_SECS)
+        _cleanup_takeover_sentinel(registry_path, gateway_host, gateway_port)
+        return {"ok": True, "reason": "already_healthy", "version_takeover_timeout": True}
+
+    # Spawn new gateway (reuse build_gateway_daemon_command + launch_detached).
+    cmd, env = build_gateway_daemon_command(
+        gateway_host=gateway_host,
+        gateway_port=gateway_port,
+        registry_dir=registry_dir,
+        dcc_type=dcc_type,
+        server_bin=server_bin,
+    )
+    try:
+        spawn = launch_detached(cmd, env=env, cwd=Path.cwd())
+    except Exception as exc:
+        _cleanup_takeover_sentinel(registry_path, gateway_host, gateway_port)
+        return {"ok": False, "reason": "spawn_failed", "error": str(exc), "command": cmd}
+
+    if not spawn.get("ok"):
+        _cleanup_takeover_sentinel(registry_path, gateway_host, gateway_port)
+        return {
+            "ok": False,
+            "reason": spawn.get("reason", "spawn_failed"),
+            "error": spawn.get("error"),
+            "command": cmd,
+            "registry_dir": str(registry_path),
+        }
+
+    if _wait_gateway_ready(gateway_host, gateway_port, timeout_secs=timeout_secs):
+        _cleanup_takeover_sentinel(registry_path, gateway_host, gateway_port)
+        logger.info("[gateway_guardian] version takeover successful — new gateway %s running", our_version)
+        return {
+            "ok": True,
+            "reason": "version_takeover_spawned",
+            "version": our_version,
+            "command": cmd,
+            "registry_dir": str(registry_path),
+            "pid": spawn.get("pid"),
+        }
+
+    _cleanup_takeover_sentinel(registry_path, gateway_host, gateway_port)
+    return {"ok": False, "reason": "spawn_timeout", "command": cmd, "registry_dir": str(registry_path)}
 
 
 def _float_env(name: str, default: float) -> float:

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -614,3 +614,397 @@ def test_daemon_backed_metadata_does_not_include_daemon_error():
     assert meta["gateway_recovery_driver"] == "none"
     assert "gateway_daemon_status" not in meta
     assert "gateway_daemon_error" not in meta
+
+# ── Version-aware takeover tests ────────────────────────────────────────────
+
+
+def test_parse_semver_strips_leading_v():
+    assert gg._parse_semver("v0.12.29") == (0, 12, 29)
+    assert gg._parse_semver("V1.2.3") == (1, 2, 3)
+
+
+def test_parse_semver_ignores_prerelease():
+    assert gg._parse_semver("1.0.0-rc1") == (1, 0, 0)
+    assert gg._parse_semver("v2.1.0-alpha.3") == (2, 1, 0)
+
+
+def test_parse_semver_missing_components_default_to_zero():
+    assert gg._parse_semver("1") == (1, 0, 0)
+    assert gg._parse_semver("1.2") == (1, 2, 0)
+    assert gg._parse_semver("") == (0, 0, 0)
+
+
+def test_is_newer_version_numeric_comparison():
+    assert gg._is_newer_version("0.12.29", "0.12.6") is True
+    assert gg._is_newer_version("0.12.6", "0.12.29") is False
+    assert gg._is_newer_version("1.0.0", "1.0.0") is False
+    assert gg._is_newer_version("2.0.0", "1.99.99") is True
+    assert gg._is_newer_version("0.13.0", "0.12.29") is True
+
+
+def test_system_time_now_json_format():
+    ts = gg._system_time_now_json()
+    assert isinstance(ts, dict)
+    assert "secs_since_epoch" in ts
+    assert "nanos_since_epoch" in ts
+    assert isinstance(ts["secs_since_epoch"], int)
+    assert isinstance(ts["nanos_since_epoch"], int)
+    assert ts["secs_since_epoch"] > 0
+    assert 0 <= ts["nanos_since_epoch"] < 1_000_000_000
+
+
+def test_sentry_stale_fresh_entry():
+    now = gg._system_time_now_json()
+    entry = {
+        "dcc_type": "__gateway__",
+        "last_heartbeat": dict(now),
+    }
+    assert gg._sentry_stale(entry, 30.0) is False
+
+
+def test_sentry_stale_outdated_entry():
+    now = time.time()
+    old = {
+        "secs_since_epoch": int(now - 120),
+        "nanos_since_epoch": 0,
+    }
+    entry = {
+        "dcc_type": "__gateway__",
+        "last_heartbeat": old,
+    }
+    assert gg._sentry_stale(entry, 30.0) is True
+
+
+def test_sentry_stale_missing_heartbeat():
+    assert gg._sentry_stale({"dcc_type": "__gateway__"}, 30.0) is True
+    assert gg._sentry_stale({"dcc_type": "__gateway__", "last_heartbeat": None}, 30.0) is True
+
+
+def test_write_and_cleanup_takeover_sentinel(tmp_path):
+    reg = tmp_path / "registry"
+    host, port = "127.0.0.1", 9765
+    version = "0.18.0"
+
+    ok = gg._write_takeover_sentinel(reg, host, port, version)
+    assert ok is True
+
+    entries = gg._read_services_json(reg)
+    sentinels = [e for e in entries if e.get("dcc_type") == "__gateway__"]
+    assert len(sentinels) == 1
+    assert sentinels[0]["host"] == host
+    assert sentinels[0]["port"] == port
+    assert sentinels[0]["version"] == version
+    assert "last_heartbeat" in sentinels[0]
+    assert "registered_at" in sentinels[0]
+
+    # Writing again with a new version replaces the old sentinel.
+    ok = gg._write_takeover_sentinel(reg, host, port, "0.19.0")
+    assert ok is True
+    entries = gg._read_services_json(reg)
+    sentinels = [e for e in entries if e.get("dcc_type") == "__gateway__"]
+    assert len(sentinels) == 1
+    assert sentinels[0]["version"] == "0.19.0"
+
+    # Cleanup removes the sentinel.
+    ok = gg._cleanup_takeover_sentinel(reg, host, port)
+    assert ok is True
+    entries = gg._read_services_json(reg)
+    sentinels = [e for e in entries if e.get("dcc_type") == "__gateway__"]
+    assert len(sentinels) == 0
+
+
+def test_write_takeover_sentinel_with_adapter_info(tmp_path):
+    reg = tmp_path / "registry"
+    ok = gg._write_takeover_sentinel(
+        reg, "127.0.0.1", 9765, "0.18.0",
+        adapter_version="0.3.0",
+        adapter_dcc="maya",
+    )
+    assert ok is True
+    entries = gg._read_services_json(reg)
+    sentinel = entries[0]
+    assert sentinel["adapter_version"] == "0.3.0"
+    assert sentinel["adapter_dcc"] == "maya"
+
+
+def test_get_core_version_from_env(monkeypatch):
+    monkeypatch.setenv("DCC_MCP_CORE_VERSION", "1.2.3")
+    assert gg._get_core_version() == "1.2.3"
+
+
+def test_get_core_version_empty_env_returns_none(monkeypatch):
+    monkeypatch.setenv("DCC_MCP_CORE_VERSION", "")
+    # Without a real package install, importlib.metadata will fail.
+    # _get_core_version tries the env first; empty → tries importlib → tries dcc_mcp_core.
+    # In test env, dcc_mcp_core should be importable and have __version__.
+    v = gg._get_core_version()
+    assert v is not None and len(v) > 0
+
+
+def test_try_version_takeover_no_sentinel_returns_already_healthy(tmp_path, monkeypatch):
+    """When services.json has no sentinel, _try_version_takeover should not trigger."""
+    reg = tmp_path / "registry"
+    monkeypatch.setattr(gg, "_get_core_version", lambda: "0.18.0")
+
+    result = gg._try_version_takeover(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=str(reg),
+        dcc_type="blender",
+        timeout_secs=5.0,
+    )
+    assert result["ok"] is True
+    assert result["reason"] == "already_healthy"
+
+
+def test_try_version_takeover_when_newer(tmp_path, monkeypatch):
+    """When we're newer than the running sentinel, takeover should trigger."""
+    reg = tmp_path / "registry"
+    monkeypatch.setattr(gg, "_get_core_version", lambda: "0.19.0")
+
+    # Write an older sentinel first.
+    now = gg._system_time_now_json()
+    services = tmp_path / "registry" / "services.json"
+    services.parent.mkdir(parents=True, exist_ok=True)
+    import json as _json
+    with open(str(services), "w") as f:
+        _json.dump([{
+            "dcc_type": "__gateway__",
+            "instance_id": "fake-old-gateway",
+            "host": "127.0.0.1",
+            "port": 9765,
+            "version": "0.18.0",
+            "status": "available",
+            "last_heartbeat": dict(now),
+            "registered_at": dict(now),
+        }], f)
+
+    health = iter([True, True, False])  # healthy, still healthy, then yields
+    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: next(health))
+
+    seen_spawn = []
+
+    def _fake_spawn(cmd, **kw):
+        seen_spawn.append(cmd)
+        return {"ok": True, "pid": 9999}
+
+    monkeypatch.setattr(gg, "launch_detached", _fake_spawn)
+    monkeypatch.setattr(gg, "_wait_gateway_ready", lambda *a, **k: True)
+
+    result = gg._try_version_takeover(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=str(reg),
+        dcc_type="blender",
+        timeout_secs=5.0,
+    )
+    assert result["ok"] is True
+    assert result["reason"] == "version_takeover_spawned"
+    assert result.get("version") == "0.19.0"
+    assert len(seen_spawn) == 1
+
+    # Sentinel should be cleaned up after successful takeover.
+    entries = gg._read_services_json(reg)
+    sentinels = [e for e in entries if e.get("dcc_type") == "__gateway__"]
+    assert len(sentinels) == 0
+
+
+def test_try_version_takeover_when_running_is_newer(tmp_path, monkeypatch):
+    """When running gateway sentinel is newer than us, no takeover."""
+    reg = tmp_path / "registry"
+    monkeypatch.setattr(gg, "_get_core_version", lambda: "0.17.0")
+
+    now = gg._system_time_now_json()
+    services = tmp_path / "registry" / "services.json"
+    services.parent.mkdir(parents=True, exist_ok=True)
+    import json as _json
+    with open(str(services), "w") as f:
+        _json.dump([{
+            "dcc_type": "__gateway__",
+            "instance_id": "fake-newer-gateway",
+            "host": "127.0.0.1",
+            "port": 9765,
+            "version": "0.18.0",
+            "status": "available",
+            "last_heartbeat": dict(now),
+            "registered_at": dict(now),
+        }], f)
+
+    # _is_healthy should NOT be called because takeover is skipped early.
+    result = gg._try_version_takeover(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=str(reg),
+        dcc_type="blender",
+        timeout_secs=5.0,
+    )
+    assert result["ok"] is True
+    assert result["reason"] == "already_healthy"
+
+
+def test_try_version_takeover_stale_sentinel_is_ignored(tmp_path, monkeypatch):
+    """A stale sentinel should not prevent takeover."""
+    reg = tmp_path / "registry"
+    monkeypatch.setattr(gg, "_get_core_version", lambda: "0.19.0")
+
+    now = time.time()
+    old = {"secs_since_epoch": int(now - 120), "nanos_since_epoch": 0}
+    services = tmp_path / "registry" / "services.json"
+    services.parent.mkdir(parents=True, exist_ok=True)
+    import json as _json
+    with open(str(services), "w") as f:
+        _json.dump([{
+            "dcc_type": "__gateway__",
+            "instance_id": "fake-stale-gateway",
+            "host": "127.0.0.1",
+            "port": 9765,
+            "version": "0.20.0",  # newer, but stale
+            "status": "available",
+            "last_heartbeat": dict(old),
+            "registered_at": dict(old),
+        }], f)
+
+    # No fresh sentinel → should_takeover stays False → already_healthy
+    result = gg._try_version_takeover(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=str(reg),
+        dcc_type="blender",
+        timeout_secs=5.0,
+    )
+    assert result["ok"] is True
+    assert result["reason"] == "already_healthy"
+
+
+def test_try_version_takeover_old_gateway_timeout(tmp_path, monkeypatch):
+    """When old gateway does not yield within timeout, return already_healthy."""
+    reg = tmp_path / "registry"
+    monkeypatch.setattr(gg, "_get_core_version", lambda: "0.19.0")
+
+    now = gg._system_time_now_json()
+    services = tmp_path / "registry" / "services.json"
+    services.parent.mkdir(parents=True, exist_ok=True)
+    import json as _json
+    with open(str(services), "w") as f:
+        _json.dump([{
+            "dcc_type": "__gateway__",
+            "instance_id": "stubborn-gateway",
+            "host": "127.0.0.1",
+            "port": 9765,
+            "version": "0.18.0",
+            "status": "available",
+            "last_heartbeat": dict(now),
+            "registered_at": dict(now),
+        }], f)
+
+    # Old gateway stays healthy (never yields).
+    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: True)
+
+    # Override wait timeout to a short value for test speed.
+    monkeypatch.setattr(gg, "_VERSION_TAKEOVER_WAIT_SECS", 0.1)
+
+    result = gg._try_version_takeover(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=str(reg),
+        dcc_type="blender",
+        timeout_secs=5.0,
+    )
+    assert result["ok"] is True
+    assert result["reason"] == "already_healthy"
+    assert result.get("version_takeover_timeout") is True
+
+
+def test_ensure_gateway_daemon_version_takeover_disabled(monkeypatch):
+    """When enable_version_takeover=False, version check is skipped entirely."""
+    called_takeover = []
+
+    def _fake_takeover(**kw):
+        called_takeover.append(1)
+        return {"ok": True, "reason": "already_healthy"}
+
+    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: True)
+    monkeypatch.setattr(gg, "_try_version_takeover", _fake_takeover)
+
+    result = gg.ensure_gateway_daemon(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=None,
+        dcc_type="blender",
+        enable_version_takeover=False,
+    )
+    assert result["ok"] is True
+    assert result["reason"] == "already_healthy"
+    assert len(called_takeover) == 0
+
+
+def test_ensure_gateway_daemon_version_takeover_enabled(monkeypatch):
+    """When enable_version_takeover=True (default), version check is called."""
+    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: True)
+    monkeypatch.setattr(
+        gg,
+        "_try_version_takeover",
+        lambda **kw: {"ok": True, "reason": "already_healthy"},
+    )
+
+    result = gg.ensure_gateway_daemon(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=None,
+        dcc_type="blender",
+    )
+    assert result["ok"] is True
+    assert result["reason"] == "already_healthy"
+
+
+def test_ensure_gateway_daemon_takeover_integration(tmp_path, monkeypatch):
+    """Integration test: ensure_gateway_daemon with version takeover."""
+    reg = tmp_path / "registry"
+
+    # Simulate an older gateway running.
+    now = gg._system_time_now_json()
+    services = tmp_path / "registry" / "services.json"
+    services.parent.mkdir(parents=True, exist_ok=True)
+    import json as _json
+    with open(str(services), "w") as f:
+        _json.dump([{
+            "dcc_type": "__gateway__",
+            "instance_id": "old-integration-gw",
+            "host": "127.0.0.1",
+            "port": 9876,
+            "version": "0.17.0",
+            "status": "available",
+            "last_heartbeat": dict(now),
+            "registered_at": dict(now),
+        }], f)
+
+    # We have a newer version.
+    monkeypatch.setattr(gg, "_get_core_version", lambda: "0.18.0")
+
+    # Gateway health: first call True → second call True → third call False (yield)
+    health_checks = iter([True, True, False])
+
+    def _health(host, port, **kw):
+        val = next(health_checks)
+        return val
+
+    monkeypatch.setattr(gg, "_is_healthy", _health)
+
+    seen_spawn = []
+
+    def _fake_spawn(cmd, **kw):
+        seen_spawn.append(cmd)
+        return {"ok": True, "pid": 8888}
+
+    monkeypatch.setattr(gg, "launch_detached", _fake_spawn)
+    monkeypatch.setattr(gg, "_wait_gateway_ready", lambda *a, **k: True)
+
+    result = gg.ensure_gateway_daemon(
+        gateway_host="127.0.0.1",
+        gateway_port=9876,
+        registry_dir=str(reg),
+        dcc_type="houdini",
+    )
+    assert result["ok"] is True
+    assert result["reason"] == "version_takeover_spawned"
+    assert len(seen_spawn) == 1

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -767,7 +767,7 @@ def test_try_version_takeover_when_newer(tmp_path, monkeypatch):
     services = tmp_path / "registry" / "services.json"
     services.parent.mkdir(parents=True, exist_ok=True)
     import json as _json
-    with open(str(services), "w") as f:
+    with services.open("w") as f:
         _json.dump([{
             "dcc_type": "__gateway__",
             "instance_id": "fake-old-gateway",
@@ -818,7 +818,7 @@ def test_try_version_takeover_when_running_is_newer(tmp_path, monkeypatch):
     services = tmp_path / "registry" / "services.json"
     services.parent.mkdir(parents=True, exist_ok=True)
     import json as _json
-    with open(str(services), "w") as f:
+    with services.open("w") as f:
         _json.dump([{
             "dcc_type": "__gateway__",
             "instance_id": "fake-newer-gateway",
@@ -852,7 +852,7 @@ def test_try_version_takeover_stale_sentinel_is_ignored(tmp_path, monkeypatch):
     services = tmp_path / "registry" / "services.json"
     services.parent.mkdir(parents=True, exist_ok=True)
     import json as _json
-    with open(str(services), "w") as f:
+    with services.open("w") as f:
         _json.dump([{
             "dcc_type": "__gateway__",
             "instance_id": "fake-stale-gateway",
@@ -885,7 +885,7 @@ def test_try_version_takeover_old_gateway_timeout(tmp_path, monkeypatch):
     services = tmp_path / "registry" / "services.json"
     services.parent.mkdir(parents=True, exist_ok=True)
     import json as _json
-    with open(str(services), "w") as f:
+    with services.open("w") as f:
         _json.dump([{
             "dcc_type": "__gateway__",
             "instance_id": "stubborn-gateway",
@@ -966,7 +966,7 @@ def test_ensure_gateway_daemon_takeover_integration(tmp_path, monkeypatch):
     services = tmp_path / "registry" / "services.json"
     services.parent.mkdir(parents=True, exist_ok=True)
     import json as _json
-    with open(str(services), "w") as f:
+    with services.open("w") as f:
         _json.dump([{
             "dcc_type": "__gateway__",
             "instance_id": "old-integration-gw",


### PR DESCRIPTION
## Summary

Implement version-aware gateway takeover in the Python `ensure_gateway_daemon()` to match the Rust sidecar's `try_version_takeover` behavior.

## Problem

The Python `ensure_gateway_daemon()` only checks `/health` and returns `"already_healthy"` without checking versions. After upgrading the core package, old standalone gateway daemons continue running until manually killed.

## Solution

When a running gateway is detected on the target port, the new logic:

1. Resolves `dcc_mcp_core` version from `DCC_MCP_CORE_VERSION` env var → `importlib.metadata` → `dcc_mcp_core.__version__`
2. Reads `services.json` from the registry directory to find `__gateway__` sentinel entries
3. Compares versions using semver (matching Rust `parse_semver`)
4. If our version is newer, writes a takeover sentinel with serde `SystemTime`-format timestamps
5. Waits up to 20s for the old gateway's 15s cleanup loop to detect the sentinel and yield
6. Spawns the new gateway and cleans up the sentinel

## Key Design Decisions

- **Stdlib-only**: Uses `json`, `os`, `importlib.metadata` — no `_core` import needed, matching the existing import-light pattern
- **Atomic writes**: `services.json` written via temp file + `os.replace`
- **Staleness check**: Matches Rust `ServiceEntry::is_stale` by parsing serde `SystemTime` format (`secs_since_epoch` + `nanos_since_epoch`)
- **Configurable**: `enable_version_takeover=False` skips the check entirely
- **Backward compatible**: No breaking changes to existing API; new params have defaults

## Files Changed

- `python/dcc_mcp_core/_server/gateway_guardian.py`: Added version takeover helpers + modified `ensure_gateway_daemon()`
- `tests/test_gateway_guardian.py`: Added 20 new tests covering all takeover scenarios

## Testing



New test coverage:
- `_parse_semver` / `_is_newer_version` correctness
- `_sentry_stale` staleness detection
- Sentinel write/cleanup round-trip
- No takeover when no sentinel exists (first start)
- Takeover when newer version
- No takeover when running gateway is newer
- Stale sentinel ignored
- Old gateway timeout fallback
- `enable_version_takeover=False` flag
- Full integration test through `ensure_gateway_daemon`

Closes PIP-1400