### PR TITLE
feat: add server release bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,13 +144,15 @@ jobs:
 
   # ── Build standalone binaries (raw Release assets + server PyPI wheel) ──
   #
-  # One job, one native cargo target/ (plus an isolated manylinux target/), three outputs:
+  # One job, one native cargo target/ (plus an isolated manylinux target/), four outputs:
   #   1. Raw binary `dcc-mcp-server[-linux-x86_64|-windows-x86_64.exe|-macos-universal2]`
   #      attached to the GitHub Release. Backward-compat artefact for
   #      ops / docker users who don't want to `pip install`.
   #   2. Raw binary `dcc-mcp-cli[-linux-x86_64|-windows-x86_64.exe|-macos-universal2]`
   #      attached to the same GitHub Release and consumed by scripts/install-cli.*.
-  #   3. PyPI wheel `dcc_mcp_server-<ver>-py3-none-<plat>.whl` built from
+  #   3. Deployable zip `dcc-mcp-server-<ver>-<platform>.zip` containing
+  #      unsuffixed `dcc-mcp-server` and `dcc-mcp-cli` binaries for that platform.
+  #   4. PyPI wheel `dcc_mcp_server-<ver>-py3-none-<plat>.whl` built from
   #      pkg/dcc-mcp-server-bin/ via maturin's `bindings = "bin"`. It has
   #      no Python extension ABI and declares Python 3.7+ compatibility so
   #      Maya 2022's embedded Python can install it. maturin reuses the
@@ -159,7 +161,7 @@ jobs:
   #      an isolated `target-manylinux2014/` because host-built Cargo build
   #      scripts cannot run inside the older manylinux2014 glibc environment.
   #
-  # Both artefacts ride the same release-please tag — there is exactly
+  # These artefacts ride the same release-please tag — there is exactly
   # one release lifecycle for the workspace, and `dcc-mcp-server` ships
   # at the same workspace.package.version as `dcc-mcp-core`.
   build-binaries:
@@ -170,16 +172,19 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            platform: linux-x86_64
             artifact_name: dcc-mcp-server-linux-x86_64
             cli_artifact_name: dcc-mcp-cli-linux-x86_64
             binary: dcc-mcp-server
             cli_binary: dcc-mcp-cli
           - os: windows-latest
+            platform: windows-x86_64
             artifact_name: dcc-mcp-server-windows-x86_64.exe
             cli_artifact_name: dcc-mcp-cli-windows-x86_64.exe
             binary: dcc-mcp-server.exe
             cli_binary: dcc-mcp-cli.exe
           - os: macos-latest
+            platform: macos-universal2
             artifact_name: dcc-mcp-server-macos-universal2
             cli_artifact_name: dcc-mcp-cli-macos-universal2
             binary: dcc-mcp-server
@@ -256,6 +261,17 @@ jobs:
           cp target/release/${{ matrix.cli_binary }} ${{ matrix.cli_artifact_name }}
         shell: bash
 
+      - name: Create deployable server bundle
+        id: server-bundle
+        shell: bash
+        run: |
+          python scripts/release/build_server_bundle.py \
+            --version "${{ needs.release-please.outputs.version }}" \
+            --platform "${{ matrix.platform }}" \
+            --server-bin "${{ matrix.artifact_name }}" \
+            --cli-bin "${{ matrix.cli_artifact_name }}" \
+            --out-dir .
+
       # ── PyPI wheel build ──────────────────────────────────────────
       # macOS / Windows reuse the same target/ directory the raw-binary
       # step just populated; maturin sees the binary as already-compiled
@@ -309,6 +325,7 @@ jobs:
           path: |
             ${{ matrix.artifact_name }}
             ${{ matrix.cli_artifact_name }}
+            ${{ steps.server-bundle.outputs.bundle_path }}
 
       - name: Upload server wheel artefact (for cross-job collection)
         uses: actions/upload-artifact@v4
@@ -323,6 +340,7 @@ jobs:
           files: |
             ${{ matrix.artifact_name }}
             ${{ matrix.cli_artifact_name }}
+            ${{ steps.server-bundle.outputs.bundle_path }}
             pkg/dcc-mcp-server-bin/wheels/*.whl
 
   # ── Build dcc-mcp-core-semantic companion wheels (issue #1395) ──
@@ -678,6 +696,13 @@ jobs:
           path: dist-server
           merge-multiple: true
 
+      - name: Download dcc-mcp-server binary artefacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: server-binary-*
+          path: dist-binaries
+          merge-multiple: true
+
       - name: Download dcc-mcp-core-semantic wheel artefacts
         uses: actions/download-artifact@v8
         with:
@@ -691,21 +716,24 @@ jobs:
           ls -la dist/
           echo "dcc-mcp-server wheels:"
           ls -la dist-server/
+          echo "dcc-mcp-server binaries and bundles:"
+          ls -la dist-binaries/
           echo "dcc-mcp-core-semantic wheels:"
           ls -la dist-semantic/
 
       # Always attempt the GitHub Release upload, even if PyPI failed; this is
       # the user-visible artefact set and must be complete per release tag.
       # Note: build-binaries / build-semantic-wheels / build-wheels already
-      # upload each per-platform wheel directly to the Release. This step
+      # upload each per-platform artefact directly to the Release. This step
       # is the safety net for the (unlikely) case where upload was skipped.
-      - name: Upload wheels to GitHub Release (safety net)
+      - name: Upload artefacts to GitHub Release (safety net)
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: |
             dist/*
             dist-server/*
+            dist-binaries/*
             dist-semantic/*
 
   # ── Aggregate release publication status for branch protection / humans ──
@@ -765,6 +793,7 @@ jobs:
             '^dcc_mcp_core_semantic-.*\.whl$'
             '^dcc-mcp-server-'
             '^dcc-mcp-cli-'
+            '^dcc-mcp-server-[0-9A-Za-z.+-]+-(linux-x86_64|windows-x86_64|macos-universal2)\.zip$'
           )
 
           release_json=""

--- a/README.md
+++ b/README.md
@@ -272,6 +272,12 @@ By default, the installers download the latest GitHub Release asset:
 | Windows x86_64 | `dcc-mcp-cli-windows-x86_64.exe` |
 | macOS universal2 | `dcc-mcp-cli-macos-universal2` |
 
+For server deployments, each GitHub Release also attaches a ready-to-unpack
+bundle named `dcc-mcp-server-<version>-<platform>.zip`. The zip contains both
+`dcc-mcp-server` and `dcc-mcp-cli` at its root (`.exe` on Windows), so operators
+can place one archive on a machine and wire both the gateway daemon and control
+plane CLI into `PATH`.
+
 Pin a release or install somewhere custom:
 
 ```bash
@@ -310,7 +316,7 @@ vx just dev           # recommended — uses the project's canonical feature set
 # or: pip install -e .
 ```
 
-Every release attaches raw `dcc-mcp-cli` and `dcc-mcp-server` binaries for Linux, Windows, and macOS universal2. `dcc-mcp-server` also ships as the `dcc-mcp-server` Python wheel for hosts that prefer `pip install`.
+Every release attaches raw `dcc-mcp-cli` and `dcc-mcp-server` binaries for Linux, Windows, and macOS universal2, plus `dcc-mcp-server-<version>-<platform>.zip` bundles containing both binaries. `dcc-mcp-server` also ships as the `dcc-mcp-server` Python wheel for hosts that prefer `pip install`.
 
 ### Serve a DCC over MCP — Skills-First (recommended)
 

--- a/docs/guide/production-deployment.md
+++ b/docs/guide/production-deployment.md
@@ -45,6 +45,14 @@ cargo install cross --locked
 cross build --release --bin dcc-mcp-server --target x86_64-unknown-linux-gnu
 ```
 
+### Downloading a Release Bundle
+
+GitHub Releases attach deployable bundles named
+`dcc-mcp-server-<version>-<platform>.zip`, for example
+`dcc-mcp-server-0.18.12-linux-x86_64.zip`. Each zip contains both
+`dcc-mcp-server` and `dcc-mcp-cli` at its root (`.exe` on Windows), so a
+deployment host can unpack one archive and put both binaries on `PATH`.
+
 ### Install Location
 
 Pick **one** location consistently per machine:

--- a/docs/zh/guide/production-deployment.md
+++ b/docs/zh/guide/production-deployment.md
@@ -45,6 +45,14 @@ cargo install cross --locked
 cross build --release --bin dcc-mcp-server --target x86_64-unknown-linux-gnu
 ```
 
+### 下载发布包
+
+GitHub Release 会附带可直接解压部署的
+`dcc-mcp-server-<version>-<platform>.zip`，例如
+`dcc-mcp-server-0.18.12-linux-x86_64.zip`。每个 zip 根目录包含
+`dcc-mcp-server` 和 `dcc-mcp-cli` 两个二进制（Windows 上带 `.exe`），
+部署机器只需要解压一次，再把两个二进制所在目录加入 `PATH`。
+
 ### 安装路径
 
 每台机器上选定一个**唯一**位置：

--- a/scripts/release/build_server_bundle.py
+++ b/scripts/release/build_server_bundle.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Build deployable dcc-mcp-server release bundles."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import sys
+from zipfile import ZIP_DEFLATED
+from zipfile import ZipFile
+from zipfile import ZipInfo
+
+
+def _github_error(message: str) -> None:
+    print(f"::error::{message}", file=sys.stderr)
+
+
+def _validate_filename_part(name: str, *, label: str) -> str:
+    if not name:
+        raise ValueError(f"{label} is required")
+    if any(sep in name for sep in ("/", "\\")):
+        raise ValueError(f"{label} must be a filename component, got {name!r}")
+    return name
+
+
+def _archive_binary_name(kind: str, source: Path) -> str:
+    suffix = ".exe" if source.suffix.lower() == ".exe" else ""
+    return f"dcc-mcp-{kind}{suffix}"
+
+
+def _write_binary(zf: ZipFile, source: Path, archive_name: str) -> None:
+    if not source.is_file():
+        raise FileNotFoundError(f"release binary not found: {source}")
+
+    info = ZipInfo.from_file(source, arcname=archive_name)
+    info.compress_type = ZIP_DEFLATED
+    with source.open("rb") as src, zf.open(info, "w") as dst:
+        shutil.copyfileobj(src, dst)
+
+
+def build_bundle(
+    *,
+    version: str,
+    platform: str,
+    server_bin: Path,
+    cli_bin: Path,
+    out_dir: Path,
+) -> Path:
+    """Create a deployable server zip and return its path."""
+    version = _validate_filename_part(version, label="version")
+    platform = _validate_filename_part(platform, label="platform")
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    bundle_path = out_dir / f"dcc-mcp-server-{version}-{platform}.zip"
+
+    with ZipFile(bundle_path, "w", ZIP_DEFLATED) as zf:
+        _write_binary(zf, server_bin, _archive_binary_name("server", server_bin))
+        _write_binary(zf, cli_bin, _archive_binary_name("cli", cli_bin))
+
+    return bundle_path
+
+
+def main() -> int:
+    """Run the release bundle builder."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--platform", required=True)
+    parser.add_argument("--server-bin", type=Path, required=True)
+    parser.add_argument("--cli-bin", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=Path())
+    args = parser.parse_args()
+
+    try:
+        bundle_path = build_bundle(
+            version=args.version,
+            platform=args.platform,
+            server_bin=args.server_bin,
+            cli_bin=args.cli_bin,
+            out_dir=args.out_dir,
+        )
+    except Exception as exc:
+        _github_error(str(exc))
+        raise SystemExit(1) from exc
+
+    bundle_output = bundle_path.as_posix()
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a", encoding="utf-8") as fh:
+            fh.write(f"bundle_path={bundle_output}\n")
+    print(bundle_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -10,6 +10,15 @@ import types
 import dcc_mcp_core._server.gateway_guardian as gg
 
 
+def _wait_until(predicate, *, timeout: float = 10.0, interval: float = 0.01) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
 class _Resp:
     status = 200
 
@@ -442,7 +451,9 @@ def test_guardian_run_catches_crash_and_increments_crash_count(monkeypatch):
 
     guardian.start()
     try:
-        assert crash_reported.wait(2.0), "Expected guardian crash status to be published"
+        assert _wait_until(lambda: crash_reported.is_set() or guardian.status().get("crash_count", 0) >= 1), (
+            "Expected guardian crash status to be published"
+        )
     finally:
         guardian.stop(timeout=2.0)
 
@@ -483,8 +494,12 @@ def test_guardian_run_continues_after_exception(monkeypatch):
 
     guardian.start()
     try:
-        assert crash_reported.wait(2.0), "Expected guardian crash status to be published"
-        assert continued_after_crash.wait(2.0), "Expected guardian loop to continue probing"
+        assert _wait_until(lambda: crash_reported.is_set() or guardian.status().get("crash_count", 0) >= 1), (
+            "Expected guardian crash status to be published"
+        )
+        assert _wait_until(lambda: continued_after_crash.is_set() or len(calls) >= 2), (
+            "Expected guardian loop to continue probing"
+        )
     finally:
         guardian.stop(timeout=2.0)
 

--- a/tests/test_release_server_bundle.py
+++ b/tests/test_release_server_bundle.py
@@ -1,0 +1,76 @@
+"""Release server bundle packaging tests."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import zipfile
+
+from conftest import REPO_ROOT
+
+SCRIPT = REPO_ROOT / "scripts" / "release" / "build_server_bundle.py"
+
+
+def test_build_server_bundle_packages_unsuffixed_unix_binaries(tmp_path) -> None:
+    server = tmp_path / "dcc-mcp-server-linux-x86_64"
+    cli = tmp_path / "dcc-mcp-cli-linux-x86_64"
+    server.write_bytes(b"server")
+    cli.write_bytes(b"cli")
+
+    out_dir = tmp_path / "dist"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--version",
+            "0.18.12",
+            "--platform",
+            "linux-x86_64",
+            "--server-bin",
+            str(server),
+            "--cli-bin",
+            str(cli),
+            "--out-dir",
+            str(out_dir),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    bundle = out_dir / "dcc-mcp-server-0.18.12-linux-x86_64.zip"
+    assert result.stdout.strip().endswith(bundle.as_posix())
+    with zipfile.ZipFile(bundle) as zf:
+        assert set(zf.namelist()) == {"dcc-mcp-server", "dcc-mcp-cli"}
+        assert zf.read("dcc-mcp-server") == b"server"
+        assert zf.read("dcc-mcp-cli") == b"cli"
+
+
+def test_build_server_bundle_preserves_windows_exe_names(tmp_path) -> None:
+    server = tmp_path / "dcc-mcp-server-windows-x86_64.exe"
+    cli = tmp_path / "dcc-mcp-cli-windows-x86_64.exe"
+    server.write_bytes(b"server")
+    cli.write_bytes(b"cli")
+
+    out_dir = tmp_path / "dist"
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--version",
+            "0.18.12",
+            "--platform",
+            "windows-x86_64",
+            "--server-bin",
+            str(server),
+            "--cli-bin",
+            str(cli),
+            "--out-dir",
+            str(out_dir),
+        ],
+        check=True,
+    )
+
+    bundle = out_dir / "dcc-mcp-server-0.18.12-windows-x86_64.zip"
+    with zipfile.ZipFile(bundle) as zf:
+        assert set(zf.namelist()) == {"dcc-mcp-server.exe", "dcc-mcp-cli.exe"}

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -89,6 +89,11 @@ def test_release_workflow_keeps_github_release_safety_net_after_pypi_jobs() -> N
     ]
     assert "always()" in safety["if"]
     assert safety["permissions"] == {"actions": "read", "contents": "write"}
+    downloads = [step for step in safety["steps"] if step.get("uses") == "actions/download-artifact@v8"]
+    download_patterns = {step["with"]["pattern"]: step["with"]["path"] for step in downloads}
+    assert download_patterns["server-binary-*"] == "dist-binaries"
+    safety_upload = next(step for step in safety["steps"] if step.get("uses") == "softprops/action-gh-release@v3")
+    assert "dist-binaries/*" in safety_upload["with"]["files"]
 
     summary = jobs["publish"]
     assert summary["needs"] == [
@@ -104,3 +109,35 @@ def test_release_workflow_keeps_github_release_safety_net_after_pypi_jobs() -> N
     assert "needs.publish-server-pypi.result" in run
     assert "needs.publish-semantic-pypi.result" in run
     assert "needs.publish-github-release-assets.result" in run
+
+
+def test_release_workflow_builds_deployable_server_zip_per_platform() -> None:
+    jobs = _release_jobs()
+    build = jobs["build-binaries"]
+    includes = build["strategy"]["matrix"]["include"]
+    assert [entry["platform"] for entry in includes] == [
+        "linux-x86_64",
+        "windows-x86_64",
+        "macos-universal2",
+    ]
+
+    bundle = next(step for step in build["steps"] if step.get("id") == "server-bundle")
+    run = bundle["run"]
+    assert "scripts/release/build_server_bundle.py" in run
+    assert '--version "${{ needs.release-please.outputs.version }}"' in run
+    assert '--platform "${{ matrix.platform }}"' in run
+    assert '--server-bin "${{ matrix.artifact_name }}"' in run
+    assert '--cli-bin "${{ matrix.cli_artifact_name }}"' in run
+
+    raw_upload = next(
+        step
+        for step in build["steps"]
+        if step.get("uses") == "actions/upload-artifact@v4" and step["with"]["name"] == "server-binary-${{ matrix.os }}"
+    )
+    assert "${{ steps.server-bundle.outputs.bundle_path }}" in raw_upload["with"]["path"]
+
+    release_upload = next(step for step in build["steps"] if step.get("uses") == "softprops/action-gh-release@v3")
+    assert "${{ steps.server-bundle.outputs.bundle_path }}" in release_upload["with"]["files"]
+
+    notify = next(step for step in jobs["publish"]["steps"] if step["name"] == "Notify Multica release-ready autopilot")
+    assert r"^dcc-mcp-server-[0-9A-Za-z.+-]+-(linux-x86_64|windows-x86_64|macos-universal2)\.zip$" in notify["run"]


### PR DESCRIPTION
## Summary
- Add deployable `dcc-mcp-server-<version>-<platform>.zip` release bundles containing both `dcc-mcp-server` and `dcc-mcp-cli`.
- Upload the bundles from the release binary job and include them in the GitHub Release safety-net upload.
- Document the bundle format in README and production deployment docs.
- Harden guardian crash-loop tests so macOS Python 3.8 full-suite scheduling does not miss the crash status publication.

## Validation
- `vx python -m pytest -q tests/test_release_workflow.py tests/test_release_server_bundle.py`
- `vx python -m pytest -q tests/test_gateway_guardian.py::test_guardian_run_catches_crash_and_increments_crash_count tests/test_gateway_guardian.py::test_guardian_run_continues_after_exception tests/test_release_workflow.py tests/test_release_server_bundle.py --tb=short --show-capture=no`
- `vx ruff check tests/test_gateway_guardian.py scripts/release/build_server_bundle.py tests/test_release_workflow.py tests/test_release_server_bundle.py`
- `vx ruff format --check tests/test_gateway_guardian.py scripts/release/build_server_bundle.py tests/test_release_workflow.py tests/test_release_server_bundle.py`
- `vx actionlint .github/workflows/release.yml`
- `vx git diff --check`

Agent-facing skill guidance update: not needed; this changes release packaging, deployment docs, and a focused CI test wait.