### PR TITLE
fix(transport): add dual-format SystemTime deserializer and defensive parse fallback

### DIFF
--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -1313,9 +1313,13 @@ impl FileRegistry {
             return Ok(Vec::new());
         }
 
-        serde_json::from_str(&content).map_err(|e| {
-            TransportError::RegistryFile(format!("failed to parse {}: {}", path.display(), e))
-        })
+        match serde_json::from_str(&content) {
+            Ok(entries) => Ok(entries),
+            Err(e) => {
+                self.quarantine_corrupted_registry_file(&path, &e);
+                Ok(Vec::new())
+            }
+        }
     }
 
     fn looks_like_zero_padded_empty_registry(content: &str) -> bool {
@@ -1344,6 +1348,29 @@ impl FileRegistry {
                 bytes,
                 error = %error,
                 "FileRegistry: registry file looked like a zero-padded NTFS artefact; failed to quarantine but starting empty"
+            ),
+        }
+    }
+
+    fn quarantine_corrupted_registry_file(&self, path: &Path, error: &serde_json::Error) {
+        let ts = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0);
+        let quarantined = path.with_extension(format!("json.corrupted-{ts}"));
+        match fs::rename(path, &quarantined) {
+            Ok(()) => tracing::warn!(
+                path = %path.display(),
+                quarantined = %quarantined.display(),
+                %error,
+                "FileRegistry: failed to parse registry file; quarantined and starting empty"
+            ),
+            Err(rename_error) => tracing::warn!(
+                path = %path.display(),
+                quarantined = %quarantined.display(),
+                %error,
+                rename_error = %rename_error,
+                "FileRegistry: failed to parse registry file; failed to quarantine but starting empty"
             ),
         }
     }

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -1139,3 +1139,80 @@ fn classify_lock_wait_warns_only_when_genuinely_slow() {
         LockWaitLevel::Slow
     );
 }
+
+/// Corrupted registry file is quarantined and the registry starts empty
+/// instead of returning an error that crashes the gateway at startup.
+#[test]
+fn test_corrupted_registry_file_is_quarantined_and_starts_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let services_json = dir.path().join("services.json");
+
+    // Write garbage that is valid JSON but not a valid ServiceEntry array
+    std::fs::write(&services_json, r#"{"garbage": true}"#).unwrap();
+
+    let registry = FileRegistry::new(dir.path()).unwrap();
+    assert!(registry.is_empty(), "registry must start empty on parse failure");
+
+    // Corrupted file must be moved aside
+    let corrupt_files = corrupted_registry_files(dir.path());
+    assert_eq!(
+        corrupt_files.len(),
+        1,
+        "garbage file must be quarantined as corrupted, found: {corrupt_files:?}"
+    );
+    assert!(
+        !services_json.exists(),
+        "original corrupted file must be renamed away"
+    );
+}
+
+/// A registry file with malformed JSON (incomplete write) is quarantined
+/// and the registry starts empty.
+#[test]
+fn test_malformed_json_registry_file_is_quarantined() {
+    let dir = tempfile::tempdir().unwrap();
+    let services_json = dir.path().join("services.json");
+
+    // Write truncated JSON (simulates crash during write)
+    std::fs::write(&services_json, r#"[{"dcc_type": "maya", "inst"#).unwrap();
+
+    let registry = FileRegistry::new(dir.path()).unwrap();
+    assert!(registry.is_empty(), "registry must start empty on malformed JSON");
+
+    let corrupt_files = corrupted_registry_files(dir.path());
+    assert_eq!(corrupt_files.len(), 1);
+    assert!(!services_json.exists());
+}
+
+/// A registry file with float Unix timestamps (Python-written format)
+/// must parse successfully.
+#[test]
+fn test_float_timestamp_registry_file_parses() {
+    let dir = tempfile::tempdir().unwrap();
+    let services_json = dir.path().join("services.json");
+
+    let content = serde_json::json!([{
+        "dcc_type": "maya",
+        "instance_id": "ab7e8a1b-2c3d-4e5f-6789-abcdef012345",
+        "host": "127.0.0.1",
+        "port": 18812,
+        "registered_at": 1712345678.123456,
+        "last_heartbeat": 1712345678.654321,
+    }]);
+    std::fs::write(&services_json, serde_json::to_string(&content).unwrap()).unwrap();
+
+    let registry = FileRegistry::new(dir.path()).unwrap();
+    assert_eq!(registry.len(), 1, "registry must load float-timestamp entries");
+
+    let key = ServiceKey {
+        dcc_type: "maya".to_string(),
+        instance_id: Uuid::parse_str("ab7e8a1b-2c3d-4e5f-6789-abcdef012345").unwrap(),
+    };
+    let entry = registry.get(&key).expect("entry must be present");
+    let got_secs = entry
+        .registered_at
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert_eq!(got_secs, 1712345678);
+}

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -1151,7 +1151,10 @@ fn test_corrupted_registry_file_is_quarantined_and_starts_empty() {
     std::fs::write(&services_json, r#"{"garbage": true}"#).unwrap();
 
     let registry = FileRegistry::new(dir.path()).unwrap();
-    assert!(registry.is_empty(), "registry must start empty on parse failure");
+    assert!(
+        registry.is_empty(),
+        "registry must start empty on parse failure"
+    );
 
     // Corrupted file must be moved aside
     let corrupt_files = corrupted_registry_files(dir.path());
@@ -1177,7 +1180,10 @@ fn test_malformed_json_registry_file_is_quarantined() {
     std::fs::write(&services_json, r#"[{"dcc_type": "maya", "inst"#).unwrap();
 
     let registry = FileRegistry::new(dir.path()).unwrap();
-    assert!(registry.is_empty(), "registry must start empty on malformed JSON");
+    assert!(
+        registry.is_empty(),
+        "registry must start empty on malformed JSON"
+    );
 
     let corrupt_files = corrupted_registry_files(dir.path());
     assert_eq!(corrupt_files.len(), 1);
@@ -1202,7 +1208,11 @@ fn test_float_timestamp_registry_file_parses() {
     std::fs::write(&services_json, serde_json::to_string(&content).unwrap()).unwrap();
 
     let registry = FileRegistry::new(dir.path()).unwrap();
-    assert_eq!(registry.len(), 1, "registry must load float-timestamp entries");
+    assert_eq!(
+        registry.len(),
+        1,
+        "registry must load float-timestamp entries"
+    );
 
     let key = ServiceKey {
         dcc_type: "maya".to_string(),

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -2,8 +2,66 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
+
+/// Custom deserializer for `SystemTime` that accepts both Unix timestamp numbers
+/// (integer or float — as written by Python bridge plugins) and the Rust std serde
+/// struct format `{"secs_since_epoch": N, "nanos_since_epoch": N}`.
+fn deserialize_system_time<'de, D>(deserializer: D) -> Result<SystemTime, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    system_time_from_json_value(&value).map_err(serde::de::Error::custom)
+}
+
+/// Custom deserializer for `Option<SystemTime>` (used by `lease_expires_at`).
+fn deserialize_optional_system_time<'de, D>(
+    deserializer: D,
+) -> Result<Option<SystemTime>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    if value.is_null() {
+        return Ok(None);
+    }
+    system_time_from_json_value(&value)
+        .map(Some)
+        .map_err(serde::de::Error::custom)
+}
+
+fn system_time_from_json_value(value: &serde_json::Value) -> Result<SystemTime, String> {
+    match value {
+        serde_json::Value::Number(n) => {
+            let secs_f64 = n.as_f64().ok_or_else(|| format!("invalid number: {n}"))?;
+            #[allow(clippy::cast_possible_truncation)]
+            #[allow(clippy::cast_sign_loss)]
+            let secs = secs_f64.trunc() as u64;
+            let nanos = ((secs_f64 - secs_f64.trunc()).abs() * 1e9) as u32;
+            UNIX_EPOCH
+                .checked_add(Duration::new(secs, nanos))
+                .ok_or_else(|| format!("timestamp out of range: {secs_f64}"))
+        }
+        serde_json::Value::Object(obj) => {
+            let secs = obj
+                .get("secs_since_epoch")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| "missing secs_since_epoch".to_string())?;
+            let nanos = obj
+                .get("nanos_since_epoch")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32;
+            UNIX_EPOCH
+                .checked_add(Duration::new(secs, nanos))
+                .ok_or_else(|| format!("timestamp out of range: {secs}.{nanos:09}"))
+        }
+        _ => Err(format!(
+            "expected Unix timestamp number or {{secs_since_epoch, nanos_since_epoch}} object, got {value}"
+        )),
+    }
+}
 
 use crate::ipc::TransportAddress;
 
@@ -173,8 +231,10 @@ pub struct ServiceEntry {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub extras: HashMap<String, serde_json::Value>,
     /// When this service was registered.
+    #[serde(deserialize_with = "deserialize_system_time")]
     pub registered_at: SystemTime,
     /// Last heartbeat timestamp.
+    #[serde(deserialize_with = "deserialize_system_time")]
     pub last_heartbeat: SystemTime,
     /// Current status.
     #[serde(default)]
@@ -192,7 +252,11 @@ pub struct ServiceEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_job_id: Option<String>,
     /// Wall-clock expiry for the current lease.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_system_time"
+    )]
     pub lease_expires_at: Option<SystemTime>,
 }
 
@@ -751,5 +815,175 @@ mod tests {
             .unwrap()
             .as_millis() as u64;
         assert!(new_ms > old_ms);
+    }
+
+    // ── SystemTime deserializer compatibility (float timestamp fix) ────
+
+    /// Python bridge plugins write `registered_at` / `last_heartbeat` as
+    /// float Unix timestamps (e.g. `1712345678.123456`).  The custom
+    /// deserializer must accept integer, float, and the Rust std struct
+    /// format.
+    #[test]
+    fn test_system_time_deserialize_from_integer() {
+        let now = SystemTime::now();
+        let secs = now
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let json = serde_json::json!({
+            "dcc_type": "maya",
+            "instance_id": "00000000-0000-0000-0000-000000000001",
+            "host": "127.0.0.1",
+            "port": 18812,
+            "registered_at": secs,
+            "last_heartbeat": secs,
+        });
+        let entry: ServiceEntry = serde_json::from_value(json).unwrap();
+        let got_secs = entry
+            .registered_at
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert_eq!(got_secs, secs);
+    }
+
+    #[test]
+    fn test_system_time_deserialize_from_float() {
+        let now = SystemTime::now();
+        let secs = now
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        let json = serde_json::json!({
+            "dcc_type": "maya",
+            "instance_id": "00000000-0000-0000-0000-000000000001",
+            "host": "127.0.0.1",
+            "port": 18812,
+            "registered_at": secs,
+            "last_heartbeat": secs,
+        });
+        let entry: ServiceEntry = serde_json::from_value(json).unwrap();
+        let got_secs = entry
+            .registered_at
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert_eq!(got_secs, secs.trunc() as u64);
+    }
+
+    #[test]
+    fn test_system_time_deserialize_from_float_with_subsecond() {
+        let json = serde_json::json!({
+            "dcc_type": "blender",
+            "instance_id": "00000000-0000-0000-0000-000000000002",
+            "host": "127.0.0.1",
+            "port": 8080,
+            "registered_at": 1712345678.5,
+            "last_heartbeat": 1712345678.5,
+        });
+        let entry: ServiceEntry = serde_json::from_value(json).unwrap();
+        let duration = entry
+            .registered_at
+            .duration_since(UNIX_EPOCH)
+            .unwrap();
+        assert_eq!(duration.as_secs(), 1712345678);
+        assert_eq!(duration.subsec_nanos(), 500_000_000);
+    }
+
+    #[test]
+    fn test_system_time_deserialize_from_rust_std_struct_format() {
+        let now = SystemTime::now();
+        let duration = now.duration_since(UNIX_EPOCH).unwrap();
+        let json = serde_json::json!({
+            "dcc_type": "houdini",
+            "instance_id": "00000000-0000-0000-0000-000000000003",
+            "host": "127.0.0.1",
+            "port": 9090,
+            "registered_at": {
+                "secs_since_epoch": duration.as_secs(),
+                "nanos_since_epoch": duration.subsec_nanos(),
+            },
+            "last_heartbeat": {
+                "secs_since_epoch": duration.as_secs(),
+                "nanos_since_epoch": duration.subsec_nanos(),
+            },
+        });
+        let entry: ServiceEntry = serde_json::from_value(json).unwrap();
+        let got_secs = entry
+            .registered_at
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert_eq!(got_secs, duration.as_secs());
+    }
+
+    #[test]
+    fn test_optional_system_time_deserialize_from_null() {
+        let json = serde_json::json!({
+            "dcc_type": "maya",
+            "instance_id": "00000000-0000-0000-0000-000000000004",
+            "host": "127.0.0.1",
+            "port": 18812,
+            "registered_at": 1712345678u64,
+            "last_heartbeat": 1712345678u64,
+            "lease_expires_at": null,
+        });
+        let entry: ServiceEntry = serde_json::from_value(json).unwrap();
+        assert!(entry.lease_expires_at.is_none());
+    }
+
+    #[test]
+    fn test_optional_system_time_deserialize_from_float() {
+        let json = serde_json::json!({
+            "dcc_type": "maya",
+            "instance_id": "00000000-0000-0000-0000-000000000005",
+            "host": "127.0.0.1",
+            "port": 18812,
+            "registered_at": 1712345678u64,
+            "last_heartbeat": 1712345678u64,
+            "lease_expires_at": 1712345700.25,
+        });
+        let entry: ServiceEntry = serde_json::from_value(json).unwrap();
+        let expires = entry.lease_expires_at.unwrap();
+        let duration = expires.duration_since(UNIX_EPOCH).unwrap();
+        assert_eq!(duration.as_secs(), 1712345700);
+        assert_eq!(duration.subsec_nanos(), 250_000_000);
+    }
+
+    /// Roundtrip through the Rust std format must survive (backward compat
+    /// with existing services.json written by Rust processes).
+    #[test]
+    fn test_system_time_full_roundtrip_rust_format() {
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        let json = serde_json::to_string(&entry).unwrap();
+        let parsed: ServiceEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.dcc_type, entry.dcc_type);
+        assert_eq!(parsed.instance_id, entry.instance_id);
+        assert!(parsed.registered_at <= SystemTime::now());
+        assert!(parsed.last_heartbeat <= SystemTime::now());
+    }
+
+    /// Roundtrip through a Python-style float timestamp must survive.
+    #[test]
+    fn test_system_time_roundtrip_float_format() {
+        let secs_f64 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        let json = serde_json::json!({
+            "dcc_type": "maya",
+            "instance_id": "00000000-0000-0000-0000-000000000006",
+            "host": "127.0.0.1",
+            "port": 18812,
+            "registered_at": secs_f64,
+            "last_heartbeat": secs_f64,
+        });
+        let entry: ServiceEntry = serde_json::from_value(json).unwrap();
+        let got_secs = entry
+            .registered_at
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert_eq!(got_secs, secs_f64.trunc() as u64);
     }
 }

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -17,9 +17,7 @@ where
 }
 
 /// Custom deserializer for `Option<SystemTime>` (used by `lease_expires_at`).
-fn deserialize_optional_system_time<'de, D>(
-    deserializer: D,
-) -> Result<Option<SystemTime>, D::Error>
+fn deserialize_optional_system_time<'de, D>(deserializer: D) -> Result<Option<SystemTime>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -826,10 +824,7 @@ mod tests {
     #[test]
     fn test_system_time_deserialize_from_integer() {
         let now = SystemTime::now();
-        let secs = now
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs();
         let json = serde_json::json!({
             "dcc_type": "maya",
             "instance_id": "00000000-0000-0000-0000-000000000001",
@@ -850,10 +845,7 @@ mod tests {
     #[test]
     fn test_system_time_deserialize_from_float() {
         let now = SystemTime::now();
-        let secs = now
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs_f64();
+        let secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs_f64();
         let json = serde_json::json!({
             "dcc_type": "maya",
             "instance_id": "00000000-0000-0000-0000-000000000001",
@@ -882,10 +874,7 @@ mod tests {
             "last_heartbeat": 1712345678.5,
         });
         let entry: ServiceEntry = serde_json::from_value(json).unwrap();
-        let duration = entry
-            .registered_at
-            .duration_since(UNIX_EPOCH)
-            .unwrap();
+        let duration = entry.registered_at.duration_since(UNIX_EPOCH).unwrap();
         assert_eq!(duration.as_secs(), 1712345678);
         assert_eq!(duration.subsec_nanos(), 500_000_000);
     }


### PR DESCRIPTION
## Summary
- Add custom `SystemTime` deserializer accepting integer, float, and Rust std struct formats
- Defensive fallback: quarantine corrupted `services.json` instead of crashing at startup

## Root cause
Python bridge plugins write timestamps as float Unix epoch seconds (`1712345678.123456`), which the Rust std serde struct format `{"secs_since_epoch", "nanos_since_epoch"}` could not parse — causing gateway startup failure.

## Changes
- `types.rs`: custom `deserialize_system_time` / `deserialize_optional_system_time` via `serde_json::Value` intermediate
- `file_registry.rs`: `quarantine_corrupted_registry_file` + parse-failure fallback in `read_entries_from_file`
- 11 new tests covering int/float/struct formats, null handling, corrupted file quarantine