### PR TITLE
style(gateway-ensure): apply rustfmt to if-let chain

### DIFF
--- a/crates/dcc-mcp-gateway-ensure/src/lib.rs
+++ b/crates/dcc-mcp-gateway-ensure/src/lib.rs
@@ -241,7 +241,9 @@ pub fn gateway_command_args(
         OsString::from("--gateway-idle-timeout-secs"),
         OsString::from(gateway_idle_timeout_secs.to_string()),
     ];
-    if let Some(name) = name && !name.trim().is_empty() {
+    if let Some(name) = name
+        && !name.trim().is_empty()
+    {
         cargs.push(OsString::from("--name"));
         cargs.push(OsString::from(name));
     }


### PR DESCRIPTION
## Summary

Fix CI failure on main. Commit cdf8961e collapsed an if-let chain to use `&&`
which didn't satisfy rustfmt's multi-line formatting.

**Root cause:** The `if let Some(name) = name && !name.trim().is_empty()` pattern
was accepted by the compiler but rejected by CI's `cargo fmt --check`.

**Fix:** Run `cargo fmt -p dcc-mcp-gateway-ensure` to format the chain across
multiple lines.

## Test plan

- [x] `cargo fmt -p dcc-mcp-gateway-ensure --check` passes
- [x] PR CI should pass — unblocking PRs #1610 and #1611

Closes PIP-1477