### PR TITLE
test: cover admin update version contract

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -454,7 +454,7 @@ async fn admin_find_instance_entry(
     }
 }
 
-enum AdminInstanceUpdateVersion {
+pub(super) enum AdminInstanceUpdateVersion {
     Known {
         current: String,
         display: Option<String>,
@@ -463,7 +463,7 @@ enum AdminInstanceUpdateVersion {
     MissingCurrentVersion,
 }
 
-fn admin_instance_update_version(
+pub(super) fn admin_instance_update_version(
     binary_name: &str,
     requested_current_version: Option<&str>,
 ) -> AdminInstanceUpdateVersion {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -93,3 +93,5 @@ pub use router::{build_admin_router, build_v1_debug_router};
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod update_tests;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/update_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/update_tests.rs
@@ -1,0 +1,47 @@
+#![cfg(all(test, feature = "admin"))]
+
+use super::handlers::{AdminInstanceUpdateVersion, admin_instance_update_version};
+
+#[test]
+fn server_update_uses_gateway_package_version_when_request_omits_current_version() {
+    match admin_instance_update_version("dcc-mcp-server", None) {
+        AdminInstanceUpdateVersion::Known {
+            current,
+            display,
+            source,
+        } => {
+            assert_eq!(current, env!("CARGO_PKG_VERSION"));
+            assert_eq!(display.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+            assert_eq!(source, "gateway_package_version");
+        }
+        AdminInstanceUpdateVersion::MissingCurrentVersion => {
+            panic!("server binary update must infer the gateway package version")
+        }
+    }
+}
+
+#[test]
+fn server_update_prefers_explicit_binary_version_from_request() {
+    match admin_instance_update_version("dcc-mcp-server", Some(" 0.18.0 ")) {
+        AdminInstanceUpdateVersion::Known {
+            current,
+            display,
+            source,
+        } => {
+            assert_eq!(current, "0.18.0");
+            assert_eq!(display.as_deref(), Some("0.18.0"));
+            assert_eq!(source, "request");
+        }
+        AdminInstanceUpdateVersion::MissingCurrentVersion => {
+            panic!("explicit current_version should be accepted")
+        }
+    }
+}
+
+#[test]
+fn non_server_binary_requires_explicit_current_version() {
+    assert!(matches!(
+        admin_instance_update_version("dcc-mcp-cli", None),
+        AdminInstanceUpdateVersion::MissingCurrentVersion
+    ));
+}


### PR DESCRIPTION
## Summary
- add focused admin update version contract tests outside the legacy large admin test file
- cover default `dcc-mcp-server` current version inference from the gateway package version
- cover explicit current version overrides and non-server binary validation

## Validation
- `vx git diff --check`
- `vx cargo fmt --check`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo test -p dcc-mcp-gateway --features admin gateway::admin::update_tests -- --test-threads=1`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo test -p dcc-mcp-gateway --features admin test_admin_instance_update -- --test-threads=1`
