### PR TITLE
fix(ci): add retry with exponential backoff for Multica 429 in publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -855,10 +855,38 @@ jobs:
               artifacts_verified: true,
               assets_count: $assets_count
             }')"
-          printf '%s' "$payload" | curl -fsS \
-            -X POST \
-            -H "Content-Type: application/json" \
-            -H "X-GitHub-Event: core_release_ready" \
-            -H "X-GitHub-Delivery: core-release-ready-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
-            --data-binary @- \
-            "$MULTICA_WEBHOOK_URL"
+          # Retry with exponential backoff for transient errors (HTTP 429 rate-limit, 5xx).
+          # A single 429 from Multica is not fatal — all build/publish jobs succeeded.
+          max_retries=5
+          delay=5
+
+          for i in $(seq 1 "$max_retries"); do
+            http_code=$(printf '%s' "$payload" | curl -fsS -o /dev/null -w '%{http_code}' \
+              -X POST \
+              -H "Content-Type: application/json" \
+              -H "X-GitHub-Event: core_release_ready" \
+              -H "X-GitHub-Delivery: core-release-ready-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+              --data-binary @- \
+              "$MULTICA_WEBHOOK_URL")
+            curl_exit=$?
+
+            if [ "$curl_exit" -eq 0 ] && [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+              echo "Multica notified successfully (HTTP ${http_code})"
+              exit 0
+            fi
+
+            if [ "$http_code" = "429" ] || [ "$http_code" -ge 500 ]; then
+              if [ "$i" -lt "$max_retries" ]; then
+                echo "::warning::Multica returned HTTP ${http_code}, attempt ${i}/${max_retries}, retrying in ${delay}s..."
+                sleep "$delay"
+                delay=$((delay * 2))
+                continue
+              fi
+            else
+              echo "::error::Multica notification failed with HTTP ${http_code} (non-retryable)"
+              exit 1
+            fi
+          done
+
+          echo "::error::Multica notification failed after ${max_retries} attempts"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -862,6 +862,8 @@ jobs:
 
           for i in $(seq 1 "$max_retries"); do
             http_code=$(printf '%s' "$payload" | curl -fsS -o /dev/null -w '%{http_code}' \
+              --connect-timeout 10 \
+              --max-time 30 \
               -X POST \
               -H "Content-Type: application/json" \
               -H "X-GitHub-Event: core_release_ready" \


### PR DESCRIPTION
## Problem

In the Release workflow's `publish` job, the **Notify Multica** step sends a `core_release_ready` webhook to trigger downstream squad automation. When Multica returns HTTP 429 (rate limited), the entire publish job is marked as **failure** even though every build/publish upload (PyPI wheels, GitHub Release assets, ClawHub skills) completed successfully.

### Evidence
- **Run:** https://github.com/dcc-mcp/dcc-mcp-core/actions/runs/27427897365
- **Release:** v0.18.21
- **Failed step:** `Notify Multica release-ready autopilot` → HTTP 429

## Fix

Replace the single-shot `curl` call with a retry loop using exponential backoff:

- **Max retries:** 5
- **Initial delay:** 5s (exponential: 5s → 10s → 20s → 40s → 80s)
- **Retryable errors:** HTTP 429 (rate limit) and 5xx (server errors)
- **Non-retryable errors:** Other 4xx (fail immediately)

When the webhook eventually succeeds (2xx), the step exits cleanly and the job is green. After all retries are exhausted the job still fails, but with a clear error message showing the attempt count.

## Verification

- GitHub Release v0.18.21 assets confirmed complete (25 assets covering all platforms)
- Downstream autopilot `dcc-mcp-core release → 下游专队迭代` manually triggered (run `00635791-6642-4f37-8536-a85920db13c5`)