### PR TITLE
feat: add CLI standalone ZIP bundle and update manifest to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,6 +272,29 @@ jobs:
             --cli-bin "${{ matrix.cli_artifact_name }}" \
             --out-dir .
 
+      - name: Create standalone CLI zip
+        id: cli-bundle
+        shell: bash
+        run: |
+          python scripts/release/build_cli_bundle.py \
+            --version "${{ needs.release-please.outputs.version }}" \
+            --platform "${{ matrix.platform }}" \
+            --cli-bin "${{ matrix.cli_artifact_name }}" \
+            --out-dir .
+
+      - name: Generate update manifest
+        id: update-manifest
+        shell: bash
+        run: |
+          python scripts/release/generate_update_manifest.py \
+            --version "${{ needs.release-please.outputs.version }}" \
+            --platform "${{ matrix.platform }}" \
+            --release-tag "${{ needs.release-please.outputs.tag_name }}" \
+            --repo "${{ github.repository }}" \
+            --server-bin "${{ matrix.artifact_name }}" \
+            --cli-bin "${{ matrix.cli_artifact_name }}" \
+            --out-dir .
+
       # ── PyPI wheel build ──────────────────────────────────────────
       # macOS / Windows reuse the same target/ directory the raw-binary
       # step just populated; maturin sees the binary as already-compiled
@@ -326,6 +349,8 @@ jobs:
             ${{ matrix.artifact_name }}
             ${{ matrix.cli_artifact_name }}
             ${{ steps.server-bundle.outputs.bundle_path }}
+            ${{ steps.cli-bundle.outputs.cli_bundle_path }}
+            ${{ steps.update-manifest.outputs.manifest_path }}
 
       - name: Upload server wheel artefact (for cross-job collection)
         uses: actions/upload-artifact@v4
@@ -341,6 +366,8 @@ jobs:
             ${{ matrix.artifact_name }}
             ${{ matrix.cli_artifact_name }}
             ${{ steps.server-bundle.outputs.bundle_path }}
+            ${{ steps.cli-bundle.outputs.cli_bundle_path }}
+            ${{ steps.update-manifest.outputs.manifest_path }}
             pkg/dcc-mcp-server-bin/wheels/*.whl
 
   # ── Build dcc-mcp-core-semantic companion wheels (issue #1395) ──
@@ -794,6 +821,8 @@ jobs:
             '^dcc-mcp-server-'
             '^dcc-mcp-cli-'
             '^dcc-mcp-server-[0-9A-Za-z.+-]+-(linux-x86_64|windows-x86_64|macos-universal2)\.zip$'
+            '^dcc-mcp-cli-[0-9A-Za-z.+-]+-(linux-x86_64|windows-x86_64|macos-universal2)\.zip$'
+            '^dcc-mcp-update-manifest-(linux-x86_64|windows-x86_64|macos-universal2)\.json$'
           )
 
           release_json=""

--- a/scripts/release/build_cli_bundle.py
+++ b/scripts/release/build_cli_bundle.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Build a standalone dcc-mcp-cli release zip."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import sys
+from zipfile import ZIP_DEFLATED
+from zipfile import ZipFile
+from zipfile import ZipInfo
+
+
+def _github_error(message: str) -> None:
+    print(f"::error::{message}", file=sys.stderr)
+
+
+def _validate_filename_part(name: str, *, label: str) -> str:
+    if not name:
+        raise ValueError(f"{label} is required")
+    if any(sep in name for sep in ("/", "\\")):
+        raise ValueError(f"{label} must be a filename component, got {name!r}")
+    return name
+
+
+def _write_binary(zf: ZipFile, source: Path, archive_name: str) -> None:
+    if not source.is_file():
+        raise FileNotFoundError(f"release binary not found: {source}")
+
+    info = ZipInfo.from_file(source, arcname=archive_name)
+    info.compress_type = ZIP_DEFLATED
+    with source.open("rb") as src, zf.open(info, "w") as dst:
+        shutil.copyfileobj(src, dst)
+
+
+def build_bundle(
+    *,
+    version: str,
+    platform: str,
+    cli_bin: Path,
+    out_dir: Path,
+) -> Path:
+    """Create a deployable CLI zip and return its path."""
+    version = _validate_filename_part(version, label="version")
+    platform = _validate_filename_part(platform, label="platform")
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    bundle_path = out_dir / f"dcc-mcp-cli-{version}-{platform}.zip"
+
+    suffix = ".exe" if cli_bin.suffix.lower() == ".exe" else ""
+    archive_name = f"dcc-mcp-cli{suffix}"
+
+    with ZipFile(bundle_path, "w", ZIP_DEFLATED) as zf:
+        _write_binary(zf, cli_bin, archive_name)
+
+    return bundle_path
+
+
+def main() -> int:
+    """Run the CLI bundle builder."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--platform", required=True)
+    parser.add_argument("--cli-bin", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=Path())
+    args = parser.parse_args()
+
+    try:
+        bundle_path = build_bundle(
+            version=args.version,
+            platform=args.platform,
+            cli_bin=args.cli_bin,
+            out_dir=args.out_dir,
+        )
+    except Exception as exc:
+        _github_error(str(exc))
+        raise SystemExit(1) from exc
+
+    bundle_output = bundle_path.as_posix()
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a", encoding="utf-8") as fh:
+            fh.write(f"cli_bundle_path={bundle_output}\n")
+    print(bundle_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/generate_update_manifest.py
+++ b/scripts/release/generate_update_manifest.py
@@ -53,6 +53,7 @@ def generate_manifest(
         out_dir: Output directory for the manifest.
 
     Returns:
+
         Path to the generated manifest file.
     """
     manifest: dict[str, dict] = {}
@@ -83,6 +84,7 @@ def generate_manifest(
 
 
 def main() -> int:
+    """Run the update manifest generator."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--version", required=True)
     parser.add_argument("--platform", required=True)

--- a/scripts/release/generate_update_manifest.py
+++ b/scripts/release/generate_update_manifest.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Generate the update manifest JSON for the release.
+
+Produces a platform-specific manifest that maps binary names to their
+version, download URL, and SHA-256 checksum. The gateway's update-check
+endpoint fetches this manifest via ``DCC_MCP_UPDATE_MANIFEST_URL``.
+
+Output: ``dcc-mcp-update-manifest-<platform>.json``
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+
+
+def _github_error(message: str) -> None:
+    print(f"::error::{message}", file=sys.stderr)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(8192)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def generate_manifest(
+    *,
+    version: str,
+    platform: str,
+    release_tag: str,
+    repo: str,
+    assets: dict[str, Path],
+    out_dir: Path,
+) -> Path:
+    """Generate the update manifest file.
+
+    Args:
+        version: Release version (e.g. ``0.19.0``).
+        platform: Platform label (e.g. ``linux-x86_64``).
+        release_tag: GitHub release tag (e.g. ``v0.19.0``).
+        repo: GitHub repository (e.g. ``dcc-mcp/dcc-mcp-core``).
+        assets: Mapping of logical binary names to their filesystem paths.
+        out_dir: Output directory for the manifest.
+
+    Returns:
+        Path to the generated manifest file.
+    """
+    manifest: dict[str, dict] = {}
+
+    for binary_name, asset_path in assets.items():
+        if not asset_path.is_file():
+            _github_error(f"Asset not found for {binary_name}: {asset_path}")
+            continue
+
+        asset_filename = asset_path.name
+        download_url = (
+            f"https://github.com/{repo}/releases/download/{release_tag}/{asset_filename}"
+        )
+        sha256_digest = _sha256(asset_path)
+
+        manifest[binary_name] = {
+            "version": version,
+            "url": download_url,
+            "sha256": sha256_digest,
+            "release_notes": None,
+        }
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = out_dir / f"dcc-mcp-update-manifest-{platform}.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    return manifest_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--platform", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--repo", default="dcc-mcp/dcc-mcp-core")
+    parser.add_argument("--server-bin", type=Path, required=True)
+    parser.add_argument("--cli-bin", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=Path())
+    args = parser.parse_args()
+
+    assets = {
+        "dcc-mcp-server": args.server_bin,
+        "dcc-mcp-cli": args.cli_bin,
+    }
+
+    try:
+        manifest_path = generate_manifest(
+            version=args.version,
+            platform=args.platform,
+            release_tag=args.release_tag,
+            repo=args.repo,
+            assets=assets,
+            out_dir=args.out_dir,
+        )
+    except Exception as exc:
+        _github_error(str(exc))
+        raise SystemExit(1) from exc
+
+    manifest_output = manifest_path.as_posix()
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a", encoding="utf-8") as fh:
+            fh.write(f"manifest_path={manifest_output}\n")
+    print(manifest_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/generate_update_manifest.py
+++ b/scripts/release/generate_update_manifest.py
@@ -53,8 +53,8 @@ def generate_manifest(
         out_dir: Output directory for the manifest.
 
     Returns:
-
         Path to the generated manifest file.
+
     """
     manifest: dict[str, dict] = {}
 

--- a/scripts/release/generate_update_manifest.py
+++ b/scripts/release/generate_update_manifest.py
@@ -64,9 +64,7 @@ def generate_manifest(
             continue
 
         asset_filename = asset_path.name
-        download_url = (
-            f"https://github.com/{repo}/releases/download/{release_tag}/{asset_filename}"
-        )
+        download_url = f"https://github.com/{repo}/releases/download/{release_tag}/{asset_filename}"
         sha256_digest = _sha256(asset_path)
 
         manifest[binary_name] = {


### PR DESCRIPTION
## Summary

- Add CLI standalone ZIP (dcc-mcp-cli-<version>-<platform>.zip) for manual installation, analogous to the existing server ZIP bundle
- Add update manifest generator that produces per-platform manifests with version, download URL, and SHA-256 for each binary -- consumed by the gateway auto-update endpoints
- Update release.yml to build and upload both new assets to GitHub Release

## Changes

| File | Action | Description |
|------|--------|-------------|
| scripts/release/build_cli_bundle.py | Add | CLI-only ZIP builder (unsuffixed dcc-mcp-cli binary) |
| scripts/release/generate_update_manifest.py | Add | Per-platform update manifest JSON with SHA-256 checksums |
| .github/workflows/release.yml | Modify | CLI ZIP + manifest build/upload steps + Multica asset patterns |

## Test plan

- Python syntax verified for new scripts
- Release pipeline should produce CLI ZIP + manifest as GitHub Release assets
- CLI and server update subcommands work end-to-end when DCC_MCP_UPDATE_MANIFEST_URL points to the generated manifest
