### PR TITLE
style: fix rustfmt in gateway-ensure let-chain expression

### DIFF
--- a/crates/dcc-mcp-gateway-ensure/src/lib.rs
+++ b/crates/dcc-mcp-gateway-ensure/src/lib.rs
@@ -241,7 +241,9 @@ pub fn gateway_command_args(
         OsString::from("--gateway-idle-timeout-secs"),
         OsString::from(gateway_idle_timeout_secs.to_string()),
     ];
-    if let Some(name) = name && !name.trim().is_empty() {
+    if let Some(name) = name
+        && !name.trim().is_empty()
+    {
         cargs.push(OsString::from("--name"));
         cargs.push(OsString::from(name));
     }


### PR DESCRIPTION
Fix rustfmt regression on main branch.

The let-chain expression in crates/dcc-mcp-gateway-ensure/src/lib.rs:244 was formatted as a one-liner but cargo fmt requires multi-line format.

Root cause: Commit cdf8961e collapsed a nested if to fix clippy collapsible_if but did not run cargo fmt afterward.

Impact: This blocks CI for ALL PRs based on main:
- PR #1610 (feat: --restart flag)
- PR #1611 (release-please 0.18.16)

Fix: cargo fmt -p dcc-mcp-gateway-ensure

Testing: cargo fmt --all -- --check should pass after this fix.
