### PR TITLE
fix: resolve packaged gateway binary

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -200,7 +200,7 @@ runs:
           source test-env/bin/activate
         fi
 
-        pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
+        pip install --force-reinstall dist/*.whl
         pip check
 
         python tests/test_imports.py

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -244,7 +244,7 @@ jobs:
         run: |
           "${PY37}" -m venv test-env
           source test-env/bin/activate
-          pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
+          pip install --force-reinstall dist/*.whl
           pip check
           python tests/test_imports.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
           path: dist/
       - name: Install wheel + test deps
         run: |
-          pip install --no-index --find-links dist dcc-mcp-core
+          pip install dist/*.whl
           if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.python-version }}" == "3.14" ]]; then
             pip install pytest pytest-cov
           else
@@ -544,7 +544,7 @@ jobs:
         run: |
           "${PY37}" -m venv test-env
           source test-env/bin/activate
-          pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
+          pip install --force-reinstall dist/*.whl
           pip check
           python tests/test_imports.py
 
@@ -655,7 +655,9 @@ jobs:
           path: dist/
 
       - name: Install wheel + test deps
-        run: pip install --no-index --find-links dist dcc-mcp-core && pip install pytest anyio
+        run: |
+          pip install dist/*.whl
+          pip install pytest anyio
         shell: bash
 
       - name: Verify mcpcall
@@ -702,7 +704,9 @@ jobs:
           name: wheel-ubuntu-latest
           path: dist/
       - name: Install wheel + pytest
-        run: pip install --no-index --find-links dist dcc-mcp-core && pip install pytest
+        run: |
+          pip install dist/*.whl
+          pip install pytest
         shell: bash
       - name: Verify Blender
         run: blender --version
@@ -728,7 +732,9 @@ jobs:
           name: wheel-ubuntu-latest
           path: dist/
       - name: Install wheel + pytest
-        run: pip install --no-index --find-links dist dcc-mcp-core && pip install pytest
+        run: |
+          pip install dist/*.whl
+          pip install pytest
         shell: bash
       - name: Verify OpenSCAD
         run: openscad --version
@@ -760,7 +766,9 @@ jobs:
           name: wheel-ubuntu-latest
           path: dist/
       - name: Install wheel + pytest
-        run: pip install --no-index --find-links dist dcc-mcp-core && pip install pytest
+        run: |
+          pip install dist/*.whl
+          pip install pytest
         shell: bash
       - name: Verify Godot
         run: godot --version
@@ -781,7 +789,9 @@ jobs:
           name: wheel-ubuntu-latest
           path: dist/
       - name: Install wheel + pytest
-        run: pip install --no-index --find-links dist dcc-mcp-core && pip install pytest
+        run: |
+          pip install dist/*.whl
+          pip install pytest
         shell: bash
       - name: Test
         run: pytest tests/test_integration_dcc_cross.py -v --tb=short

--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -118,7 +118,9 @@ jobs:
           name: wheel-dcc-integration
           path: dist/
       - name: Install wheel + pytest
-        run: pip install --no-index --find-links dist dcc-mcp-core && pip install pytest
+        run: |
+          pip install dist/*.whl
+          pip install pytest
         shell: bash
       - name: Verify Blender
         run: blender --version
@@ -159,7 +161,9 @@ jobs:
           name: wheel-dcc-integration
           path: dist/
       - name: Install wheel + pytest
-        run: pip install --no-index --find-links dist dcc-mcp-core; pip install pytest
+        run: |
+          pip install dist/*.whl
+          pip install pytest
         shell: bash
       - name: Verify OpenSCAD
         run: openscad --version
@@ -193,7 +197,9 @@ jobs:
           name: wheel-dcc-integration
           path: dist/
       - name: Install wheel + pytest
-        run: pip install --no-index --find-links dist dcc-mcp-core; pip install pytest
+        run: |
+          pip install dist/*.whl
+          pip install pytest
         shell: bash
       - name: Verify Godot
         run: godot --version
@@ -216,7 +222,9 @@ jobs:
           name: wheel-dcc-integration
           path: dist/
       - name: Install wheel + pytest
-        run: pip install --no-index --find-links dist dcc-mcp-core; pip install pytest
+        run: |
+          pip install dist/*.whl
+          pip install pytest
         shell: bash
       - name: Test
         run: pytest tests/test_integration_dcc_cross.py -v --tb=short

--- a/.github/workflows/python-matrix-full.yml
+++ b/.github/workflows/python-matrix-full.yml
@@ -48,7 +48,9 @@ jobs:
         run: vx just build
         shell: bash
       - name: Install wheel + test deps
-        run: pip install --no-index --find-links dist dcc-mcp-core && pip install pytest
+        run: |
+          pip install dist/*.whl
+          pip install pytest
         shell: bash
       - name: Test
         run: vx just test

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 `dcc-mcp-core` turns DCC applications into discoverable, routable MCP endpoints. Agents stop guessing from shell output and start working with live scene state, scoped tool catalogs, structured results, viewport diagnostics, audit logs, and workflows that can survive real production constraints.
 
-It combines **MCP 2025-03-26 Streamable HTTP**, a **zero-code Skills system** built on [agentskills.io 1.0](https://agentskills.io/specification), and a Rust gateway for discovery, routing, installation, linting, and operations. The Python package keeps **zero runtime Python dependencies** for embedded DCC hosts, while standalone `dcc-mcp-cli` and `dcc-mcp-server` binaries ship through GitHub Releases for workstation-style installs. Supports Python 3.7–3.14.
+It combines **MCP 2025-03-26 Streamable HTTP**, a **zero-code Skills system** built on [agentskills.io 1.0](https://agentskills.io/specification), and a Rust gateway for discovery, routing, installation, linting, and operations. The Python package keeps **zero third-party Python library dependencies** for embedded DCC hosts and depends on the companion `dcc-mcp-server` wheel so daemon-backed gateway startup has a packaged binary even when `PATH` is empty. Standalone `dcc-mcp-cli` and `dcc-mcp-server` binaries also ship through GitHub Releases for workstation-style installs. Supports Python 3.7–3.14.
 
 Use it when you want agents to operate production DCC sessions without flooding the context window, hand-writing Python glue for every tool, or shipping fragile one-off shell scripts. Start with the CLI in two commands, or embed the Python core directly in a DCC adapter.
 
@@ -620,7 +620,7 @@ tools/list response (Maya session, nothing loaded yet):
 ## Highlights
 
 - **Rust-powered performance** — Zero-copy serialisation (`rmp-serde`), LZ4 shared memory, lock-free data structures.
-- **Zero runtime Python deps** — Everything compiled into the native extension.
+- **Zero third-party Python library deps** — Core logic is compiled into the native extension; the companion `dcc-mcp-server` wheel supplies the gateway daemon binary.
 - **Skills-First MCP server** — `create_skill_server()` gives a ready-to-use MCP 2025-03-26 Streamable HTTP endpoint with progressive discovery.
 - **Workflow primitive** — `WorkflowSpec` / `WorkflowExecutor`: declarative multi-step workflows with retry, timeout, idempotency keys, approval gates, foreach / parallel / branch steps, SQLite-backed recovery.
 - **Scheduler** — Cron + webhook (HMAC-SHA256) triggered workflows via sibling `schedules.yaml` (opt-in feature).

--- a/README_zh.md
+++ b/README_zh.md
@@ -24,7 +24,7 @@
 
 `dcc-mcp-core` 把 DCC 应用变成可发现、可路由的 MCP 端点。Agent 不再只能猜测 shell 输出，而是可以面对实时场景状态、受作用域约束的工具目录、结构化结果、视口诊断、审计日志，以及能适应真实生产约束的工作流。
 
-它结合 **MCP 2025-03-26 Streamable HTTP**、遵循 [agentskills.io 1.0](https://agentskills.io/specification) 的 **零代码 Skills 系统**，以及负责发现、路由、安装、lint 和运维的 Rust gateway。Python 包面向嵌入式 DCC 宿主保持**运行时零 Python 依赖**；独立的 `dcc-mcp-cli` 与 `dcc-mcp-server` 二进制随 GitHub Release 发布，适合像传统软件一样下载安装到工作站。支持 Python 3.7–3.14。
+它结合 **MCP 2025-03-26 Streamable HTTP**、遵循 [agentskills.io 1.0](https://agentskills.io/specification) 的 **零代码 Skills 系统**，以及负责发现、路由、安装、lint 和运维的 Rust gateway。Python 包面向嵌入式 DCC 宿主保持**零第三方 Python 库依赖**，并依赖同套发布的 `dcc-mcp-server` wheel，确保 daemon-backed gateway 启动时即使 `PATH` 为空也有可用的打包二进制。独立的 `dcc-mcp-cli` 与 `dcc-mcp-server` 二进制也会随 GitHub Release 发布，适合像传统软件一样下载安装到工作站。支持 Python 3.7–3.14。
 
 当你希望 Agent 操作真实 DCC 会话，同时避免上下文爆炸、为每个工具手写 Python 胶水、或者维护脆弱的一次性 shell 脚本时，它就是这层基础设施。你可以用两条命令从 CLI 开始，也可以把 Python core 直接嵌进 DCC adapter。
 
@@ -544,7 +544,7 @@ tools/list 响应（Maya 会话、尚未加载任何 skill）：
 ## 能力亮点
 
 - **Rust 驱动性能** —— 零拷贝序列化（`rmp-serde`）、LZ4 共享内存、无锁数据结构。
-- **运行时零 Python 依赖** —— 一切编译进原生扩展。
+- **零第三方 Python 库依赖** —— 核心逻辑编译进原生扩展；配套 `dcc-mcp-server` wheel 提供 gateway daemon 二进制。
 - **Skills-First MCP 服务器** —— `create_skill_server()` 提供开箱即用的 MCP 2025-03-26 Streamable HTTP 端点，内置渐进式发现。
 - **Workflow 原语** —— `WorkflowSpec` / `WorkflowExecutor`：声明式多步工作流，支持重试、超时、幂等键、审批闸门、foreach / parallel / branch 步骤、SQLite 恢复。
 - **调度器** —— Cron + Webhook（HMAC-SHA256）触发的工作流，通过同级 `schedules.yaml`（可选 feature）。

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -537,7 +537,9 @@ The workspace builds a single PyO3 native extension (`dcc_mcp_core._core`) via `
 # pyproject.toml
 [project]
 requires-python = ">=3.7"
-dependencies = []  # Zero runtime dependencies
+dependencies = [
+    "dcc-mcp-server>=0.18.17,<1.0.0",
+]  # Companion binary wheel for daemon-backed gateway startup
 ```
 
 ### Python Package Structure

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -31,9 +31,9 @@ The core library works with any Python 3.7+ environment.
 
 Python 3.7–3.14 are tested in CI. Wheels are built with `abi3-py38` for maximum compatibility.
 
-### Does it have any Python runtime dependencies?
+### Does it have any Python library runtime dependencies?
 
-**No.** The library has zero Python runtime dependencies. Everything is compiled into the Rust core.
+**No third-party Python libraries.** Core logic is compiled into the Rust extension. The default package does depend on the companion `dcc-mcp-server` wheel so `DccServerBase` can launch the gateway daemon from a packaged binary without relying on `PATH`.
 
 ## Installation
 

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -379,12 +379,12 @@ Supported types (stdlib only): `bool`, `int`, `float`, `str`, `bytes`,
 spell containers and unions with `typing.List`, `typing.Dict`,
 `typing.Tuple`, `typing.Optional`, and `typing.Union`; `Literal` and
 `TypedDict` require `typing_extensions` in the skill author's environment.
-The core package still imports with zero runtime dependencies. Unsupported
+The core package still imports without third-party Python library dependencies. Unsupported
 types raise `TypeError` with a clear escape hatch: pass an explicit
 `input_schema=...` dict or use pydantic's `MyModel.model_json_schema()`.
 
 ::: tip Why not pydantic?
-We intentionally stay zero-dependency. Adding `pydantic` for this one
+We intentionally stay free of third-party Python library dependencies. Adding `pydantic` for this one
 feature would drag in a 3MB wheel plus `pydantic-core` and is too
 heavy for authors who only want a few dataclass handlers. For callers
 who already use pydantic, the emitted shape matches pydantic's

--- a/docs/guide/what-is-dcc-mcp-core.md
+++ b/docs/guide/what-is-dcc-mcp-core.md
@@ -5,7 +5,7 @@
 - **AI assistants** → a small, static **MCP** discovery set (`search`, `describe`) via the gateway, plus REST `/v1/*` for execution.
 - **Traditional callers** (cURL, CI, any HTTP client) → a full **`/v1/*` REST API** on every per-DCC server and on the gateway facade.
 
-The core is Rust, compiled to a Python extension via [PyO3](https://pyo3.rs/) + [maturin](https://github.com/PyO3/maturin). Zero Python runtime dependencies.
+The core is Rust, compiled to a Python extension via [PyO3](https://pyo3.rs/) + [maturin](https://github.com/PyO3/maturin). It has no third-party Python library runtime dependencies; the companion `dcc-mcp-server` wheel supplies the packaged gateway daemon binary.
 
 ---
 
@@ -61,7 +61,7 @@ flowchart LR
 - **Multi-DCC gateway aggregation** — file-based service registry + TCP-probe health checks, auto-evicts instances after 3 consecutive probe failures, prunes ghost rows, arbitrates contention via a three-tier `crate_version → adapter_version → adapter_dcc` election.
 - **Tool slug contract** — `<dcc>.<id8>.<tool>` three-part slugs are the only addressable form; the gateway parses them to route REST `/v1/call` to the owning backend.
 - **Tunnels (#504)** — `dcc-mcp-tunnel-relay` + `dcc-mcp-tunnel-agent` binaries for zero-config remote access from SaaS AI clients to a workstation's DCC.
-- **PyO3 bindings** — every Rust-accelerated API transparent to Python. Zero Python runtime deps.
+- **PyO3 bindings** — every Rust-accelerated API transparent to Python. No third-party Python library runtime deps; gateway daemon startup uses the companion `dcc-mcp-server` wheel.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ features:
     details: Multiple DCC instances compete for the gateway role. Newer adapters can take over cleanly while existing instances stay discoverable.
   - icon: 🦀
     title: Rust-Powered Core
-    details: Zero runtime Python dependencies. Zero-copy IPC via Named Pipes and Unix Sockets. rmp-serde serialization. LZ4 shared memory. Sub-millisecond tool calls.
+    details: Zero third-party Python library dependencies. Packaged gateway daemon binary via dcc-mcp-server. Zero-copy IPC via Named Pipes and Unix Sockets. rmp-serde serialization. LZ4 shared memory. Sub-millisecond tool calls.
   - icon: 🔒
     title: SkillPolicy & Scope
     details: allow_implicit_invocation controls whether AI can call a skill without explicit load_skill. products filter visibility by DCC. Trust levels (repo < user < system < admin).

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -385,7 +385,9 @@ workspace 通过 `maturin` 构建为单一 PyO3 原生扩展（`dcc_mcp_core._co
 # pyproject.toml
 [project]
 requires-python = ">=3.7"
-dependencies = []  # 零运行时依赖
+dependencies = [
+    "dcc-mcp-server>=0.18.17,<1.0.0",
+]  # daemon-backed gateway 启动所需的配套二进制 wheel
 ```
 
 ### Python 包结构

--- a/docs/zh/guide/faq.md
+++ b/docs/zh/guide/faq.md
@@ -49,9 +49,9 @@ config.dcc_type = "maya"
 
 Python 3.7–3.14 在 CI 中全部测试。使用 `abi3-py38` 构建 wheel 以最大化兼容性。
 
-### 是否有 Python 运行时依赖？
+### 是否有 Python 库运行时依赖？
 
-**没有。** 库没有任何 Python 运行时依赖，所有内容都编译进 Rust 核心。
+**没有第三方 Python 库依赖。** 核心逻辑编译进 Rust 扩展。默认包会依赖配套的 `dcc-mcp-server` wheel，让 `DccServerBase` 可以从打包二进制启动 gateway daemon，而不依赖 `PATH`。
 
 ## 安装
 

--- a/docs/zh/guide/skills.md
+++ b/docs/zh/guide/skills.md
@@ -240,7 +240,7 @@ register_tools(server, [spec], dcc_name="maya")
 
 若有返回类型标注，会作为 `outputSchema`，MCP 2025-06-18 的客户端即可用它校验 `structuredContent`。未类型化的 handler 抛 `TypeError`，不会静默回退成宽松的 `{"type": "object"}`（修掉 #588 同代的陷阱）。
 
-支持的类型（全标准库）：`bool`、`int`、`float`、`str`、`bytes`、`None`、`list[X]`、`tuple[X, ...]`、定长 `tuple[A, B, ...]`、`dict[str, V]`、`Optional[X]` / `X | None`、`Union[A, B]`、`Literal[...]`、`Enum`、`datetime.datetime`、`datetime.date`、`pathlib.Path`、`uuid.UUID`、`@dataclass`、`TypedDict`。Python 3.7 中请用 `typing.List`、`typing.Dict`、`typing.Tuple`、`typing.Optional`、`typing.Union` 来书写容器与联合类型；`Literal` 与 `TypedDict` 需要由 skill 作者环境提供 `typing_extensions`。核心包自身仍保持零运行时依赖。不支持的类型会抛 `TypeError` 并附一条明确的"逃生通道"：显式传 `input_schema=...` dict 或用 pydantic 的 `MyModel.model_json_schema()`。
+支持的类型（全标准库）：`bool`、`int`、`float`、`str`、`bytes`、`None`、`list[X]`、`tuple[X, ...]`、定长 `tuple[A, B, ...]`、`dict[str, V]`、`Optional[X]` / `X | None`、`Union[A, B]`、`Literal[...]`、`Enum`、`datetime.datetime`、`datetime.date`、`pathlib.Path`、`uuid.UUID`、`@dataclass`、`TypedDict`。Python 3.7 中请用 `typing.List`、`typing.Dict`、`typing.Tuple`、`typing.Optional`、`typing.Union` 来书写容器与联合类型；`Literal` 与 `TypedDict` 需要由 skill 作者环境提供 `typing_extensions`。核心包自身仍不依赖第三方 Python 库。不支持的类型会抛 `TypeError` 并附一条明确的"逃生通道"：显式传 `input_schema=...` dict 或用 pydantic 的 `MyModel.model_json_schema()`。
 
 ::: tip 为什么不用 pydantic？
 我们刻意保持 0 依赖。仅为此特性引入 `pydantic` 会拉进 3MB wheel 再加 `pydantic-core`，对只想写几个 dataclass handler 的作者成本过高。对于已经在用 pydantic 的调用方，派生出的 shape 与 pydantic 的约定一致（`title`、`$defs`、`$ref`、`anyOf`、`required`），因此换成 `MyModel.model_json_schema()` 是即插即用的。

--- a/docs/zh/guide/what-is-dcc-mcp-core.md
+++ b/docs/zh/guide/what-is-dcc-mcp-core.md
@@ -5,7 +5,7 @@
 - **AI 助手** → 通过 gateway 的**少量、固定、只读** **MCP 发现工具**（`search` / `describe`），再用 REST `/v1/*` 执行。
 - **传统调用方** →（cURL / CI / 任意 HTTP 客户端）通过**完整的 `/v1/*` REST 服务**。
 
-底层是 Rust，通过 [PyO3](https://pyo3.rs/) + [maturin](https://github.com/PyO3/maturin) 编译成一个 Python 扩展模块。零 Python 运行时依赖。
+底层是 Rust，通过 [PyO3](https://pyo3.rs/) + [maturin](https://github.com/PyO3/maturin) 编译成一个 Python 扩展模块。它没有第三方 Python 库运行时依赖；配套的 `dcc-mcp-server` wheel 提供打包后的 gateway daemon 二进制。
 
 ---
 
@@ -61,7 +61,7 @@ flowchart LR
 - **多 DCC 网关汇聚** —— 文件型服务注册表 + TCP 心跳探测，自动剔除 3 连失败的实例、清理 ghost 行，基于 `crate_version → adapter_version → adapter_dcc` 的三级选举仲裁。
 - **Tool Slug 契约** —— `<dcc>.<id8>.<tool>` 三段 slug 是唯一的全局寻址方式，网关据此把 REST `/v1/call` 路由到正确的后端。
 - **Tunnel（#504）** —— `dcc-mcp-tunnel-relay` + `dcc-mcp-tunnel-agent` 两个可执行二进制，让远程 AI 客户端直接访问工作站上的 DCC。
-- **PyO3 绑定** —— Rust 加速的一切从 Python 透明可用；零 Python 运行时依赖。
+- **PyO3 绑定** —— Rust 加速的一切从 Python 透明可用；没有第三方 Python 库运行时依赖，gateway daemon 启动使用配套的 `dcc-mcp-server` wheel。
 
 ---
 

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -31,7 +31,7 @@ features:
     details: 多 DCC 实例竞争网关角色，新版本 adapter 可干净接管，已有实例仍可被发现和路由。
   - icon: 🦀
     title: Rust 驱动核心
-    details: 零运行时 Python 依赖。通过 Named Pipe 和 Unix Socket 实现零拷贝 IPC。rmp-serde 序列化。LZ4 共享内存。毫秒级工具调用。
+    details: 零第三方 Python 库依赖。通过 dcc-mcp-server 提供打包 gateway daemon 二进制。通过 Named Pipe 和 Unix Socket 实现零拷贝 IPC。rmp-serde 序列化。LZ4 共享内存。毫秒级工具调用。
   - icon: 🔒
     title: SkillPolicy 与作用域
     details: allow_implicit_invocation 控制 AI 是否可直接调用 Skill。products 按 DCC 过滤可见性。信任层级（repo < user < system < admin）。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ classifiers = [
     "Topic :: Multimedia :: Graphics :: 3D Modeling",
 ]
 
-dependencies = []
+dependencies = [
+    "dcc-mcp-server>=0.18.17,<1.0.0",
+]
 
 [project.optional-dependencies]
 test = [

--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -46,6 +46,15 @@ def _resolve_server_bin() -> str:
     explicit = (os.environ.get("DCC_MCP_SERVER_BIN") or "").strip()
     if explicit:
         return explicit
+    try:
+        from dcc_mcp_server import binary_path
+    except Exception as exc:
+        logger.debug("dcc_mcp_server.binary_path unavailable: %s", exc)
+    else:
+        try:
+            return str(binary_path())
+        except Exception as exc:
+            logger.debug("dcc_mcp_server.binary_path failed: %s", exc)
     found = shutil.which("dcc-mcp-server")
     return found or "dcc-mcp-server"
 

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+import sys
 import time
+import types
 
 import dcc_mcp_core._server.gateway_guardian as gg
 
@@ -26,6 +29,30 @@ def test_ensure_gateway_daemon_reports_existing_health(monkeypatch):
     )
     assert result["ok"] is True
     assert result["reason"] == "already_healthy"
+
+
+def test_resolve_server_bin_uses_packaged_binary_when_path_missing(monkeypatch, tmp_path):
+    binary = tmp_path / "dcc-mcp-server"
+    binary.write_text("", encoding="utf-8")
+    module = types.ModuleType("dcc_mcp_server")
+    module.binary_path = lambda: binary
+
+    monkeypatch.delenv("DCC_MCP_SERVER_BIN", raising=False)
+    monkeypatch.setattr(gg.shutil, "which", lambda _name: None)
+    monkeypatch.setitem(sys.modules, "dcc_mcp_server", module)
+
+    assert gg._resolve_server_bin() == str(binary)
+
+
+def test_resolve_server_bin_prefers_explicit_env(monkeypatch, tmp_path):
+    explicit = tmp_path / "custom-server"
+    module = types.ModuleType("dcc_mcp_server")
+    module.binary_path = lambda: Path("/unused/dcc-mcp-server")
+
+    monkeypatch.setenv("DCC_MCP_SERVER_BIN", str(explicit))
+    monkeypatch.setitem(sys.modules, "dcc_mcp_server", module)
+
+    assert gg._resolve_server_bin() == str(explicit)
 
 
 def test_ensure_gateway_daemon_spawns_and_becomes_healthy(tmp_path, monkeypatch):

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,21 @@
+"""Package metadata contract tests."""
+
+from __future__ import annotations
+
+import re
+
+from conftest import REPO_ROOT
+
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+SERVER_BINARY_DEP = "dcc-mcp-server>=0.18.17,<1.0.0"
+
+
+def _project_dependencies() -> list[str]:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r"(?ms)^dependencies\s*=\s*\[(.*?)\]\s*(?=^\[)", text)
+    assert match is not None, "pyproject.toml must declare [project] dependencies"
+    return re.findall(r'"([^"]+)"', match.group(1))
+
+
+def test_core_requires_packaged_server_binary_runtime() -> None:
+    assert SERVER_BINARY_DEP in _project_dependencies()


### PR DESCRIPTION
## Summary
- Resolve the gateway daemon binary through the installed dcc_mcp_server.binary_path() helper.
- Make dcc-mcp-core depend on the companion dcc-mcp-server wheel so daemon-backed startup has a packaged binary by default.
- Install built core wheels in CI through their wheel path so package metadata dependencies are exercised during smoke tests.
- Preserve explicit DCC_MCP_SERVER_BIN overrides and PATH/command-name fallback for custom developer/runtime environments.

## Tests
- DCC_MCP_ADMIN_UI_PREBUILT=1 vx just dev
- .\.venv\Scripts\python.exe -m pytest tests/test_package_metadata.py tests/test_gateway_guardian.py -q
- vx ruff check python/dcc_mcp_core/_server/gateway_guardian.py tests/test_gateway_guardian.py tests/test_package_metadata.py
- actionlint .github/workflows/ci.yml .github/workflows/build-wheels.yml .github/workflows/dcc-integration.yml .github/workflows/python-matrix-full.yml