### PR TITLE
feat(admin): slide-out detail panel for installed marketplace packages

### DIFF
--- a/admin-ui/src/features/marketplace/MarketplaceInstalledDetailPanel.css
+++ b/admin-ui/src/features/marketplace/MarketplaceInstalledDetailPanel.css
@@ -1,0 +1,208 @@
+/* Slide-out detail panel for installed marketplace packages.
+ * Follows the same visual pattern as skill-detail-backdrop / skill-detail-modal
+ * in styles/skills.css — right-aligned slide-in with blur backdrop. */
+
+.marketplace-installed-detail-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-end;
+  animation: mkp-installed-fade 180ms ease-out;
+}
+
+.marketplace-installed-detail-modal {
+  position: relative;
+  width: min(720px, 100%);
+  max-width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  background: var(--card);
+  border-left: 1px solid var(--border);
+  box-shadow: -24px 0 48px -24px rgba(0, 0, 0, 0.35);
+  padding: 22px 26px 32px;
+  animation: mkp-installed-slide-in 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.marketplace-installed-detail-modal .marketplace-installed-detail-panel {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  margin: 0;
+  padding: 0;
+  overflow: visible;
+}
+
+.marketplace-installed-detail-modal .marketplace-installed-detail-heading {
+  position: sticky;
+  top: -22px;
+  margin: -22px -26px 16px;
+  padding: 18px 26px;
+  background: color-mix(in srgb, var(--card) 92%, transparent);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border);
+  z-index: 1;
+}
+
+.marketplace-installed-detail-close {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.marketplace-installed-detail-close:hover {
+  background: var(--muted);
+  color: var(--foreground);
+  border-color: color-mix(in srgb, var(--skill-brand) 35%, var(--border));
+}
+
+@keyframes mkp-installed-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes mkp-installed-slide-in {
+  from { transform: translateX(24px); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+/* ── Panel content ───────────────────────────────────────────────────────── */
+
+.marketplace-installed-detail-panel {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin: 0.35rem 0 1.2rem;
+  overflow: hidden;
+  padding: 1rem;
+}
+
+.marketplace-installed-detail-heading {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.marketplace-installed-detail-heading h3 {
+  color: var(--foreground);
+  font-size: 1rem;
+  line-height: 1.25;
+  margin: 0 0 0.35rem;
+  overflow-wrap: anywhere;
+}
+
+.marketplace-installed-detail-meta {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.marketplace-installed-detail-version {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-foreground);
+}
+
+.marketplace-installed-detail-desc {
+  color: var(--foreground);
+  margin: 0.65rem 0;
+  max-width: 58rem;
+  line-height: 1.55;
+}
+
+.marketplace-installed-detail-summary-grid {
+  display: grid;
+  gap: 0.45rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0.75rem 0;
+}
+
+.marketplace-installed-detail-summary-grid span {
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--foreground);
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 0.5rem 0.6rem;
+}
+
+.marketplace-installed-detail-summary-grid strong {
+  color: var(--muted-foreground);
+  display: block;
+  font-size: 0.68rem;
+  letter-spacing: 0;
+  margin-bottom: 0.15rem;
+  text-transform: uppercase;
+}
+
+.marketplace-installed-detail-summary-grid code,
+.marketplace-installed-detail-summary-grid a {
+  font-size: 0.82rem;
+}
+
+.marketplace-installed-detail-summary-grid a {
+  color: var(--link);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.marketplace-installed-detail-summary-grid a:hover {
+  text-decoration: underline;
+}
+
+.marketplace-installed-detail-outdated {
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: var(--radius);
+  color: #d97706;
+  font-size: 0.82rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  padding: 0.55rem 0.75rem;
+}
+
+.marketplace-installed-detail-section {
+  margin-bottom: 0.75rem;
+}
+
+.marketplace-installed-detail-section h4 {
+  color: var(--muted-foreground);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  margin: 0 0 0.35rem;
+  text-transform: uppercase;
+}
+
+.marketplace-installed-detail-chips {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+@media (max-width: 720px) {
+  .marketplace-installed-detail-modal {
+    width: 100%;
+    padding: 18px 18px 24px;
+  }
+}

--- a/admin-ui/src/features/marketplace/MarketplaceInstalledDetailPanel.tsx
+++ b/admin-ui/src/features/marketplace/MarketplaceInstalledDetailPanel.tsx
@@ -1,0 +1,137 @@
+import { type InterpolationValues, type MessageKey } from '../../i18n';
+import type { InstalledMarketplacePackage, MarketplaceEntry } from '../../admin-types';
+import './MarketplaceInstalledDetailPanel.css';
+
+type Translator = (key: MessageKey, values?: InterpolationValues) => string;
+
+export type MarketplaceInstalledDetailPanelProps = {
+  pkg: InstalledMarketplacePackage;
+  /** Matched catalog entry (if this package is in the marketplace catalog). */
+  catalogEntry?: MarketplaceEntry | null;
+  isOutdated?: boolean;
+  installing?: boolean;
+  onUninstall: () => void;
+  onUpdate?: () => void;
+  onClose: () => void;
+  t: Translator;
+};
+
+/// Slide-out detail panel for an installed marketplace package.
+///
+/// Follows the same layout/behaviour as SkillDetailPanel — right-aligned
+/// slide-in with backdrop blur, sticky heading, summary grid, and action
+/// buttons. Reuses existing marketplace locale keys where possible.
+export function MarketplaceInstalledDetailPanel({
+  pkg,
+  catalogEntry,
+  isOutdated,
+  installing,
+  onUninstall,
+  onUpdate,
+  onClose,
+  t,
+}: MarketplaceInstalledDetailPanelProps) {
+  const version = pkg.version ?? catalogEntry?.version ?? t('marketplace.card.noVersion');
+  const description = catalogEntry?.description || null;
+  const tags = catalogEntry?.tags ?? [];
+  const maintainer = catalogEntry?.maintainer ?? null;
+
+  const installedDate = pkg.installed_at_ms
+    ? new Date(pkg.installed_at_ms).toLocaleString()
+    : null;
+
+  return (
+    <section className="marketplace-installed-detail-panel" aria-live="polite">
+      <div className="marketplace-installed-detail-heading">
+        <div>
+          <h3>{pkg.name}</h3>
+          <div className="marketplace-installed-detail-meta">
+            <span className="source-pill">{pkg.dcc}</span>
+            <span className="marketplace-installed-detail-version">
+              {t('marketplace.detail.version')}: {version}
+            </span>
+            {maintainer ? (
+              <span className="marketplace-installed-detail-version">{maintainer}</span>
+            ) : null}
+          </div>
+        </div>
+        <div className="table-actions">
+          {isOutdated && onUpdate ? (
+            <button
+              className="refresh-btn"
+              type="button"
+              disabled={installing}
+              onClick={onUpdate}
+            >
+              {installing ? t('marketplace.card.updating') : t('marketplace.card.update')}
+            </button>
+          ) : null}
+          <button
+            className="refresh-btn"
+            type="button"
+            disabled={installing}
+            onClick={onUninstall}
+            style={{ color: 'var(--err)' }}
+          >
+            {installing ? t('marketplace.card.installing') : t('marketplace.card.uninstall')}
+          </button>
+          <button className="linkish" type="button" onClick={onClose}>
+            {t('action.close')}
+          </button>
+        </div>
+      </div>
+
+      {description ? (
+        <p className="marketplace-installed-detail-desc">{description}</p>
+      ) : null}
+
+      <div className="marketplace-installed-detail-summary-grid">
+        <span>
+          <strong>{t('marketplace.detail.installType')}</strong>
+          {pkg.install_type}
+        </span>
+        <span>
+          <strong>{t('marketplace.detail.source')}</strong>
+          {pkg.source_url ? (
+            <a
+              href={pkg.source_url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {pkg.source_name}
+            </a>
+          ) : (
+            pkg.source_name
+          )}
+        </span>
+        <span>
+          <strong>Path</strong>
+          <code className="mono-path">{pkg.path}</code>
+        </span>
+        <span>
+          <strong>Installed</strong>
+          {installedDate ?? '—'}
+        </span>
+      </div>
+
+      {isOutdated ? (
+        <div className="marketplace-installed-detail-outdated" role="alert">
+          {t('marketplace.card.outdated')}
+        </div>
+      ) : null}
+
+      {tags.length > 0 ? (
+        <div className="marketplace-installed-detail-section">
+          <h4>{t('marketplace.card.tags')}</h4>
+          <div className="marketplace-installed-detail-chips">
+            {tags.map((tag) => (
+              <code key={tag} className="marketplace-card-chip marketplace-card-chip-tag">
+                {tag}
+              </code>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/admin-ui/src/features/marketplace/MarketplacePanel.tsx
+++ b/admin-ui/src/features/marketplace/MarketplacePanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { InterpolationValues, MessageKey } from '../../i18n';
 import {
   PanelHeader,
@@ -25,6 +26,7 @@ import type {
 } from '../../admin-types';
 import { MarketplaceCard } from './MarketplaceCard';
 import { MarketplaceDetailModal } from './MarketplaceDetailModal';
+import { MarketplaceInstalledDetailPanel } from './MarketplaceInstalledDetailPanel';
 
 type Translator = (key: MessageKey, values?: InterpolationValues) => string;
 
@@ -70,6 +72,10 @@ export function MarketplacePanel({
   const [tab, setTab] = useState<MarketplaceTab>('browse');
   const [installingKey, setInstallingKey] = useState<string | null>(null);
   const [detailEntry, setDetailEntry] = useState<MarketplaceEntry | null>(null);
+  const [installedDetail, setInstalledDetail] = useState<{
+    pkg: InstalledMarketplacePackage;
+    catalogEntry?: MarketplaceEntry | null;
+  } | null>(null);
   const [dccFilter, setDccFilter] = useState<string | null>(null);
   const [forceInstall, setForceInstall] = useState(false);
   /// { name, dcc } of the most recently installed/uninstalled package for the inline notice.
@@ -353,6 +359,17 @@ export function MarketplacePanel({
     setDetailEntry(null);
   }, []);
 
+  const handleOpenInstalledDetail = useCallback(
+    (pkg: InstalledMarketplacePackage, catalogEntry?: MarketplaceEntry | null) => {
+      setInstalledDetail({ pkg, catalogEntry });
+    },
+    [],
+  );
+
+  const handleCloseInstalledDetail = useCallback(() => {
+    setInstalledDetail(null);
+  }, []);
+
   const handleViewInSkills = useCallback(() => {
     if (installNotice && onNavigateToSkills) {
       onNavigateToSkills(installNotice.name);
@@ -624,7 +641,7 @@ export function MarketplacePanel({
                     onInstall={handleInstall}
                     onUninstall={handleUninstall}
                     onUpdate={handleUpdate}
-                    onOpenDetail={handleOpenDetail}
+                    onOpenDetail={() => handleOpenInstalledDetail(pkg, catalogEntry)}
                     isOutdated={outdatedByKey.has(pkgKey)}
                     t={t}
                   />
@@ -642,6 +659,92 @@ export function MarketplacePanel({
         onClose={handleCloseDetail}
         t={t}
       />
+
+      {/* Installed package detail (portal-based slide-out) */}
+      <MarketplaceInstalledDetailModal
+        detail={installedDetail}
+        isOutdated={installedDetail ? outdatedByKey.has(`${installedDetail.pkg.name}:${installedDetail.pkg.dcc}`) : false}
+        installingKey={installingKey}
+        onUninstall={handleUninstall}
+        onUpdate={handleUpdate}
+        onClose={handleCloseInstalledDetail}
+        t={t}
+      />
     </section>
+  );
+}
+
+/// Portal-based modal that renders the installed detail panel as a slide-in overlay.
+/// Follows the same pattern as SkillDetailModal in SkillsPanel.
+function MarketplaceInstalledDetailModal({
+  detail,
+  isOutdated,
+  installingKey,
+  onUninstall,
+  onUpdate,
+  onClose,
+  t,
+}: {
+  detail: { pkg: InstalledMarketplacePackage; catalogEntry?: MarketplaceEntry | null } | null;
+  isOutdated: boolean;
+  installingKey: string | null;
+  onUninstall: (pkg: InstalledMarketplacePackage) => void;
+  onUpdate: (pkgName: string, dcc: string) => void;
+  onClose: () => void;
+  t: Translator;
+}) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!detail) return;
+    document.addEventListener('keydown', handleKeyDown);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+    };
+  }, [detail, handleKeyDown]);
+
+  if (!detail) return null;
+
+  const pkgKey = `${detail.pkg.name}:${detail.pkg.dcc}`;
+  const isInstalling = installingKey === pkgKey;
+
+  return createPortal(
+    <div
+      className="marketplace-installed-detail-backdrop"
+      role="dialog"
+      aria-modal="true"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="marketplace-installed-detail-modal">
+        <button
+          type="button"
+          className="marketplace-installed-detail-close"
+          aria-label={t('action.close')}
+          onClick={onClose}
+        >
+          &times;
+        </button>
+        <MarketplaceInstalledDetailPanel
+          pkg={detail.pkg}
+          catalogEntry={detail.catalogEntry}
+          isOutdated={isOutdated}
+          installing={isInstalling}
+          onUninstall={() => onUninstall(detail.pkg)}
+          onUpdate={onUpdate ? () => onUpdate(detail.pkg.name, detail.pkg.dcc) : undefined}
+          onClose={onClose}
+          t={t}
+        />
+      </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
Installed packages in the Marketplace panel now open a right-aligned
slide-out detail overlay when clicked, matching the Skills page detail
layout/behavior:

- **MarketplaceInstalledDetailPanel** — new component showing install
  path, install type, source, timestamp, version, tags, and catalog
  metadata (when available)
- **Slide-out modal** — same portal-based right slide-in pattern as
  SkillDetailModal with backdrop blur, Escape key close, sticky heading
- **Installed tab cards** — now clickable via `onOpenDetail`, wired to
  the new slide-out instead of the centered MarketplaceDetailModal
- CSS follows the same animation/variable naming conventions as
  `styles/skills.css` for consistency

Part of PIP-1428