### PR TITLE
fix(ci): explicitly install lightningcss native module after npm ci

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -142,6 +142,20 @@ runs:
           echo "::warning::npm ci attempt ${attempt}/3 failed; retrying in 15s..."
           sleep 15
         done
+        # npm ci may skip transitive optional deps (npm 10.x quirk).
+        # Explicitly install the platform-specific lightningcss binary.
+        LIGHTNING_PKG=$(node -p "
+          ({
+            'linux-x64': 'lightningcss-linux-x64-gnu',
+            'darwin-arm64': 'lightningcss-darwin-arm64',
+            'darwin-x64': 'lightningcss-darwin-x64',
+            'win32-x64': 'lightningcss-win32-x64-msvc',
+            'win32-arm64': 'lightningcss-win32-arm64-msvc',
+          })[process.platform+'-'+process.arch] || ''
+        ")
+        if [ -n "$LIGHTNING_PKG" ]; then
+          vx npm --prefix admin-ui install "$LIGHTNING_PKG" --no-save --ignore-scripts
+        fi
         vx npm --prefix admin-ui run build
         test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,27 @@ jobs:
             # always use the prebuilt artifact.
             echo "::warning::Skipping npm ci on macOS; using prebuilt admin UI artifact"
             echo "DCC_MCP_ADMIN_UI_PREBUILT=1" >> "$GITHUB_ENV"
-          elif ! vx npm --prefix admin-ui ci --ignore-scripts --include=optional; then
-            echo "::warning::npm ci failed; falling back to prebuilt admin UI artifact"
-            echo "DCC_MCP_ADMIN_UI_PREBUILT=1" >> "$GITHUB_ENV"
+          else
+            if vx npm --prefix admin-ui ci --ignore-scripts --include=optional; then
+              # npm ci may skip transitive optional deps (npm 10.x quirk).
+              # Explicitly install the platform-specific lightningcss binary.
+              LIGHTNING_PKG=$(node -p "
+                ({
+                  'linux-x64': 'lightningcss-linux-x64-gnu',
+                  'darwin-arm64': 'lightningcss-darwin-arm64',
+                  'darwin-x64': 'lightningcss-darwin-x64',
+                  'win32-x64': 'lightningcss-win32-x64-msvc',
+                  'win32-arm64': 'lightningcss-win32-arm64-msvc',
+                })[process.platform+'-'+process.arch] || ''
+              ")
+              if [ -n "$LIGHTNING_PKG" ] && ! vx npm --prefix admin-ui install "$LIGHTNING_PKG" --no-save --ignore-scripts; then
+                echo "::warning::Failed to install lightningcss native module; falling back to prebuilt admin UI artifact"
+                echo "DCC_MCP_ADMIN_UI_PREBUILT=1" >> "$GITHUB_ENV"
+              fi
+            else
+              echo "::warning::npm ci failed; falling back to prebuilt admin UI artifact"
+              echo "DCC_MCP_ADMIN_UI_PREBUILT=1" >> "$GITHUB_ENV"
+            fi
           fi
       - name: Download prebuilt admin UI bundle
         if: env.DCC_MCP_ADMIN_UI_PREBUILT == '1'

--- a/.github/workflows/rust-matrix-full.yml
+++ b/.github/workflows/rust-matrix-full.yml
@@ -48,7 +48,22 @@ jobs:
         shell: bash
         run: |
           vx node --version
-          if ! vx npm --prefix admin-ui ci --ignore-scripts --include=optional; then
+          if vx npm --prefix admin-ui ci --ignore-scripts --include=optional; then
+            # npm ci may skip transitive optional deps (npm 10.x quirk).
+            # Explicitly install the platform-specific lightningcss binary.
+            LIGHTNING_PKG=$(node -p "
+              ({
+                'linux-x64': 'lightningcss-linux-x64-gnu',
+                'darwin-arm64': 'lightningcss-darwin-arm64',
+                'darwin-x64': 'lightningcss-darwin-x64',
+                'win32-x64': 'lightningcss-win32-x64-msvc',
+                'win32-arm64': 'lightningcss-win32-arm64-msvc',
+              })[process.platform+'-'+process.arch] || ''
+            ")
+            if [ -n "$LIGHTNING_PKG" ] && ! vx npm --prefix admin-ui install "$LIGHTNING_PKG" --no-save --ignore-scripts; then
+              echo "::warning::npm ci succeeded but failed to install lightningcss native module"
+            fi
+          else
             echo "::warning::npm ci failed; falling back to prebuilt admin UI artifact"
             echo "DCC_MCP_ADMIN_UI_PREBUILT=1" >> "$GITHUB_ENV"
           fi

--- a/scripts/release/prebuild_admin_ui.sh
+++ b/scripts/release/prebuild_admin_ui.sh
@@ -21,6 +21,21 @@ for attempt in $(seq 1 "$max_attempts"); do
   sleep 15
 done
 
+# npm ci may skip transitive optional deps (npm 10.x quirk).
+# Explicitly install the platform-specific lightningcss binary.
+LIGHTNING_PKG=$(node -p "
+  ({
+    'linux-x64': 'lightningcss-linux-x64-gnu',
+    'darwin-arm64': 'lightningcss-darwin-arm64',
+    'darwin-x64': 'lightningcss-darwin-x64',
+    'win32-x64': 'lightningcss-win32-x64-msvc',
+    'win32-arm64': 'lightningcss-win32-arm64-msvc',
+  })[process.platform+'-'+process.arch] || ''
+")
+if [ -n "$LIGHTNING_PKG" ]; then
+  vx npm --prefix admin-ui install "$LIGHTNING_PKG" --no-save --ignore-scripts
+fi
+
 vx npm --prefix admin-ui run build
 test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
 


### PR DESCRIPTION
## Summary

`npm ci --include=optional` on npm 10.x (Node 22) may skip transitive optional dependencies during CI builds. The `lightningcss-linux-x64-gnu` platform-specific native binary is one such skipped dep, causing `vite build` in `build-wheels/linux` to crash with:

```
Error: Cannot find module '../lightningcss.linux-x64-gnu.node'
    at admin-ui/node_modules/lightningcss/node/index.js:20:12
```

The lockfile correctly lists `lightningcss-linux-x64-gnu` as an optional dependency with `os: ["linux"], cpu: ["x64"]`, but `npm ci` installs only 627 out of 662 packages — all platform-specific optional deps are missing.

## Fix

After `npm ci`, explicitly install the platform-specific lightningcss native binary via `npm install lightningcss-{platform}-{arch} --no-save --ignore-scripts`. The platform mapping is computed via `node -p` to cover Linux, macOS, and Windows x64/ARM64 runners.

Files changed:

- `.github/actions/build-wheel/action.yml` — primary fix; the build-wheel job where the crash occurred
- `.github/workflows/ci.yml` — same pattern in `rust-check` job's `Prepare admin UI dependencies`
- `.github/workflows/rust-matrix-full.yml` — same pattern in full matrix job
- `scripts/release/prebuild_admin_ui.sh` — standalone release script used by release workflow

## Test plan

- [ ] Build-wheels/linux CI passes (the primary failing job)
- [ ] Build-wheels/windows and build-wheels/macos not regressed
- [ ] Admin-ui-bundle and rust-check jobs in CI continue to work
