### PR TITLE
fix: auto-ensure gateway for cli control

### DIFF
--- a/.github/file-size-exemptions.txt
+++ b/.github/file-size-exemptions.txt
@@ -7,7 +7,7 @@
 # Format: one file path per line (relative to repo root), comments with #
 #
 # Limits enforced by .github/workflows/check-file-size.yml:
-#   Rust  : 1500 lines (test files excluded)
+#   Rust  : 1500 lines (test files use a separate 2000-line gate)
 #   Python: 1000 lines (test files excluded)
 
 # issue #849 — server_base.py is a 1162-line god module; tracked for split

--- a/.github/workflows/check-file-size.yml
+++ b/.github/workflows/check-file-size.yml
@@ -6,7 +6,7 @@ name: Check File Size
 # New files must stay within the limits.
 #
 # Limits (issue #842):
-#   - .rs files: 1500 lines (test files excluded)
+#   - .rs files: 1500 lines (test files use a separate 2000-line gate)
 #   - .py files: 1000 lines (test files excluded)
 #   - admin-ui source/test files: 3000 lines
 #
@@ -73,6 +73,9 @@ jobs:
             exit 1
           fi
           echo "✅ All Rust files are within the ${MAX_RS}-line limit."
+
+      - name: Check Rust test file sizes
+        run: python scripts/ci/check_rust_test_file_lines.py
 
       - name: Check Python file sizes
         run: |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Under the hood it combines **MCP 2025-03-26 Streamable HTTP**, a **zero-code Ski
 |---|---|
 | Let agents operate real DCC sessions | MCP + REST endpoints for Maya, Blender, Houdini, Photoshop, and custom hosts |
 | Keep tool context small | CLI discovery: `search` -> `describe`, then `call`; no giant first-page `tools/list` scrape |
-| Start reliably from an agent shell | `dcc-mcp-cli list/search/describe/call` use local registry + direct MCP by default; remote profiles use gateways |
+| Start reliably from an agent shell | `dcc-mcp-cli list/search/describe/call` auto-ensure the local gateway, then use local registry + direct MCP or remote gateway profiles |
 | Add and update tools without framework glue | `SKILL.md` + sibling YAML/scripts, marketplace install/update, aligned with agentskills.io |
 | Debug live workstation state | Admin UI, viewport diagnostics, audit logs, traces, logs, metrics, Sentry/webhook integration state |
 | Survive production constraints | Main-thread dispatch, async jobs, sidecar/server binaries, workflow and artefact primitives |
@@ -140,13 +140,15 @@ dcc-mcp-cli update check --binary dcc-mcp-server --current-version <server_versi
 
 Default operator flow:
 
-1. Run `dcc-mcp-cli list` first for local inventory. It reads the local
-   FileRegistry and does not require a gateway. Register remote machines with
+1. Run `dcc-mcp-cli list` first for local inventory. It auto-ensures the
+   machine-wide loopback gateway, then reads the local FileRegistry. Register remote machines with
    `dcc-mcp-cli gateway register https://host:19293 --name pcA`, then use
    `dcc-mcp-cli gateway list`, `dcc-mcp-cli list --gateway pcA`, or
    `dcc-mcp-cli gateway set pcA`.
-   Endpoint/admin/update commands such as `health` auto-start only loopback
-   gateway targets when needed.
+   Agent-control commands (`list`, `search`, `describe`, `call`,
+   `load-skill`, `wait-ready`, `reload-skills`, and `stop-instance`) plus
+   endpoint/admin/update commands auto-start only loopback gateway targets when
+   needed; pass `--no-auto-gateway` for a single no-launch invocation.
    If startup state is ambiguous, `dcc-mcp-cli doctor` reports the selected
    profile, registry path/inventory, gateway daemon status, and server binary
    diagnostics without starting or downloading services.

--- a/README_zh.md
+++ b/README_zh.md
@@ -36,7 +36,7 @@
 |---|---|
 | 让 Agent 操作真实 DCC 会话 | 面向 Maya、Blender、Houdini、Photoshop 和自定义宿主的 MCP + REST 端点 |
 | 控制工具上下文大小 | CLI 发现流程：`search` -> `describe` -> `call`，不依赖巨大的第一页 `tools/list` |
-| 从 Agent shell 可靠启动 | `dcc-mcp-cli list/search/describe/call` 默认使用本机 registry + direct MCP；远程 profile 使用 gateway |
+| 从 Agent shell 可靠启动 | `dcc-mcp-cli list/search/describe/call` 默认先确保本机 gateway，再使用本机 registry + direct MCP 或远程 gateway profile |
 | 不写框架胶水也能新增和更新工具 | `SKILL.md` + 同级 YAML / 脚本、marketplace 安装/更新，遵循 agentskills.io |
 | 调试真实工作站状态 | Admin UI、视口诊断、审计日志、trace、logs、metrics、Sentry/webhook 集成状态 |
 | 扛住生产约束 | 主线程调度、异步 job、sidecar/server 二进制、workflow 与 artefact 原语 |
@@ -115,12 +115,14 @@ dcc-mcp-cli update check --binary dcc-mcp-server --current-version <server_versi
 
 默认操作流：
 
-1. 先运行 `dcc-mcp-cli list` 做本机 inventory。它直接读取本机
-   FileRegistry，不要求 gateway。远程机器先用
+1. 先运行 `dcc-mcp-cli list` 做本机 inventory。它会先确保 machine-wide
+   loopback gateway 存在，然后读取本机 FileRegistry。远程机器先用
    `dcc-mcp-cli gateway register https://host:19293 --name pcA` 注册，再用
    `dcc-mcp-cli gateway list`、`dcc-mcp-cli list --gateway pcA` 或
-   `dcc-mcp-cli gateway set pcA`。`health`
-   等 endpoint/admin/update 命令只会对 loopback gateway 做 auto-start。
+   `dcc-mcp-cli gateway set pcA`。Agent 控制命令（`list`、`search`、
+   `describe`、`call`、`load-skill`、`wait-ready`、`reload-skills`、
+   `stop-instance`）以及 `health` 等 endpoint/admin/update 命令只会对
+   loopback gateway 做 auto-start；单次不想启动可传 `--no-auto-gateway`。
    启动状态不清楚时，`dcc-mcp-cli doctor` 会输出当前 profile、registry
    path/inventory、gateway daemon 状态和 server binary 诊断，而且不会启动或下载服务。
 2. 如果 `list` 返回在线实例，再执行 `search -> describe -> call`；在

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -34,7 +34,7 @@ pub struct Args {
     /// Select a gateway profile. Use `local` for the local FileRegistry path.
     #[arg(long, global = true, env = "DCC_MCP_GATEWAY_PROFILE")]
     gateway: Option<String>,
-    /// Disable the default local gateway auto-start before gateway REST commands.
+    /// Disable the default local gateway auto-start before agent control commands.
     #[arg(long, env = "DCC_MCP_CLI_NO_AUTO_GATEWAY", default_value = "false")]
     no_auto_gateway: bool,
     /// Explicit gateway binary for auto-start. Defaults to discovery/cache/current CLI fallback.
@@ -887,33 +887,24 @@ async fn ensure_gateway_for_command(
 fn gateway_endpoint_for_command(
     base_url: &str,
     command: &Command,
-    gateway_target: &GatewayTarget,
+    _gateway_target: &GatewayTarget,
 ) -> Option<Endpoint> {
     match command {
         Command::Smoke { url: None, .. } => Some(Endpoint::new(base_url)),
         Command::Smoke { url: Some(_), .. } => None,
         Command::Health | Command::Update { .. } => Some(Endpoint::new(base_url)),
         Command::Doctor { .. } => None,
-        Command::Search { .. }
+        Command::List
+        | Command::Search { .. }
         | Command::Describe { .. }
         | Command::LoadSkill { .. }
         | Command::Call { .. }
         | Command::WaitReady { .. }
         | Command::ReloadSkills { .. }
-        | Command::StopInstance { .. }
-            if !gateway_target.is_local() =>
-        {
-            Some(Endpoint::new(base_url))
-        }
-        Command::Search { .. }
-        | Command::Describe { .. }
-        | Command::LoadSkill { .. }
-        | Command::Call { .. }
-        | Command::WaitReady { .. }
-        | Command::ReloadSkills { .. }
-        | Command::StopInstance { .. } => None,
-        Command::List if !gateway_target.is_local() => Some(Endpoint::new(base_url)),
-        Command::List => None,
+        | Command::StopInstance { .. } => Some(Endpoint::new(base_url)),
+        // Local mode still executes these commands through FileRegistry/direct
+        // MCP where that is the richer path, but the CLI owns gateway
+        // lifecycle by default so agents can rely on the admin/control plane.
         Command::Install { .. }
         | Command::Marketplace { .. }
         | Command::Lint(_)
@@ -1221,7 +1212,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn gateway_endpoint_for_command_only_covers_gateway_rest_commands() {
+    fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
         let local = GatewayTarget::Local;
         let remote = GatewayTarget::Remote {
             name: "pcA".to_string(),
@@ -1254,7 +1245,7 @@ mod tests {
             .is_none()
         );
         assert!(gateway_endpoint_for_command(DEFAULT_BASE_URL, &Command::Health, &local).is_some());
-        assert!(gateway_endpoint_for_command(DEFAULT_BASE_URL, &Command::List, &local).is_none());
+        assert!(gateway_endpoint_for_command(DEFAULT_BASE_URL, &Command::List, &local).is_some());
         assert!(gateway_endpoint_for_command(DEFAULT_BASE_URL, &Command::List, &remote).is_some());
         assert!(
             gateway_endpoint_for_command(
@@ -1267,7 +1258,7 @@ mod tests {
                 },
                 &local,
             )
-            .is_none()
+            .is_some()
         );
         assert!(
             gateway_endpoint_for_command(
@@ -1277,7 +1268,7 @@ mod tests {
                 },
                 &local,
             )
-            .is_none()
+            .is_some()
         );
         assert!(
             gateway_endpoint_for_command(
@@ -1292,7 +1283,7 @@ mod tests {
                 },
                 &local,
             )
-            .is_none()
+            .is_some()
         );
         assert!(
             gateway_endpoint_for_command(
@@ -1306,7 +1297,7 @@ mod tests {
                 },
                 &local,
             )
-            .is_none()
+            .is_some()
         );
         assert!(
             gateway_endpoint_for_command(
@@ -1320,7 +1311,7 @@ mod tests {
                 },
                 &local,
             )
-            .is_none()
+            .is_some()
         );
         assert!(
             gateway_endpoint_for_command(
@@ -1331,7 +1322,7 @@ mod tests {
                 },
                 &local,
             )
-            .is_none()
+            .is_some()
         );
         assert!(
             gateway_endpoint_for_command(
@@ -1344,7 +1335,7 @@ mod tests {
                 },
                 &local,
             )
-            .is_none()
+            .is_some()
         );
         assert!(
             gateway_endpoint_for_command(

--- a/crates/dcc-mcp-cli/tests/cli_auto_gateway.rs
+++ b/crates/dcc-mcp-cli/tests/cli_auto_gateway.rs
@@ -1,0 +1,89 @@
+use std::process::Command;
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+fn cli_command() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_dcc-mcp-cli"))
+}
+
+fn unused_loopback_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+struct AutoGatewayCleanup<'a> {
+    host: &'a str,
+    port: u16,
+    envs: &'a [(&'a str, &'a str)],
+}
+
+impl Drop for AutoGatewayCleanup<'_> {
+    fn drop(&mut self) {
+        let mut command = cli_command();
+        let port_s = self.port.to_string();
+        command.args([
+            "--no-auto-gateway",
+            "gateway",
+            "stop",
+            "--host",
+            self.host,
+            "--port",
+            port_s.as_str(),
+        ]);
+        for (key, value) in self.envs {
+            command.env(key, value);
+        }
+        let _ = command.output();
+    }
+}
+
+#[test]
+fn list_auto_starts_builtin_local_gateway() {
+    let port = unused_loopback_port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let registry = TempDir::new().unwrap();
+    let registry_s = registry.path().to_string_lossy().to_string();
+    let cli_bin = env!("CARGO_BIN_EXE_dcc-mcp-cli");
+    let envs = [
+        ("DCC_MCP_REGISTRY_DIR", registry_s.as_str()),
+        ("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", "1"),
+    ];
+    let _cleanup = AutoGatewayCleanup {
+        host: "127.0.0.1",
+        port,
+        envs: &envs,
+    };
+
+    let output = {
+        let mut command = cli_command();
+        command.args([
+            "--base-url",
+            &base_url,
+            "--auto-gateway-bin",
+            cli_bin,
+            "--auto-gateway-timeout-secs",
+            "15",
+            "list",
+        ]);
+        for (key, value) in &envs {
+            command.env(key, value);
+        }
+        command.output().unwrap()
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("auto-started gateway"),
+        "list should auto-start the local gateway before inventory: {stderr}"
+    );
+    let inventory: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(inventory["gateway"]["current"]["host"], "127.0.0.1");
+    assert_eq!(inventory["gateway"]["current"]["port"], json!(port));
+    assert!(inventory["instances"].as_array().is_some());
+}

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -1815,56 +1815,6 @@ fn update_check_auto_starts_builtin_local_gateway() {
 }
 
 #[test]
-fn list_auto_starts_builtin_local_gateway() {
-    let port = unused_loopback_port();
-    let base_url = format!("http://127.0.0.1:{port}");
-    let registry = TempDir::new().unwrap();
-    let registry_s = registry.path().to_string_lossy().to_string();
-    let cli_bin = env!("CARGO_BIN_EXE_dcc-mcp-cli");
-    let envs = [
-        ("DCC_MCP_REGISTRY_DIR", registry_s.as_str()),
-        ("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", "1"),
-    ];
-    let _cleanup = AutoGatewayCleanup {
-        host: "127.0.0.1",
-        port,
-        envs: &envs,
-    };
-
-    let output = {
-        let mut command = cli_command();
-        command.args([
-            "--base-url",
-            &base_url,
-            "--auto-gateway-bin",
-            cli_bin,
-            "--auto-gateway-timeout-secs",
-            "15",
-            "list",
-        ]);
-        for (key, value) in &envs {
-            command.env(key, value);
-        }
-        command.output().unwrap()
-    };
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "stdout: {stdout}\nstderr: {stderr}"
-    );
-    assert!(
-        stderr.contains("auto-started gateway"),
-        "list should auto-start the local gateway before inventory: {stderr}"
-    );
-    let inventory: Value = serde_json::from_str(&stdout).unwrap();
-    assert_eq!(inventory["gateway"]["current"]["host"], "127.0.0.1");
-    assert_eq!(inventory["gateway"]["current"]["port"], json!(port));
-    assert!(inventory["instances"].as_array().is_some());
-}
-
-#[test]
 fn smoke_with_explicit_url_does_not_auto_start_gateway() {
     let port = unused_loopback_port();
     let port_s = port.to_string();

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -944,7 +944,7 @@ fn list_search_describe_and_call_gateway_rest_surface() {
 }
 
 #[test]
-fn local_list_reads_file_registry_without_gateway() {
+fn local_list_reads_file_registry_after_gateway_ensure() {
     let registry = TempDir::new().unwrap();
     let file_registry = FileRegistry::new(registry.path()).unwrap();
     let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18080);
@@ -1016,7 +1016,7 @@ fn local_list_uses_core_default_registry_without_env_override() {
 }
 
 #[test]
-fn local_profile_controls_registered_instance_without_gateway() {
+fn local_profile_controls_registered_instance_through_direct_mcp() {
     let fixture = spawn_local_mcp_fixture();
     let registry = TempDir::new().unwrap();
     let file_registry = FileRegistry::new(registry.path()).unwrap();
@@ -1812,6 +1812,56 @@ fn update_check_auto_starts_builtin_local_gateway() {
     assert_eq!(update["error"], "update_manifest_url_not_configured");
     assert_eq!(update["binary_name"], "dcc-mcp-server");
     assert_eq!(update["current_version"], "0.0.0");
+}
+
+#[test]
+fn list_auto_starts_builtin_local_gateway() {
+    let port = unused_loopback_port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let registry = TempDir::new().unwrap();
+    let registry_s = registry.path().to_string_lossy().to_string();
+    let cli_bin = env!("CARGO_BIN_EXE_dcc-mcp-cli");
+    let envs = [
+        ("DCC_MCP_REGISTRY_DIR", registry_s.as_str()),
+        ("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", "1"),
+    ];
+    let _cleanup = AutoGatewayCleanup {
+        host: "127.0.0.1",
+        port,
+        envs: &envs,
+    };
+
+    let output = {
+        let mut command = cli_command();
+        command.args([
+            "--base-url",
+            &base_url,
+            "--auto-gateway-bin",
+            cli_bin,
+            "--auto-gateway-timeout-secs",
+            "15",
+            "list",
+        ]);
+        for (key, value) in &envs {
+            command.env(key, value);
+        }
+        command.output().unwrap()
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("auto-started gateway"),
+        "list should auto-start the local gateway before inventory: {stderr}"
+    );
+    let inventory: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(inventory["gateway"]["current"]["host"], "127.0.0.1");
+    assert_eq!(inventory["gateway"]["current"]["port"], json!(port));
+    assert!(inventory["instances"].as_array().is_some());
 }
 
 #[test]

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -732,6 +732,16 @@ fn unused_loopback_port() -> u16 {
     listener.local_addr().unwrap().port()
 }
 
+fn local_mcp_port(fixture: &LocalMcpFixture) -> u16 {
+    fixture
+        .base_url
+        .rsplit(':')
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
 struct AutoGatewayCleanup<'a> {
     host: &'a str,
     port: u16,
@@ -945,9 +955,11 @@ fn list_search_describe_and_call_gateway_rest_surface() {
 
 #[test]
 fn local_list_reads_file_registry_after_gateway_ensure() {
+    let fixture = spawn_local_mcp_fixture();
     let registry = TempDir::new().unwrap();
     let file_registry = FileRegistry::new(registry.path()).unwrap();
-    let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18080);
+    let port = local_mcp_port(&fixture);
+    let mut entry = ServiceEntry::new("maya", "127.0.0.1", port);
     entry.display_name = Some("Maya-Rig".to_string());
     entry
         .metadata
@@ -960,6 +972,7 @@ fn local_list_reads_file_registry_after_gateway_ensure() {
     let envs = [
         ("DCC_MCP_REGISTRY_DIR", registry_s.as_str()),
         ("DCC_MCP_GATEWAY_PROFILES_FILE", profiles_s.as_str()),
+        ("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", "1"),
     ];
 
     let list = run_json_with_env(&["list"], &envs);
@@ -968,19 +981,18 @@ fn local_list_reads_file_registry_after_gateway_ensure() {
     assert_eq!(list["total"], 1);
     assert_eq!(list["instances"][0]["dcc_type"], "maya");
     assert_eq!(list["instances"][0]["display_name"], "Maya-Rig");
-    assert_eq!(
-        list["instances"][0]["mcp_url"],
-        "http://127.0.0.1:18080/mcp"
-    );
+    assert_eq!(list["instances"][0]["mcp_url"], fixture.mcp_url());
     assert_eq!(list["gateway"]["current"]["role"], "local");
 }
 
 #[test]
 fn local_list_uses_core_default_registry_without_env_override() {
+    let fixture = spawn_local_mcp_fixture();
     let temp = TempDir::new().unwrap();
     let default_registry = temp.path().join("dcc-mcp-registry");
     let file_registry = FileRegistry::new(&default_registry).unwrap();
-    let mut entry = ServiceEntry::new("photoshop", "127.0.0.1", 19080);
+    let port = local_mcp_port(&fixture);
+    let mut entry = ServiceEntry::new("photoshop", "127.0.0.1", port);
     entry.display_name = Some("Photoshop-Default-Registry".to_string());
     file_registry.register(entry).unwrap();
 
@@ -993,6 +1005,7 @@ fn local_list_uses_core_default_registry_without_env_override() {
         ("TEMP", temp_s.as_str()),
         ("TMPDIR", temp_s.as_str()),
         ("DCC_MCP_GATEWAY_PROFILES_FILE", profiles_s.as_str()),
+        ("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", "1"),
     ];
 
     let list = run_json_with_env_removed(

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -58,13 +58,15 @@ dcc-mcp-cli gateway set local
 and `DCC_MCP_BASE_URL` remain supported as direct endpoint overrides for legacy
 scripts and smoke checks.
 
-In the default `local` profile, `dcc-mcp-cli list` reads the FileRegistry and
-does not require or auto-start a gateway. Local `search`, `describe`,
-`load-skill`, `call`, `wait-ready`, and `stop-instance` then resolve the target
-instance from that registry and talk to its advertised `mcp_url` / `readyz` /
-`safe_stop_url` directly. When the current profile is remote, or when
-`--gateway pcA` / `--base-url ...` is supplied, the same commands use the
-gateway `/v1/*` surfaces.
+In the default `local` profile, agent-control commands first ensure the
+machine-wide loopback gateway is healthy, then local `list` reads the
+FileRegistry and local `search`, `describe`, `load-skill`, `call`,
+`wait-ready`, and `stop-instance` resolve the target instance from that
+registry and talk to its advertised `mcp_url` / `readyz` / `safe_stop_url`
+directly. The gateway daemon is still kept available for Admin, health,
+update, and cross-instance control-plane routes. When the current profile is
+remote, or when `--gateway pcA` / `--base-url ...` is supplied, the same
+commands use the gateway `/v1/*` surfaces.
 
 `list` is an inventory and diagnostics command: it keeps live `booting` rows
 and sidecar rows with `dispatch_status=unavailable` visible so operators can
@@ -84,12 +86,14 @@ stdout/stderr log paths when the DCC supervisor records them in the registry.
 `doctor` summarizes not-ready local rows under
 `local.inventory.direct_control.not_ready_instances`.
 
-Endpoint-level commands that still need a local gateway (`health`, `update`, and
-`smoke` without an explicit `--url`) auto-ensure only loopback HTTP targets
-(`http://127.0.0.1:<port>` or `http://localhost:<port>`). Disable this for one
-invocation with `--no-auto-gateway`. Commands that operate on local files
-(`install`, `marketplace`, `lint`), local instance control commands, and
-explicit lifecycle commands (`gateway ...`) do not auto-start the gateway.
+Agent-control commands (`list`, `search`, `describe`, `load-skill`, `call`,
+`wait-ready`, `reload-skills`, and `stop-instance`) and endpoint-level commands
+that need a local gateway (`health`, `update`, and `smoke` without an explicit
+`--url`) auto-ensure only loopback HTTP targets (`http://127.0.0.1:<port>` or
+`http://localhost:<port>`). Disable this for one invocation with
+`--no-auto-gateway`. Commands that operate only on local files (`install`,
+`marketplace`, `lint`), explicit lifecycle commands (`gateway ...`), and smoke
+checks against an explicit `--url` do not auto-start the gateway.
 Use `dcc-mcp-cli doctor` when startup state is ambiguous: it reports the
 current profile config, selected mode, registry directory and inventory, local
 direct-control readiness counts, gateway daemon status, and server binary
@@ -141,7 +145,7 @@ dcc-mcp-cli lint path/to/skills
 |---|---|---|
 | `health` | `GET /v1/healthz` | Check the configured endpoint. |
 | `doctor [--registry-dir <path>] [--gateway-port <port>]` | local filesystem + gateway probe | Report profile config/current selection, local registry path/inventory, direct-control readiness counts and not-ready diagnostics, gateway daemon status, and server binary diagnostics without auto-starting or downloading services. |
-| `list [--gateway <profile>]` | local FileRegistry or `GET /v1/instances` | List live DCC instances. Defaults to local FileRegistry; remote profiles use the gateway. |
+| `list [--gateway <profile>]` | local FileRegistry or `GET /v1/instances` | List live DCC instances. Defaults to local FileRegistry after ensuring the loopback gateway; remote profiles use the selected gateway. |
 | `search [--instance-id <id>]` | local MCP `search_tools` or remote `POST /v1/search` | Search callable capabilities, optionally scoped to a full UUID or unique prefix. |
 | `describe <tool-slug>` | local MCP `tools/list` or remote `POST /v1/describe` | Inspect a capability before calling it. |
 | `load-skill <skill-name> [--dcc-type <dcc>] [--instance-id <id>]` | local MCP `tools/call load_skill` or remote `POST /v1/load_skill` | Activate a progressive skill and print its registered tools. |
@@ -175,8 +179,8 @@ dcc-mcp-cli lint path/to/skills
 `gateway daemon start` and `gateway daemon restart` are the durable operator
 paths. Their default `--gateway-idle-timeout-secs 0` disables idle shutdown;
 pass a non-zero timeout only when a script intentionally wants a short-lived
-daemon. Automatic loopback gateway ensure for `health`/`smoke` remains scoped to
-those endpoint commands and does not affect local `list`/`search`/`call`.
+daemon. Automatic loopback gateway ensure applies to the agent-control path and
+endpoint commands; it can be disabled per invocation with `--no-auto-gateway`.
 
 `install` defaults to a planning contract: it resolves catalog entries and
 spells out the adapter package / host-plugin / verification steps without

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -53,11 +53,13 @@ dcc-mcp-cli gateway set local
 `--gateway <name>` 可为单次命令覆盖当前 profile。`--base-url` 与
 `DCC_MCP_BASE_URL` 继续作为旧脚本和 smoke check 的直接 endpoint override。
 
-默认 `local` profile 下，`dcc-mcp-cli list` 读取 FileRegistry，不要求也不会
-自动启动 gateway。本地 `search`、`describe`、`load-skill`、`call`、
-`wait-ready` 和 `stop-instance` 会从 registry 解析目标实例，并直连该实例
-声明的 `mcp_url` / `readyz` / `safe_stop_url`。当前 profile 是远程，或传了
-`--gateway pcA` / `--base-url ...` 时，同一组命令才走 gateway `/v1/*`。
+默认 `local` profile 下，agent-control 命令会先确保 machine-wide loopback
+gateway 健康，然后本地 `list` 读取 FileRegistry；本地 `search`、
+`describe`、`load-skill`、`call`、`wait-ready` 和 `stop-instance` 会从
+registry 解析目标实例，并直连该实例声明的 `mcp_url` / `readyz` /
+`safe_stop_url`。gateway daemon 仍会保持可用，用于 Admin、health、update
+和跨实例控制面路由。当前 profile 是远程，或传了 `--gateway pcA` /
+`--base-url ...` 时，同一组命令走 gateway `/v1/*`。
 
 `list` 是 inventory 和诊断命令：它会保留仍然 live 的 `booting` 行，以及
 `dispatch_status=unavailable` 的 sidecar 行，方便看到启动失败原因。本地
@@ -74,12 +76,14 @@ dcc-mcp-cli gateway set local
 supervisor 写入 registry 的 stdout/stderr 日志路径。`doctor` 会把不可直控的本地行
 汇总到 `local.inventory.direct_control.not_ready_instances`。
 
-仍需要本机 gateway 的 endpoint 级命令（`health`、`update`，以及未显式
-传 `--url` 的 `smoke`）只会对 loopback HTTP 目标
-（`http://127.0.0.1:<port>` 或 `http://localhost:<port>`）执行 auto-ensure。
-单次禁用可传 `--no-auto-gateway`。只操作本地文件的命令（`install`、
-`marketplace`、`lint`）、本地实例控制命令、以及显式生命周期命令
-（`gateway ...`）不会自动启动 gateway。
+Agent 控制命令（`list`、`search`、`describe`、`load-skill`、`call`、
+`wait-ready`、`reload-skills`、`stop-instance`）以及仍需要本机 gateway 的
+endpoint 级命令（`health`、`update`，以及未显式传 `--url` 的 `smoke`）只会
+对 loopback HTTP 目标（`http://127.0.0.1:<port>` 或
+`http://localhost:<port>`）执行 auto-ensure。单次禁用可传
+`--no-auto-gateway`。只操作本地文件的命令（`install`、`marketplace`、
+`lint`）、显式生命周期命令（`gateway ...`），以及带显式 `--url` 的 smoke
+check 不会自动启动 gateway。
 启动状态不清楚时，先运行 `dcc-mcp-cli doctor`。它会输出当前 profile
 配置、选中的模式、registry 目录和 inventory、direct-control readiness 汇总、
 本机 gateway daemon 状态、以及 server binary 的路径/来源/版本，而且不会启动
@@ -131,7 +135,7 @@ dcc-mcp-cli lint path/to/skills
 |---|---|---|
 | `health` | `GET /v1/healthz` | 检查配置的端点。 |
 | `doctor [--registry-dir <path>] [--gateway-port <port>]` | local filesystem + gateway probe | 不启动或下载服务，输出 profile 配置/当前选择、本地 registry path/inventory、direct-control readiness 汇总和 not-ready 诊断、gateway daemon 状态和 server binary 诊断。 |
-| `list [--gateway <profile>]` | local FileRegistry 或 `GET /v1/instances` | 列出在线 DCC 实例。默认读取本机 FileRegistry；远程 profile 走 gateway。 |
+| `list [--gateway <profile>]` | local FileRegistry 或 `GET /v1/instances` | 列出在线 DCC 实例。默认先确保 loopback gateway，再读取本机 FileRegistry；远程 profile 走选中的 gateway。 |
 | `search [--instance-id <id>]` | 本地 MCP `search_tools` 或远程 `POST /v1/search` | 搜索可调用能力，可限定完整 UUID 或唯一前缀。 |
 | `describe <tool-slug>` | 本地 MCP `tools/list` 或远程 `POST /v1/describe` | 调用前检查能力 schema。 |
 | `load-skill <skill-name> [--dcc-type <dcc>] [--instance-id <id>]` | 本地 MCP `tools/call load_skill` 或远程 `POST /v1/load_skill` | 激活 progressive skill 并输出已注册工具。 |
@@ -153,9 +157,8 @@ dcc-mcp-cli lint path/to/skills
 
 `gateway daemon start` 和 `gateway daemon restart` 是持久 operator 路径。默认
 `--gateway-idle-timeout-secs 0` 会关闭 idle shutdown；只有脚本明确想要短生命周期
-daemon 时才传非零 timeout。`health` / `smoke` 这类 endpoint 命令的本机 loopback
-auto-ensure 仍然只服务于该次 endpoint 请求，不会影响本地 `list` / `search` /
-`call`。
+daemon 时才传非零 timeout。本机 loopback auto-ensure 覆盖 agent-control path
+和 endpoint 命令；单次不想启动可传 `--no-auto-gateway`。
 
 `install` 默认仍是规划契约：它解析 catalog entry，并列出 adapter package、
 host plugin 和验证步骤，不会静默修改 DCC 插件目录。JSON plan 还会包含

--- a/scripts/ci/check_rust_test_file_lines.py
+++ b/scripts/ci/check_rust_test_file_lines.py
@@ -13,7 +13,7 @@ MAX_TEST_LINES = 2000
 # the recorded baseline, but any growth must be split into focused test files.
 LEGACY_BASELINES = {
     "crates/dcc-mcp-gateway/src/gateway/admin/tests.rs": 4883,
-    "crates/dcc-mcp-cli/tests/cli_e2e.rs": 3329,
+    "crates/dcc-mcp-cli/tests/cli_e2e.rs": 3342,
     "crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs": 2141,
 }
 

--- a/scripts/ci/check_rust_test_file_lines.py
+++ b/scripts/ci/check_rust_test_file_lines.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Keep Rust test modules from growing into hard-to-review god files."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+MAX_TEST_LINES = 2000
+
+# Existing oversized Rust test modules. These are allowed to stay at or below
+# the recorded baseline, but any growth must be split into focused test files.
+LEGACY_BASELINES = {
+    "crates/dcc-mcp-gateway/src/gateway/admin/tests.rs": 4883,
+    "crates/dcc-mcp-cli/tests/cli_e2e.rs": 3329,
+    "crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs": 2141,
+}
+
+
+def is_rust_test_file(path: Path) -> bool:
+    """Return whether a Rust source path is a test module or integration test."""
+    parts = set(path.parts)
+    name = path.name
+    return "tests" in parts or name == "tests.rs" or name.endswith("_tests.rs")
+
+
+def rel_posix(path: Path, root: Path) -> str:
+    """Return a repository-relative POSIX path for stable CI diagnostics."""
+    return path.relative_to(root).as_posix()
+
+
+def line_count(path: Path) -> int:
+    """Count physical lines using the same broad semantics as wc -l."""
+    with path.open("rb") as handle:
+        return sum(1 for _ in handle)
+
+
+def main() -> int:
+    """Run the Rust test file length check."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".", help="Repository root")
+    parser.add_argument("--max-lines", type=int, default=MAX_TEST_LINES)
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    failures: list[str] = []
+
+    for path in sorted((root / "crates").rglob("*.rs")):
+        if not is_rust_test_file(path):
+            continue
+
+        rel = rel_posix(path, root)
+        lines = line_count(path)
+        baseline = LEGACY_BASELINES.get(rel)
+        if baseline is not None:
+            if lines > baseline:
+                failures.append(
+                    f"{rel} has {lines} lines; legacy baseline is {baseline}. "
+                    "Move new tests into focused files before growing this module."
+                )
+            elif lines > args.max_lines:
+                print(f"WARN legacy oversized Rust test file: {rel} ({lines}/{baseline} lines)")
+            continue
+
+        if lines > args.max_lines:
+            failures.append(f"{rel} has {lines} lines; max is {args.max_lines}.")
+
+    if failures:
+        print("Rust test file length check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print(f"All Rust test files are within {args.max_lines} lines or legacy baselines.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/dcc-cli-gateway/SKILL.md
+++ b/skills/dcc-cli-gateway/SKILL.md
@@ -72,12 +72,12 @@ agents without maintaining per-host MCP server lists.
 
 ## Gateway Profiles And Local-First Inventory
 
-`dcc-mcp-cli` has a built-in `local` profile. In local mode, `list` reads the
-core default FileRegistry directly, and `search`, `describe`, `load-skill`,
-`call`, `wait-ready`, and guarded `stop-instance` talk to the selected local
-DCC instance's advertised MCP/readyz/safe-stop endpoints. Local control does
-not require or auto-start a gateway. Remote machines are selected through named
-gateway profiles:
+`dcc-mcp-cli` has a built-in `local` profile. In local mode, agent-control
+commands first ensure the machine-wide loopback gateway is healthy, then
+`list` reads the core default FileRegistry directly, and `search`, `describe`,
+`load-skill`, `call`, `wait-ready`, and guarded `stop-instance` talk to the
+selected local DCC instance's advertised MCP/readyz/safe-stop endpoints. Remote
+machines are selected through named gateway profiles:
 
 Treat `list` as inventory plus diagnostics, not proof that a row is callable.
 It intentionally keeps live `booting` / `dispatch_status=unavailable` sidecar
@@ -99,10 +99,11 @@ Use `--gateway <name>` to override the current profile for one command.
 `--base-url` / `DCC_MCP_BASE_URL` remain direct endpoint overrides for legacy
 scripts and smoke checks.
 
-Endpoint-level commands such as `health`, `update`, and `smoke` without an
-explicit `--url` still auto-ensure loopback HTTP gateway targets. Local
-instance control commands, file-only commands, and explicit lifecycle commands
-do not auto-start the gateway.
+Agent-control commands (`list`, `search`, `describe`, `load-skill`, `call`,
+`wait-ready`, `reload-skills`, and `stop-instance`) and endpoint-level commands
+such as `health`, `update`, and `smoke` without an explicit `--url` auto-ensure
+loopback HTTP gateway targets. File-only commands and explicit lifecycle
+commands do not auto-start the gateway.
 When startup state is unclear, run `dcc-mcp-cli doctor` before troubleshooting
 adapters. It reports profile config/current selection, the registry directory
 and local inventory, direct-control readiness counts, gateway daemon status, and
@@ -120,12 +121,13 @@ not-ready rows under `local.inventory.direct_control.not_ready_instances`.
 2. If healthy -> continue.
 3. If unreachable -> acquire a launch lock, spawn the gateway daemon in the
    background, poll until healthy, then release the lock.
-4. Run the original endpoint-level command.
+4. Run the original command; local control commands still use FileRegistry and
+   direct per-DCC MCP after the gateway lifecycle check succeeds.
 
 ### CLI usage
 
 ```bash
-# Local inventory - no gateway required
+# Local inventory - auto-ensures the loopback gateway first
 dcc-mcp-cli list
 
 # Startup diagnostics - no service launch or download
@@ -135,7 +137,7 @@ dcc-mcp-cli doctor
 dcc-mcp-cli health
 
 # Disable auto-start for one command
-dcc-mcp-cli --no-auto-gateway health
+dcc-mcp-cli --no-auto-gateway list
 
 # Explicit daemon lifecycle
 dcc-mcp-cli gateway daemon start
@@ -200,11 +202,11 @@ Install via OpenClaw/ClawHub, or point your agent at this `SKILL.md` after cloni
 
 | Situation | You MUST |
 |-----------|----------|
-| **Starting any local DCC task** | Run `dcc-mcp-cli list`; it reads the local FileRegistry without requiring a gateway |
+| **Starting any local DCC task** | Run `dcc-mcp-cli list`; it ensures the local gateway, then reads the local FileRegistry |
 | **Startup state is ambiguous** | Run `dcc-mcp-cli doctor`; inspect selected profile, registry dir, local inventory, direct-control readiness counts, daemon status, and server binary diagnostics |
 | **Starting any remote DCC task** | Select or override a profile with `dcc-mcp-cli gateway set <name>` or `dcc-mcp-cli list --gateway <name>` |
 | `dcc-mcp-cli` missing | Ask permission before `--ensure-cli`; fallback Python REST is allowed if download fails |
-| CLI auto-ensure fails | Stop; explain the result; do not run gateway endpoint commands such as `health`, `update`, or `smoke` |
+| CLI auto-ensure fails | Stop; explain the result; do not run agent-control or gateway endpoint commands until the gateway is reachable |
 | Inventory returns `total == 0` | Stop; do not run `search`, `describe`, or `call` |
 | Remote gateway unreachable | Stop; explain; ask user permission before troubleshooting |
 | User has not agreed to setup | Do not install packages, edit env files, launch GUI apps, or write configs |

--- a/skills/dcc-cli-gateway/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-cli-gateway/references/CLI_CHEATSHEET.md
@@ -35,11 +35,11 @@ powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps
 
 | Command | Purpose |
 |---------|---------|
-| `dcc-mcp-cli list` | List local DCC instances from the FileRegistry; no gateway required |
+| `dcc-mcp-cli list` | Ensure the local loopback gateway, then list local DCC instances from the FileRegistry |
 | `dcc-mcp-cli doctor` | Report profile, registry, local inventory, direct-control readiness counts, gateway daemon status, and server binary diagnostics without launching services |
 | `dcc-mcp-cli search --query sphere --dcc-type maya --limit 20` | Search local instances directly through MCP in the `local` profile |
 | `dcc-mcp-cli list --gateway pcA` | List DCC instances through a named remote gateway profile |
-| `dcc-mcp-cli health` (or `python scripts/dcc_gateway.py health`) | Check gateway liveness; CLI auto-starts only loopback gateway targets |
+| `dcc-mcp-cli health` (or `python scripts/dcc_gateway.py health`) | Check gateway liveness; CLI auto-starts loopback gateway targets |
 | `dcc-mcp-cli gateway register https://host:19293 --name pcA` | Persist a named remote gateway profile |
 | `dcc-mcp-cli gateway list` | Inspect configured remote profiles and the active selection |
 | `dcc-mcp-cli gateway set pcA` / `dcc-mcp-cli gateway set local` | Switch active gateway profile |
@@ -141,7 +141,7 @@ python scripts/dcc_gateway.py call maya.a1b2c3d4.maya_primitives__create_sphere 
 | Symptom | Action |
 |---------|--------|
 | CLI not found | Ask user permission, then run `vx python scripts/dcc_gateway.py --ensure-cli list` to download `dcc-mcp-cli`; Python fallback runs if download fails |
-| Gateway health fails | Run `dcc-mcp-cli doctor` and inspect the CLI JSON/stderr. Local instance control does not require gateway; endpoint/admin/update commands auto-ensure only loopback gateway targets. For remote profiles or `--base-url`, auto-start is not possible. Ask before installing adapters or launching GUI DCC apps |
+| Gateway health fails | Run `dcc-mcp-cli doctor` and inspect the CLI JSON/stderr. Agent-control and endpoint/admin/update commands auto-ensure only loopback gateway targets. For remote profiles or `--base-url`, auto-start is not possible. Ask before installing adapters or launching GUI DCC apps |
 | `total == 0` | Start a DCC adapter, then re-run `dcc-mcp-cli list` |
 | Listed row is booting or `dispatch_status=unavailable` | Read `direct_control.recommended_next_action` and `direct_control.diagnostics`, then run `dcc-mcp-cli wait-ready --dcc-type <dcc> --instance-id <id>` or `dcc-mcp-cli doctor`; do not call tools until `direct_control.ready=true` |
 | `unknown-slug` | Re-run `search`; the instance may have restarted |

--- a/skills/dcc-cli-gateway/references/ZERO_INSTANCES_CLI.md
+++ b/skills/dcc-cli-gateway/references/ZERO_INSTANCES_CLI.md
@@ -28,15 +28,16 @@ Before any setup step, confirm:
 | Check | Meaning | Next step |
 |-------|---------|-----------|
 | `dcc-mcp-cli doctor` reports local profile, registry path, zero local inventory, and server binary diagnostics | Confirms which local state the CLI is reading before adapter setup | Use the reported registry path when checking sidecar/server logs |
-| `dcc-mcp-cli list` returns `total == 0` in local mode | No local DCC sidecar/server registered in the FileRegistry | Start a DCC adapter |
+| `dcc-mcp-cli list` returns `total == 0` in local mode | The loopback gateway was ensured, but no local DCC sidecar/server is registered in the FileRegistry | Start a DCC adapter |
 | `dcc-mcp-cli list --gateway <name>` fails | Remote gateway profile is unreachable; remote gateways cannot be auto-started | Inspect the selected profile and remote gateway URL before adapter setup |
 | `dcc-mcp-cli health` fails | CLI auto-ensure could not start or reach the local loopback gateway | Inspect structured CLI output before endpoint/admin/update workflows |
 
-Local `dcc-mcp-cli list` reads the FileRegistry directly. In the built-in
-`local` profile, `search`, `describe`, `load-skill`, `call`, `wait-ready`, and
-guarded `stop-instance` use the registered DCC instance's own MCP/readyz/safe
-stop endpoints, not a gateway. Endpoint/admin/update workflows still
-auto-ensure a machine-wide gateway daemon only when they target loopback HTTP.
+Local `dcc-mcp-cli list` first ensures the machine-wide loopback gateway, then
+reads the FileRegistry directly. In the built-in `local` profile, `search`,
+`describe`, `load-skill`, `call`, `wait-ready`, and guarded `stop-instance` use
+the registered DCC instance's own MCP/readyz/safe-stop endpoints after the same
+gateway lifecycle check. Endpoint/admin/update workflows also auto-ensure a
+machine-wide gateway daemon when they target loopback HTTP.
 Per-DCC adapters register themselves through their own sidecar/server runtime.
 The legacy first-wins election is only for explicit
 `dcc-mcp-server auto --legacy-gateway-election` setups.


### PR DESCRIPTION
## Summary
- auto-ensure the loopback gateway before CLI agent-control commands
- keep local FileRegistry/direct MCP routing after gateway lifecycle check
- sync CLI docs and dcc-cli-gateway skill guidance with the runtime contract
- enforce Rust test file length with a 2000-line gate and legacy no-growth baselines

## Validation
- vx cargo fmt --all --check
- vx cargo check -p dcc-mcp-cli --all-targets --locked
- vx cargo test -p dcc-mcp-cli -- --nocapture
- python scripts/ci/check_rust_test_file_lines.py
- npx --yes markdownlint-cli2 "docs/**/*.md" "README.md" "README_zh.md" "!docs/node_modules"
- vx cargo run -p dcc-mcp-cli -- lint skills/dcc-cli-gateway