### PR TITLE
fix: set DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES=1 in ScopedMarketplaceInstallRoot

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -100,19 +100,26 @@ mod admin_tests {
 
     struct ScopedMarketplaceInstallRoot {
         previous: Option<String>,
+        previous_no_default_sources: Option<String>,
     }
 
     impl ScopedMarketplaceInstallRoot {
         fn new(root: &std::path::Path) -> Self {
             let previous = std::env::var("DCC_MCP_MARKETPLACE_INSTALL_ROOT").ok();
+            let previous_no_default_sources =
+                std::env::var("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES").ok();
             // SAFETY: tests are serialized with `MARKETPLACE_ENV_LOCK`.
             unsafe {
                 std::env::set_var(
                     "DCC_MCP_MARKETPLACE_INSTALL_ROOT",
                     root.to_string_lossy().as_ref(),
                 );
+                std::env::set_var("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES", "1");
             }
-            Self { previous }
+            Self {
+                previous,
+                previous_no_default_sources,
+            }
         }
     }
 
@@ -123,6 +130,10 @@ mod admin_tests {
                 match &self.previous {
                     Some(v) => std::env::set_var("DCC_MCP_MARKETPLACE_INSTALL_ROOT", v),
                     None => std::env::remove_var("DCC_MCP_MARKETPLACE_INSTALL_ROOT"),
+                }
+                match &self.previous_no_default_sources {
+                    Some(v) => std::env::set_var("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES", v),
+                    None => std::env::remove_var("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES"),
                 }
             }
         }
@@ -3374,6 +3385,10 @@ filters:
         let root = tmp.path().join("marketplace");
         std::fs::create_dir_all(&root).unwrap();
         let _scoped_root = ScopedMarketplaceInstallRoot::new(&root);
+        // This test specifically needs builtin sources; re-enable them.
+        unsafe {
+            std::env::remove_var("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES");
+        }
 
         let state = make_admin_state();
         let router = build_admin_router(state);


### PR DESCRIPTION
## Summary
- Fix flaky test `test_marketplace_error_envelope_has_kind_and_message` that failed CI on main (commit `66bcb334`) with "internal_error" instead of "not_found"
- Root cause: marketplace tests depend on network-fetched built-in sources; when network is unavailable or slow, the test gets an internal_error instead of the expected not_found
- Set `DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES=1` in `ScopedMarketplaceInstallRoot::new()` so all marketplace tests are isolated from network-dependent default sources by default
- `test_marketplace_sources_returns_builtin_config_and_env` (which specifically tests builtin sources) re-enables them after setup

## Test plan
- [x] `test_marketplace_error_envelope_has_kind_and_message` passes
- [x] All 9 marketplace-related tests pass (`cargo test --package dcc-mcp-gateway --features admin -- test_marketplace`)
- [ ] CI green on this PR