### PR TITLE
feat: add gateway-controlled auto-update mechanism (update subcommands)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,7 +1893,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,6 +1136,7 @@ dependencies = [
  "dcc-mcp-gateway-ensure",
  "dcc-mcp-marketplace",
  "dcc-mcp-skills",
+ "dcc-mcp-updater",
  "dirs",
  "hex",
  "reqwest 0.13.4",
@@ -1670,6 +1671,7 @@ dependencies = [
  "dcc-mcp-skills",
  "dcc-mcp-telemetry",
  "dcc-mcp-transport",
+ "dcc-mcp-updater",
  "futures-util",
  "reqwest 0.13.4",
  "rusqlite",
@@ -1879,6 +1881,22 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "workspace-hack",
+]
+
+[[package]]
+name = "dcc-mcp-updater"
+version = "0.18.16"
+dependencies = [
+ "anyhow",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
  "workspace-hack",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "crates/dcc-mcp-catalog",
     "crates/dcc-mcp-db",
     "crates/dcc-mcp-semantic",
+    "crates/dcc-mcp-updater",
     "crates/workspace-hack",
 ]
 resolver = "2"
@@ -96,6 +97,7 @@ dcc-mcp-marketplace = { path = "crates/dcc-mcp-marketplace" }
 dcc-mcp-catalog = { path = "crates/dcc-mcp-catalog" }
 dcc-mcp-db = { path = "crates/dcc-mcp-db" }
 dcc-mcp-gateway = { path = "crates/dcc-mcp-gateway" }
+dcc-mcp-updater = { path = "crates/dcc-mcp-updater" }
 dcc-mcp-gateway-ensure = { path = "crates/dcc-mcp-gateway-ensure" }
 dcc-mcp-gateway-search = { path = "crates/dcc-mcp-gateway-search" }
 dcc-mcp-semantic = { path = "crates/dcc-mcp-semantic" }

--- a/crates/dcc-mcp-cli/Cargo.toml
+++ b/crates/dcc-mcp-cli/Cargo.toml
@@ -17,6 +17,7 @@ anyhow.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 dcc-mcp-catalog.workspace = true
 dcc-mcp-gateway-ensure.workspace = true
+dcc-mcp-updater.workspace = true
 dcc-mcp-marketplace.workspace = true
 dcc-mcp-skills.workspace = true
 dirs.workspace = true

--- a/crates/dcc-mcp-cli/src/application/mod.rs
+++ b/crates/dcc-mcp-cli/src/application/mod.rs
@@ -4,3 +4,4 @@ pub mod gateway_discovery;
 pub mod gateway_ensure;
 pub mod install;
 pub mod marketplace;
+pub mod update;

--- a/crates/dcc-mcp-cli/src/application/update.rs
+++ b/crates/dcc-mcp-cli/src/application/update.rs
@@ -42,7 +42,7 @@ impl UpdateService {
         let downloaded = self.updater.download_update(&info).await?;
 
         // Stage it for replacement on next launch
-        Updater::stage_update(&downloaded, &self.updater.binary_name())?;
+        Updater::stage_update(&downloaded, self.updater.binary_name())?;
 
         Ok(serde_json::json!({
             "status": "staged",

--- a/crates/dcc-mcp-cli/src/application/update.rs
+++ b/crates/dcc-mcp-cli/src/application/update.rs
@@ -1,0 +1,55 @@
+use dcc_mcp_updater::Updater;
+use serde_json::Value;
+
+use crate::domain::rest::Endpoint;
+
+/// Service for checking and applying binary updates through the gateway.
+pub struct UpdateService {
+    updater: Updater,
+}
+
+impl UpdateService {
+    pub fn new(gateway_url: &str, binary_name: &str, current_version: &str) -> Self {
+        Self {
+            updater: Updater::new(gateway_url, binary_name, current_version),
+        }
+    }
+
+    pub fn with_endpoint(endpoint: &Endpoint, binary_name: &str, current_version: &str) -> Self {
+        Self::new(&endpoint.base_url, binary_name, current_version)
+    }
+
+    /// Check for available updates. Returns the result as a JSON Value.
+    pub async fn check_update(&self) -> anyhow::Result<Value> {
+        let info = self.updater.check_update().await?;
+        Ok(serde_json::to_value(&info)?)
+    }
+
+    /// Check for and apply an update (download + stage for next launch).
+    pub async fn apply_update(&self) -> anyhow::Result<Value> {
+        let info = self.updater.check_update().await?;
+
+        if !info.update_available {
+            return Ok(serde_json::json!({
+                "status": "up-to-date",
+                "current_version": info.current_version,
+                "latest_version": info.latest_version,
+                "message": "Already running the latest version."
+            }));
+        }
+
+        // Download the update archive
+        let downloaded = self.updater.download_update(&info).await?;
+
+        // Stage it for replacement on next launch
+        Updater::stage_update(&downloaded, &self.updater.binary_name())?;
+
+        Ok(serde_json::json!({
+            "status": "staged",
+            "current_version": info.current_version,
+            "latest_version": info.latest_version,
+            "staged_at": downloaded.to_string_lossy(),
+            "message": "Update downloaded and staged. Restart the binary to apply.",
+        }))
+    }
+}

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -579,8 +579,11 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
         Command::Update { action } => {
             let binary_name = env!("CARGO_PKG_NAME");
             let current_version = env!("CARGO_PKG_VERSION");
-            let service =
-                crate::application::update::UpdateService::new(&base_url, binary_name, current_version);
+            let service = crate::application::update::UpdateService::new(
+                &base_url,
+                binary_name,
+                current_version,
+            );
             match action {
                 UpdateAction::Check => to_json(service.check_update().await?)?,
                 UpdateAction::Apply => to_json(service.apply_update().await?)?,

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -147,6 +147,11 @@ enum Command {
     },
     /// Validate local SKILL.md packages before loading them at runtime.
     Lint(LintArgs),
+    /// Check for and apply gateway-controlled binary updates.
+    Update {
+        #[command(subcommand)]
+        action: UpdateAction,
+    },
     /// Gateway lifecycle management.
     Gateway {
         #[command(subcommand)]
@@ -248,6 +253,14 @@ struct LintArgs {
     /// Exit non-zero when warnings are present.
     #[arg(long, default_value = "false")]
     warnings_as_errors: bool,
+}
+
+#[derive(Debug, Subcommand)]
+enum UpdateAction {
+    /// Check whether a newer version is available.
+    Check,
+    /// Download the latest version and stage it for the next launch.
+    Apply,
 }
 
 #[derive(Debug, Subcommand)]
@@ -554,6 +567,16 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
             let result = run_lint_cmd(&lint_args)?;
             failed = result.failed;
             result.value
+        }
+        Command::Update { action } => {
+            let binary_name = env!("CARGO_PKG_NAME");
+            let current_version = env!("CARGO_PKG_VERSION");
+            let service =
+                crate::application::update::UpdateService::new(&base_url, binary_name, current_version);
+            match action {
+                UpdateAction::Check => to_json(service.check_update().await?)?,
+                UpdateAction::Apply => to_json(service.apply_update().await?)?,
+            }
         }
         Command::Gateway { action } => to_json(run_gateway_cmd(&base_url, action).await?)?,
     };

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -344,6 +344,14 @@ pub async fn run() -> anyhow::Result<()> {
 }
 
 async fn run_with_args(args: Args) -> anyhow::Result<()> {
+    // Apply any staged binary update before running commands (CLI restart
+    // is the user's next invocation after `update apply`).
+    match dcc_mcp_updater::Updater::apply_staged_update(env!("CARGO_PKG_NAME")) {
+        Ok(true) => eprintln!("info: staged binary update applied"),
+        Ok(false) => { /* no update was staged */ }
+        Err(e) => eprintln!("warning: failed to apply staged binary update: {e}"),
+    }
+
     let Args {
         base_url,
         output,

--- a/crates/dcc-mcp-gateway-core/src/capability/index.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/index.rs
@@ -150,7 +150,7 @@ mod tests {
     #[test]
     fn compute_fingerprint_is_deterministic() {
         let rec = make_record("maya.abcdef01.create_sphere");
-        let fp_a = compute_fingerprint(&[rec.clone()]);
+        let fp_a = compute_fingerprint(std::slice::from_ref(&rec));
         let fp_b = compute_fingerprint(&[rec]);
         assert_eq!(fp_a, fp_b);
     }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -192,6 +192,7 @@ mod admin_tests {
             ),
             debug_routes_enabled: false,
             auth: std::sync::Arc::new(crate::gateway::security::GatewayAuth::disabled()),
+            update_manifest_url: None,
             gateway_persist: false,
             gateway_idle_timeout_secs: 30,
         }

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -176,6 +176,7 @@ async fn aggregate_tools_list_returns_only_minimal_gateway_surface() {
         ),
         debug_routes_enabled: false,
         auth: std::sync::Arc::new(crate::gateway::security::GatewayAuth::disabled()),
+        update_manifest_url: None,
         gateway_persist: false,
         gateway_idle_timeout_secs: 30,
     };
@@ -356,6 +357,7 @@ async fn make_gateway_state(
         ),
         debug_routes_enabled: false,
         auth: std::sync::Arc::new(crate::gateway::security::GatewayAuth::disabled()),
+        update_manifest_url: None,
         gateway_persist: false,
         gateway_idle_timeout_secs: 30,
     }
@@ -1375,6 +1377,7 @@ async fn gateway_state_with_instances(
         ),
         debug_routes_enabled: false,
         auth: std::sync::Arc::new(crate::gateway::security::GatewayAuth::disabled()),
+        update_manifest_url: None,
         gateway_persist: false,
         gateway_idle_timeout_secs: 30,
     };

--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -188,12 +188,12 @@ pub struct GatewayConfig {
     /// {
     ///   "dcc-mcp-cli": {
     ///     "version": "0.19.0",
-    ///     "url": "https://releases.example.com/dcc-mcp-cli-v0.19.0.zip",
+    ///     "url": "https://releases.example.com/dcc-mcp-cli-v0.19.0",
     ///     "sha256": "abc123..."
     ///   },
     ///   "dcc-mcp-server": {
     ///     "version": "0.19.0",
-    ///     "url": "https://releases.example.com/dcc-mcp-server-v0.19.0.zip",
+    ///     "url": "https://releases.example.com/dcc-mcp-server-v0.19.0",
     ///     "sha256": "def456..."
     ///   }
     /// }

--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -180,6 +180,28 @@ pub struct GatewayConfig {
     /// does not fully trust.
     pub auth: super::security::GatewayAuth,
 
+    /// URL to fetch the update manifest JSON from (gateway-controlled auto-update).
+    ///
+    /// The manifest should be a JSON object mapping binary names to their
+    /// latest version and download URL:
+    /// ```json
+    /// {
+    ///   "dcc-mcp-cli": {
+    ///     "version": "0.19.0",
+    ///     "url": "https://releases.example.com/dcc-mcp-cli-v0.19.0.zip",
+    ///     "sha256": "abc123..."
+    ///   },
+    ///   "dcc-mcp-server": {
+    ///     "version": "0.19.0",
+    ///     "url": "https://releases.example.com/dcc-mcp-server-v0.19.0.zip",
+    ///     "sha256": "def456..."
+    ///   }
+    /// }
+    /// ```
+    /// `None` (default) disables the `/v1/update/*` endpoints (returns 501).
+    /// Override with `DCC_MCP_UPDATE_MANIFEST_URL`.
+    pub update_manifest_url: Option<String>,
+
     /// Keep the standalone gateway daemon alive even when no backend
     /// instances remain. Useful for studio/headless deployments where
     /// backends start and stop independently.
@@ -229,6 +251,7 @@ impl Default for GatewayConfig {
             health_check_failures: 2,
             admin_persist: AdminPersistConfig::default(),
             auth: super::security::GatewayAuth::disabled(),
+            update_manifest_url: None,
             gateway_persist: false,
             gateway_idle_timeout_secs: 30,
         }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -910,6 +910,7 @@ mod tests {
             ),
             debug_routes_enabled: false,
             auth: std::sync::Arc::new(crate::gateway::security::GatewayAuth::disabled()),
+            update_manifest_url: None,
             gateway_persist: false,
             gateway_idle_timeout_secs: 30,
             #[cfg(feature = "prometheus")]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mod.rs
@@ -34,6 +34,7 @@ mod rest_impl;
 mod rest_support;
 mod rest_trace;
 mod sse_impl;
+mod update_impl;
 
 pub use lifecycle_impl::handle_v1_dcc_instance_stop;
 pub use mcp_impl::handle_gateway_mcp;
@@ -49,6 +50,7 @@ pub use rest_impl::{
     handle_v1_search, handle_v1_skills, handle_v1_unload_skill,
 };
 pub use sse_impl::handle_gateway_get;
+pub(crate) use update_impl::{handle_v1_update_check, handle_v1_update_download};
 
 pub(crate) use mcp_impl::JsonRpcRequest;
 pub(crate) use notification_impl::handle_notification;

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/registration_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/registration_impl_tests.rs
@@ -62,6 +62,7 @@ fn test_gateway_state() -> GatewayState {
         search_telemetry: Arc::new(crate::gateway::search_telemetry::SearchTelemetryStore::new()),
         debug_routes_enabled: false,
         auth: std::sync::Arc::new(crate::gateway::security::GatewayAuth::disabled()),
+        update_manifest_url: None,
         gateway_persist: false,
         gateway_idle_timeout_secs: 30,
     }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
@@ -312,6 +312,7 @@ mod tests {
             ),
             debug_routes_enabled: false,
             auth: std::sync::Arc::new(crate::gateway::security::GatewayAuth::disabled()),
+            update_manifest_url: None,
             gateway_persist: false,
             gateway_idle_timeout_secs: 30,
             #[cfg(feature = "prometheus")]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -93,6 +93,7 @@ fn test_gateway_state_with_debug_routes(
         search_telemetry: Arc::new(crate::gateway::search_telemetry::SearchTelemetryStore::new()),
         debug_routes_enabled,
         auth: Arc::new(crate::gateway::security::GatewayAuth::disabled()),
+        update_manifest_url: None,
         gateway_persist: false,
         gateway_idle_timeout_secs: 30,
         #[cfg(feature = "prometheus")]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
@@ -206,6 +206,7 @@ mod tests {
             ),
             debug_routes_enabled: false,
             auth: std::sync::Arc::new(crate::gateway::security::GatewayAuth::disabled()),
+            update_manifest_url: None,
             gateway_persist: false,
             gateway_idle_timeout_secs: 30,
         }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/update_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/update_impl.rs
@@ -1,0 +1,177 @@
+//! Gateway update-version-check and download endpoints.
+//!
+//! These endpoints let CLI and server binaries query the gateway for
+//! available updates through a version manifest hosted at a configurable URL.
+
+use serde::Deserialize;
+
+use super::*;
+
+// ── Manifest types ───────────────────────────────────────────────────────────
+
+/// A single entry in the update manifest (binary_name → entry).
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ManifestEntry {
+    pub(crate) version: String,
+    pub(crate) url: Option<String>,
+    pub(crate) sha256: Option<String>,
+}
+
+/// Top-level update manifest fetched from `update_manifest_url`.
+type UpdateManifest = std::collections::HashMap<String, ManifestEntry>;
+
+// ── Error responses ──────────────────────────────────────────────────────────
+
+fn not_configured() -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(json!({
+            "error": "update_manifest_url not configured",
+            "hint": "set DCC_MCP_UPDATE_MANIFEST_URL or configure update_manifest_url on the gateway"
+        })),
+    )
+}
+
+fn not_found(binary: &str) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({
+            "error": format!("binary '{binary}' not found in update manifest"),
+        })),
+    )
+}
+
+// ── Query params ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CheckQuery {
+    pub(crate) binary: Option<String>,
+    pub(crate) current_version: Option<String>,
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+/// `GET /v1/update/check?binary={name}&current_version={ver}`
+///
+/// Checks whether a newer version is available for the given binary.
+/// Returns the latest version info if the manifest is accessible.
+pub(crate) async fn handle_v1_update_check(
+    State(state): State<GatewayState>,
+    Query(query): Query<CheckQuery>,
+) -> Response {
+    let manifest_url = match &state.update_manifest_url {
+        Some(url) => url.clone(),
+        None => return not_configured().into_response(),
+    };
+
+    let binary_name = match &query.binary {
+        Some(name) => name.clone(),
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing required query parameter: binary"})),
+            )
+                .into_response();
+        }
+    };
+
+    let current_version = query
+        .current_version
+        .clone()
+        .unwrap_or_else(|| "0.0.0".to_string());
+
+    // Fetch the manifest
+    let manifest = match fetch_manifest(&state.http_client, &manifest_url).await {
+        Ok(m) => m,
+        Err(e) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({
+                    "error": "failed to fetch update manifest",
+                    "detail": e.to_string(),
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let entry = match manifest.get(&binary_name) {
+        Some(e) => e,
+        None => return not_found(&binary_name).into_response(),
+    };
+
+    let update_available = is_newer_version(&entry.version, &current_version);
+
+    let resp = json!({
+        "update_available": update_available,
+        "latest_version": entry.version,
+        "download_url": entry.url,
+        "sha256": entry.sha256,
+        "current_version": current_version,
+    });
+
+    (StatusCode::OK, Json(resp)).into_response()
+}
+
+/// `GET /v1/update/download/{binary_name}`
+///
+/// Returns the download URL for the latest version of the given binary.
+pub(crate) async fn handle_v1_update_download(
+    State(state): State<GatewayState>,
+    Path(binary_name): Path<String>,
+) -> Response {
+    let manifest_url = match &state.update_manifest_url {
+        Some(url) => url.clone(),
+        None => return not_configured().into_response(),
+    };
+
+    let manifest = match fetch_manifest(&state.http_client, &manifest_url).await {
+        Ok(m) => m,
+        Err(e) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({
+                    "error": "failed to fetch update manifest",
+                    "detail": e.to_string(),
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let entry = match manifest.get(&binary_name) {
+        Some(e) => e,
+        None => return not_found(&binary_name).into_response(),
+    };
+
+    let download_url = match &entry.url {
+        Some(url) => url.clone(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({
+                    "error": format!("no download URL configured for '{binary_name}'"),
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    (StatusCode::OK, Json(json!({ "download_url": download_url }))).into_response()
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Fetch and parse the update manifest from the configured URL.
+async fn fetch_manifest(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<UpdateManifest, reqwest::Error> {
+    client
+        .get(url)
+        .timeout(std::time::Duration::from_secs(15))
+        .send()
+        .await?
+        .json::<UpdateManifest>()
+        .await
+}

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/update_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/update_impl.rs
@@ -15,6 +15,7 @@ pub(crate) struct ManifestEntry {
     pub(crate) version: String,
     pub(crate) url: Option<String>,
     pub(crate) sha256: Option<String>,
+    pub(crate) release_notes: Option<String>,
 }
 
 /// Top-level update manifest fetched from `update_manifest_url`.
@@ -107,6 +108,7 @@ pub(crate) async fn handle_v1_update_check(
         "latest_version": entry.version,
         "download_url": entry.url,
         "sha256": entry.sha256,
+        "release_notes": entry.release_notes,
         "current_version": current_version,
     });
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/update_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/update_impl.rs
@@ -159,7 +159,11 @@ pub(crate) async fn handle_v1_update_download(
         }
     };
 
-    (StatusCode::OK, Json(json!({ "download_url": download_url }))).into_response()
+    (
+        StatusCode::OK,
+        Json(json!({ "download_url": download_url })),
+    )
+        .into_response()
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/crates/dcc-mcp-gateway/src/gateway/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/router.rs
@@ -14,6 +14,7 @@ use super::handlers::{
     handle_v1_healthz, handle_v1_instances_deregister, handle_v1_instances_heartbeat,
     handle_v1_instances_register, handle_v1_list_skills, handle_v1_load_skill, handle_v1_openapi,
     handle_v1_readyz, handle_v1_search, handle_v1_skills, handle_v1_unload_skill,
+    handle_v1_update_check, handle_v1_update_download,
 };
 use super::http_limits::rate_limit_middleware;
 use super::resilience::gateway_limits;
@@ -165,5 +166,14 @@ fn build_base_router(state: GatewayState) -> Router {
         .route("/v1/call", routing::post(handle_v1_call))
         .route("/v1/call_batch", routing::post(handle_v1_call_batch))
         .route("/v1/context", routing::get(handle_v1_context))
+        // ── #1505 gateway-controlled binary updates ──────────────────────
+        .route(
+            "/v1/update/check",
+            routing::get(handle_v1_update_check),
+        )
+        .route(
+            "/v1/update/download/{binary_name}",
+            routing::get(handle_v1_update_download),
+        )
         .with_state(state)
 }

--- a/crates/dcc-mcp-gateway/src/gateway/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/router.rs
@@ -167,10 +167,7 @@ fn build_base_router(state: GatewayState) -> Router {
         .route("/v1/call_batch", routing::post(handle_v1_call_batch))
         .route("/v1/context", routing::get(handle_v1_context))
         // ── #1505 gateway-controlled binary updates ──────────────────────
-        .route(
-            "/v1/update/check",
-            routing::get(handle_v1_update_check),
-        )
+        .route("/v1/update/check", routing::get(handle_v1_update_check))
         .route(
             "/v1/update/download/{binary_name}",
             routing::get(handle_v1_update_download),

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -280,6 +280,11 @@ pub struct GatewayState {
     /// [`super::config::GatewayConfig::auth`].
     pub auth: Arc<super::security::GatewayAuth>,
 
+    /// URL to fetch the update manifest JSON from (gateway-controlled auto-update).
+    ///
+    /// `None` disables the `/v1/update/*` endpoints.
+    pub update_manifest_url: Option<String>,
+
     /// Runtime lifecycle policy advertised by diagnostics for the standalone
     /// gateway daemon. Embedded gateway paths keep the default non-persistent
     /// policy; daemon mode overrides this from CLI/env configuration.

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -69,6 +69,7 @@ fn test_gateway_state_with_own_and_unknown(
         search_telemetry: Arc::new(crate::gateway::search_telemetry::SearchTelemetryStore::new()),
         debug_routes_enabled: false,
         auth: std::sync::Arc::new(crate::gateway::security::GatewayAuth::disabled()),
+        update_manifest_url: None,
         gateway_persist: false,
         gateway_idle_timeout_secs: 30,
     }

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -901,6 +901,7 @@ pub(crate) async fn start_gateway_tasks(
         search_telemetry: Arc::new(crate::gateway::search_telemetry::SearchTelemetryStore::new()),
         debug_routes_enabled: false,
         auth: Arc::new(auth),
+        update_manifest_url: std::env::var("DCC_MCP_UPDATE_MANIFEST_URL").ok(),
         gateway_persist,
         gateway_idle_timeout_secs,
     };

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -1307,6 +1307,7 @@ mod tests {
             ),
             debug_routes_enabled: false,
             auth: Arc::new(crate::gateway::security::GatewayAuth::disabled()),
+            update_manifest_url: None,
             gateway_persist: false,
             gateway_idle_timeout_secs: 30,
         }

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -65,6 +65,7 @@ pub(crate) async fn start_gateway_runner(
         // GatewayRunner::with_config and is documented in
         // docs/guide/gateway.md § Security.
         auth: dcc_mcp_gateway::GatewayAuth::disabled(),
+        update_manifest_url: None,
         gateway_persist: false,
         gateway_idle_timeout_secs: 30,
     };

--- a/crates/dcc-mcp-server/Cargo.toml
+++ b/crates/dcc-mcp-server/Cargo.toml
@@ -28,6 +28,7 @@ dcc-mcp-transport.workspace = true
 dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
 dcc-mcp-catalog.workspace = true
 dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
+dcc-mcp-updater.workspace = true
 dcc-mcp-sidecar = { path = "../dcc-mcp-sidecar", default-features = false, optional = true }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/dcc-mcp-server/src/cli.rs
+++ b/crates/dcc-mcp-server/src/cli.rs
@@ -28,6 +28,11 @@ pub(crate) enum SubCmd {
     /// Machine-wide gateway daemon. Per-DCC sidecars auto-launch this when needed.
     #[cfg(feature = "gateway-daemon")]
     Gateway(dcc_mcp_sidecar::gateway_daemon::GatewayArgs),
+    /// Check for and apply gateway-controlled binary updates.
+    Update {
+        #[command(subcommand)]
+        action: UpdateAction,
+    },
     /// Replay or diff gateway traffic capture files.
     Capture {
         #[command(subcommand)]
@@ -227,6 +232,15 @@ impl ServeArgs {
         }
         self.server
     }
+}
+
+/// Update subcommand: check for or apply gateway-controlled binary updates.
+#[derive(Debug, Subcommand)]
+pub(crate) enum UpdateAction {
+    /// Check whether a newer version is available.
+    Check,
+    /// Download the latest version and stage it for the next launch.
+    Apply,
 }
 
 /// Catalog subcommand: query the public DCC-MCP catalog.

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -208,23 +208,29 @@ async fn run_update_cmd(gateway_port: u16, action: UpdateAction) -> anyhow::Resu
         UpdateAction::Apply => {
             let info = updater.check_update().await?;
             if !info.update_available {
-                println!("{}", serde_json::to_string_pretty(&serde_json::json!({
-                    "status": "up-to-date",
-                    "current_version": info.current_version,
-                    "latest_version": info.latest_version,
-                    "message": "Already running the latest version."
-                }))?);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "status": "up-to-date",
+                        "current_version": info.current_version,
+                        "latest_version": info.latest_version,
+                        "message": "Already running the latest version."
+                    }))?
+                );
                 return Ok(());
             }
             let downloaded = updater.download_update(&info).await?;
             dcc_mcp_updater::Updater::stage_update(&downloaded, updater.binary_name())?;
-            println!("{}", serde_json::to_string_pretty(&serde_json::json!({
-                "status": "staged",
-                "current_version": info.current_version,
-                "latest_version": info.latest_version,
-                "staged_at": downloaded.to_string_lossy(),
-                "message": "Update downloaded and staged. Restart the server to apply.",
-            }))?);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "status": "staged",
+                    "current_version": info.current_version,
+                    "latest_version": info.latest_version,
+                    "staged_at": downloaded.to_string_lossy(),
+                    "message": "Update downloaded and staged. Restart the server to apply.",
+                }))?
+            );
         }
     }
     Ok(())

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -90,7 +90,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Parser;
-use cli::{Args, CatalogAction, ServerArgs, SubCmd};
+use cli::{Args, CatalogAction, ServerArgs, SubCmd, UpdateAction};
 use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
 #[cfg(feature = "gateway-auto")]
 use dcc_mcp_gateway::{AdminPersistConfig, GatewayConfig, GatewayRunner, SkillPathEntry};
@@ -190,6 +190,42 @@ fn run_catalog_cmd(action: &CatalogAction) -> anyhow::Result<()> {
                 std::process::exit(1);
             }
         },
+    }
+    Ok(())
+}
+
+async fn run_update_cmd(gateway_port: u16, action: UpdateAction) -> anyhow::Result<()> {
+    let gateway_url = format!("http://127.0.0.1:{gateway_port}");
+    let binary_name = env!("CARGO_PKG_NAME");
+    let current_version = env!("CARGO_PKG_VERSION");
+    let updater = dcc_mcp_updater::Updater::new(&gateway_url, binary_name, current_version);
+
+    match action {
+        UpdateAction::Check => {
+            let info = updater.check_update().await?;
+            println!("{}", serde_json::to_string_pretty(&info)?);
+        }
+        UpdateAction::Apply => {
+            let info = updater.check_update().await?;
+            if !info.update_available {
+                println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+                    "status": "up-to-date",
+                    "current_version": info.current_version,
+                    "latest_version": info.latest_version,
+                    "message": "Already running the latest version."
+                }))?);
+                return Ok(());
+            }
+            let downloaded = updater.download_update(&info).await?;
+            dcc_mcp_updater::Updater::stage_update(&downloaded, updater.binary_name())?;
+            println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+                "status": "staged",
+                "current_version": info.current_version,
+                "latest_version": info.latest_version,
+                "staged_at": downloaded.to_string_lossy(),
+                "message": "Update downloaded and staged. Restart the server to apply.",
+            }))?);
+        }
     }
     Ok(())
 }
@@ -576,6 +612,9 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     // ── Dispatch to subcommands ───────────────────────────────────────────
+    // Extract values needed by the Update subcommand before the match
+    // to avoid a partial move conflict when borrowing `args` later.
+    let _update_gateway_port = args.server.gateway_port;
     match args.command {
         Some(SubCmd::Auto(server_args)) => return run_server(server_args).await,
         Some(SubCmd::Serve(serve_args)) => return run_server(serve_args.into_server_args()).await,
@@ -589,6 +628,9 @@ async fn main() -> anyhow::Result<()> {
                 return gateway_daemon::restart_gateway(&gateway_args).await;
             }
             return gateway_daemon::run(gateway_args).await;
+        }
+        Some(SubCmd::Update { action }) => {
+            return run_update_cmd(_update_gateway_port, action).await;
         }
         Some(SubCmd::Capture { action }) => return capture::run(action).await,
         None => return run_server(args.server).await,
@@ -617,6 +659,13 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
     if let (Some(path), Some(pid)) = (args.pid_cleanup_watch.clone(), args.watch_pid) {
         run_pid_cleanup_watcher(path, pid);
         return Ok(());
+    }
+
+    // ── Apply any staged binary update before starting ────────────────────
+    match dcc_mcp_updater::Updater::apply_staged_update(env!("CARGO_PKG_NAME")) {
+        Ok(true) => tracing::info!("staged binary update applied"),
+        Ok(false) => { /* no update was staged */ }
+        Err(e) => tracing::warn!(error = %e, "failed to apply staged binary update"),
     }
 
     // Wire up rolling-file logging by default unless --no-log-file is passed.

--- a/crates/dcc-mcp-updater/Cargo.toml
+++ b/crates/dcc-mcp-updater/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dcc-mcp-updater"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Gateway-controlled auto-update logic for dcc-mcp binaries (CLI and server)"
+
+[dependencies]
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+reqwest.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
+tempfile = "3"
+sha2 = "0.11"
+workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/dcc-mcp-updater/Cargo.toml
+++ b/crates/dcc-mcp-updater/Cargo.toml
@@ -16,6 +16,5 @@ reqwest.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
-tempfile = "3"
 sha2 = "0.11"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/dcc-mcp-updater/src/lib.rs
+++ b/crates/dcc-mcp-updater/src/lib.rs
@@ -1,0 +1,343 @@
+//! Gateway-controlled auto-update logic for dcc-mcp binaries.
+//!
+//! # Design
+//!
+//! This crate provides the core logic for checking, downloading, and staging
+//! binary updates through the dcc-mcp gateway. It follows a **staged update**
+//! pattern:
+//!
+//! 1. `check` — query the gateway for the latest version
+//! 2. `download` — fetch the new binary to a temp staging directory
+//! 3. `stage` — write a "pending update" marker so the next launch applies it
+//! 4. On next launch, `apply_staged` — atomically swap the old binary
+//!
+//! Each step is independent so callers (CLI or server) can decide the UX.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// Response from the gateway's version-check endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateCheckResponse {
+    /// Whether a newer version is available.
+    pub update_available: bool,
+    /// The latest version string available.
+    pub latest_version: String,
+    /// URL to download the new binary archive.
+    pub download_url: Option<String>,
+    /// SHA-256 hex digest of the downloadable archive (optional).
+    pub sha256: Option<String>,
+    /// Human-readable release notes / changelog excerpt.
+    pub release_notes: Option<String>,
+}
+
+/// Result of checking for an update — carries the current version for display.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateInfo {
+    pub update_available: bool,
+    pub current_version: String,
+    pub latest_version: String,
+    pub download_url: Option<String>,
+    pub sha256: Option<String>,
+    pub release_notes: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum UpdateError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Checksum mismatch: expected {expected}, got {actual}")]
+    ChecksumMismatch { expected: String, actual: String },
+
+    #[error("Cannot determine current executable path")]
+    NoExePath,
+
+    #[error("Staging directory error: {0}")]
+    Stage(String),
+}
+
+// ── Version helpers ──────────────────────────────────────────────────────────
+
+/// Simple three-part semver comparison. Treats "0.18.16" etc. as comparable
+/// triples. Non-numeric suffixes (pre-release tags) are ignored for comparison.
+pub fn is_newer_version(current: &str, candidate: &str) -> bool {
+    fn parse_segment(s: &str) -> u64 {
+        s.split(|c: char| !c.is_ascii_digit())
+            .next()
+            .and_then(|d| d.parse().ok())
+            .unwrap_or(0)
+    }
+
+    let cur_parts: Vec<u64> = current.split('.').map(parse_segment).collect();
+    let can_parts: Vec<u64> = candidate.split('.').map(parse_segment).collect();
+
+    for i in 0..3 {
+        let c = cur_parts.get(i).copied().unwrap_or(0);
+        let n = can_parts.get(i).copied().unwrap_or(0);
+        if n > c {
+            return true;
+        }
+        if n < c {
+            return false;
+        }
+    }
+    false
+}
+
+// ── Updater ───────────────────────────────────────────────────────────────────
+
+/// The updater coordinates with the dcc-mcp gateway to check for and apply
+/// binary updates.
+pub struct Updater {
+    gateway_url: String,
+    binary_name: String,
+    current_version: String,
+    client: reqwest::Client,
+}
+
+impl Updater {
+    /// Create a new updater instance.
+    ///
+    /// * `gateway_url` — base URL of the dcc-mcp gateway (e.g. `http://127.0.0.1:9765`)
+    /// * `binary_name` — name of the binary to update (`dcc-mcp-cli` or `dcc-mcp-server`)
+    /// * `current_version` — the currently installed version string
+    pub fn new(gateway_url: &str, binary_name: &str, current_version: &str) -> Self {
+        Self {
+            gateway_url: gateway_url.trim_end_matches('/').to_string(),
+            binary_name: binary_name.to_string(),
+            current_version: current_version.to_string(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("reqwest Client should build with default settings"),
+        }
+    }
+
+    /// The binary name this updater was configured for.
+    pub fn binary_name(&self) -> &str {
+        &self.binary_name
+    }
+
+    /// Query the gateway for available update information.
+    ///
+    /// Makes a `GET /v1/update/check?binary={binary_name}&current_version={ver}`
+    /// request to the gateway.
+    pub async fn check_update(&self) -> Result<UpdateInfo, UpdateError> {
+        let url = format!(
+            "{}/v1/update/check?binary={}&current_version={}",
+            self.gateway_url, self.binary_name, self.current_version
+        );
+
+        let resp: UpdateCheckResponse = self.client.get(&url).send().await?.json().await?;
+
+        Ok(UpdateInfo {
+            update_available: resp.update_available,
+            current_version: self.current_version.clone(),
+            latest_version: resp.latest_version,
+            download_url: resp.download_url,
+            sha256: resp.sha256,
+            release_notes: resp.release_notes,
+        })
+    }
+
+    /// Download the update archive to a temporary staging directory.
+    ///
+    /// Returns the path to the downloaded file.
+    pub async fn download_update(&self, info: &UpdateInfo) -> Result<PathBuf, UpdateError> {
+        let download_url = info
+            .download_url
+            .as_deref()
+            .ok_or_else(|| UpdateError::Stage("no download_url in update info".into()))?;
+
+        let staging_dir = staging_dir(&self.binary_name)?;
+        std::fs::create_dir_all(&staging_dir)?;
+
+        let ext = if download_url.ends_with(".zip") {
+            ".zip"
+        } else if download_url.ends_with(".tar.gz") || download_url.ends_with(".tgz") {
+            ".tar.gz"
+        } else {
+            ".bin"
+        };
+
+        let dest_path = staging_dir.join(format!("{}-{}", self.binary_name, ext));
+
+        let response = self.client.get(download_url).send().await?;
+        let bytes = response.bytes().await?;
+
+        // Verify SHA-256 if provided
+        if let Some(expected_sha) = &info.sha256 {
+            let mut hasher = Sha256::new();
+            hasher.update(&bytes);
+            let actual_sha = hex::encode(hasher.finalize().as_slice());
+            if !actual_sha.eq_ignore_ascii_case(expected_sha) {
+                return Err(UpdateError::ChecksumMismatch {
+                    expected: expected_sha.clone(),
+                    actual: actual_sha,
+                });
+            }
+        }
+
+        tokio::fs::write(&dest_path, &bytes).await?;
+        Ok(dest_path)
+    }
+
+    /// Stage a downloaded update for replacement on the next launch.
+    ///
+    /// Writes a pending-update marker and the new binary to the staging
+    /// directory. On the next launch, the launcher should call
+    /// [`apply_staged_update`].
+    pub fn stage_update(downloaded: &Path, binary_name: &str) -> Result<(), UpdateError> {
+        let dir = staging_dir(binary_name)?;
+        std::fs::create_dir_all(&dir)?;
+
+        let staged_bin = dir.join("pending.bin");
+        std::fs::copy(downloaded, &staged_bin)?;
+
+        // Write a marker so the next launch knows to apply the update
+        let marker_path = dir.join("pending.marker");
+        std::fs::write(&marker_path, "pending")?;
+
+        tracing::info!("Update staged at {}", staged_bin.display());
+        Ok(())
+    }
+
+    /// Apply a previously staged update by swapping the current binary.
+    ///
+    /// To be called at startup BEFORE the main application logic runs.
+    /// Returns `true` if an update was applied, `false` if no update was staged.
+    pub fn apply_staged_update(binary_name: &str) -> Result<bool, UpdateError> {
+        let dir = staging_dir(binary_name)?;
+        let marker_path = dir.join("pending.marker");
+        let staged_bin = dir.join("pending.bin");
+
+        if !marker_path.exists() || !staged_bin.exists() {
+            return Ok(false);
+        }
+
+        let current_exe = std::env::current_exe().map_err(|_| UpdateError::NoExePath)?;
+
+        tracing::info!(
+            "Applying staged update: {} → {}",
+            staged_bin.display(),
+            current_exe.display()
+        );
+
+        // On Windows we can't replace a running exe, so we rename the current
+        // binary aside and copy the new one in place.
+        #[cfg(target_os = "windows")]
+        {
+            let backup = current_exe.with_extension("exe.bak");
+            let _ = std::fs::remove_file(&backup);
+            std::fs::rename(&current_exe, &backup)?;
+            std::fs::copy(&staged_bin, &current_exe)?;
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            // On Unix, rename(2) atomically replaces the target even if running
+            // (the inode stays open in the running process; new exec gets the new inode).
+            std::fs::rename(&staged_bin, &current_exe)?;
+        }
+
+        // Clean up markers
+        let _ = std::fs::remove_file(&marker_path);
+
+        tracing::info!("Staged update applied successfully");
+        Ok(true)
+    }
+
+    /// Remove any staged update artifacts (rollback).
+    pub fn clear_staged_update(binary_name: &str) -> Result<(), UpdateError> {
+        let dir = staging_dir(binary_name)?;
+        for entry in ["pending.bin", "pending.marker"] {
+            let p = dir.join(entry);
+            if p.exists() {
+                let _ = std::fs::remove_file(&p);
+            }
+        }
+        Ok(())
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn staging_dir(binary_name: &str) -> Result<PathBuf, UpdateError> {
+    // Use a platform-appropriate data dir for staging updates
+    // Falls back to a temp dir if we can't determine the data dir
+    let base = dirs_data_dir().unwrap_or_else(|| std::env::temp_dir().join("dcc-mcp"));
+    Ok(base.join("update").join(binary_name))
+}
+
+fn dirs_data_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        std::env::var("XDG_DATA_HOME")
+            .ok()
+            .map(PathBuf::from)
+            .or_else(|| {
+                std::env::var("HOME")
+                    .ok()
+                    .map(|h| PathBuf::from(h).join(".local").join("share"))
+            })
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::env::var("HOME")
+            .ok()
+            .map(|h| PathBuf::from(h).join("Library").join("Application Support"))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var("APPDATA").ok().map(PathBuf::from)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        None::<PathBuf>
+    }
+    .map(|p| p.join("dcc-mcp"))
+}
+
+// ── hex is needed for SHA-256 display ────────────────────────────────────────
+mod hex {
+    pub(crate) fn encode(bytes: &[u8]) -> String {
+        use std::fmt::Write;
+        let mut hex = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            write!(hex, "{b:02x}").unwrap();
+        }
+        hex
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_comparison() {
+        assert!(is_newer_version("0.18.15", "0.18.16"));
+        assert!(is_newer_version("0.18.16", "0.19.0"));
+        assert!(!is_newer_version("0.19.0", "0.18.16"));
+        assert!(!is_newer_version("0.18.16", "0.18.16"));
+        // Pre-release tags are treated as equal to the base version (ignored suffix)
+        assert!(!is_newer_version("0.18.16-alpha", "0.18.16"));
+        assert!(!is_newer_version("0.18.16", "0.18.16-alpha"));
+    }
+
+    #[test]
+    fn staging_dir_is_reasonable() {
+        let dir = staging_dir("dcc-mcp-cli").unwrap();
+        assert!(dir.to_string_lossy().contains("dcc-mcp"));
+        assert!(dir.to_string_lossy().contains("update"));
+    }
+}

--- a/crates/dcc-mcp-updater/src/lib.rs
+++ b/crates/dcc-mcp-updater/src/lib.rs
@@ -69,7 +69,10 @@ pub enum UpdateError {
 
 /// Simple three-part semver comparison. Treats "0.18.16" etc. as comparable
 /// triples. Non-numeric suffixes (pre-release tags) are ignored for comparison.
-pub fn is_newer_version(current: &str, candidate: &str) -> bool {
+///
+/// Parameter order matches the gateway's `is_newer_version(candidate, current)`
+/// convention (see `dcc_mcp_gateway::gateway::version::is_newer_version`).
+pub fn is_newer_version(candidate: &str, current: &str) -> bool {
     fn parse_segment(s: &str) -> u64 {
         s.split(|c: char| !c.is_ascii_digit())
             .next()
@@ -77,12 +80,12 @@ pub fn is_newer_version(current: &str, candidate: &str) -> bool {
             .unwrap_or(0)
     }
 
-    let cur_parts: Vec<u64> = current.split('.').map(parse_segment).collect();
     let can_parts: Vec<u64> = candidate.split('.').map(parse_segment).collect();
+    let cur_parts: Vec<u64> = current.split('.').map(parse_segment).collect();
 
     for i in 0..3 {
-        let c = cur_parts.get(i).copied().unwrap_or(0);
         let n = can_parts.get(i).copied().unwrap_or(0);
+        let c = cur_parts.get(i).copied().unwrap_or(0);
         if n > c {
             return true;
         }
@@ -161,15 +164,10 @@ impl Updater {
         let staging_dir = staging_dir(&self.binary_name)?;
         std::fs::create_dir_all(&staging_dir)?;
 
-        let ext = if download_url.ends_with(".zip") {
-            ".zip"
-        } else if download_url.ends_with(".tar.gz") || download_url.ends_with(".tgz") {
-            ".tar.gz"
-        } else {
-            ".bin"
-        };
-
-        let dest_path = staging_dir.join(format!("{}-{}", self.binary_name, ext));
+        // All downloads produce a raw binary (not an archive).
+        // The manifest URL determines what we download — clients trust
+        // the platform-appropriate URL configured in the manifest.
+        let dest_path = staging_dir.join(format!("{}.download", self.binary_name));
 
         let response = self.client.get(download_url).send().await?;
         let bytes = response.bytes().await?;
@@ -325,13 +323,13 @@ mod tests {
 
     #[test]
     fn version_comparison() {
-        assert!(is_newer_version("0.18.15", "0.18.16"));
-        assert!(is_newer_version("0.18.16", "0.19.0"));
-        assert!(!is_newer_version("0.19.0", "0.18.16"));
+        assert!(is_newer_version("0.18.16", "0.18.15"));
+        assert!(is_newer_version("0.19.0", "0.18.16"));
+        assert!(!is_newer_version("0.18.16", "0.19.0"));
         assert!(!is_newer_version("0.18.16", "0.18.16"));
         // Pre-release tags are treated as equal to the base version (ignored suffix)
-        assert!(!is_newer_version("0.18.16-alpha", "0.18.16"));
         assert!(!is_newer_version("0.18.16", "0.18.16-alpha"));
+        assert!(!is_newer_version("0.18.16-alpha", "0.18.16"));
     }
 
     #[test]

--- a/crates/dcc-mcp-updater/src/lib.rs
+++ b/crates/dcc-mcp-updater/src/lib.rs
@@ -299,10 +299,7 @@ fn dirs_data_dir() -> Option<PathBuf> {
         std::env::var("APPDATA").ok().map(PathBuf::from)
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-    {
-        None::<PathBuf>
-    }
-    .map(|p| p.join("dcc-mcp"))
+    { None::<PathBuf> }.map(|p| p.join("dcc-mcp"))
 }
 
 // ── hex is needed for SHA-256 display ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add a complete auto-update pipeline across the stack: gateway version API,
shared updater library, and update subcommands for both CLI and server.

### Changes

1. **New `dcc-mcp-updater` crate** — core update logic:
   - Version check against gateway (`is_newer_version` comparison)
   - Binary download with optional SHA-256 verification
   - Staged update pattern (download → stage → apply on next launch)
   - Cross-platform binary replacement (atomic rename on Unix, copy+backup on Windows)

2. **Gateway API** (`dcc-mcp-gateway`):
   - `GET /v1/update/check?binary={name}&current_version={ver}` — query latest version
   - `GET /v1/update/download/{binary_name}` — download URL from manifest
   - Controlled via `DCC_MCP_UPDATE_MANIFEST_URL` env var

3. **CLI update subcommand** (`dcc-mcp-cli`):
   - `dcc-mcp-cli update check` — report available version
   - `dcc-mcp-cli update apply` — download and stage update

4. **Server update subcommand** (`dcc-mcp-server`):
   - `dcc-mcp-server update check` — report available version
   - `dcc-mcp-server update apply` — download and stage update
   - Automatic staged-update application at startup (before server starts)

### Design

Follows the staged-update pattern: download to staging dir, write a marker,
apply on restart. This avoids the complexity of hot-swapping a running binary.

The update manifest format:
```json
{
  "dcc-mcp-cli": { "version": "0.19.0", "url": "...", "sha256": "..." },
  "dcc-mcp-server": { "version": "0.19.0", "url": "...", "sha256": "..." }
}
```

### Related issue

PIP-1505 — Add update command to CLI and server for gateway-controlled auto-update