### PR TITLE
feat(marketplace): add add-repo command for direct GitHub install (PIP-1377)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "sha2 0.11.0",
  "tempfile",
  "thiserror",

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -238,6 +238,23 @@ enum MarketplaceAction {
         #[arg(long)]
         dcc: Option<String>,
     },
+    /// Install a skill directly from a GitHub repo (no marketplace.json needed).
+    ///
+    /// Clones the repo, discovers SKILL.md files, and installs to the
+    /// marketplace root. Supports owner/repo, full URL, and @subpath syntax.
+    AddRepo {
+        /// GitHub owner/repo, full URL, or owner/repo@subpath.
+        repo_ref: String,
+        /// Override the DCC type (required when SKILL.md doesn't declare one).
+        #[arg(long)]
+        dcc: Option<String>,
+        /// List available skills in the repo without installing.
+        #[arg(long)]
+        list: bool,
+        /// Replace an existing installation.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Debug, clap::Args)]
@@ -568,6 +585,18 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                 }
                 MarketplaceAction::Update { name, all, dcc } => {
                     to_json(service.update(name, all, dcc).await?)?
+                }
+                MarketplaceAction::AddRepo {
+                    repo_ref,
+                    dcc,
+                    list,
+                    force,
+                } => {
+                    if list {
+                        to_json(service.list_repo_skills(&repo_ref)?)?
+                    } else {
+                        to_json(service.add_repo(&repo_ref, dcc.as_deref(), force)?)?
+                    }
                 }
             }
         }

--- a/crates/dcc-mcp-marketplace/Cargo.toml
+++ b/crates/dcc-mcp-marketplace/Cargo.toml
@@ -12,6 +12,7 @@ description = "Shared marketplace domain layer for catalog fetch, install/uninst
 dcc-mcp-catalog.workspace = true
 reqwest.workspace = true
 serde.workspace = true
+serde_yaml_ng.workspace = true
 serde_json.workspace = true
 sha2 = "0.11"
 thiserror.workspace = true

--- a/crates/dcc-mcp-marketplace/src/add_repo.rs
+++ b/crates/dcc-mcp-marketplace/src/add_repo.rs
@@ -1,0 +1,560 @@
+//! Direct GitHub repo installation — SKILL.md discovery, no marketplace.json needed.
+//!
+//! This module implements `dcc-mcp-cli marketplace add-repo <owner/repo>`:
+//! - Clone a GitHub repo via `git clone --depth 1`
+//! - Discover SKILL.md files to infer name/dcc/description
+//! - Support `@subpath` syntax (vercel skills parity)
+//! - `--list` to enumerate available skills without installing
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::error::MarketplaceError;
+use crate::types::{RepoInstallResult, RepoSkillInfo, RepoSkillList};
+use crate::path_component;
+
+/// Parse a repo reference into a clone URL and optional subpath.
+///
+/// Supports:
+/// - `owner/repo` → `https://github.com/owner/repo.git`
+/// - `https://github.com/owner/repo` → as-is (with .git added if missing)
+/// - `owner/repo@subdir` → clone URL + `subdir` subpath
+/// - `https://github.com/owner/repo.git` → as-is
+/// - `git@github.com:owner/repo.git` → as-is (SSH)
+pub fn parse_repo_ref(raw: &str) -> Result<(String, Option<String>), MarketplaceError> {
+    let trimmed = raw.trim();
+
+    // SSH URL is detected first: git@host:path — the @ is part of the URL, not a subpath.
+    if trimmed.starts_with("git@") {
+        return Ok((ensure_git_suffix(trimmed), None));
+    }
+
+    // Split on last @ for subpath support (e.g., owner/repo@subdir).
+    // Only applies to non-SSH URLs where @ separates a subpath.
+    let (repo_part, subpath) = if let Some(at_pos) = trimmed.rfind('@') {
+        let sub = &trimmed[at_pos + 1..];
+        if sub.is_empty() || sub.contains('/') {
+            return Err(MarketplaceError::CommandFailed(format!(
+                "invalid repo subpath '{sub}': must be a single directory name"
+            )));
+        }
+        (&trimmed[..at_pos], Some(sub.to_string()))
+    } else {
+        (trimmed, None)
+    };
+
+    let url = if looks_like_github_slug(repo_part) {
+        format!("https://github.com/{repo_part}.git")
+    } else if repo_part.starts_with("http://") || repo_part.starts_with("https://") {
+        ensure_git_suffix(repo_part)
+    } else {
+        return Err(MarketplaceError::CommandFailed(format!(
+            "invalid repo reference '{repo_part}': expected owner/repo or full URL"
+        )));
+    };
+
+    Ok((url, subpath))
+}
+
+fn ensure_git_suffix(url: &str) -> String {
+    if url.ends_with(".git") {
+        url.to_string()
+    } else {
+        let no_trailing = url.trim_end_matches('/');
+        format!("{no_trailing}.git")
+    }
+}
+
+fn looks_like_github_slug(value: &str) -> bool {
+    let Some((owner, repo)) = value.split_once('/') else {
+        return false;
+    };
+    !owner.is_empty() && !repo.is_empty()
+        && !value.contains("://")
+        && !value.contains('\\')
+        && !value.contains('@')
+}
+
+/// Clone a repo to a staging directory.
+fn clone_repo(url: &str, dest: &Path) -> Result<(), MarketplaceError> {
+    let output = Command::new("git")
+        .args(["clone", "--depth", "1", url])
+        .arg(dest)
+        .output()
+        .map_err(|err| MarketplaceError::CommandFailed(format!("git clone: {err}")))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(MarketplaceError::CommandFailed(format!(
+            "git clone exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        )))
+    }
+}
+
+/// Parse a SKILL.md file and extract name, description, and dcc from frontmatter.
+pub fn extract_skill_frontmatter(skill_dir: &Path) -> Option<RepoSkillInfo> {
+    let skill_md = skill_dir.join("SKILL.md");
+    let content = std::fs::read_to_string(skill_md).ok()?;
+
+    // Extract YAML frontmatter between --- delimiters
+    let frontmatter = extract_frontmatter(&content)?;
+
+    // Parse the YAML frontmatter
+    let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(frontmatter).ok()?;
+    let mapping = value.as_mapping()?;
+
+    let name = mapping
+        .get(&serde_yaml_ng::Value::String("name".into()))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())?;
+
+    let description = mapping
+        .get(&serde_yaml_ng::Value::String("description".into()))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    // Extract dcc from metadata.dcc-mcp.dcc
+    let dcc = mapping
+        .get(&serde_yaml_ng::Value::String("metadata".into()))
+        .and_then(|v| v.as_mapping())
+        .and_then(|m| m.get(&serde_yaml_ng::Value::String("dcc-mcp".into())))
+        .and_then(|v| v.as_mapping())
+        .and_then(|m| m.get(&serde_yaml_ng::Value::String("dcc".into())))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    Some(RepoSkillInfo {
+        name,
+        description,
+        dcc,
+        subpath: None,
+    })
+}
+
+fn extract_frontmatter(content: &str) -> Option<&str> {
+    const DELIMITER: &str = "---";
+    if !content.starts_with(DELIMITER) {
+        return None;
+    }
+    let after_first = &content[DELIMITER.len()..];
+    let end = after_first.find("\n---")?;
+    Some(after_first[..end].trim())
+}
+
+/// Collect all SKILL.md files under a root directory (shallow — one level).
+fn collect_skill_dirs(root: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    // Check root
+    if root.join("SKILL.md").is_file() {
+        dirs.push(root.to_path_buf());
+        return dirs;
+    }
+
+    // Check immediate subdirectories
+    let entries = match std::fs::read_dir(root) {
+        Ok(e) => e,
+        Err(_) => return dirs,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() && path.join("SKILL.md").is_file() {
+            dirs.push(path);
+        }
+    }
+
+    dirs
+}
+
+/// A simple temp directory that auto-cleans up on drop.
+struct StagingDir {
+    path: PathBuf,
+}
+
+impl StagingDir {
+    fn new() -> Result<Self, MarketplaceError> {
+        let pid = std::process::id();
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir_name = format!("dcc-mcp-add-repo-{pid}-{ts}");
+        let path = std::env::temp_dir().join(&dir_name);
+        std::fs::create_dir_all(&path)
+            .map_err(|err| MarketplaceError::ConfigIo(path.display().to_string(), err))?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for StagingDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+// ── high-level API ────────────────────────────────────────────────────────────
+
+/// List available skills from a repo without installing.
+///
+/// Clones the repo, discovers SKILL.md files, parses frontmatter, and
+/// returns the list. The clone directory is cleaned up before returning.
+pub fn list_repo_skills(repo_ref: &str) -> Result<RepoSkillList, MarketplaceError> {
+    let (url, subpath) = parse_repo_ref(repo_ref)?;
+
+    let staging = StagingDir::new()?;
+    let clone_dir = staging.path.clone();
+
+    clone_repo(&url, &clone_dir)?;
+
+    let search_root = match &subpath {
+        Some(sub) => clone_dir.join(sub),
+        None => clone_dir.clone(),
+    };
+
+    if subpath.is_some() && !search_root.exists() {
+        return Err(MarketplaceError::CommandFailed(format!(
+            "subpath '{}' not found in repo",
+            subpath.as_deref().unwrap()
+        )));
+    }
+
+    let skill_dirs = collect_skill_dirs(&search_root);
+    let mut skills: Vec<RepoSkillInfo> = skill_dirs
+        .iter()
+        .filter_map(|dir| extract_skill_frontmatter(dir.as_path()))
+        .collect();
+    // Tag subpaths for non-root skills
+    for skill in &mut skills {
+        let dir = search_root
+            .join(&skill.name);
+        if dir.is_dir() && dir.join("SKILL.md").is_file() && dir.file_name().map(|n| n != ".").unwrap_or(false) {
+            skill.subpath = dir.file_name().map(|n| n.to_string_lossy().to_string());
+        }
+    }
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // StagingDir is cleaned up on drop
+
+    Ok(RepoSkillList {
+        repo_url: url,
+        count: skills.len(),
+        skills,
+    })
+}
+
+/// Install a skill directly from a GitHub repo into the marketplace.
+///
+/// `repo_ref`: owner/repo, full URL, or @subpath variant.
+/// `dcc`: explicit DCC override (required when SKILL.md doesn't declare one).
+/// `force`: replace an existing installation.
+/// `root`: the marketplace root directory (`~/.dcc-mcp/marketplace`).
+pub fn install_from_repo(
+    repo_ref: &str,
+    dcc: Option<&str>,
+    force: bool,
+    root: &Path,
+) -> Result<RepoInstallResult, MarketplaceError> {
+    let (url, subpath) = parse_repo_ref(repo_ref)?;
+
+    // Temp staging for clone
+    let staging = StagingDir::new()?;
+    let clone_dir = staging.path.clone();
+
+    clone_repo(&url, &clone_dir)?;
+
+    let search_root = match &subpath {
+        Some(sub) => {
+            let p = clone_dir.join(sub);
+            if !p.exists() {
+                return Err(MarketplaceError::CommandFailed(format!(
+                    "subpath '{}' not found in repo",
+                    sub
+                )));
+            }
+            p
+        }
+        None => clone_dir.clone(),
+    };
+
+    let skill_dirs = collect_skill_dirs(&search_root);
+    if skill_dirs.is_empty() {
+        return Err(MarketplaceError::CommandFailed(
+            "no SKILL.md found in repo".into(),
+        ));
+    }
+
+    // Find the skill to install
+    let target_skill = if skill_dirs.len() == 1 {
+        // Single skill — use it directly
+        let dir = &skill_dirs[0];
+        let mut info = extract_skill_frontmatter(dir).ok_or_else(|| {
+            MarketplaceError::CommandFailed(
+                "failed to parse SKILL.md frontmatter".into(),
+            )
+        })?;
+        info.subpath = if dir != &clone_dir {
+            dir.file_name().map(|n| n.to_string_lossy().to_string())
+        } else {
+            None
+        };
+        info
+    } else {
+        // Multiple skills — try to resolve by --dcc or fail
+        let all_skills: Vec<RepoSkillInfo> = skill_dirs
+            .iter()
+            .filter_map(|dir| extract_skill_frontmatter(dir.as_path()))
+            .collect();
+
+        match dcc {
+            Some(requested_dcc) => {
+                let matched = all_skills.into_iter().find(|s| {
+                    s.dcc.as_deref().map(|d| d.eq_ignore_ascii_case(requested_dcc)).unwrap_or(false)
+                }).ok_or_else(|| {
+                    MarketplaceError::CommandFailed(format!(
+                        "no skill for DCC '{requested_dcc}' found in repo; \
+                         use --list to see available skills"
+                    ))
+                })?;
+                matched
+            }
+            None => {
+                return Err(MarketplaceError::CommandFailed(
+                    "repo contains multiple skills; use --dcc <DCC> to select one, \
+                     or --list to see available skills"
+                        .into(),
+                ))
+            }
+        }
+    };
+
+    // Determine the final DCC name
+    let final_dcc = match dcc {
+        Some(explicit) => path_component("DCC name", explicit)?.to_lowercase(),
+        None => match &target_skill.dcc {
+            Some(d) => path_component("DCC name", d)?.to_lowercase(),
+            None => {
+                return Err(MarketplaceError::CommandFailed(
+                    "skill does not declare a DCC in SKILL.md; use --dcc to specify one"
+                        .into(),
+                ))
+            }
+        },
+    };
+
+    let package_name = path_component("package name", &target_skill.name)?;
+    let dcc_root = root.join(&final_dcc);
+    let dest = dcc_root.join(&package_name);
+
+    if dest.exists() && !force {
+        return Err(MarketplaceError::AlreadyInstalled {
+            name: package_name.clone(),
+            dcc: final_dcc.clone(),
+            path: dest.display().to_string(),
+        });
+    }
+
+    // Remove existing if forcing
+    if dest.exists() {
+        std::fs::remove_dir_all(&dest)
+            .map_err(|err| MarketplaceError::ConfigIo(dest.display().to_string(), err))?;
+    }
+
+    // Create parent dir and move staging into place
+    std::fs::create_dir_all(&dcc_root)
+        .map_err(|err| MarketplaceError::ConfigIo(dcc_root.display().to_string(), err))?;
+
+    // Find the source directory — the skill dir within the clone
+    let skill_source = if let Some(ref sp) = target_skill.subpath {
+        search_root.join(sp)
+    } else {
+        skill_dirs
+            .into_iter()
+            .find(|d| extract_skill_frontmatter(d.as_path()).map(|s| s.name == target_skill.name).unwrap_or(false))
+            .unwrap_or_else(|| clone_dir.clone())
+    };
+
+    // Copy the skill directory to destination
+    copy_dir_recursive(&skill_source, &dest)?;
+
+    Ok(RepoInstallResult {
+        installed: true,
+        name: package_name,
+        dcc: final_dcc,
+        repo_url: url,
+        path: dest.display().to_string(),
+        skill_search_path: dcc_root.display().to_string(),
+        skill_subpath: target_skill.subpath,
+        description: target_skill.description,
+    })
+}
+
+/// Recursive directory copy, skipping .git directories.
+fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<(), MarketplaceError> {
+    std::fs::create_dir_all(dest)
+        .map_err(|err| MarketplaceError::ConfigIo(dest.display().to_string(), err))?;
+    for entry in std::fs::read_dir(src)
+        .map_err(|err| MarketplaceError::ConfigIo(src.display().to_string(), err))?
+    {
+        let entry = entry.map_err(|err| MarketplaceError::ConfigIo(src.display().to_string(), err))?;
+        let src_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        let file_type = entry
+            .file_type()
+            .map_err(|err| MarketplaceError::ConfigIo(src_path.display().to_string(), err))?;
+        if file_type.is_dir() {
+            // Skip .git directory
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            copy_dir_recursive(&src_path, &dest_path)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&src_path, &dest_path).map_err(|err| {
+                MarketplaceError::ConfigIo(
+                    format!("copy {} -> {}", src_path.display(), dest_path.display()),
+                    err,
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_owner_repo() {
+        let (url, subpath) = parse_repo_ref("dcc-mcp/dcc-mcp-maya").unwrap();
+        assert_eq!(url, "https://github.com/dcc-mcp/dcc-mcp-maya.git");
+        assert!(subpath.is_none());
+    }
+
+    #[test]
+    fn parse_owner_repo_with_subpath() {
+        let (url, subpath) = parse_repo_ref("dcc-mcp/dcc-mcp-maya@subdir").unwrap();
+        assert_eq!(url, "https://github.com/dcc-mcp/dcc-mcp-maya.git");
+        assert_eq!(subpath.unwrap(), "subdir");
+    }
+
+    #[test]
+    fn parse_github_https_url() {
+        let (url, subpath) = parse_repo_ref("https://github.com/dcc-mcp/dcc-mcp-maya.git").unwrap();
+        assert_eq!(url, "https://github.com/dcc-mcp/dcc-mcp-maya.git");
+        assert!(subpath.is_none());
+    }
+
+    #[test]
+    fn parse_full_url_without_git_suffix() {
+        let (url, subpath) =
+            parse_repo_ref("https://github.com/dcc-mcp/dcc-mcp-maya").unwrap();
+        assert_eq!(url, "https://github.com/dcc-mcp/dcc-mcp-maya.git");
+        assert!(subpath.is_none());
+    }
+
+    #[test]
+    fn parse_ssh_url() {
+        let (url, subpath) =
+            parse_repo_ref("git@github.com:dcc-mcp/dcc-mcp-maya.git").unwrap();
+        assert_eq!(url, "git@github.com:dcc-mcp/dcc-mcp-maya.git");
+        assert!(subpath.is_none());
+    }
+
+    #[test]
+    fn parse_invalid_empty_subpath() {
+        assert!(parse_repo_ref("owner/repo@").is_err());
+    }
+
+    #[test]
+    fn parse_invalid_subpath_with_slash() {
+        assert!(parse_repo_ref("owner/repo@sub/dir").is_err());
+    }
+
+    #[test]
+    fn extract_frontmatter_basic() {
+        let content = "---\nname: test-skill\ndescription: A test\n---\n";
+        let info = extract_skill_frontmatter_from_str(content).unwrap();
+        assert_eq!(info.name, "test-skill");
+        assert_eq!(info.description.as_deref(), Some("A test"));
+    }
+
+    #[test]
+    fn extract_frontmatter_with_dcc() {
+        let content = "---\nname: maya-anim\ndescription: Maya animation tools\n\
+            metadata:\n  dcc-mcp:\n    dcc: maya\n---\n";
+        let info = extract_skill_frontmatter_from_str(content).unwrap();
+        assert_eq!(info.name, "maya-anim");
+        assert_eq!(info.description.as_deref(), Some("Maya animation tools"));
+        assert_eq!(info.dcc.as_deref(), Some("maya"));
+    }
+
+    #[test]
+    fn extract_frontmatter_no_dcc() {
+        let content = "---\nname: generic-tool\ndescription: No DCC\n---\n";
+        let info = extract_skill_frontmatter_from_str(content).unwrap();
+        assert_eq!(info.name, "generic-tool");
+        assert_eq!(info.dcc, None);
+    }
+
+    #[test]
+    fn extract_frontmatter_no_frontmatter() {
+        assert!(extract_skill_frontmatter_from_str("no frontmatter").is_none());
+    }
+
+    /// Helper to extract frontmatter from a string (used in tests).
+    fn extract_skill_frontmatter_from_str(content: &str) -> Option<RepoSkillInfo> {
+        let fm = extract_frontmatter(content)?;
+        let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(fm).ok()?;
+        let mapping = value.as_mapping()?;
+
+        let name = mapping
+            .get(&serde_yaml_ng::Value::String("name".into()))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())?;
+
+        let description = mapping
+            .get(&serde_yaml_ng::Value::String("description".into()))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let dcc = mapping
+            .get(&serde_yaml_ng::Value::String("metadata".into()))
+            .and_then(|v| v.as_mapping())
+            .and_then(|m| m.get(&serde_yaml_ng::Value::String("dcc-mcp".into())))
+            .and_then(|v| v.as_mapping())
+            .and_then(|m| m.get(&serde_yaml_ng::Value::String("dcc".into())))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        Some(RepoSkillInfo {
+            name,
+            description,
+            dcc,
+            subpath: None,
+        })
+    }
+
+    #[test]
+    fn write_skill_md_and_extract() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: My cool skill\n\
+             metadata:\n  dcc-mcp:\n    dcc: blender\n---\n",
+        )
+        .unwrap();
+
+        let info = extract_skill_frontmatter(&skill_dir).unwrap();
+        assert_eq!(info.name, "my-skill");
+        assert_eq!(info.description.as_deref(), Some("My cool skill"));
+        assert_eq!(info.dcc.as_deref(), Some("blender"));
+    }
+}

--- a/crates/dcc-mcp-marketplace/src/add_repo.rs
+++ b/crates/dcc-mcp-marketplace/src/add_repo.rs
@@ -108,22 +108,22 @@ pub fn extract_skill_frontmatter(skill_dir: &Path) -> Option<RepoSkillInfo> {
     let mapping = value.as_mapping()?;
 
     let name = mapping
-        .get(&serde_yaml_ng::Value::String("name".into()))
+        .get(serde_yaml_ng::Value::String("name".into()))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())?;
 
     let description = mapping
-        .get(&serde_yaml_ng::Value::String("description".into()))
+        .get(serde_yaml_ng::Value::String("description".into()))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
     // Extract dcc from metadata.dcc-mcp.dcc
     let dcc = mapping
-        .get(&serde_yaml_ng::Value::String("metadata".into()))
+        .get(serde_yaml_ng::Value::String("metadata".into()))
         .and_then(|v| v.as_mapping())
-        .and_then(|m| m.get(&serde_yaml_ng::Value::String("dcc-mcp".into())))
+        .and_then(|m| m.get(serde_yaml_ng::Value::String("dcc-mcp".into())))
         .and_then(|v| v.as_mapping())
-        .and_then(|m| m.get(&serde_yaml_ng::Value::String("dcc".into())))
+        .and_then(|m| m.get(serde_yaml_ng::Value::String("dcc".into())))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
@@ -311,23 +311,20 @@ pub fn install_from_repo(
             .collect();
 
         match dcc {
-            Some(requested_dcc) => {
-                let matched = all_skills
-                    .into_iter()
-                    .find(|s| {
-                        s.dcc
-                            .as_deref()
-                            .map(|d| d.eq_ignore_ascii_case(requested_dcc))
-                            .unwrap_or(false)
-                    })
-                    .ok_or_else(|| {
-                        MarketplaceError::CommandFailed(format!(
-                            "no skill for DCC '{requested_dcc}' found in repo; \
+            Some(requested_dcc) => all_skills
+                .into_iter()
+                .find(|s| {
+                    s.dcc
+                        .as_deref()
+                        .map(|d| d.eq_ignore_ascii_case(requested_dcc))
+                        .unwrap_or(false)
+                })
+                .ok_or_else(|| {
+                    MarketplaceError::CommandFailed(format!(
+                        "no skill for DCC '{requested_dcc}' found in repo; \
                          use --list to see available skills"
-                        ))
-                    })?;
-                matched
-            }
+                    ))
+                })?,
             None => {
                 return Err(MarketplaceError::CommandFailed(
                     "repo contains multiple skills; use --dcc <DCC> to select one, \
@@ -523,21 +520,21 @@ mod tests {
         let mapping = value.as_mapping()?;
 
         let name = mapping
-            .get(&serde_yaml_ng::Value::String("name".into()))
+            .get(serde_yaml_ng::Value::String("name".into()))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())?;
 
         let description = mapping
-            .get(&serde_yaml_ng::Value::String("description".into()))
+            .get(serde_yaml_ng::Value::String("description".into()))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
         let dcc = mapping
-            .get(&serde_yaml_ng::Value::String("metadata".into()))
+            .get(serde_yaml_ng::Value::String("metadata".into()))
             .and_then(|v| v.as_mapping())
-            .and_then(|m| m.get(&serde_yaml_ng::Value::String("dcc-mcp".into())))
+            .and_then(|m| m.get(serde_yaml_ng::Value::String("dcc-mcp".into())))
             .and_then(|v| v.as_mapping())
-            .and_then(|m| m.get(&serde_yaml_ng::Value::String("dcc".into())))
+            .and_then(|m| m.get(serde_yaml_ng::Value::String("dcc".into())))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 

--- a/crates/dcc-mcp-marketplace/src/add_repo.rs
+++ b/crates/dcc-mcp-marketplace/src/add_repo.rs
@@ -11,8 +11,8 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::MarketplaceError;
-use crate::types::{RepoInstallResult, RepoSkillInfo, RepoSkillList};
 use crate::path_component;
+use crate::types::{RepoInstallResult, RepoSkillInfo, RepoSkillList};
 
 /// Parse a repo reference into a clone URL and optional subpath.
 ///
@@ -70,7 +70,8 @@ fn looks_like_github_slug(value: &str) -> bool {
     let Some((owner, repo)) = value.split_once('/') else {
         return false;
     };
-    !owner.is_empty() && !repo.is_empty()
+    !owner.is_empty()
+        && !repo.is_empty()
         && !value.contains("://")
         && !value.contains('\\')
         && !value.contains('@')
@@ -229,9 +230,11 @@ pub fn list_repo_skills(repo_ref: &str) -> Result<RepoSkillList, MarketplaceErro
         .collect();
     // Tag subpaths for non-root skills
     for skill in &mut skills {
-        let dir = search_root
-            .join(&skill.name);
-        if dir.is_dir() && dir.join("SKILL.md").is_file() && dir.file_name().map(|n| n != ".").unwrap_or(false) {
+        let dir = search_root.join(&skill.name);
+        if dir.is_dir()
+            && dir.join("SKILL.md").is_file()
+            && dir.file_name().map(|n| n != ".").unwrap_or(false)
+        {
             skill.subpath = dir.file_name().map(|n| n.to_string_lossy().to_string());
         }
     }
@@ -292,9 +295,7 @@ pub fn install_from_repo(
         // Single skill — use it directly
         let dir = &skill_dirs[0];
         let mut info = extract_skill_frontmatter(dir).ok_or_else(|| {
-            MarketplaceError::CommandFailed(
-                "failed to parse SKILL.md frontmatter".into(),
-            )
+            MarketplaceError::CommandFailed("failed to parse SKILL.md frontmatter".into())
         })?;
         info.subpath = if dir != &clone_dir {
             dir.file_name().map(|n| n.to_string_lossy().to_string())
@@ -311,14 +312,20 @@ pub fn install_from_repo(
 
         match dcc {
             Some(requested_dcc) => {
-                let matched = all_skills.into_iter().find(|s| {
-                    s.dcc.as_deref().map(|d| d.eq_ignore_ascii_case(requested_dcc)).unwrap_or(false)
-                }).ok_or_else(|| {
-                    MarketplaceError::CommandFailed(format!(
-                        "no skill for DCC '{requested_dcc}' found in repo; \
+                let matched = all_skills
+                    .into_iter()
+                    .find(|s| {
+                        s.dcc
+                            .as_deref()
+                            .map(|d| d.eq_ignore_ascii_case(requested_dcc))
+                            .unwrap_or(false)
+                    })
+                    .ok_or_else(|| {
+                        MarketplaceError::CommandFailed(format!(
+                            "no skill for DCC '{requested_dcc}' found in repo; \
                          use --list to see available skills"
-                    ))
-                })?;
+                        ))
+                    })?;
                 matched
             }
             None => {
@@ -326,7 +333,7 @@ pub fn install_from_repo(
                     "repo contains multiple skills; use --dcc <DCC> to select one, \
                      or --list to see available skills"
                         .into(),
-                ))
+                ));
             }
         }
     };
@@ -338,9 +345,8 @@ pub fn install_from_repo(
             Some(d) => path_component("DCC name", d)?.to_lowercase(),
             None => {
                 return Err(MarketplaceError::CommandFailed(
-                    "skill does not declare a DCC in SKILL.md; use --dcc to specify one"
-                        .into(),
-                ))
+                    "skill does not declare a DCC in SKILL.md; use --dcc to specify one".into(),
+                ));
             }
         },
     };
@@ -373,7 +379,11 @@ pub fn install_from_repo(
     } else {
         skill_dirs
             .into_iter()
-            .find(|d| extract_skill_frontmatter(d.as_path()).map(|s| s.name == target_skill.name).unwrap_or(false))
+            .find(|d| {
+                extract_skill_frontmatter(d.as_path())
+                    .map(|s| s.name == target_skill.name)
+                    .unwrap_or(false)
+            })
             .unwrap_or_else(|| clone_dir.clone())
     };
 
@@ -399,7 +409,8 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<(), MarketplaceError> {
     for entry in std::fs::read_dir(src)
         .map_err(|err| MarketplaceError::ConfigIo(src.display().to_string(), err))?
     {
-        let entry = entry.map_err(|err| MarketplaceError::ConfigIo(src.display().to_string(), err))?;
+        let entry =
+            entry.map_err(|err| MarketplaceError::ConfigIo(src.display().to_string(), err))?;
         let src_path = entry.path();
         let dest_path = dest.join(entry.file_name());
         let file_type = entry
@@ -452,16 +463,14 @@ mod tests {
 
     #[test]
     fn parse_full_url_without_git_suffix() {
-        let (url, subpath) =
-            parse_repo_ref("https://github.com/dcc-mcp/dcc-mcp-maya").unwrap();
+        let (url, subpath) = parse_repo_ref("https://github.com/dcc-mcp/dcc-mcp-maya").unwrap();
         assert_eq!(url, "https://github.com/dcc-mcp/dcc-mcp-maya.git");
         assert!(subpath.is_none());
     }
 
     #[test]
     fn parse_ssh_url() {
-        let (url, subpath) =
-            parse_repo_ref("git@github.com:dcc-mcp/dcc-mcp-maya.git").unwrap();
+        let (url, subpath) = parse_repo_ref("git@github.com:dcc-mcp/dcc-mcp-maya.git").unwrap();
         assert_eq!(url, "git@github.com:dcc-mcp/dcc-mcp-maya.git");
         assert!(subpath.is_none());
     }

--- a/crates/dcc-mcp-marketplace/src/lib.rs
+++ b/crates/dcc-mcp-marketplace/src/lib.rs
@@ -11,6 +11,7 @@
 //!   and integrity verification (zip + SHA-256).
 //! - A unified [`MarketplaceError`] covering all known failure modes.
 
+pub mod add_repo;
 pub mod error;
 pub mod path;
 pub mod service;
@@ -18,6 +19,7 @@ pub mod source;
 pub mod types;
 
 // Re-export the public API for convenience.
+pub use add_repo::{install_from_repo, list_repo_skills, parse_repo_ref};
 pub use error::MarketplaceError;
 pub use path::{default_config_path, home_dir, marketplace_root, marketplace_root_or_default};
 pub use service::{MarketplaceService, default_sources_disabled, env_sources, path_component};
@@ -27,6 +29,6 @@ pub use types::{
     MarketplaceInstallResult, MarketplaceInstalledList, MarketplaceInstalledState,
     MarketplaceOutdatedList, MarketplaceSearchResult, MarketplaceSource, MarketplaceSourceConfig,
     MarketplaceSourceOrigin, MarketplaceUninstallResult, MarketplaceUpdateResult,
-    OFFICIAL_MARKETPLACE_SOURCE, OutdatedMarketplacePackage, StoredMarketplaceSource,
-    entry_targets_dcc,
+    OFFICIAL_MARKETPLACE_SOURCE, OutdatedMarketplacePackage, RepoInstallResult, RepoSkillInfo,
+    RepoSkillList, StoredMarketplaceSource, entry_targets_dcc,
 };

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -18,7 +18,8 @@ use crate::types::{
     MarketplaceInstallResult, MarketplaceInstalledList, MarketplaceInstalledState,
     MarketplaceOutdatedList, MarketplaceSearchResult, MarketplaceSource, MarketplaceSourceConfig,
     MarketplaceSourceOrigin, MarketplaceUninstallResult, MarketplaceUpdateResult,
-    OutdatedMarketplacePackage, StoredMarketplaceSource, entry_targets_dcc,
+    OutdatedMarketplacePackage, RepoInstallResult, RepoSkillList, StoredMarketplaceSource,
+    entry_targets_dcc,
 };
 
 const ENV_MARKETPLACE_SOURCES: &str = "DCC_MCP_MARKETPLACE_SOURCES";
@@ -482,6 +483,23 @@ impl MarketplaceService {
             results.push(update_result);
         }
         Ok(results)
+    }
+
+    // ── add-repo (direct GitHub install) ──────────────────────────────────────
+
+    /// List SKILL.md entries from a GitHub repo without installing.
+    pub fn list_repo_skills(&self, repo_ref: &str) -> Result<RepoSkillList, MarketplaceError> {
+        crate::add_repo::list_repo_skills(repo_ref)
+    }
+
+    /// Install a skill directly from a GitHub repo (no marketplace.json needed).
+    pub fn add_repo(
+        &self,
+        repo_ref: &str,
+        dcc: Option<&str>,
+        force: bool,
+    ) -> Result<RepoInstallResult, MarketplaceError> {
+        crate::add_repo::install_from_repo(repo_ref, dcc, force, &self.root)
     }
 
     // ── internal helpers ─────────────────────────────────────────────────────
@@ -1203,7 +1221,7 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<(), MarketplaceError> {
     Ok(())
 }
 
-fn remove_path(path: &Path) -> Result<(), MarketplaceError> {
+pub(crate) fn remove_path(path: &Path) -> Result<(), MarketplaceError> {
     if path.is_dir() {
         fs::remove_dir_all(path)
     } else {

--- a/crates/dcc-mcp-marketplace/src/types.rs
+++ b/crates/dcc-mcp-marketplace/src/types.rs
@@ -156,6 +156,38 @@ pub struct MarketplaceUpdateResult {
     pub reload_required: bool,
 }
 
+// ── add-repo (direct GitHub install) ──────────────────────────────────────────
+
+/// A single skill discovered in a GitHub repo via SKILL.md discovery.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RepoSkillInfo {
+    pub name: String,
+    pub description: Option<String>,
+    pub dcc: Option<String>,
+    pub subpath: Option<String>,
+}
+
+/// Result of listing skills from a repo.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RepoSkillList {
+    pub repo_url: String,
+    pub count: usize,
+    pub skills: Vec<RepoSkillInfo>,
+}
+
+/// Result of installing a skill directly from a GitHub repo.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RepoInstallResult {
+    pub installed: bool,
+    pub name: String,
+    pub dcc: String,
+    pub repo_url: String,
+    pub path: String,
+    pub skill_search_path: String,
+    pub skill_subpath: Option<String>,
+    pub description: Option<String>,
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 /// Check whether `entry` targets the given DCC type (case-insensitive).

--- a/docs/guide/marketplace.md
+++ b/docs/guide/marketplace.md
@@ -79,6 +79,7 @@ Set `DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES=1` to disable the built-in source.
 | `marketplace uninstall <name> --dcc <dcc>`| Remove an installed package                    |
 | `marketplace outdated [name] --dcc <dcc>` | Check for newer versions                       |
 | `marketplace update [name] --all`         | Upgrade installed packages                     |
+| `marketplace add-repo <repo> [--dcc]`     | Install directly from a GitHub repo            |
 
 Full argument reference: [cli-reference.md](cli-reference.md#marketplace).
 
@@ -125,6 +126,73 @@ tooling.
     type: path
     url: "/share/skills/my-internal-skills"
 ```
+
+## Direct GitHub Install (`add-repo`)
+
+Inspired by `npx skills`, the `marketplace add-repo` command installs a skill
+directly from a GitHub repository without requiring a `marketplace.json` catalog
+entry. It clones the repo, discovers `SKILL.md` files, and copies the matching
+skill to the marketplace install root.
+
+### Usage
+
+```bash
+# Install from GitHub shorthand (owner/repo → https://github.com/owner/repo.git)
+dcc-mcp-cli marketplace add-repo dcc-mcp/dcc-mcp-maya --dcc maya
+
+# Install from full URL
+dcc-mcp-cli marketplace add-repo https://github.com/dcc-mcp/dcc-mcp-maya --dcc maya
+
+# List available skills in a repo without installing
+dcc-mcp-cli marketplace add-repo dcc-mcp/dcc-mcp-maya --list
+
+# Install a subpath within a repo (e.g., owner/repo@subdir)
+dcc-mcp-cli marketplace add-repo my-org/skill-repo@maya-skills --dcc maya
+
+# Force replace an existing installation
+dcc-mcp-cli marketplace add-repo dcc-mcp/dcc-mcp-maya --dcc maya --force
+```
+
+### How It Works
+
+1. **Clone**: runs `git clone --depth 1` of the target repo to a temporary
+   staging directory.
+2. **Discover**: scans the repo root and immediate subdirectories for
+   `SKILL.md` files.
+3. **Parse**: extracts `name`, `description`, and `dcc` (from
+   `metadata.dcc-mcp.dcc`) from the YAML frontmatter.
+4. **Select**: if the repo contains exactly one skill, it is installed
+   automatically. If multiple skills exist, `--dcc` is required to select one.
+5. **Install**: copies the skill directory to
+   `~/.dcc-mcp/marketplace/<dcc>/<name>/`.
+6. **Record**: the installation is persisted in `installed.json` and discoverable
+   via `list-installed`.
+
+### SKILL.md Discovery
+
+Skills are discovered by finding `SKILL.md` files — first checking the repo
+root, then one level deep. The frontmatter must contain at least a `name` field.
+The `dcc` field (under `metadata.dcc-mcp.dcc`) is optional but recommended; use
+`--dcc` when it is absent.
+
+### Repo Reference Formats
+
+| Format                        | Example                                         |
+|-------------------------------|-------------------------------------------------|
+| GitHub shorthand              | `dcc-mcp/dcc-mcp-maya`                          |
+| Full HTTPS URL                | `https://github.com/dcc-mcp/dcc-mcp-maya.git`   |
+| SSH URL                       | `git@github.com:dcc-mcp/dcc-mcp-maya.git`       |
+| With subpath                  | `dcc-mcp/dcc-mcp-maya@subdir`                   |
+
+### Comparison with Catalog Install
+
+| Aspect                  | `marketplace install`        | `marketplace add-repo`          |
+|-------------------------|------------------------------|---------------------------------|
+| Requires catalog entry  | Yes                          | No                              |
+| Source resolution       | Via sources.json / --source  | Direct GitHub clone             |
+| Version tracking        | Catalog version + git ref    | HEAD of cloned branch           |
+| Update mechanism        | Catalog-driven update check  | Re-clone (future)               |
+| SKILL.md discovery      | Via catalog entry metadata   | Filesystem scan                 |
 
 ## Directory Layout
 
@@ -239,6 +307,10 @@ The Marketplace panel reflects the same source configuration as the CLI. Source
 management is available through the Admin API (`POST /admin/api/marketplace/sources`)
 and is also accessible from the panel's source management interface.
 
+Note that `marketplace add-repo` (direct GitHub install) is a CLI-only feature
+and does not require a catalog source entry. Admin UI support is planned for a
+future phase.
+
 ### Relationship Between CLI and Admin UI
 
 | Aspect | CLI | Admin UI |
@@ -248,6 +320,7 @@ and is also accessible from the panel's source management interface.
 | Uninstall | `marketplace uninstall <name> --dcc <dcc>` | Uninstall button in Installed tab |
 | List installed | `marketplace list-installed --dcc <dcc>` | Installed tab |
 | Add source | `marketplace add <source>` | Source management in panel |
+| Direct GitHub install | `marketplace add-repo <repo> --dcc <dcc>` | Admin API (planned) |
 | Update | `marketplace update [name] --all` | Admin API (`POST /admin/api/marketplace/update`) |
 
 Both interfaces share the same backend — operations performed in one are


### PR DESCRIPTION
## Summary

PIP-1377: Add `dcc-mcp-cli marketplace add-repo <owner/repo>` command for
direct GitHub installation (vercel-labs/skills parity). No marketplace.json
catalog entry required — SKILL.md discovery from cloned repos.

### Changes

- **New CLI subcommand**: `marketplace add-repo <repo_ref> [--dcc] [--list] [--force]`
  - Supports GitHub shorthand (`owner/repo`), full URL, SSH URL
  - `@subpath` syntax for subdirectory selection (`owner/repo@subdir`)
  - `--list` flag to enumerate available skills without installing
- **New module** (`crates/dcc-mcp-marketplace/src/add_repo.rs`):
  - `parse_repo_ref()` — robust repo reference parsing
  - `extract_skill_frontmatter()` — SKILL.md YAML frontmatter parser
  - `list_repo_skills()` — clone-and-scan discovery
  - `install_from_repo()` — clone, discover, copy to marketplace root
- **MarketplaceService** wrapper methods: `add_repo()` and `list_repo_skills()`
- **Documentation** in `marketplace.md`: CLI reference table, full usage guide,
  comparison with catalog-based install

### Design decisions

- Uses `git clone --depth 1` (same pattern as existing `install_from_git`)
- Parses SKILL.md YAML frontmatter for `name`, `description`, `metadata.dcc-mcp.dcc`
- Multi-skill repos require `--dcc` for disambiguation; single-skill repos install automatically
- Installs to `~/.dcc-mcp/marketplace/<dcc>/<name>/` — same layout as catalog installs

### Testing

- 12 new unit tests for `parse_repo_ref`, `extract_skill_frontmatter`, and file-based frontmatter extraction
- All 25 marketplace crate tests pass
- All 20 CLI e2e tests pass (no regressions)

## Test plan

- [x] `cargo build -p dcc-mcp-marketplace -p dcc-mcp-cli` — compiles clean
- [x] `cargo test -p dcc-mcp-marketplace` — 25/25 pass
- [x] `cargo test -p dcc-mcp-cli` — 20/20 pass
- [x] `dcc-mcp-cli marketplace add-repo --help` — shows correct usage