### PR TITLE
fix: use instance server version for updates

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -20,6 +20,7 @@ use super::links::AdminLinkBuilder;
 use super::skill_reload::reload_skill_paths_and_refresh_backends;
 use super::state::{AdminAuditRecord, AdminState};
 use super::trace::{AgentContext, DispatchTrace};
+use super::update::{AdminInstanceUpdateVersion, admin_instance_update_version};
 use crate::gateway::capability::RefreshReason;
 use crate::gateway::capability_service::refresh_all_live_backends;
 use crate::gateway::resilience::{self as gw_resilience, gateway_limits};
@@ -65,8 +66,8 @@ pub struct AdminInstanceUpdateRequest {
     apply: Option<bool>,
     /// Defaults to the server binary because instance cards represent backends.
     binary: Option<String>,
-    /// Current version of the requested binary. Optional for dcc-mcp-server,
-    /// where the gateway package version is the matching server binary version.
+    /// Current version of the requested binary. Optional when the target
+    /// instance reports its server binary version in registry metadata.
     current_version: Option<String>,
 }
 
@@ -188,7 +189,8 @@ pub async fn handle_admin_instance_update(
     let instance_id = instance.instance_id.to_string();
     let instance_short_id = instance_short(&instance.instance_id);
     let (current_version, displayed_current_version, current_version_source) =
-        match admin_instance_update_version(&binary_name, req.current_version.as_deref()) {
+        match admin_instance_update_version(&instance, &binary_name, req.current_version.as_deref())
+        {
             AdminInstanceUpdateVersion::Known {
                 current,
                 display,
@@ -452,40 +454,6 @@ async fn admin_find_instance_entry(
         )
             .into_response()),
     }
-}
-
-enum AdminInstanceUpdateVersion {
-    Known {
-        current: String,
-        display: Option<String>,
-        source: &'static str,
-    },
-    MissingCurrentVersion,
-}
-
-fn admin_instance_update_version(
-    binary_name: &str,
-    requested_current_version: Option<&str>,
-) -> AdminInstanceUpdateVersion {
-    if let Some(version) = requested_current_version
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        return AdminInstanceUpdateVersion::Known {
-            current: version.to_string(),
-            display: Some(version.to_string()),
-            source: "request",
-        };
-    }
-    if binary_name == "dcc-mcp-server" {
-        let version = env!("CARGO_PKG_VERSION").to_string();
-        return AdminInstanceUpdateVersion::Known {
-            current: version.clone(),
-            display: Some(version),
-            source: "gateway_package_version",
-        };
-    }
-    AdminInstanceUpdateVersion::MissingCurrentVersion
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -68,6 +68,8 @@ pub mod stats;
 pub mod trace;
 mod trace_log;
 mod traffic;
+#[cfg(feature = "admin")]
+mod update;
 pub mod workers;
 pub mod workflows;
 

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -3925,15 +3925,15 @@ webhooks:
         let (status, body) = post_json(
             router,
             &format!("/api/instances/{instance_id}/update"),
-            json!({ "apply": true }),
+            json!({ "apply": true, "current_version": "0.18.0" }),
         )
         .await;
 
         assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
         assert_eq!(body["status"], "not_configured");
         assert_eq!(body["binary_name"], "dcc-mcp-server");
-        assert_eq!(body["current_version"], env!("CARGO_PKG_VERSION"));
-        assert_eq!(body["current_version_source"], "gateway_package_version");
+        assert_eq!(body["current_version"], "0.18.0");
+        assert_eq!(body["current_version_source"], "request");
         assert_eq!(body["requires_restart"], false);
     }
 
@@ -3991,7 +3991,7 @@ webhooks:
         let (status, body) = post_json(
             router,
             &format!("/api/instances/{instance_id}/update"),
-            json!({ "apply": true }),
+            json!({ "apply": true, "current_version": env!("CARGO_PKG_VERSION") }),
         )
         .await;
         let _ = shutdown.send(());
@@ -4000,7 +4000,7 @@ webhooks:
         assert_eq!(body["status"], "up_to_date");
         assert_eq!(body["update_available"], false);
         assert_eq!(body["current_version"], env!("CARGO_PKG_VERSION"));
-        assert_eq!(body["current_version_source"], "gateway_package_version");
+        assert_eq!(body["current_version_source"], "request");
         assert_eq!(body["latest_version"], env!("CARGO_PKG_VERSION"));
         assert_eq!(body["requires_restart"], false);
     }
@@ -4032,7 +4032,7 @@ webhooks:
         let (status, body) = post_json(
             router,
             &format!("/api/instances/{instance_id}/update"),
-            json!({ "apply": true }),
+            json!({ "apply": true, "current_version": "0.18.0" }),
         )
         .await;
         let _ = shutdown.send(());
@@ -4041,8 +4041,8 @@ webhooks:
         assert_eq!(body["status"], "download_failed");
         assert_eq!(body["error"], "download_url_not_configured");
         assert_eq!(body["binary_name"], "dcc-mcp-server");
-        assert_eq!(body["current_version"], env!("CARGO_PKG_VERSION"));
-        assert_eq!(body["current_version_source"], "gateway_package_version");
+        assert_eq!(body["current_version"], "0.18.0");
+        assert_eq!(body["current_version_source"], "request");
         assert_eq!(body["latest_version"], "999.0.0");
         assert_eq!(body["update_available"], true);
         assert_eq!(body["requires_restart"], false);
@@ -4068,7 +4068,7 @@ webhooks:
         let (status, body) = post_json(
             router,
             &format!("/api/instances/{instance_id}/update"),
-            json!({ "apply": false }),
+            json!({ "apply": false, "current_version": "0.18.0" }),
         )
         .await;
         let _ = shutdown.send(());
@@ -4076,8 +4076,8 @@ webhooks:
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body["status"], "available");
         assert_eq!(body["binary_name"], "dcc-mcp-server");
-        assert_eq!(body["current_version"], env!("CARGO_PKG_VERSION"));
-        assert_eq!(body["current_version_source"], "gateway_package_version");
+        assert_eq!(body["current_version"], "0.18.0");
+        assert_eq!(body["current_version_source"], "request");
         assert_eq!(body["latest_version"], "999.0.0");
         assert_eq!(body["update_available"], true);
         assert_eq!(body["requires_restart"], false);
@@ -4105,7 +4105,7 @@ webhooks:
         let (status, body) = post_json(
             router,
             &format!("/api/instances/{instance_id}/update"),
-            json!({ "apply": true }),
+            json!({ "apply": true, "current_version": "0.18.0" }),
         )
         .await;
         let _ = shutdown.send(());
@@ -4113,8 +4113,8 @@ webhooks:
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body["status"], "staged");
         assert_eq!(body["binary_name"], "dcc-mcp-server");
-        assert_eq!(body["current_version"], env!("CARGO_PKG_VERSION"));
-        assert_eq!(body["current_version_source"], "gateway_package_version");
+        assert_eq!(body["current_version"], "0.18.0");
+        assert_eq!(body["current_version_source"], "request");
         assert_eq!(body["latest_version"], "999.0.0");
         assert_eq!(body["update_available"], true);
         assert_eq!(body["requires_restart"], true);
@@ -4148,7 +4148,7 @@ webhooks:
         let (status, body) = post_json(
             router,
             &format!("/api/instances/{instance_id}/update"),
-            json!({ "apply": true }),
+            json!({ "apply": true, "current_version": "0.18.0" }),
         )
         .await;
         let _ = shutdown.send(());

--- a/crates/dcc-mcp-gateway/src/gateway/admin/update.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/update.rs
@@ -1,0 +1,110 @@
+use dcc_mcp_transport::discovery::types::{SERVER_BINARY_VERSION_METADATA_KEY, ServiceEntry};
+use serde_json::Value;
+
+pub(super) enum AdminInstanceUpdateVersion {
+    Known {
+        current: String,
+        display: Option<String>,
+        source: &'static str,
+    },
+    MissingCurrentVersion,
+}
+
+pub(super) fn admin_instance_update_version(
+    instance: &ServiceEntry,
+    binary_name: &str,
+    requested_current_version: Option<&str>,
+) -> AdminInstanceUpdateVersion {
+    if let Some(version) = requested_current_version
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return AdminInstanceUpdateVersion::Known {
+            current: version.to_string(),
+            display: Some(version.to_string()),
+            source: "request",
+        };
+    }
+    if binary_name == "dcc-mcp-server"
+        && let Some((version, source)) = instance_server_binary_version(instance)
+    {
+        return AdminInstanceUpdateVersion::Known {
+            current: version.clone(),
+            display: Some(version),
+            source,
+        };
+    }
+    AdminInstanceUpdateVersion::MissingCurrentVersion
+}
+
+fn instance_server_binary_version(instance: &ServiceEntry) -> Option<(String, &'static str)> {
+    const SERVER_VERSION_KEYS: [&str; 3] = [
+        SERVER_BINARY_VERSION_METADATA_KEY,
+        "server_binary_version",
+        "server_version",
+    ];
+
+    for key in SERVER_VERSION_KEYS {
+        if let Some(version) = instance
+            .metadata
+            .get(key)
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Some((version.to_string(), "instance_metadata"));
+        }
+    }
+
+    for key in SERVER_VERSION_KEYS {
+        if let Some(version) = instance
+            .extras
+            .get(key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Some((version.to_string(), "instance_extras"));
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_version_uses_server_binary_metadata() {
+        let mut instance = ServiceEntry::new("maya", "127.0.0.1", 18813);
+        instance.version = Some("2024.0".to_string());
+        instance.adapter_version = Some("0.3.0".to_string());
+        instance.metadata.insert(
+            SERVER_BINARY_VERSION_METADATA_KEY.to_string(),
+            "0.18.0".to_string(),
+        );
+
+        let AdminInstanceUpdateVersion::Known {
+            current, source, ..
+        } = admin_instance_update_version(&instance, "dcc-mcp-server", None)
+        else {
+            panic!("expected metadata-backed server version");
+        };
+
+        assert_eq!(current, "0.18.0");
+        assert_eq!(source, "instance_metadata");
+    }
+
+    #[test]
+    fn update_version_does_not_use_dcc_or_adapter_version() {
+        let mut instance = ServiceEntry::new("maya", "127.0.0.1", 18813);
+        instance.version = Some("2024.0".to_string());
+        instance.adapter_version = Some("0.3.0".to_string());
+
+        assert!(matches!(
+            admin_instance_update_version(&instance, "dcc-mcp-server", None),
+            AdminInstanceUpdateVersion::MissingCurrentVersion
+        ));
+    }
+}

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -86,7 +86,7 @@ use dcc_mcp_skills::constants::resolve_registry_dcc_type;
 #[cfg(feature = "gateway-auto")]
 use dcc_mcp_skills::constants::{ENV_SKILL_PATHS, app_skill_paths_env_key};
 #[cfg(feature = "gateway-auto")]
-use dcc_mcp_transport::discovery::types::ServiceEntry;
+use dcc_mcp_transport::discovery::types::{SERVER_BINARY_VERSION_METADATA_KEY, ServiceEntry};
 #[cfg(feature = "telemetry")]
 use serde::Deserialize;
 use sysinfo::{Pid, ProcessesToUpdate, System};
@@ -377,6 +377,10 @@ fn gateway_recovery_driver(runtime_mode: &str, guardian_enabled: bool) -> &'stat
 fn stamp_server_gateway_runtime_metadata(entry: &mut ServiceEntry, args: &ServerArgs) {
     let runtime_mode = server_gateway_runtime_mode(args);
     let guardian_enabled = server_gateway_guardian_enabled(args);
+    entry.metadata.insert(
+        SERVER_BINARY_VERSION_METADATA_KEY.to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    );
     entry.metadata.insert(
         GATEWAY_RUNTIME_MODE_METADATA_KEY.to_string(),
         runtime_mode.to_string(),

--- a/crates/dcc-mcp-server/src/main_tests.rs
+++ b/crates/dcc-mcp-server/src/main_tests.rs
@@ -285,6 +285,13 @@ fn server_registration_metadata_reports_gateway_guardian_mode() {
             .map(String::as_str),
         Some(REGISTRATION_REFRESH_MODE_FILE_REGISTRY_HEARTBEAT)
     );
+    assert_eq!(
+        entry
+            .metadata
+            .get(SERVER_BINARY_VERSION_METADATA_KEY)
+            .map(String::as_str),
+        Some(env!("CARGO_PKG_VERSION"))
+    );
 
     let args = Args::try_parse_from(["dcc-mcp-server", "--app", "maya", "--gateway-port", "0"])
         .expect("valid CLI args");

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -81,6 +81,14 @@ fn is_default_capacity(capacity: &u32) -> bool {
 /// can special-case it without depending on `dcc-mcp-http`.
 pub const GATEWAY_SENTINEL_DCC_TYPE: &str = "__gateway__";
 
+/// Metadata key for the `dcc-mcp-server` binary version that registered a
+/// backend instance.
+///
+/// This is intentionally separate from [`ServiceEntry::version`] (the DCC
+/// application version) and [`ServiceEntry::adapter_version`] (the adapter
+/// package version).
+pub const SERVER_BINARY_VERSION_METADATA_KEY: &str = "dcc_mcp_server_version";
+
 /// Status of a discovered DCC service instance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
## Summary
- stamp backend registry rows with the dcc-mcp-server binary version
- make admin instance updates use request or instance server metadata instead of DCC/adapter versions
- add regression coverage for the version contract

## Validation
- vx cargo fmt --all --check
- vx cargo test -p dcc-mcp-gateway --features admin admin_instance_update -- --nocapture
- vx cargo test -p dcc-mcp-gateway --features admin admin_instance_update_version -- --nocapture
- vx cargo test -p dcc-mcp-server server_registration_metadata_reports_gateway_guardian_mode -- --nocapture
- vx cargo check -p dcc-mcp-gateway --features admin --all-targets
- vx cargo check -p dcc-mcp-server --all-targets

Skill guidance update: not needed; the agent-facing CLI workflow is unchanged and the server now auto-stamps the registry metadata.