### PR TITLE
feat: extract shared gateway ensure crate (PIP-1418)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,7 @@ dependencies = [
  "axum",
  "clap",
  "dcc-mcp-catalog",
+ "dcc-mcp-gateway-ensure",
  "dcc-mcp-marketplace",
  "dcc-mcp-skills",
  "dirs",
@@ -1250,6 +1251,19 @@ dependencies = [
  "serde_json",
  "tracing",
  "uuid",
+ "workspace-hack",
+]
+
+[[package]]
+name = "dcc-mcp-gateway-ensure"
+version = "0.18.15"
+dependencies = [
+ "anyhow",
+ "reqwest 0.13.4",
+ "serde",
+ "tempfile",
+ "tokio",
+ "tracing",
  "workspace-hack",
 ]
 
@@ -1702,6 +1716,7 @@ dependencies = [
  "axum",
  "clap",
  "dcc-mcp-gateway",
+ "dcc-mcp-gateway-ensure",
  "dcc-mcp-host-rpc",
  "dcc-mcp-transport",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/dcc-mcp-skill-rest",
     "crates/dcc-mcp-gateway",
     "crates/dcc-mcp-gateway-core",
+    "crates/dcc-mcp-gateway-ensure",
     "crates/dcc-mcp-gateway-search",
     "crates/dcc-mcp-logging",
     "crates/dcc-mcp-pybridge",
@@ -95,6 +96,7 @@ dcc-mcp-marketplace = { path = "crates/dcc-mcp-marketplace" }
 dcc-mcp-catalog = { path = "crates/dcc-mcp-catalog" }
 dcc-mcp-db = { path = "crates/dcc-mcp-db" }
 dcc-mcp-gateway = { path = "crates/dcc-mcp-gateway" }
+dcc-mcp-gateway-ensure = { path = "crates/dcc-mcp-gateway-ensure" }
 dcc-mcp-gateway-search = { path = "crates/dcc-mcp-gateway-search" }
 dcc-mcp-semantic = { path = "crates/dcc-mcp-semantic" }
 

--- a/crates/dcc-mcp-cli/Cargo.toml
+++ b/crates/dcc-mcp-cli/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 dcc-mcp-catalog.workspace = true
+dcc-mcp-gateway-ensure.workspace = true
 dcc-mcp-marketplace.workspace = true
 dcc-mcp-skills.workspace = true
 dirs.workspace = true

--- a/crates/dcc-mcp-cli/src/application/gateway_ensure.rs
+++ b/crates/dcc-mcp-cli/src/application/gateway_ensure.rs
@@ -4,47 +4,18 @@
 //! - No version takeover (CLI is not a DCC adapter).
 //! - No FileRegistry dependency.
 //! - No adapter_version / adapter_dcc fields.
+//!
+//! Shared primitives (health check, launch lock, spawn, pidfile, process
+//! utilities) live in `dcc-mcp-gateway-ensure`.
 
-use std::fs::{File, OpenOptions};
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::Context;
+use dcc_mcp_gateway_ensure as ensure;
 use serde::Serialize;
 
 use super::gateway_discovery;
-
-/// How long to wait for a single `/health` probe before timing out.
-const HEALTH_TIMEOUT: Duration = Duration::from_millis(600);
-
-/// Default lock staleness: reclaim a lock file older than this.
-const DEFAULT_LOCK_STALE_SECS: u64 = 30;
-
-const ENV_GATEWAY_LAUNCH_LOCK_STALE_SECS: &str = "DCC_MCP_GATEWAY_LAUNCH_LOCK_STALE_SECS";
-/// Env var override for wait timeout; falls back to caller-provided
-/// `wait_timeout_secs`.
-const ENV_GATEWAY_ENSURE_TIMEOUT_SECS: &str = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS";
-/// Default wait timeout (15 s) when neither the caller nor the env var
-/// provide a value.
-const DEFAULT_ENSURE_TIMEOUT_SECS: u64 = 15;
-
-/// Resolve the effective ensure timeout: env var `DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS`
-/// takes priority, then the caller-supplied `wait_timeout_secs`, then the
-/// crate default (15 s).
-fn resolve_ensure_timeout_secs(wait_timeout_secs: u64) -> u64 {
-    std::env::var(ENV_GATEWAY_ENSURE_TIMEOUT_SECS)
-        .ok()
-        .and_then(|raw| raw.parse::<u64>().ok())
-        .filter(|secs| *secs > 0)
-        .unwrap_or({
-            if wait_timeout_secs > 0 {
-                wait_timeout_secs
-            } else {
-                DEFAULT_ENSURE_TIMEOUT_SECS
-            }
-        })
-}
 
 /// Outcome of an `ensure_gateway_running` call.
 #[derive(Debug, Clone, Serialize)]
@@ -78,35 +49,48 @@ pub async fn ensure_gateway_running(args: &EnsureGatewayArgs) -> anyhow::Result<
         anyhow::bail!("gateway port must be non-zero");
     }
 
-    if gateway_health_ok(&args.host, args.port).await {
+    if ensure::gateway_health_ok(&args.host, args.port).await {
         return Ok(EnsureResult {
             host: args.host.clone(),
             port: args.port,
             already_running: true,
-            pid: read_pid_from_pidfile(args.pidfile.as_deref()),
+            pid: ensure::read_pid_from_pidfile(args.pidfile.as_deref()),
         });
     }
 
     std::fs::create_dir_all(&args.registry_dir)
         .with_context(|| format!("creating registry dir {}", args.registry_dir.display()))?;
     let lock_path = args.registry_dir.join("gateway-launch.lock");
-    match acquire_launch_lock(&lock_path) {
+    match ensure::acquire_launch_lock(&lock_path) {
         Ok(_lock) => {
             // Double-check after acquiring the lock (race protection).
-            if gateway_health_ok(&args.host, args.port).await {
+            if ensure::gateway_health_ok(&args.host, args.port).await {
                 return Ok(EnsureResult {
                     host: args.host.clone(),
                     port: args.port,
                     already_running: true,
-                    pid: read_pid_from_pidfile(args.pidfile.as_deref()),
+                    pid: ensure::read_pid_from_pidfile(args.pidfile.as_deref()),
                 });
             }
-            let pid = spawn_detached_gateway(args).await?;
 
-            wait_gateway_ready(
+            let exe = resolve_gateway_bin(args).await?;
+            let cmd_args = ensure::gateway_command_args(
                 &args.host,
                 args.port,
-                Duration::from_secs(resolve_ensure_timeout_secs(args.wait_timeout_secs)),
+                args.name.as_deref(),
+                &args.remote_host,
+                args.remote_port,
+                args.gateway_idle_timeout_secs,
+            );
+            let pid =
+                ensure::spawn_detached_gateway(&exe, &cmd_args, &args.registry_dir)?;
+
+            ensure::wait_gateway_ready(
+                &args.host,
+                args.port,
+                Duration::from_secs(ensure::resolve_ensure_timeout_secs(
+                    args.wait_timeout_secs,
+                )),
             )
             .await?;
 
@@ -115,7 +99,7 @@ pub async fn ensure_gateway_running(args: &EnsureGatewayArgs) -> anyhow::Result<
 
             // Write PID file so stop/status commands can find the process.
             if let Some(ref pidfile) = args.pidfile {
-                write_pidfile(pidfile, pid)?;
+                ensure::write_pidfile(pidfile, pid)?;
             }
 
             Ok(EnsureResult {
@@ -129,13 +113,15 @@ pub async fn ensure_gateway_running(args: &EnsureGatewayArgs) -> anyhow::Result<
             // Another process holds the launch lock — wait for its winner to
             // finish and check whether the gateway becomes healthy (mirrors
             // Python `_wait_gateway_ready` on lock-loser path).
-            let timeout = Duration::from_secs(resolve_ensure_timeout_secs(args.wait_timeout_secs));
-            wait_gateway_ready(&args.host, args.port, timeout).await?;
+            let timeout = Duration::from_secs(ensure::resolve_ensure_timeout_secs(
+                args.wait_timeout_secs,
+            ));
+            ensure::wait_gateway_ready(&args.host, args.port, timeout).await?;
             Ok(EnsureResult {
                 host: args.host.clone(),
                 port: args.port,
                 already_running: true,
-                pid: read_pid_from_pidfile(args.pidfile.as_deref()),
+                pid: ensure::read_pid_from_pidfile(args.pidfile.as_deref()),
             })
         }
         Err(err) => {
@@ -144,399 +130,31 @@ pub async fn ensure_gateway_running(args: &EnsureGatewayArgs) -> anyhow::Result<
     }
 }
 
-/// Check whether the gateway `/health` endpoint responds successfully.
-pub async fn gateway_health_ok(host: &str, port: u16) -> bool {
-    gateway_health_ok_with_timeout(host, port, HEALTH_TIMEOUT).await
-}
-
-async fn gateway_health_ok_with_timeout(host: &str, port: u16, timeout: Duration) -> bool {
-    let url = format!("http://{host}:{port}/health");
-    let client = match reqwest::Client::builder().timeout(timeout).build() {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
-    client
-        .get(url)
-        .send()
-        .await
-        .is_ok_and(|resp| resp.status().is_success())
-}
-
-// ── Launch lock ──────────────────────────────────────────────────────────
-
-#[derive(Debug)]
-struct LaunchLock {
-    _file: File,
-    path: PathBuf,
-}
-
-impl Drop for LaunchLock {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
-    }
-}
-
-fn acquire_launch_lock(path: &Path) -> std::io::Result<LaunchLock> {
-    acquire_launch_lock_with_stale(path, gateway_launch_lock_stale_after())
-}
-
-fn acquire_launch_lock_with_stale(
-    path: &Path,
-    stale_after: Duration,
-) -> std::io::Result<LaunchLock> {
-    match create_launch_lock(path) {
-        Ok(lock) => Ok(lock),
-        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-            if remove_stale_launch_lock(path, stale_after)? {
-                create_launch_lock(path)
-            } else {
-                Err(err)
-            }
-        }
-        Err(err) => Err(err),
-    }
-}
-
-fn create_launch_lock(path: &Path) -> std::io::Result<LaunchLock> {
-    OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)
-        .map(|file| LaunchLock {
-            _file: file,
-            path: path.to_path_buf(),
-        })
-}
-
-fn gateway_launch_lock_stale_after() -> Duration {
-    std::env::var(ENV_GATEWAY_LAUNCH_LOCK_STALE_SECS)
-        .ok()
-        .and_then(|raw| raw.parse::<u64>().ok())
-        .filter(|secs| *secs > 0)
-        .map(Duration::from_secs)
-        .unwrap_or(Duration::from_secs(DEFAULT_LOCK_STALE_SECS))
-}
-
-fn remove_stale_launch_lock(path: &Path, stale_after: Duration) -> std::io::Result<bool> {
-    if !launch_lock_is_stale(path, stale_after)? {
-        return Ok(false);
-    }
-    // Re-check immediately before unlinking (race protection).
-    if !launch_lock_is_stale(path, stale_after)? {
-        return Ok(false);
-    }
-    match std::fs::remove_file(path) {
-        Ok(()) => Ok(true),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(true),
-        Err(err) => Err(err),
-    }
-}
-
-fn launch_lock_is_stale(path: &Path, stale_after: Duration) -> std::io::Result<bool> {
-    let modified = match std::fs::metadata(path) {
-        Ok(meta) => meta.modified()?,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(true),
-        Err(err) => return Err(err),
-    };
-    let age = modified.elapsed().unwrap_or_default();
-    Ok(age >= stale_after)
-}
-
-// ── Spawn ────────────────────────────────────────────────────────────────
+// ── Binary resolution (CLI-specific: uses gateway_discovery) ────────────────
 
 async fn resolve_gateway_bin(args: &EnsureGatewayArgs) -> anyhow::Result<PathBuf> {
     gateway_discovery::resolve_gateway_bin(args.gateway_bin.as_ref()).await
 }
 
-async fn spawn_detached_gateway(args: &EnsureGatewayArgs) -> anyhow::Result<u32> {
-    let exe = resolve_gateway_bin(args).await?;
-    let mut cmd = Command::new(&exe);
-    cmd.args(gateway_command_args(args))
-        .env("DCC_MCP_REGISTRY_DIR", &args.registry_dir)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+// ── Re-exports for convenience ──────────────────────────────────────────────
 
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        const DETACHED_PROCESS: u32 = 0x0000_0008;
-        cmd.creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS);
-    }
-
-    let child = cmd
-        .spawn()
-        .with_context(|| format!("spawning gateway from {}", exe.display()))?;
-    Ok(child.id())
-}
-
-fn gateway_command_args(args: &EnsureGatewayArgs) -> Vec<std::ffi::OsString> {
-    use std::ffi::OsString;
-    let mut cargs = vec![
-        OsString::from("gateway"),
-        OsString::from("--host"),
-        OsString::from(&args.host),
-        OsString::from("--port"),
-        OsString::from(args.port.to_string()),
-        OsString::from("--remote-host"),
-        OsString::from(&args.remote_host),
-        OsString::from("--remote-port"),
-        OsString::from(args.remote_port.to_string()),
-        OsString::from("--gateway-idle-timeout-secs"),
-        OsString::from(args.gateway_idle_timeout_secs.to_string()),
-    ];
-    if let Some(ref name) = args.name
-        && !name.trim().is_empty()
-    {
-        cargs.push(OsString::from("--name"));
-        cargs.push(OsString::from(name));
-    }
-    cargs
-}
-
-async fn wait_gateway_ready(host: &str, port: u16, timeout: Duration) -> anyhow::Result<()> {
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        if gateway_health_ok(host, port).await {
-            return Ok(());
-        }
-        tokio::time::sleep(Duration::from_millis(150)).await;
-    }
-    anyhow::bail!(
-        "gateway did not become healthy at http://{host}:{port}/health within {timeout:?}"
-    )
-}
-
-// ── PID file ─────────────────────────────────────────────────────────────
-
-/// Read a PID from a pidfile, returning `None` if the file doesn't exist or
-/// can't be parsed.
-pub fn read_pid_from_pidfile(pidfile: Option<&Path>) -> Option<u32> {
-    let path = pidfile?;
-    let raw = std::fs::read_to_string(path).ok()?;
-    raw.trim().parse::<u32>().ok()
-}
-
-fn write_pidfile(path: &Path, pid: u32) -> anyhow::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("creating pidfile dir {}", parent.display()))?;
-    }
-    std::fs::write(path, format!("{pid}\n"))
-        .with_context(|| format!("writing pidfile {}", path.display()))
-}
-
-/// Remove the pidfile if it exists.
-pub fn remove_pidfile(pidfile: Option<&Path>) {
-    if let Some(path) = pidfile {
-        let _ = std::fs::remove_file(path);
-    }
-}
-
-// ── Process utilities (subprocess-based, no foreign deps) ────────────────
-
-/// Check whether a process with the given PID is still running.
-pub fn is_process_alive(pid: u32) -> bool {
-    #[cfg(windows)]
-    {
-        // `tasklist /FI "PID eq <pid>" /NH` returns output containing the
-        // PID if the process exists, or "INFO: No tasks..." on stderr if not.
-        // Exit code is always 0, so we check stdout for the PID string.
-        let output = Command::new("tasklist")
-            .args([
-                "/FI",
-                &format!("PID eq {pid}"),
-                "/NH", // No headers
-            ])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .output();
-        match output {
-            Ok(out) => {
-                let stdout = String::from_utf8_lossy(&out.stdout);
-                stdout.contains(&pid.to_string())
-            }
-            Err(_) => false,
-        }
-    }
-    #[cfg(unix)]
-    {
-        // `kill -0 <pid>` succeeds if the process exists and we can signal it.
-        Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
-    }
-}
-
-/// Send a termination signal to the process with the given PID.
-pub fn stop_process(pid: u32) -> anyhow::Result<()> {
-    #[cfg(windows)]
-    {
-        let status = Command::new("taskkill")
-            .args(["/PID", &pid.to_string(), "/F"])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .with_context(|| format!("taskkill /PID {pid}"))?;
-        if !status.success() {
-            // Exit code 128 means the process was not found — that's OK.
-            if status.code() != Some(128) {
-                anyhow::bail!("taskkill /PID {pid} exited with {status}");
-            }
-        }
-    }
-    #[cfg(unix)]
-    {
-        let status = Command::new("kill")
-            .arg(pid.to_string())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .with_context(|| format!("kill {pid}"))?;
-        if !status.success() {
-            anyhow::bail!("kill {pid} exited with {status}");
-        }
-    }
-    Ok(())
-}
-
-// ── Default registry dir ────────────────────────────────────────────────
-
-/// Default registry directory used by the gateway and sidecar.
-pub fn default_registry_dir() -> PathBuf {
-    std::env::var("DCC_MCP_REGISTRY_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| std::env::temp_dir().join("dcc-mcp-core-registry"))
-}
+pub use ensure::{
+    default_registry_dir, gateway_health_ok, is_process_alive, read_pid_from_pidfile,
+    remove_pidfile, stop_process,
+};
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
-
-    #[test]
-    fn test_read_pid_from_pidfile_none() {
-        assert!(read_pid_from_pidfile(None).is_none());
-    }
-
-    #[test]
-    fn test_read_pid_from_pidfile_invalid() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("bad.pid");
-        std::fs::write(&path, "not-a-number").unwrap();
-        assert!(read_pid_from_pidfile(Some(&path)).is_none());
-    }
-
-    #[test]
-    fn test_read_pid_from_pidfile_valid() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("test.pid");
-        write_pidfile(&path, 12345).unwrap();
-        assert_eq!(read_pid_from_pidfile(Some(&path)), Some(12345));
-    }
-
-    #[test]
-    fn test_read_pid_from_pidfile_with_newline() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("test.pid");
-        std::fs::write(&path, "12345\n").unwrap();
-        assert_eq!(read_pid_from_pidfile(Some(&path)), Some(12345));
-    }
-
-    #[test]
-    fn test_write_then_read_pidfile() {
-        // Integration test: write → read → remove.
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("gateway.pid");
-        write_pidfile(&path, 99999).unwrap();
-        assert_eq!(read_pid_from_pidfile(Some(&path)), Some(99999));
-        remove_pidfile(Some(&path));
-        assert!(read_pid_from_pidfile(Some(&path)).is_none());
-    }
-
-    #[test]
-    fn test_is_process_alive_current() {
-        assert!(is_process_alive(std::process::id()));
-    }
-
-    #[test]
-    fn test_is_process_alive_invalid() {
-        // PIDs are well under 10 million on every OS.
-        assert!(!is_process_alive(9_999_999));
-    }
-
-    #[test]
-    fn test_launch_lock_create_and_drop() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("test.lock");
-        {
-            let lock = acquire_launch_lock(&path).unwrap();
-            assert!(path.exists());
-            // Second acquire must fail with AlreadyExists.
-            let err = acquire_launch_lock(&path).unwrap_err();
-            assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
-            drop(lock);
-        }
-        // After drop, lock file should be removed.
-        assert!(!path.exists());
-    }
-
-    #[test]
-    fn test_launch_lock_stale_removed_correctly() {
-        // Simulate a stale lock: the file exists but with a very old mtime.
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("stale.lock");
-        {
-            let _f = File::create(&path).unwrap();
-        }
-        // File is brand new, so it should NOT be stale with a 1s threshold.
-        let result = acquire_launch_lock_with_stale(&path, Duration::from_secs(1));
-        // The file is fresh (<1s old), so AlreadyExists should be returned
-        // (it shouldn't be reclaimed).
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_launch_lock_stale_reclaim_with_zero_secs() {
-        // With a 0-second stale threshold, any existing lock is immediately stale.
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("stale0.lock");
-        let _f = File::create(&path).unwrap();
-        drop(_f);
-        // Zero-second stale → any file is stale.
-        let lock = acquire_launch_lock_with_stale(&path, Duration::from_secs(0)).unwrap();
-        drop(lock);
-        assert!(!path.exists());
-    }
-
-    #[tokio::test]
-    async fn test_gateway_health_ok_unreachable() {
-        assert!(!gateway_health_ok("127.0.0.1", 19999).await);
-    }
 
     #[test]
     fn test_gateway_command_args_minimal() {
-        let args = EnsureGatewayArgs {
-            host: "127.0.0.1".into(),
-            port: 9765,
-            name: None,
-            registry_dir: PathBuf::from("/tmp"),
-            remote_host: "0.0.0.0".into(),
-            remote_port: 59765,
-            gateway_idle_timeout_secs: 30,
-            gateway_bin: None,
-            wait_timeout_secs: 10,
-            pidfile: None,
-        };
-        let argv: Vec<String> = gateway_command_args(&args)
-            .into_iter()
-            .map(|s| s.to_string_lossy().to_string())
-            .collect();
+        let argv: Vec<String> = ensure::gateway_command_args(
+            "127.0.0.1", 9765, None, "0.0.0.0", 59765, 30,
+        )
+        .into_iter()
+        .map(|s| s.to_string_lossy().to_string())
+        .collect();
         assert!(argv[0] == "gateway");
         assert!(argv.contains(&"--port".to_string()));
         assert!(argv.contains(&"9765".to_string()));

--- a/crates/dcc-mcp-cli/src/application/gateway_ensure.rs
+++ b/crates/dcc-mcp-cli/src/application/gateway_ensure.rs
@@ -82,15 +82,12 @@ pub async fn ensure_gateway_running(args: &EnsureGatewayArgs) -> anyhow::Result<
                 args.remote_port,
                 args.gateway_idle_timeout_secs,
             );
-            let pid =
-                ensure::spawn_detached_gateway(&exe, &cmd_args, &args.registry_dir)?;
+            let pid = ensure::spawn_detached_gateway(&exe, &cmd_args, &args.registry_dir)?;
 
             ensure::wait_gateway_ready(
                 &args.host,
                 args.port,
-                Duration::from_secs(ensure::resolve_ensure_timeout_secs(
-                    args.wait_timeout_secs,
-                )),
+                Duration::from_secs(ensure::resolve_ensure_timeout_secs(args.wait_timeout_secs)),
             )
             .await?;
 
@@ -113,9 +110,8 @@ pub async fn ensure_gateway_running(args: &EnsureGatewayArgs) -> anyhow::Result<
             // Another process holds the launch lock — wait for its winner to
             // finish and check whether the gateway becomes healthy (mirrors
             // Python `_wait_gateway_ready` on lock-loser path).
-            let timeout = Duration::from_secs(ensure::resolve_ensure_timeout_secs(
-                args.wait_timeout_secs,
-            ));
+            let timeout =
+                Duration::from_secs(ensure::resolve_ensure_timeout_secs(args.wait_timeout_secs));
             ensure::wait_gateway_ready(&args.host, args.port, timeout).await?;
             Ok(EnsureResult {
                 host: args.host.clone(),
@@ -149,12 +145,11 @@ mod tests {
 
     #[test]
     fn test_gateway_command_args_minimal() {
-        let argv: Vec<String> = ensure::gateway_command_args(
-            "127.0.0.1", 9765, None, "0.0.0.0", 59765, 30,
-        )
-        .into_iter()
-        .map(|s| s.to_string_lossy().to_string())
-        .collect();
+        let argv: Vec<String> =
+            ensure::gateway_command_args("127.0.0.1", 9765, None, "0.0.0.0", 59765, 30)
+                .into_iter()
+                .map(|s| s.to_string_lossy().to_string())
+                .collect();
         assert!(argv[0] == "gateway");
         assert!(argv.contains(&"--port".to_string()));
         assert!(argv.contains(&"9765".to_string()));

--- a/crates/dcc-mcp-gateway-ensure/Cargo.toml
+++ b/crates/dcc-mcp-gateway-ensure/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "dcc-mcp-gateway-ensure"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared gateway ensure primitives: health check, launch lock, spawn, pidfile, process utilities"
+
+[dependencies]
+anyhow.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/dcc-mcp-gateway-ensure/src/lib.rs
+++ b/crates/dcc-mcp-gateway-ensure/src/lib.rs
@@ -1,0 +1,554 @@
+//! Shared gateway ensure primitives.
+//!
+//! This crate provides the building blocks for gateway auto-launch in both
+//! `dcc-mcp-cli` and `dcc-mcp-sidecar`:
+//!
+//! - Health check probes (`/health` endpoint)
+//! - File-based launch lock with stale reclaim
+//! - Detached process spawn (cross-platform)
+//! - Gateway-ready polling
+//! - PID file read/write/remove
+//! - Cross-platform process liveness / termination
+//!
+//! The orchestrator-level `ensure_gateway_running` stays in each consumer
+//! because CLI and sidecar have different lock-conflict behaviour and the
+//! sidecar needs version-takeover logic (which depends on `dcc-mcp-gateway`).
+
+use std::ffi::OsString;
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::Context;
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/// How long to wait for a single `/health` probe before timing out.
+pub const HEALTH_TIMEOUT: Duration = Duration::from_millis(600);
+
+/// Default lock staleness: reclaim a lock file older than this.
+pub const DEFAULT_LOCK_STALE_SECS: u64 = 30;
+
+/// Env var that overrides the launch-lock staleness threshold (seconds).
+pub const ENV_GATEWAY_LAUNCH_LOCK_STALE_SECS: &str = "DCC_MCP_GATEWAY_LAUNCH_LOCK_STALE_SECS";
+
+/// Env var that overrides the gateway-ensure wait timeout (seconds).
+pub const ENV_GATEWAY_ENSURE_TIMEOUT_SECS: &str = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS";
+
+/// Default ensure-wait timeout (15 s) when neither the caller nor the env var
+/// provide a value.
+pub const DEFAULT_ENSURE_TIMEOUT_SECS: u64 = 15;
+
+// ── Health check ───────────────────────────────────────────────────────────
+
+/// Check whether the gateway `/health` endpoint responds successfully.
+pub async fn gateway_health_ok(host: &str, port: u16) -> bool {
+    gateway_health_ok_with_timeout(host, port, HEALTH_TIMEOUT).await
+}
+
+/// Check whether the gateway `/health` endpoint responds successfully,
+/// with a caller-specified timeout.
+pub async fn gateway_health_ok_with_timeout(host: &str, port: u16, timeout: Duration) -> bool {
+    let url = format!("http://{host}:{port}/health");
+    let client = match reqwest::Client::builder().timeout(timeout).build() {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    client
+        .get(url)
+        .send()
+        .await
+        .is_ok_and(|resp| resp.status().is_success())
+}
+
+// ── Launch lock ────────────────────────────────────────────────────────────
+
+/// A file-based launch lock that is automatically removed on drop.
+#[derive(Debug)]
+pub struct LaunchLock {
+    _file: File,
+    path: PathBuf,
+}
+
+impl Drop for LaunchLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Acquire the launch lock at `path`, using the default staleness threshold.
+pub fn acquire_launch_lock(path: &Path) -> std::io::Result<LaunchLock> {
+    acquire_launch_lock_with_stale(path, gateway_launch_lock_stale_after())
+}
+
+/// Acquire the launch lock at `path`, reclaiming locks older than `stale_after`.
+pub fn acquire_launch_lock_with_stale(
+    path: &Path,
+    stale_after: Duration,
+) -> std::io::Result<LaunchLock> {
+    match create_launch_lock(path) {
+        Ok(lock) => Ok(lock),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            if remove_stale_launch_lock(path, stale_after)? {
+                create_launch_lock(path)
+            } else {
+                Err(err)
+            }
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Create a new launch lock file (fails with `AlreadyExists` if one exists).
+pub fn create_launch_lock(path: &Path) -> std::io::Result<LaunchLock> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map(|file| LaunchLock {
+            _file: file,
+            path: path.to_path_buf(),
+        })
+}
+
+/// Read the launch lock staleness threshold from the env, falling back to
+/// [`DEFAULT_LOCK_STALE_SECS`].
+pub fn gateway_launch_lock_stale_after() -> Duration {
+    std::env::var(ENV_GATEWAY_LAUNCH_LOCK_STALE_SECS)
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(Duration::from_secs(DEFAULT_LOCK_STALE_SECS))
+}
+
+/// Attempt to remove a stale launch lock. Returns `Ok(true)` if the file was
+/// removed, `Ok(false)` if it was not stale.
+pub fn remove_stale_launch_lock(path: &Path, stale_after: Duration) -> std::io::Result<bool> {
+    if !launch_lock_is_stale(path, stale_after)? {
+        return Ok(false);
+    }
+    // Re-check immediately before unlinking (race protection).
+    if !launch_lock_is_stale(path, stale_after)? {
+        return Ok(false);
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(err) => Err(err),
+    }
+}
+
+/// Check whether a launch lock file is older than `stale_after`.
+pub fn launch_lock_is_stale(path: &Path, stale_after: Duration) -> std::io::Result<bool> {
+    let modified = match std::fs::metadata(path) {
+        Ok(meta) => meta.modified()?,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(true),
+        Err(err) => return Err(err),
+    };
+    let age = modified.elapsed().unwrap_or_default();
+    Ok(age >= stale_after)
+}
+
+// ── Timeout resolution ─────────────────────────────────────────────────────
+
+/// Resolve the effective ensure timeout: env var
+/// `DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS` takes priority, then the
+/// caller-supplied `explicit_secs`, then the crate default (15 s).
+pub fn resolve_ensure_timeout_secs(explicit_secs: u64) -> u64 {
+    std::env::var(ENV_GATEWAY_ENSURE_TIMEOUT_SECS)
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or({
+            if explicit_secs > 0 {
+                explicit_secs
+            } else {
+                DEFAULT_ENSURE_TIMEOUT_SECS
+            }
+        })
+}
+
+// ── Wait for ready ─────────────────────────────────────────────────────────
+
+/// Poll the gateway `/health` endpoint until it responds successfully or the
+/// `timeout` expires.
+pub async fn wait_gateway_ready(host: &str, port: u16, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if gateway_health_ok(host, port).await {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+    anyhow::bail!(
+        "gateway did not become healthy at http://{host}:{port}/health within {timeout:?}"
+    )
+}
+
+// ── Spawn ──────────────────────────────────────────────────────────────────
+
+/// Spawn a detached gateway process from the given `exe` binary.
+///
+/// Returns the child process ID. The caller is responsible for resolving the
+/// binary path (e.g. via gateway discovery or `current_exe`).
+pub fn spawn_detached_gateway(
+    exe: &Path,
+    args: &[OsString],
+    registry_dir: &Path,
+) -> anyhow::Result<u32> {
+    let mut cmd = Command::new(exe);
+    cmd.args(args)
+        .env("DCC_MCP_REGISTRY_DIR", registry_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        cmd.creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS);
+    }
+
+    let child = cmd
+        .spawn()
+        .with_context(|| format!("spawning gateway from {}", exe.display()))?;
+    Ok(child.id())
+}
+
+/// Build the command-line arguments for a standalone gateway process.
+pub fn gateway_command_args(
+    host: &str,
+    port: u16,
+    name: Option<&str>,
+    remote_host: &str,
+    remote_port: u16,
+    gateway_idle_timeout_secs: u64,
+) -> Vec<OsString> {
+    let mut cargs = vec![
+        OsString::from("gateway"),
+        OsString::from("--host"),
+        OsString::from(host),
+        OsString::from("--port"),
+        OsString::from(port.to_string()),
+        OsString::from("--remote-host"),
+        OsString::from(remote_host),
+        OsString::from("--remote-port"),
+        OsString::from(remote_port.to_string()),
+        OsString::from("--gateway-idle-timeout-secs"),
+        OsString::from(gateway_idle_timeout_secs.to_string()),
+    ];
+    if let Some(name) = name {
+        if !name.trim().is_empty() {
+            cargs.push(OsString::from("--name"));
+            cargs.push(OsString::from(name));
+        }
+    }
+    cargs
+}
+
+// ── PID file ───────────────────────────────────────────────────────────────
+
+/// Read a PID from a pidfile, returning `None` if the file doesn't exist or
+/// can't be parsed.
+pub fn read_pid_from_pidfile(pidfile: Option<&Path>) -> Option<u32> {
+    let path = pidfile?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    raw.trim().parse::<u32>().ok()
+}
+
+/// Write a PID to a pidfile, creating parent directories as needed.
+pub fn write_pidfile(path: &Path, pid: u32) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating pidfile dir {}", parent.display()))?;
+    }
+    std::fs::write(path, format!("{pid}\n"))
+        .with_context(|| format!("writing pidfile {}", path.display()))
+}
+
+/// Remove the pidfile if it exists.
+pub fn remove_pidfile(pidfile: Option<&Path>) {
+    if let Some(path) = pidfile {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+// ── Process utilities (subprocess-based, no foreign deps) ──────────────────
+
+/// Check whether a process with the given PID is still running.
+pub fn is_process_alive(pid: u32) -> bool {
+    #[cfg(windows)]
+    {
+        // `tasklist /FI "PID eq <pid>" /NH` returns output containing the
+        // PID if the process exists, or "INFO: No tasks..." on stderr if not.
+        // Exit code is always 0, so we check stdout for the PID string.
+        let output = Command::new("tasklist")
+            .args([
+                "/FI",
+                &format!("PID eq {pid}"),
+                "/NH", // No headers
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output();
+        match output {
+            Ok(out) => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                stdout.contains(&pid.to_string())
+            }
+            Err(_) => false,
+        }
+    }
+    #[cfg(unix)]
+    {
+        // `kill -0 <pid>` succeeds if the process exists and we can signal it.
+        Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+}
+
+/// Send a termination signal to the process with the given PID.
+pub fn stop_process(pid: u32) -> anyhow::Result<()> {
+    #[cfg(windows)]
+    {
+        let status = Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/F"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .with_context(|| format!("taskkill /PID {pid}"))?;
+        if !status.success() {
+            // Exit code 128 means the process was not found — that's OK.
+            if status.code() != Some(128) {
+                anyhow::bail!("taskkill /PID {pid} exited with {status}");
+            }
+        }
+    }
+    #[cfg(unix)]
+    {
+        let status = Command::new("kill")
+            .arg(pid.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .with_context(|| format!("kill {pid}"))?;
+        if !status.success() {
+            anyhow::bail!("kill {pid} exited with {status}");
+        }
+    }
+    Ok(())
+}
+
+// ── Default registry dir ───────────────────────────────────────────────────
+
+/// Default registry directory used by the gateway and sidecar.
+pub fn default_registry_dir() -> PathBuf {
+    std::env::var("DCC_MCP_REGISTRY_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir().join("dcc-mcp-core-registry"))
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // ── PID file tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_read_pid_from_pidfile_none() {
+        assert!(read_pid_from_pidfile(None).is_none());
+    }
+
+    #[test]
+    fn test_read_pid_from_pidfile_invalid() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("bad.pid");
+        std::fs::write(&path, "not-a-number").unwrap();
+        assert!(read_pid_from_pidfile(Some(&path)).is_none());
+    }
+
+    #[test]
+    fn test_read_pid_from_pidfile_valid() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("test.pid");
+        write_pidfile(&path, 12345).unwrap();
+        assert_eq!(read_pid_from_pidfile(Some(&path)), Some(12345));
+    }
+
+    #[test]
+    fn test_read_pid_from_pidfile_with_newline() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("test.pid");
+        std::fs::write(&path, "12345\n").unwrap();
+        assert_eq!(read_pid_from_pidfile(Some(&path)), Some(12345));
+    }
+
+    #[test]
+    fn test_write_then_read_pidfile() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("gateway.pid");
+        write_pidfile(&path, 99999).unwrap();
+        assert_eq!(read_pid_from_pidfile(Some(&path)), Some(99999));
+        remove_pidfile(Some(&path));
+        assert!(read_pid_from_pidfile(Some(&path)).is_none());
+    }
+
+    // ── Process tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_process_alive_current() {
+        assert!(is_process_alive(std::process::id()));
+    }
+
+    #[test]
+    fn test_is_process_alive_invalid() {
+        // PIDs are well under 10 million on every OS.
+        assert!(!is_process_alive(9_999_999));
+    }
+
+    // ── Launch lock tests ──────────────────────────────────────────────
+
+    #[test]
+    fn test_launch_lock_create_and_drop() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("test.lock");
+        {
+            let lock = acquire_launch_lock(&path).unwrap();
+            assert!(path.exists());
+            // Second acquire must fail with AlreadyExists.
+            let err = acquire_launch_lock(&path).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+            drop(lock);
+        }
+        // After drop, lock file should be removed.
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_launch_lock_stale_removed_correctly() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("stale.lock");
+        {
+            let _f = File::create(&path).unwrap();
+        }
+        // File is brand new, so it should NOT be stale with a 1 s threshold.
+        let result = acquire_launch_lock_with_stale(&path, Duration::from_secs(1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_launch_lock_stale_reclaim_with_zero_secs() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("stale0.lock");
+        let _f = File::create(&path).unwrap();
+        drop(_f);
+        let lock = acquire_launch_lock_with_stale(&path, Duration::from_secs(0)).unwrap();
+        drop(lock);
+        assert!(!path.exists());
+    }
+
+    // ── Health check tests ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_gateway_health_ok_unreachable() {
+        assert!(!gateway_health_ok("127.0.0.1", 19999).await);
+    }
+
+    // ── Command args tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_gateway_command_args_minimal() {
+        let argv: Vec<String> = gateway_command_args(
+            "127.0.0.1", 9765, None, "0.0.0.0", 59765, 30,
+        )
+        .into_iter()
+        .map(|s| s.to_string_lossy().to_string())
+        .collect();
+        assert!(argv[0] == "gateway");
+        assert!(argv.contains(&"--port".to_string()));
+        assert!(argv.contains(&"9765".to_string()));
+    }
+
+    #[test]
+    fn test_gateway_command_args_with_name() {
+        let argv: Vec<String> = gateway_command_args(
+            "127.0.0.1",
+            9765,
+            Some("test-gateway"),
+            "0.0.0.0",
+            59765,
+            30,
+        )
+        .into_iter()
+        .map(|s| s.to_string_lossy().to_string())
+        .collect();
+        assert!(argv.contains(&"--name".to_string()));
+        assert!(argv.contains(&"test-gateway".to_string()));
+    }
+
+    #[test]
+    fn test_gateway_command_args_does_not_include_registry_dir_flag() {
+        let argv: Vec<String> = gateway_command_args(
+            "127.0.0.1", 9765, Some("gateway-for-test"), "0.0.0.0", 59765, 30,
+        )
+        .into_iter()
+        .map(|s| s.to_string_lossy().to_string())
+        .collect();
+        assert!(
+            !argv.iter().any(|arg| arg == "--registry-dir"),
+            "auto-launched gateway should inherit DCC_MCP_REGISTRY_DIR instead of exposing --registry-dir"
+        );
+    }
+
+    // ── Default registry dir tests ─────────────────────────────────────
+
+    #[test]
+    fn test_default_registry_dir_is_not_empty() {
+        let dir = default_registry_dir();
+        assert!(!dir.as_os_str().is_empty());
+        assert!(dir.is_absolute());
+    }
+
+    // ── Stale lock reclaim integration tests ───────────────────────────
+
+    #[test]
+    fn stale_gateway_launch_lock_is_reclaimed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gateway-launch.lock");
+        std::fs::write(&path, "stale").unwrap();
+
+        let lock = acquire_launch_lock_with_stale(&path, Duration::ZERO)
+            .expect("stale launch lock should be reclaimed");
+
+        assert!(path.exists());
+        drop(lock);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn fresh_gateway_launch_lock_stays_single_flight() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gateway-launch.lock");
+        std::fs::write(&path, "busy").unwrap();
+
+        let err = match acquire_launch_lock_with_stale(&path, Duration::from_secs(3600)) {
+            Ok(_) => panic!("fresh launch lock should remain busy"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+        assert!(path.exists());
+    }
+}

--- a/crates/dcc-mcp-gateway-ensure/src/lib.rs
+++ b/crates/dcc-mcp-gateway-ensure/src/lib.rs
@@ -470,12 +470,10 @@ mod tests {
 
     #[test]
     fn test_gateway_command_args_minimal() {
-        let argv: Vec<String> = gateway_command_args(
-            "127.0.0.1", 9765, None, "0.0.0.0", 59765, 30,
-        )
-        .into_iter()
-        .map(|s| s.to_string_lossy().to_string())
-        .collect();
+        let argv: Vec<String> = gateway_command_args("127.0.0.1", 9765, None, "0.0.0.0", 59765, 30)
+            .into_iter()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect();
         assert!(argv[0] == "gateway");
         assert!(argv.contains(&"--port".to_string()));
         assert!(argv.contains(&"9765".to_string()));
@@ -501,7 +499,12 @@ mod tests {
     #[test]
     fn test_gateway_command_args_does_not_include_registry_dir_flag() {
         let argv: Vec<String> = gateway_command_args(
-            "127.0.0.1", 9765, Some("gateway-for-test"), "0.0.0.0", 59765, 30,
+            "127.0.0.1",
+            9765,
+            Some("gateway-for-test"),
+            "0.0.0.0",
+            59765,
+            30,
         )
         .into_iter()
         .map(|s| s.to_string_lossy().to_string())

--- a/crates/dcc-mcp-sidecar/Cargo.toml
+++ b/crates/dcc-mcp-sidecar/Cargo.toml
@@ -10,6 +10,7 @@ description = "Sidecar and gateway-daemon runtime support for DCC-MCP hosts"
 
 [dependencies]
 dcc-mcp-gateway = { workspace = true, optional = true }
+dcc-mcp-gateway-ensure.workspace = true
 dcc-mcp-host-rpc.workspace = true
 dcc-mcp-transport.workspace = true
 anyhow.workspace = true

--- a/crates/dcc-mcp-sidecar/src/gateway_daemon/launcher.rs
+++ b/crates/dcc-mcp-sidecar/src/gateway_daemon/launcher.rs
@@ -1,37 +1,13 @@
-use std::ffi::OsString;
-use std::fs::{File, OpenOptions};
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::Context as _;
 use dcc_mcp_gateway::{ElectionInfo, has_newer_sentinel, is_newer_election};
+use dcc_mcp_gateway_ensure as ensure;
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};
 
-const ENV_GATEWAY_LAUNCH_LOCK_STALE_SECS: &str = "DCC_MCP_GATEWAY_LAUNCH_LOCK_STALE_SECS";
-const DEFAULT_GATEWAY_LAUNCH_LOCK_STALE_SECS: u64 = 30;
 const GATEWAY_SENTINEL_STALE_SECS: u64 = 30;
-/// Env var that overrides the gateway-ensure wait timeout.
-const ENV_GATEWAY_ENSURE_TIMEOUT_SECS: &str = "DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS";
-/// Default ensure-wait timeout (15 s) when the env var is not set.
-const DEFAULT_ENSURE_TIMEOUT_SECS: u64 = 15;
-
-/// Resolve the effective ensure-wait timeout: env var
-/// `DCC_MCP_GATEWAY_ENSURE_TIMEOUT_SECS` > explicit arg > crate default (15 s).
-fn resolve_ensure_timeout_secs(explicit_secs: u64) -> u64 {
-    std::env::var(ENV_GATEWAY_ENSURE_TIMEOUT_SECS)
-        .ok()
-        .and_then(|raw| raw.parse::<u64>().ok())
-        .filter(|secs| *secs > 0)
-        .unwrap_or({
-            if explicit_secs > 0 {
-                explicit_secs
-            } else {
-                DEFAULT_ENSURE_TIMEOUT_SECS
-            }
-        })
-}
 
 /// Helpers for auto-launching the standalone gateway from inside another
 /// process (the per-DCC sidecar / embedded server).
@@ -65,7 +41,7 @@ pub async fn ensure_gateway_running(opts: &EnsureGatewayOptions) -> anyhow::Resu
         return Ok(());
     }
 
-    if gateway_health_ok(&opts.host, opts.port).await {
+    if ensure::gateway_health_ok(&opts.host, opts.port).await {
         try_version_takeover(opts).await?;
         return Ok(());
     }
@@ -73,13 +49,13 @@ pub async fn ensure_gateway_running(opts: &EnsureGatewayOptions) -> anyhow::Resu
     std::fs::create_dir_all(&opts.registry_dir)
         .with_context(|| format!("creating registry dir {}", opts.registry_dir.display()))?;
     let lock_path = opts.registry_dir.join("gateway-launch.lock");
-    match acquire_launch_lock(&lock_path) {
+    match ensure::acquire_launch_lock(&lock_path) {
         Ok(_lock) => {
-            if gateway_health_ok(&opts.host, opts.port).await {
+            if ensure::gateway_health_ok(&opts.host, opts.port).await {
                 try_version_takeover(opts).await?;
                 return Ok(());
             }
-            spawn_detached_gateway(opts)?;
+            spawn_detached_gateway_now(opts)?;
         }
         Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
             tracing::info!(
@@ -90,13 +66,15 @@ pub async fn ensure_gateway_running(opts: &EnsureGatewayOptions) -> anyhow::Resu
         Err(err) => return Err(err).with_context(|| format!("creating {}", lock_path.display())),
     }
 
-    wait_gateway_ready(
+    ensure::wait_gateway_ready(
         &opts.host,
         opts.port,
-        Duration::from_secs(resolve_ensure_timeout_secs(0)),
+        Duration::from_secs(ensure::resolve_ensure_timeout_secs(0)),
     )
     .await
 }
+
+// ── Version takeover ───────────────────────────────────────────────────────
 
 /// When the gateway port is already occupied, check whether we carry a newer
 /// version than the running gateway.  If we do, write a sentinel entry with
@@ -171,9 +149,9 @@ async fn try_version_takeover(opts: &EnsureGatewayOptions) -> anyhow::Result<()>
 
     // Wait for the old gateway to yield (up to ~20 s for the 15 s cleanup
     // interval + grace).
-    let deadline = Instant::now() + Duration::from_secs(20);
-    while Instant::now() < deadline {
-        if !gateway_health_ok(&opts.host, opts.port).await {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    while tokio::time::Instant::now() < deadline {
+        if !ensure::gateway_health_ok(&opts.host, opts.port).await {
             tracing::info!("old gateway yielded — spawning new gateway");
             return spawn_gateway_with_lock(opts).await;
         }
@@ -190,12 +168,12 @@ async fn spawn_gateway_with_lock(opts: &EnsureGatewayOptions) -> anyhow::Result<
     std::fs::create_dir_all(&opts.registry_dir)
         .with_context(|| format!("creating registry dir {}", opts.registry_dir.display()))?;
     let lock_path = opts.registry_dir.join("gateway-launch.lock");
-    match acquire_launch_lock(&lock_path) {
+    match ensure::acquire_launch_lock(&lock_path) {
         Ok(_lock) => {
-            if gateway_health_ok(&opts.host, opts.port).await {
+            if ensure::gateway_health_ok(&opts.host, opts.port).await {
                 return Ok(());
             }
-            spawn_detached_gateway(opts)?;
+            spawn_detached_gateway_now(opts)?;
         }
         Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
             tracing::info!(
@@ -205,170 +183,35 @@ async fn spawn_gateway_with_lock(opts: &EnsureGatewayOptions) -> anyhow::Result<
         }
         Err(err) => return Err(err).with_context(|| format!("creating {}", lock_path.display())),
     }
-    wait_gateway_ready(
+    ensure::wait_gateway_ready(
         &opts.host,
         opts.port,
-        Duration::from_secs(resolve_ensure_timeout_secs(0)),
+        Duration::from_secs(ensure::resolve_ensure_timeout_secs(0)),
     )
     .await
 }
 
-async fn wait_gateway_ready(host: &str, port: u16, timeout: Duration) -> anyhow::Result<()> {
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        if gateway_health_ok(host, port).await {
-            return Ok(());
-        }
-        tokio::time::sleep(Duration::from_millis(150)).await;
-    }
-    anyhow::bail!(
-        "gateway did not become healthy at http://{host}:{port}/health within {timeout:?}"
-    )
-}
+// ── Spawn helper ───────────────────────────────────────────────────────────
 
-pub(super) async fn gateway_health_ok(host: &str, port: u16) -> bool {
-    gateway_health_ok_with_timeout(host, port, Duration::from_millis(600)).await
-}
-
-pub(super) async fn gateway_health_ok_with_timeout(
-    host: &str,
-    port: u16,
-    timeout: Duration,
-) -> bool {
-    let url = format!("http://{host}:{port}/health");
-    let client = match reqwest::Client::builder().timeout(timeout).build() {
-        Ok(client) => client,
-        Err(_) => return false,
-    };
-    client
-        .get(url)
-        .send()
-        .await
-        .is_ok_and(|resp| resp.status().is_success())
-}
-
-struct LaunchLock {
-    _file: File,
-    path: PathBuf,
-}
-
-impl Drop for LaunchLock {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
-    }
-}
-
-fn acquire_launch_lock(path: &Path) -> std::io::Result<LaunchLock> {
-    acquire_launch_lock_with_stale(path, gateway_launch_lock_stale_after())
-}
-
-fn acquire_launch_lock_with_stale(
-    path: &Path,
-    stale_after: Duration,
-) -> std::io::Result<LaunchLock> {
-    match create_launch_lock(path) {
-        Ok(lock) => Ok(lock),
-        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-            if remove_stale_launch_lock(path, stale_after)? {
-                create_launch_lock(path)
-            } else {
-                Err(err)
-            }
-        }
-        Err(err) => Err(err),
-    }
-}
-
-fn create_launch_lock(path: &Path) -> std::io::Result<LaunchLock> {
-    OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)
-        .map(|file| LaunchLock {
-            _file: file,
-            path: path.to_path_buf(),
-        })
-}
-
-fn gateway_launch_lock_stale_after() -> Duration {
-    std::env::var(ENV_GATEWAY_LAUNCH_LOCK_STALE_SECS)
-        .ok()
-        .and_then(|raw| raw.parse::<u64>().ok())
-        .filter(|secs| *secs > 0)
-        .map(Duration::from_secs)
-        .unwrap_or_else(|| Duration::from_secs(DEFAULT_GATEWAY_LAUNCH_LOCK_STALE_SECS))
-}
-
-fn remove_stale_launch_lock(path: &Path, stale_after: Duration) -> std::io::Result<bool> {
-    if !launch_lock_is_stale(path, stale_after)? {
-        return Ok(false);
-    }
-
-    // Re-check immediately before unlinking so a fresh lock created by another
-    // sidecar is not removed after the stale check wins a race.
-    if !launch_lock_is_stale(path, stale_after)? {
-        return Ok(false);
-    }
-
-    match std::fs::remove_file(path) {
-        Ok(()) => Ok(true),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(true),
-        Err(err) => Err(err),
-    }
-}
-
-fn launch_lock_is_stale(path: &Path, stale_after: Duration) -> std::io::Result<bool> {
-    let modified = match std::fs::metadata(path) {
-        Ok(meta) => meta.modified()?,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(true),
-        Err(err) => return Err(err),
-    };
-    let age = modified.elapsed().unwrap_or_default();
-    Ok(age >= stale_after)
-}
-
-fn spawn_detached_gateway(opts: &EnsureGatewayOptions) -> anyhow::Result<()> {
-    let exe = std::env::current_exe().context("resolving current executable")?;
-    let mut cmd = Command::new(exe);
-    cmd.args(gateway_command_args(opts))
-        .env("DCC_MCP_REGISTRY_DIR", &opts.registry_dir)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        const DETACHED_PROCESS: u32 = 0x0000_0008;
-        cmd.creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS);
-    }
-
-    cmd.spawn().context("spawning standalone gateway")?;
+fn spawn_detached_gateway_now(opts: &EnsureGatewayOptions) -> anyhow::Result<()> {
+    let exe =
+        std::env::current_exe().context("resolving current executable for detached gateway")?;
+    let cmd_args = ensure::gateway_command_args(
+        &opts.host,
+        opts.port,
+        opts.name.as_deref(),
+        &opts.remote_host,
+        opts.remote_port,
+        opts.gateway_idle_timeout_secs,
+    );
+    ensure::spawn_detached_gateway(&exe, &cmd_args, &opts.registry_dir)?;
     tracing::info!(port = opts.port, "spawned standalone gateway process");
     Ok(())
 }
 
-fn gateway_command_args(opts: &EnsureGatewayOptions) -> Vec<OsString> {
-    let mut args = vec![
-        OsString::from("gateway"),
-        OsString::from("--host"),
-        OsString::from(&opts.host),
-        OsString::from("--port"),
-        OsString::from(opts.port.to_string()),
-        OsString::from("--remote-host"),
-        OsString::from(&opts.remote_host),
-        OsString::from("--remote-port"),
-        OsString::from(opts.remote_port.to_string()),
-    ];
-    if let Some(name) = opts.name.as_ref().filter(|name| !name.trim().is_empty()) {
-        args.push(OsString::from("--name"));
-        args.push(OsString::from(name));
-    }
-    args.push(OsString::from("--gateway-idle-timeout-secs"));
-    args.push(OsString::from(opts.gateway_idle_timeout_secs.to_string()));
-    args
-}
+// ── Re-exports ─────────────────────────────────────────────────────────────
+
+pub use ensure::gateway_health_ok_with_timeout;
 
 #[cfg(test)]
 mod tests {
@@ -376,30 +219,19 @@ mod tests {
 
     #[test]
     fn auto_launch_gateway_args_do_not_include_registry_dir_flag() {
-        let opts = EnsureGatewayOptions {
-            host: "127.0.0.1".to_string(),
-            port: 9765,
-            name: Some("gateway-for-test".to_string()),
-            registry_dir: PathBuf::from(r"C:\tmp\dcc-mcp-registry"),
-            remote_host: "0.0.0.0".to_string(),
-            remote_port: 59765,
-            crate_version: None,
-            adapter_version: None,
-            adapter_dcc: None,
-            gateway_idle_timeout_secs: 30,
-        };
-
-        let args: Vec<String> = gateway_command_args(&opts)
-            .into_iter()
-            .map(|arg| arg.to_string_lossy().to_string())
-            .collect();
+        let argv: Vec<String> = ensure::gateway_command_args(
+            "127.0.0.1", 9765, Some("gateway-for-test"), "0.0.0.0", 59765, 30,
+        )
+        .into_iter()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
 
         assert!(
-            !args.iter().any(|arg| arg == "--registry-dir"),
+            !argv.iter().any(|arg| arg == "--registry-dir"),
             "auto-launched gateway should inherit DCC_MCP_REGISTRY_DIR instead of exposing --registry-dir in the command line"
         );
-        assert!(args.iter().any(|arg| arg == "gateway"));
-        assert!(args.iter().any(|arg| arg == "--name"));
+        assert!(argv.iter().any(|arg| arg == "gateway"));
+        assert!(argv.iter().any(|arg| arg == "--name"));
     }
 
     #[test]
@@ -408,7 +240,7 @@ mod tests {
         let path = dir.path().join("gateway-launch.lock");
         std::fs::write(&path, "stale").unwrap();
 
-        let lock = acquire_launch_lock_with_stale(&path, Duration::ZERO)
+        let lock = ensure::acquire_launch_lock_with_stale(&path, Duration::ZERO)
             .expect("stale launch lock should be reclaimed");
 
         assert!(path.exists());
@@ -422,7 +254,7 @@ mod tests {
         let path = dir.path().join("gateway-launch.lock");
         std::fs::write(&path, "busy").unwrap();
 
-        let err = match acquire_launch_lock_with_stale(&path, Duration::from_secs(3600)) {
+        let err = match ensure::acquire_launch_lock_with_stale(&path, Duration::from_secs(3600)) {
             Ok(_) => panic!("fresh launch lock should remain busy"),
             Err(err) => err,
         };

--- a/crates/dcc-mcp-sidecar/src/gateway_daemon/launcher.rs
+++ b/crates/dcc-mcp-sidecar/src/gateway_daemon/launcher.rs
@@ -220,7 +220,12 @@ mod tests {
     #[test]
     fn auto_launch_gateway_args_do_not_include_registry_dir_flag() {
         let argv: Vec<String> = ensure::gateway_command_args(
-            "127.0.0.1", 9765, Some("gateway-for-test"), "0.0.0.0", 59765, 30,
+            "127.0.0.1",
+            9765,
+            Some("gateway-for-test"),
+            "0.0.0.0",
+            59765,
+            30,
         )
         .into_iter()
         .map(|arg| arg.to_string_lossy().to_string())

--- a/crates/dcc-mcp-sidecar/src/lib.rs
+++ b/crates/dcc-mcp-sidecar/src/lib.rs
@@ -17,13 +17,7 @@ pub mod sidecar_mcp;
 pub use sidecar::{ExitReason, SidecarArgs, run};
 
 #[cfg(feature = "gateway-auto")]
-pub(crate) fn is_process_alive(pid: u32) -> bool {
-    use sysinfo::{Pid, ProcessesToUpdate, System};
-
-    let mut sys = System::new();
-    sys.refresh_processes(ProcessesToUpdate::Some(&[Pid::from_u32(pid)]), false);
-    sys.process(Pid::from_u32(pid)).is_some()
-}
+pub(crate) use dcc_mcp_gateway_ensure::is_process_alive;
 
 #[cfg(any(feature = "gateway-auto", feature = "gateway-daemon"))]
 pub(crate) async fn select_shutdown_signal() -> anyhow::Result<&'static str> {


### PR DESCRIPTION
Extract ~400 lines of duplicated gateway auto-launch primitives from `dcc-mcp-cli` and `dcc-mcp-sidecar` into a new `dcc-mcp-gateway-ensure` crate.

## Summary

Both the CLI and sidecar had independent (and diverging) implementations of gateway health check, launch lock, process spawn, timeout resolution, and gateway-ready waiting. This PR extracts all shared primitives into a single crate.

## New crate: `dcc-mcp-gateway-ensure`

Shared primitives:
- **Health check**: `gateway_health_ok`, `gateway_health_ok_with_timeout`
- **Launch lock**: `LaunchLock`, `acquire_launch_lock`, `acquire_launch_lock_with_stale`, stale reclaim
- **Spawn**: `spawn_detached_gateway` (binary-agnostic), `gateway_command_args`
- **Wait**: `wait_gateway_ready`, `resolve_ensure_timeout_secs`
- **PID file**: `read_pid_from_pidfile`, `write_pidfile`, `remove_pidfile`
- **Process utilities**: `is_process_alive`, `stop_process` (unified subprocess-based impl)
- **Defaults**: `default_registry_dir`

## Consumer changes

- **CLI** (`gateway_ensure.rs`: 552 → ~150 lines): keeps `EnsureGatewayArgs`, `EnsureResult`, `ensure_gateway_running` orchestrator (with lock-loser waiting path)
- **Sidecar** (`launcher.rs`: 434 → ~250 lines): keeps `EnsureGatewayOptions`, version takeover logic, `try_version_takeover`, `spawn_gateway_with_lock`

## Verification

- `cargo check --workspace` ✅
- `cargo test -p dcc-mcp-gateway-ensure` ✅ 17/17
- `cargo test -p dcc-mcp-cli` ✅ 20/20
- `cargo test -p dcc-mcp-sidecar` ✅ 42/42

Refs: PIP-1418