### PR TITLE
refactor: Phase 1 unsafe cleanup — shared test-utils, bytemuck shm, safe pyo3 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -1216,6 +1230,7 @@ dependencies = [
  "dcc-mcp-skill-rest",
  "dcc-mcp-skills",
  "dcc-mcp-telemetry",
+ "dcc-mcp-test-utils",
  "dcc-mcp-transport",
  "dcc-mcp-updater",
  "futures",
@@ -1263,6 +1278,7 @@ name = "dcc-mcp-gateway-ensure"
 version = "0.18.23"
 dependencies = [
  "anyhow",
+ "dcc-mcp-test-utils",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -1487,6 +1503,7 @@ name = "dcc-mcp-marketplace"
 version = "0.18.23"
 dependencies = [
  "dcc-mcp-catalog",
+ "dcc-mcp-test-utils",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -1675,6 +1692,7 @@ dependencies = [
  "dcc-mcp-sidecar",
  "dcc-mcp-skills",
  "dcc-mcp-telemetry",
+ "dcc-mcp-test-utils",
  "dcc-mcp-transport",
  "dcc-mcp-updater",
  "futures-util",
@@ -1700,6 +1718,7 @@ dependencies = [
 name = "dcc-mcp-shm"
 version = "0.18.23"
 dependencies = [
+ "bytemuck",
  "ipckit",
  "libc",
  "lz4_flex",
@@ -1725,6 +1744,7 @@ dependencies = [
  "dcc-mcp-gateway",
  "dcc-mcp-gateway-ensure",
  "dcc-mcp-host-rpc",
+ "dcc-mcp-test-utils",
  "dcc-mcp-transport",
  "libc",
  "reqwest 0.13.4",
@@ -1747,6 +1767,7 @@ dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-models",
  "dcc-mcp-skills",
+ "dcc-mcp-test-utils",
  "futures",
  "parking_lot",
  "serde",
@@ -1770,6 +1791,7 @@ dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-paths",
  "dcc-mcp-pybridge",
+ "dcc-mcp-test-utils",
  "dirs",
  "notify",
  "parking_lot",
@@ -1807,6 +1829,13 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "workspace-hack",
+]
+
+[[package]]
+name = "dcc-mcp-test-utils"
+version = "0.18.23"
+dependencies = [
  "workspace-hack",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7976,6 +7976,7 @@ dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
+ "bytemuck",
  "cc",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "crates/dcc-mcp-db",
     "crates/dcc-mcp-semantic",
     "crates/dcc-mcp-updater",
+    "crates/dcc-mcp-test-utils",
     "crates/workspace-hack",
 ]
 resolver = "2"
@@ -137,6 +138,9 @@ base64 = "0.22"
 # only when the `job-persist-sqlite` feature is enabled on `dcc-mcp-http`;
 # otherwise zero SQLite code compiles into the wheel.
 rusqlite = { version = "0.39", features = ["bundled"] }
+
+# Safe zero-copy (de)serialisation for shared-memory headers.
+bytemuck = { version = "1.22", features = ["derive", "extern_crate_alloc", "min_const_generics"] }
 
 # JWT bearer auth for the tunnel relay (issue #504). HS256 today; RS256/EdDSA
 # can be added in a later PR without touching the protocol crate's public API.

--- a/crates/dcc-mcp-gateway-ensure/Cargo.toml
+++ b/crates/dcc-mcp-gateway-ensure/Cargo.toml
@@ -19,3 +19,4 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 tempfile = "3"
+dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }

--- a/crates/dcc-mcp-gateway-ensure/src/lib.rs
+++ b/crates/dcc-mcp-gateway-ensure/src/lib.rs
@@ -613,10 +613,8 @@ pub fn default_registry_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use dcc_mcp_test_utils::EnvVarGuard;
     use tempfile::TempDir;
-
-    static REGISTRY_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     // ── PID file tests ─────────────────────────────────────────────────
 
@@ -902,15 +900,9 @@ mod tests {
 
     #[test]
     fn test_default_registry_dir_matches_gateway_runner_and_sidecar_fallback() {
-        let _guard = REGISTRY_ENV_LOCK.lock().expect("registry env lock");
-        let saved = std::env::var("DCC_MCP_REGISTRY_DIR").ok();
-        unsafe { std::env::remove_var("DCC_MCP_REGISTRY_DIR") };
+        let _guard = EnvVarGuard::set("DCC_MCP_REGISTRY_DIR", None);
 
         let dir = default_registry_dir();
-
-        if let Some(prev) = saved {
-            unsafe { std::env::set_var("DCC_MCP_REGISTRY_DIR", prev) };
-        }
 
         assert_eq!(
             dir,
@@ -921,18 +913,10 @@ mod tests {
 
     #[test]
     fn test_default_registry_dir_honours_env_var_override() {
-        let _guard = REGISTRY_ENV_LOCK.lock().expect("registry env lock");
-        let saved = std::env::var("DCC_MCP_REGISTRY_DIR").ok();
         let custom = std::env::temp_dir().join("dcc-mcp-cli-registry-test");
-        unsafe { std::env::set_var("DCC_MCP_REGISTRY_DIR", &custom) };
+        let _guard = EnvVarGuard::set("DCC_MCP_REGISTRY_DIR", custom.to_str());
 
         let dir = default_registry_dir();
-
-        if let Some(prev) = saved {
-            unsafe { std::env::set_var("DCC_MCP_REGISTRY_DIR", prev) };
-        } else {
-            unsafe { std::env::remove_var("DCC_MCP_REGISTRY_DIR") };
-        }
 
         assert_eq!(dir, custom);
     }

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -71,6 +71,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"
 criterion = { version = "0.8", features = ["html_reports"] }
 tower = { version = "0.5", features = ["util"] }
 proptest = "1.5"
+dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }
 
 [[bench]]
 name = "search_bench"

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/catalog.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/catalog.rs
@@ -299,10 +299,9 @@ mod tests {
 
     // ── build_payload end-to-end (YAML → JSON) ───────────────────────────
 
+    use dcc_mcp_test_utils::EnvVarsGuard;
     use std::io::Write;
     use tempfile::NamedTempFile;
-
-    static CATALOG_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
     fn write_catalog_yaml(content: &str) -> NamedTempFile {
         let mut f = NamedTempFile::new().unwrap();
@@ -337,14 +336,12 @@ entries:
 
     #[tokio::test]
     async fn build_payload_list_empty_query_returns_all() {
-        let _env_guard = CATALOG_ENV_LOCK.lock().await;
         LOADER.clear_cache().await;
         let f = write_catalog_yaml(TWO_ENTRY_YAML);
-        // SAFETY: process-wide env mutation is serialized by CATALOG_ENV_LOCK.
-        unsafe {
-            std::env::set_var("DCC_MCP_MARKETPLACE_OFFLINE", "1");
-            std::env::set_var("DCC_MCP_CATALOG_PATH", f.path());
-        }
+        let _g = EnvVarsGuard::set(&[
+            ("DCC_MCP_MARKETPLACE_OFFLINE", Some("1")),
+            ("DCC_MCP_CATALOG_PATH", f.path().to_str()),
+        ]);
 
         let v = build_payload(&Query::List {
             query: String::new(),
@@ -353,23 +350,16 @@ entries:
         .expect("build_payload should succeed");
 
         assert_eq!(v["total"], 2);
-        // SAFETY: cleanup symmetrical to set_var above.
-        unsafe {
-            std::env::remove_var("DCC_MCP_MARKETPLACE_OFFLINE");
-            std::env::remove_var("DCC_MCP_CATALOG_PATH");
-        }
     }
 
     #[tokio::test]
     async fn build_payload_list_keyword_filters_results() {
-        let _env_guard = CATALOG_ENV_LOCK.lock().await;
         LOADER.clear_cache().await;
         let f = write_catalog_yaml(TWO_ENTRY_YAML);
-        // SAFETY: process-wide env mutation is serialized by CATALOG_ENV_LOCK.
-        unsafe {
-            std::env::set_var("DCC_MCP_MARKETPLACE_OFFLINE", "1");
-            std::env::set_var("DCC_MCP_CATALOG_PATH", f.path());
-        }
+        let _g = EnvVarsGuard::set(&[
+            ("DCC_MCP_MARKETPLACE_OFFLINE", Some("1")),
+            ("DCC_MCP_CATALOG_PATH", f.path().to_str()),
+        ]);
 
         let v = build_payload(&Query::List {
             query: "maya".to_string(),
@@ -379,23 +369,16 @@ entries:
 
         assert_eq!(v["total"], 1);
         assert_eq!(v["entries"][0]["name"], "maya-skills");
-        // SAFETY: see above.
-        unsafe {
-            std::env::remove_var("DCC_MCP_MARKETPLACE_OFFLINE");
-            std::env::remove_var("DCC_MCP_CATALOG_PATH");
-        }
     }
 
     #[tokio::test]
     async fn build_payload_single_existing_entry_returns_data() {
-        let _env_guard = CATALOG_ENV_LOCK.lock().await;
         LOADER.clear_cache().await;
         let f = write_catalog_yaml(ONE_ENTRY_YAML);
-        // SAFETY: process-wide env mutation is serialized by CATALOG_ENV_LOCK.
-        unsafe {
-            std::env::set_var("DCC_MCP_MARKETPLACE_OFFLINE", "1");
-            std::env::set_var("DCC_MCP_CATALOG_PATH", f.path());
-        }
+        let _g = EnvVarsGuard::set(&[
+            ("DCC_MCP_MARKETPLACE_OFFLINE", Some("1")),
+            ("DCC_MCP_CATALOG_PATH", f.path().to_str()),
+        ]);
 
         let v = build_payload(&Query::Single {
             name: "maya-skills".to_string(),
@@ -405,23 +388,16 @@ entries:
 
         assert_eq!(v["name"], "maya-skills");
         assert_eq!(v["dcc"][0], "maya");
-        // SAFETY: see above.
-        unsafe {
-            std::env::remove_var("DCC_MCP_MARKETPLACE_OFFLINE");
-            std::env::remove_var("DCC_MCP_CATALOG_PATH");
-        }
     }
 
     #[tokio::test]
     async fn build_payload_single_missing_entry_errors() {
-        let _env_guard = CATALOG_ENV_LOCK.lock().await;
         LOADER.clear_cache().await;
         let f = write_catalog_yaml(ONE_ENTRY_YAML);
-        // SAFETY: process-wide env mutation is serialized by CATALOG_ENV_LOCK.
-        unsafe {
-            std::env::set_var("DCC_MCP_MARKETPLACE_OFFLINE", "1");
-            std::env::set_var("DCC_MCP_CATALOG_PATH", f.path());
-        }
+        let _g = EnvVarsGuard::set(&[
+            ("DCC_MCP_MARKETPLACE_OFFLINE", Some("1")),
+            ("DCC_MCP_CATALOG_PATH", f.path().to_str()),
+        ]);
 
         let err = build_payload(&Query::Single {
             name: "does-not-exist".to_string(),
@@ -430,10 +406,5 @@ entries:
         .expect_err("missing entry should return Err");
 
         assert!(err.contains("not found"));
-        // SAFETY: see above.
-        unsafe {
-            std::env::remove_var("DCC_MCP_MARKETPLACE_OFFLINE");
-            std::env::remove_var("DCC_MCP_CATALOG_PATH");
-        }
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/traffic/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/traffic/mod.rs
@@ -561,12 +561,10 @@ fn truthy_env(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dcc_mcp_test_utils::{EnvVarGuard, EnvVarsGuard};
     use serde_json::Value;
     use std::io::Write;
     use std::path::PathBuf;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn sample_frame(method: &str, url: &str) -> TrafficFrame {
         TrafficFrame::json(
@@ -789,26 +787,16 @@ redact:
 
     #[test]
     fn production_profile_blocks_env_capture_without_force() {
-        let _guard = ENV_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let capture_path = dir.path().join("capture.jsonl");
-        // SAFETY: serialized by ENV_LOCK for this test module.
-        unsafe {
-            std::env::set_var(ENV_PROD_PROFILE, "1");
-            std::env::remove_var(ENV_FORCE_CAPTURE);
-            std::env::set_var(ENV_CAPTURE, format!("jsonl:{}", capture_path.display()));
-            std::env::remove_var(ENV_CONFIG);
-        }
+        let _guard = EnvVarsGuard::set(&[
+            (ENV_PROD_PROFILE, Some("1")),
+            (ENV_FORCE_CAPTURE, None),
+            (ENV_CAPTURE, Some(capture_path.to_str().unwrap_or(""))),
+            (ENV_CONFIG, None),
+        ]);
 
         let err = TrafficCapture::from_env().unwrap_err();
         assert!(matches!(err, TrafficCaptureError::ProdProfileBlocked));
-
-        // SAFETY: serialized by ENV_LOCK for this test module.
-        unsafe {
-            std::env::remove_var(ENV_PROD_PROFILE);
-            std::env::remove_var(ENV_FORCE_CAPTURE);
-            std::env::remove_var(ENV_CAPTURE);
-            std::env::remove_var(ENV_CONFIG);
-        }
     }
 }

--- a/crates/dcc-mcp-marketplace/Cargo.toml
+++ b/crates/dcc-mcp-marketplace/Cargo.toml
@@ -22,3 +22,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tempfile = "3"
+dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -1294,27 +1294,27 @@ mod tests {
 
     #[test]
     fn default_sources_disabled_false_when_unset() {
-        // SAFETY: test-only env manipulation; isolated to this specific var.
-        unsafe { std::env::remove_var(ENV_MARKETPLACE_NO_DEFAULT_SOURCES) };
+        let _guard = dcc_mcp_test_utils::EnvVarGuard::set(ENV_MARKETPLACE_NO_DEFAULT_SOURCES, None);
         assert!(!default_sources_disabled());
     }
 
     #[test]
     fn default_sources_disabled_respects_truthy_values() {
-        // Save/restore to avoid leaking across tests.
-        let saved = std::env::var(ENV_MARKETPLACE_NO_DEFAULT_SOURCES).ok();
+        // EnvVarGuard saves the current value and restores it on drop.
+        // Inside the loop we mutate directly under the guard's serialised
+        // scope (edition 2024 makes set_var unsafe, but the RAII guard
+        // ensures cleanup even on panic).
+        let _guard =
+            dcc_mcp_test_utils::EnvVarGuard::set(ENV_MARKETPLACE_NO_DEFAULT_SOURCES, Some("1"));
         for v in ["1", "true", "TRUE", "yes", "YES"] {
+            // SAFETY: serialized by EnvVarGuard which restores on drop.
             unsafe { std::env::set_var(ENV_MARKETPLACE_NO_DEFAULT_SOURCES, v) };
             assert!(default_sources_disabled(), "expected true for '{v}'");
         }
         for v in ["0", "false", "no", "", "FALSE", "NO"] {
+            // SAFETY: serialized by EnvVarGuard which restores on drop.
             unsafe { std::env::set_var(ENV_MARKETPLACE_NO_DEFAULT_SOURCES, v) };
             assert!(!default_sources_disabled(), "expected false for '{v}'");
-        }
-        // Restore original value (or unset).
-        match saved {
-            Some(v) => unsafe { std::env::set_var(ENV_MARKETPLACE_NO_DEFAULT_SOURCES, v) },
-            None => unsafe { std::env::remove_var(ENV_MARKETPLACE_NO_DEFAULT_SOURCES) },
         }
     }
 }

--- a/crates/dcc-mcp-server/Cargo.toml
+++ b/crates/dcc-mcp-server/Cargo.toml
@@ -133,3 +133,4 @@ sentry = ["dep:sentry"]
 [dev-dependencies]
 tempfile = "3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }

--- a/crates/dcc-mcp-server/src/main_tests.rs
+++ b/crates/dcc-mcp-server/src/main_tests.rs
@@ -1,54 +1,7 @@
 use super::*;
-#[cfg(feature = "telemetry")]
-use std::sync::{Mutex, MutexGuard};
 
 #[cfg(feature = "telemetry")]
-static OTLP_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-#[cfg(feature = "telemetry")]
-struct EnvVarsGuard {
-    previous: Vec<(&'static str, Option<String>)>,
-    _lock: MutexGuard<'static, ()>,
-}
-
-#[cfg(feature = "telemetry")]
-impl EnvVarsGuard {
-    fn set(vars: &[(&'static str, Option<&str>)]) -> Self {
-        let lock = OTLP_ENV_LOCK.lock().expect("env lock poisoned");
-        let previous = vars
-            .iter()
-            .map(|(key, _)| (*key, std::env::var(key).ok()))
-            .collect::<Vec<_>>();
-        // SAFETY: serialized by OTLP_ENV_LOCK; tests restore previous values on drop.
-        unsafe {
-            for (key, value) in vars {
-                match value {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-        Self {
-            previous,
-            _lock: lock,
-        }
-    }
-}
-
-#[cfg(feature = "telemetry")]
-impl Drop for EnvVarsGuard {
-    fn drop(&mut self) {
-        // SAFETY: serialized by OTLP_ENV_LOCK held for the guard lifetime.
-        unsafe {
-            for (key, value) in &self.previous {
-                match value {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-    }
-}
+use dcc_mcp_test_utils::EnvVarsGuard;
 
 #[test]
 fn no_log_file_disables_default_file_logging() {

--- a/crates/dcc-mcp-server/src/sentry_init.rs
+++ b/crates/dcc-mcp-server/src/sentry_init.rs
@@ -178,89 +178,8 @@ mod tests {
     use super::{
         DEFAULT_SENTRY_CONFIG_FILE, ENV_DCC_MCP_ETC_DIR, init_sentry, resolved_sentry_config,
     };
-    use std::sync::{Mutex, MutexGuard};
+    use dcc_mcp_test_utils::{EnvVarGuard, EnvVarsGuard};
     use std::time::Duration;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<String>,
-        _lock: MutexGuard<'static, ()>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: Option<&str>) -> Self {
-            let lock = ENV_LOCK.lock().expect("env lock poisoned");
-            let previous = std::env::var(key).ok();
-            // SAFETY: serialized by ENV_LOCK; tests restore previous values on drop.
-            unsafe {
-                match value {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-            Self {
-                key,
-                previous,
-                _lock: lock,
-            }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            // SAFETY: serialized by ENV_LOCK held for the guard lifetime.
-            unsafe {
-                match &self.previous {
-                    Some(v) => std::env::set_var(self.key, v),
-                    None => std::env::remove_var(self.key),
-                }
-            }
-        }
-    }
-
-    struct EnvVarsGuard {
-        previous: Vec<(&'static str, Option<String>)>,
-        _lock: MutexGuard<'static, ()>,
-    }
-
-    impl EnvVarsGuard {
-        fn set(vars: &[(&'static str, Option<&str>)]) -> Self {
-            let lock = ENV_LOCK.lock().expect("env lock poisoned");
-            let previous = vars
-                .iter()
-                .map(|(key, _)| (*key, std::env::var(key).ok()))
-                .collect::<Vec<_>>();
-            // SAFETY: serialized by ENV_LOCK; tests restore previous values on drop.
-            unsafe {
-                for (key, value) in vars {
-                    match value {
-                        Some(v) => std::env::set_var(key, v),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
-            Self {
-                previous,
-                _lock: lock,
-            }
-        }
-    }
-
-    impl Drop for EnvVarsGuard {
-        fn drop(&mut self) {
-            // SAFETY: serialized by ENV_LOCK held for the guard lifetime.
-            unsafe {
-                for (key, value) in &self.previous {
-                    match value {
-                        Some(v) => std::env::set_var(key, v),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
-        }
-    }
 
     #[test]
     fn init_sentry_absent_dsn_returns_none() {
@@ -351,13 +270,11 @@ mod tests {
             }
         };
 
-        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        // SAFETY: serialized by ENV_LOCK; e2e probe restores env when the lock drops.
-        unsafe {
-            std::env::set_var("DCC_MCP_SENTRY_DSN", &dsn);
-            std::env::set_var("DCC_MCP_SENTRY_ENVIRONMENT", "ci-e2e");
-            std::env::set_var("DCC_MCP_SENTRY_SAMPLE_RATE", "1.0");
-        }
+        let _g = EnvVarsGuard::set(&[
+            ("DCC_MCP_SENTRY_DSN", Some(&dsn)),
+            ("DCC_MCP_SENTRY_ENVIRONMENT", Some("ci-e2e")),
+            ("DCC_MCP_SENTRY_SAMPLE_RATE", Some("1.0")),
+        ]);
 
         let guard = init_sentry().expect("valid DCC_MCP_SENTRY_DSN should initialise Sentry");
         let probe = format!("dcc-mcp-core sentry e2e probe {}", uuid::Uuid::new_v4());

--- a/crates/dcc-mcp-shm/Cargo.toml
+++ b/crates/dcc-mcp-shm/Cargo.toml
@@ -18,6 +18,7 @@ uuid.workspace = true
 parking_lot.workspace = true
 ipckit.workspace = true
 lz4_flex.workspace = true
+bytemuck.workspace = true
 
 # PyO3 (optional)
 pyo3 = { workspace = true, optional = true }

--- a/crates/dcc-mcp-shm/src/buffer.rs
+++ b/crates/dcc-mcp-shm/src/buffer.rs
@@ -32,6 +32,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use bytemuck::{bytes_of, pod_read_unaligned, AnyBitPattern, NoUninit};
 use ipckit::SharedMemory;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -45,7 +46,7 @@ use crate::error::{ShmError, ShmResult};
 ///
 /// Total size: 48 bytes.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, AnyBitPattern, NoUninit)]
 pub(crate) struct RegionHeader {
     /// Magic marker to detect corruption (0xDCC0_0000_5348_4D01).
     pub magic: u64,
@@ -184,9 +185,7 @@ impl SharedBuffer {
             compressed: 0,
             _pad: [0u8; 7],
         };
-        let header_bytes = unsafe {
-            std::slice::from_raw_parts(&header as *const RegionHeader as *const u8, HEADER_SIZE)
-        };
+        let header_bytes = bytes_of(&header);
         shm.write(0, header_bytes)
             .map_err(|e| ShmError::Internal(format!("header write failed: {e}")))?;
 
@@ -227,8 +226,7 @@ impl SharedBuffer {
         let header_bytes = shm
             .read(0, HEADER_SIZE)
             .map_err(|e| ShmError::Internal(format!("header read failed: {e}")))?;
-        let header: RegionHeader =
-            unsafe { std::ptr::read_unaligned(header_bytes.as_ptr() as *const RegionHeader) };
+        let header: RegionHeader = pod_read_unaligned(&header_bytes);
         if header.magic != HEADER_MAGIC {
             return Err(ShmError::Internal("invalid magic bytes in header".into()));
         }
@@ -288,9 +286,7 @@ impl SharedBuffer {
             compressed: 0,
             _pad: [0u8; 7],
         };
-        let header_bytes = unsafe {
-            std::slice::from_raw_parts(&header as *const RegionHeader as *const u8, HEADER_SIZE)
-        };
+        let header_bytes = bytes_of(&header);
         shm.write(0, header_bytes)
             .map_err(|e| ShmError::Internal(format!("header write failed: {e}")))?;
 
@@ -343,9 +339,7 @@ impl SharedBuffer {
             compressed: 0,
             _pad: [0u8; 7],
         };
-        let header_bytes = unsafe {
-            std::slice::from_raw_parts(&header as *const RegionHeader as *const u8, HEADER_SIZE)
-        };
+        let header_bytes = bytes_of(&header);
         shm.write(0, header_bytes)
             .map_err(|e| ShmError::Internal(format!("clear header write failed: {e}")))?;
         Ok(())
@@ -369,8 +363,7 @@ impl SharedBuffer {
             .read(0, HEADER_SIZE)
             .map_err(|e| ShmError::Internal(format!("header read failed: {e}")))?;
         // SAFETY: the region has been sized to hold the header at construction.
-        let header: RegionHeader =
-            unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const RegionHeader) };
+        let header: RegionHeader = pod_read_unaligned(&bytes);
         if header.magic != HEADER_MAGIC {
             return Err(ShmError::Internal("invalid magic bytes in header".into()));
         }
@@ -462,8 +455,7 @@ fn gc_orphans_scan(shm_dir: &str, max_age: Duration) -> usize {
             Ok(b) => b,
             Err(_) => continue,
         };
-        let header: RegionHeader =
-            unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const RegionHeader) };
+        let header: RegionHeader = pod_read_unaligned(&bytes);
         if header.magic != HEADER_MAGIC {
             continue;
         }

--- a/crates/dcc-mcp-shm/src/buffer.rs
+++ b/crates/dcc-mcp-shm/src/buffer.rs
@@ -32,7 +32,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use bytemuck::{bytes_of, pod_read_unaligned, AnyBitPattern, NoUninit};
+use bytemuck::{AnyBitPattern, NoUninit, bytes_of, pod_read_unaligned};
 use ipckit::SharedMemory;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};

--- a/crates/dcc-mcp-sidecar/Cargo.toml
+++ b/crates/dcc-mcp-sidecar/Cargo.toml
@@ -49,6 +49,7 @@ prometheus = ["dcc-mcp-gateway?/prometheus"]
 [dev-dependencies]
 tempfile = "3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/dcc-mcp-sidecar/src/gateway_daemon/guardian.rs
+++ b/crates/dcc-mcp-sidecar/src/gateway_daemon/guardian.rs
@@ -440,12 +440,12 @@ mod tests {
 
     #[test]
     fn settings_from_env_parses_positive_values() {
-        unsafe {
-            std::env::set_var("DCC_MCP_GATEWAY_GUARDIAN_INTERVAL", "3");
-            std::env::set_var("DCC_MCP_GATEWAY_GUARDIAN_TIMEOUT", "0.8");
-            std::env::set_var("DCC_MCP_GATEWAY_GUARDIAN_FAILURES", "4");
-            std::env::set_var("DCC_MCP_GATEWAY_GUARDIAN_REENSURE_JITTER_MAX", "1.5");
-        }
+        let _g = dcc_mcp_test_utils::EnvVarsGuard::set(&[
+            ("DCC_MCP_GATEWAY_GUARDIAN_INTERVAL", Some("3")),
+            ("DCC_MCP_GATEWAY_GUARDIAN_TIMEOUT", Some("0.8")),
+            ("DCC_MCP_GATEWAY_GUARDIAN_FAILURES", Some("4")),
+            ("DCC_MCP_GATEWAY_GUARDIAN_REENSURE_JITTER_MAX", Some("1.5")),
+        ]);
 
         let s = GatewayGuardianSettings::from_env();
         assert_eq!(s.interval(), Duration::from_secs(3));

--- a/crates/dcc-mcp-sidecar/src/sidecar_tests.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_tests.rs
@@ -8,17 +8,13 @@ use crate::sidecar::registry::{
     REGISTRATION_REFRESH_MODE_FILE_REGISTRY_HEARTBEAT, REGISTRATION_REFRESH_MODE_METADATA_KEY,
     REGISTRY_DIR_METADATA_KEY,
 };
+use dcc_mcp_test_utils::EnvVarGuard;
 use dcc_mcp_transport::discovery::types::{ServiceEntry, ServiceKey, ServiceStatus};
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::Mutex;
 use std::time::Instant;
 use tempfile::TempDir;
 use uuid::Uuid;
-
-// ── Regression: ``default_registry_dir`` must match GatewayRunner's ──
-
-static REGISTRY_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 #[cfg(feature = "gateway-daemon")]
 fn guardian_test_args() -> SidecarArgs {
@@ -46,30 +42,10 @@ fn guardian_test_args() -> SidecarArgs {
 
 #[test]
 fn default_registry_dir_matches_gateway_runner_fallback() {
-    let _guard = REGISTRY_ENV_LOCK.lock().expect("registry env lock");
-    // ``GatewayRunner::new`` (crates/dcc-mcp-gateway/src/gateway/
-    // runner.rs) falls back to ``std::env::temp_dir().join("dcc-mcp-
-    // registry")``. The sidecar binary MUST agree, otherwise an
-    // adapter that spawns a sidecar without forwarding
-    // ``--registry-dir`` will split-brain the registry.
-    //
-    // Wipe ``DCC_MCP_REGISTRY_DIR`` for this assertion so we hit the
-    // fallback path (the env-var path is tested separately below).
-    // Other parallel tests may also touch the env, but the value is
-    // restored at the end so the suite stays clean.
-    let saved = std::env::var("DCC_MCP_REGISTRY_DIR").ok();
-    // SAFETY: single-threaded mutation guarded by ``saved``/restore
-    // immediately after the call. Other tests in this file that
-    // touch ``DCC_MCP_REGISTRY_DIR`` would have set their own values
-    // and we don't disturb those.
-    unsafe { std::env::remove_var("DCC_MCP_REGISTRY_DIR") };
+    let _guard = EnvVarGuard::set("DCC_MCP_REGISTRY_DIR", None);
 
     let got = default_registry_dir();
     let expected = std::env::temp_dir().join("dcc-mcp-registry");
-
-    if let Some(prev) = saved {
-        unsafe { std::env::set_var("DCC_MCP_REGISTRY_DIR", prev) };
-    }
 
     assert_eq!(
         got, expected,
@@ -81,18 +57,10 @@ fn default_registry_dir_matches_gateway_runner_fallback() {
 
 #[test]
 fn default_registry_dir_honours_env_var_override() {
-    let _guard = REGISTRY_ENV_LOCK.lock().expect("registry env lock");
-    let saved = std::env::var("DCC_MCP_REGISTRY_DIR").ok();
     let custom = std::env::temp_dir().join("dcc-mcp-custom-registry-test");
-    unsafe { std::env::set_var("DCC_MCP_REGISTRY_DIR", &custom) };
+    let _guard = EnvVarGuard::set("DCC_MCP_REGISTRY_DIR", Some(custom.to_str().unwrap_or("")));
 
     let got = default_registry_dir();
-
-    if let Some(prev) = saved {
-        unsafe { std::env::set_var("DCC_MCP_REGISTRY_DIR", prev) };
-    } else {
-        unsafe { std::env::remove_var("DCC_MCP_REGISTRY_DIR") };
-    }
 
     assert_eq!(
         got, custom,
@@ -275,17 +243,9 @@ fn sidecar_service_entry_reports_gateway_guardian_metadata() {
 #[cfg(feature = "gateway-daemon")]
 #[test]
 fn gateway_daemon_options_clamp_tiny_nonzero_idle_timeout() {
-    let _guard = REGISTRY_ENV_LOCK.lock().expect("registry env lock");
-    let saved = std::env::var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS").ok();
-    unsafe { std::env::set_var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", "1") };
+    let _guard = EnvVarGuard::set("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", Some("1"));
 
     let opts = build_gateway_daemon_options(&guardian_test_args(), PathBuf::from("registry"));
-
-    if let Some(prev) = saved {
-        unsafe { std::env::set_var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", prev) };
-    } else {
-        unsafe { std::env::remove_var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS") };
-    }
 
     assert_eq!(
         opts.gateway_idle_timeout_secs, 30,
@@ -296,17 +256,9 @@ fn gateway_daemon_options_clamp_tiny_nonzero_idle_timeout() {
 #[cfg(feature = "gateway-daemon")]
 #[test]
 fn gateway_daemon_options_preserve_zero_idle_timeout_as_persist() {
-    let _guard = REGISTRY_ENV_LOCK.lock().expect("registry env lock");
-    let saved = std::env::var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS").ok();
-    unsafe { std::env::set_var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", "0") };
+    let _guard = EnvVarGuard::set("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", Some("0"));
 
     let opts = build_gateway_daemon_options(&guardian_test_args(), PathBuf::from("registry"));
-
-    if let Some(prev) = saved {
-        unsafe { std::env::set_var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", prev) };
-    } else {
-        unsafe { std::env::remove_var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS") };
-    }
 
     assert_eq!(
         opts.gateway_idle_timeout_secs, 0,
@@ -339,15 +291,9 @@ fn gateway_daemon_options_preserve_host_name_and_registry() {
 #[cfg(feature = "gateway-daemon")]
 #[test]
 fn gateway_daemon_options_default_idle_timeout_covers_startup_race() {
-    let _guard = REGISTRY_ENV_LOCK.lock().expect("registry env lock");
-    let saved = std::env::var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS").ok();
-    unsafe { std::env::remove_var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS") };
+    let _guard = EnvVarGuard::set("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", None);
 
     let opts = build_gateway_daemon_options(&guardian_test_args(), PathBuf::from("registry"));
-
-    if let Some(prev) = saved {
-        unsafe { std::env::set_var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", prev) };
-    }
 
     assert_eq!(
         opts.gateway_idle_timeout_secs, SIDECAR_GATEWAY_IDLE_TIMEOUT_SECS,
@@ -358,17 +304,9 @@ fn gateway_daemon_options_default_idle_timeout_covers_startup_race() {
 #[cfg(feature = "gateway-daemon")]
 #[test]
 fn gateway_daemon_options_honour_idle_timeout_env_override() {
-    let _guard = REGISTRY_ENV_LOCK.lock().expect("registry env lock");
-    let saved = std::env::var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS").ok();
-    unsafe { std::env::set_var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", "45") };
+    let _guard = EnvVarGuard::set("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", Some("45"));
 
     let opts = build_gateway_daemon_options(&guardian_test_args(), PathBuf::from("registry"));
-
-    if let Some(prev) = saved {
-        unsafe { std::env::set_var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", prev) };
-    } else {
-        unsafe { std::env::remove_var("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS") };
-    }
 
     assert_eq!(opts.gateway_idle_timeout_secs, 45);
 }

--- a/crates/dcc-mcp-skill-rest/Cargo.toml
+++ b/crates/dcc-mcp-skill-rest/Cargo.toml
@@ -39,3 +39,4 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 axum-test = "20"
+dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }

--- a/crates/dcc-mcp-skill-rest/src/tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/tests.rs
@@ -366,22 +366,16 @@ async fn docs_ui_served_and_can_be_disabled() {
     let (svc, _, _) = fixture_loaded_spheres();
     let (server, _) = build_server(svc);
 
-    unsafe {
-        std::env::remove_var("DCC_MCP_DOCS_UI");
-    }
+    let _g = dcc_mcp_test_utils::EnvVarGuard::set("DCC_MCP_DOCS_UI", None);
     let resp = server.get("/docs").await;
     resp.assert_status_ok();
     let html = resp.text();
     assert!(html.contains("scalar") || html.contains("Scalar"));
+    drop(_g);
 
-    unsafe {
-        std::env::set_var("DCC_MCP_DOCS_UI", "0");
-    }
+    let _g = dcc_mcp_test_utils::EnvVarGuard::set("DCC_MCP_DOCS_UI", Some("0"));
     let disabled = server.get("/docs").await;
     disabled.assert_status_not_found();
-    unsafe {
-        std::env::remove_var("DCC_MCP_DOCS_UI");
-    }
 }
 
 /// Context endpoint reports loaded skills and action count.

--- a/crates/dcc-mcp-skills/Cargo.toml
+++ b/crates/dcc-mcp-skills/Cargo.toml
@@ -33,6 +33,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [dev-dependencies]
 tempfile = "3"
 dcc-mcp-models = { workspace = true, features = ["testing"] }
+dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }
 
 [features]
 default = []

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -135,7 +135,7 @@ getattr(_mod, "__mcp_result__", {"success": True, "message": ""})
     .ok_or_else(|| {
         // Distinguish between "Python not initialized at all" and
         // "initialized but GIL not held / wrong thread".
-        let initialized = unsafe { pyo3::ffi::Py_IsInitialized() } != 0;
+        let initialized = pyo3::Python::is_initialized();
         if initialized {
             format!(
                 "Python interpreter is initialized but the GIL is not held; \

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -133,25 +133,13 @@ getattr(_mod, "__mcp_result__", {"success": True, "message": ""})
         py_any_to_json_value(&result_obj).map_err(|e| format!("result → JSON: {e}"))
     })
     .ok_or_else(|| {
-        // Distinguish between "Python not initialized at all" and
-        // "initialized but GIL not held / wrong thread".
-        let initialized = pyo3::Python::is_initialized();
-        if initialized {
-            format!(
-                "Python interpreter is initialized but the GIL is not held; \
-                 cannot execute '{script_path}' in-process. \
-                 Hint: ensure you are calling this from the main Python thread \
-                 or that the in-process executor is registered via \
-                 SkillCatalog::with_in_process_executor."
-            )
-        } else {
-            format!(
-                "Python interpreter is not initialized in this process; \
-                 cannot execute '{script_path}' in-process. \
-                 Hint: when running inside a DCC, register an in-process executor \
-                 via SkillCatalog::with_in_process_executor."
-            )
-        }
+        format!(
+            "Python interpreter is not initialized or the GIL is not held; \
+             cannot execute '{script_path}' in-process. \
+             Hint: ensure Python is initialized and you are calling this \
+             from the main Python thread, or register an in-process executor \
+             via SkillCatalog::with_in_process_executor."
+        )
     })
     .and_then(|r| r)
 }

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_env.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_env.rs
@@ -1,55 +1,28 @@
 //! Regression tests for issue #231 (silent ambient-python fallback) and
 //! GUI-executable guard.
 //!
-//! These tests manipulate process env vars. They run serially relative to
-//! each other — guarded by EXEC_ENV_MUTEX so parallel `cargo test` threads
-//! don't interleave SET/REMOVE calls.
+//! These tests manipulate process env vars. Each test wraps its env-var
+//! mutations in a shared [`EnvVarsGuard`] so that dropped values are
+//! restored atomically, even on panic.
 use super::*;
+use dcc_mcp_test_utils::EnvVarsGuard;
 
-static EXEC_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// RAII guard that clears the three Python-execution env vars for the
-/// duration of a test, restoring their prior values on drop.
-/// Holds [`EXEC_ENV_MUTEX`] to prevent parallel races.
-struct ExecEnvGuard<'a> {
-    _lock: std::sync::MutexGuard<'a, ()>,
-    saved: Vec<(&'static str, Option<String>)>,
-}
-
-impl<'a> ExecEnvGuard<'a> {
-    fn new() -> Self {
-        let lock = EXEC_ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        let keys = [
-            "DCC_MCP_PYTHON_EXECUTABLE",
-            "DCC_MCP_PYTHON_INIT_SNIPPET",
-            "DCC_MCP_ALLOW_AMBIENT_PYTHON",
-        ];
-        let saved: Vec<(&'static str, Option<String>)> =
-            keys.iter().map(|k| (*k, std::env::var(*k).ok())).collect();
-        for (k, _) in &saved {
-            // SAFETY: tests run serially for this module via EXEC_ENV_MUTEX.
-            unsafe { std::env::remove_var(k) };
-        }
-        Self { _lock: lock, saved }
-    }
-}
-
-impl<'a> Drop for ExecEnvGuard<'a> {
-    fn drop(&mut self) {
-        for (k, v) in &self.saved {
-            match v {
-                Some(val) => unsafe { std::env::set_var(k, val) },
-                None => unsafe { std::env::remove_var(k) },
-            }
-        }
-    }
+/// Clear the three Python-execution env vars and return a guard that restores
+/// them on drop. Individual tests may then `unsafe { set_var }` one of them
+/// under the guard's serialised scope.
+fn clear_exec_env() -> EnvVarsGuard {
+    EnvVarsGuard::set(&[
+        ("DCC_MCP_PYTHON_EXECUTABLE", None),
+        ("DCC_MCP_PYTHON_INIT_SNIPPET", None),
+        ("DCC_MCP_ALLOW_AMBIENT_PYTHON", None),
+    ])
 }
 
 // ── Ambient-python checks (issue #231) ──────────────────────────────────────
 
 #[test]
 fn test_execute_script_rejects_ambient_python_for_host_dcc() {
-    let _g = ExecEnvGuard::new();
+    let _g = clear_exec_env();
 
     let result = execute_script(
         "any_skill.py",
@@ -69,7 +42,7 @@ fn test_execute_script_rejects_ambient_python_for_host_dcc() {
 
 #[test]
 fn test_execute_script_rejects_ambient_python_case_insensitive() {
-    let _g = ExecEnvGuard::new();
+    let _g = clear_exec_env();
     let err = execute_script("any.py", serde_json::json!({}), Some("Houdini"))
         .expect_err("Houdini must also require a host python");
     assert!(err.contains("DCC_MCP_PYTHON_EXECUTABLE"));
@@ -77,7 +50,7 @@ fn test_execute_script_rejects_ambient_python_case_insensitive() {
 
 #[test]
 fn test_execute_script_allows_opt_out_via_env_var() {
-    let _g = ExecEnvGuard::new();
+    let _g = clear_exec_env();
     unsafe { std::env::set_var("DCC_MCP_ALLOW_AMBIENT_PYTHON", "1") };
 
     let result = execute_script("/does/not/exist.py", serde_json::json!({}), Some("maya"));
@@ -91,7 +64,7 @@ fn test_execute_script_allows_opt_out_via_env_var() {
 
 #[test]
 fn test_execute_script_skips_check_when_executable_set() {
-    let _g = ExecEnvGuard::new();
+    let _g = clear_exec_env();
     unsafe { std::env::set_var("DCC_MCP_PYTHON_EXECUTABLE", "python") };
 
     let result = execute_script("/does/not/exist.py", serde_json::json!({}), Some("maya"));
@@ -105,7 +78,7 @@ fn test_execute_script_skips_check_when_executable_set() {
 
 #[test]
 fn test_execute_script_allows_generic_python_dcc() {
-    let _g = ExecEnvGuard::new();
+    let _g = clear_exec_env();
     let result = execute_script("/does/not/exist.py", serde_json::json!({}), Some("python"));
     if let Err(err) = result {
         assert!(
@@ -117,7 +90,7 @@ fn test_execute_script_allows_generic_python_dcc() {
 
 #[test]
 fn test_execute_script_no_dcc_hint_does_not_trigger_check() {
-    let _g = ExecEnvGuard::new();
+    let _g = clear_exec_env();
     let result = execute_script("/does/not/exist.py", serde_json::json!({}), None);
     if let Err(err) = result {
         assert!(
@@ -131,7 +104,7 @@ fn test_execute_script_no_dcc_hint_does_not_trigger_check() {
 
 #[test]
 fn test_execute_script_rejects_gui_executable_maya_exe() {
-    let _g = ExecEnvGuard::new();
+    let _g = clear_exec_env();
     unsafe { std::env::set_var("DCC_MCP_PYTHON_EXECUTABLE", "maya.exe") };
 
     let result = execute_script("any_skill.py", serde_json::json!({}), None);
@@ -149,7 +122,7 @@ fn test_execute_script_rejects_gui_executable_maya_exe() {
 
 #[test]
 fn test_execute_script_rejects_gui_executable_case_insensitive() {
-    let _g = ExecEnvGuard::new();
+    let _g = clear_exec_env();
     unsafe {
         std::env::set_var(
             "DCC_MCP_PYTHON_EXECUTABLE",
@@ -167,7 +140,7 @@ fn test_execute_script_rejects_gui_executable_case_insensitive() {
 
 #[test]
 fn test_execute_script_rejects_gui_executable_blender() {
-    let _g = ExecEnvGuard::new();
+    let _g = clear_exec_env();
     unsafe { std::env::set_var("DCC_MCP_PYTHON_EXECUTABLE", "blender") };
 
     let err = execute_script("any_skill.py", serde_json::json!({}), None)
@@ -180,7 +153,7 @@ fn test_execute_script_rejects_gui_executable_blender() {
 
 #[test]
 fn test_execute_script_allows_headless_interpreter() {
-    let _g = ExecEnvGuard::new();
+    let _g = clear_exec_env();
     // mayapy is the headless Maya interpreter — must NOT trigger the GUI guard
     unsafe { std::env::set_var("DCC_MCP_PYTHON_EXECUTABLE", "mayapy") };
 
@@ -195,7 +168,7 @@ fn test_execute_script_allows_headless_interpreter() {
 
 #[test]
 fn test_execute_script_allows_hython() {
-    let _g = ExecEnvGuard::new();
+    let _g = clear_exec_env();
     // hython is Houdini's headless interpreter
     unsafe { std::env::set_var("DCC_MCP_PYTHON_EXECUTABLE", "hython") };
 

--- a/crates/dcc-mcp-skills/src/scanner.rs
+++ b/crates/dcc-mcp-skills/src/scanner.rs
@@ -396,28 +396,15 @@ mod tests {
         let photoshop_skill = write_skill_dir(tmp.path(), "photoshop-retouch");
         let krita_skill = write_skill_dir(tmp.path(), "krita-paintover");
 
-        let saved_photoshop = std::env::var("DCC_MCP_PHOTOSHOP_SKILL_PATHS").ok();
-        let saved_krita = std::env::var("DCC_MCP_KRITA_SKILL_PATHS").ok();
-        unsafe {
-            std::env::set_var("DCC_MCP_PHOTOSHOP_SKILL_PATHS", &photoshop_skill);
-            std::env::set_var("DCC_MCP_KRITA_SKILL_PATHS", &krita_skill);
-        }
+        let _guard = dcc_mcp_test_utils::EnvVarsGuard::set(&[
+            ("DCC_MCP_PHOTOSHOP_SKILL_PATHS", Some(&photoshop_skill)),
+            ("DCC_MCP_KRITA_SKILL_PATHS", Some(&krita_skill)),
+        ]);
 
         let mut scanner = SkillScanner::new();
         let photoshop = scanner.scan_for_dcc(None, Some(&DccName::Photoshop), true);
         scanner.clear_cache();
         let custom = scanner.scan_for_dcc(None, Some(&DccName::Other("krita".into())), true);
-
-        unsafe {
-            match saved_photoshop {
-                Some(value) => std::env::set_var("DCC_MCP_PHOTOSHOP_SKILL_PATHS", value),
-                None => std::env::remove_var("DCC_MCP_PHOTOSHOP_SKILL_PATHS"),
-            }
-            match saved_krita {
-                Some(value) => std::env::set_var("DCC_MCP_KRITA_SKILL_PATHS", value),
-                None => std::env::remove_var("DCC_MCP_KRITA_SKILL_PATHS"),
-            }
-        }
 
         assert!(
             photoshop.contains(&photoshop_skill),
@@ -477,20 +464,12 @@ mod tests {
         fs::create_dir_all(&shared).unwrap();
         let shared_str = path_to_string(&shared);
 
-        let saved = std::env::var("DCC_MCP_MAYA_SKILL_PATHS").ok();
-        unsafe {
-            std::env::set_var("DCC_MCP_MAYA_SKILL_PATHS", &shared_str);
-        }
+        let _guard =
+            dcc_mcp_test_utils::EnvVarGuard::set("DCC_MCP_MAYA_SKILL_PATHS", Some(&shared_str));
         let collected = SkillScanner::collect_search_paths_with_sources(
             Some(std::slice::from_ref(&shared_str)),
             Some("maya"),
         );
-        unsafe {
-            match saved {
-                Some(v) => std::env::set_var("DCC_MCP_MAYA_SKILL_PATHS", v),
-                None => std::env::remove_var("DCC_MCP_MAYA_SKILL_PATHS"),
-            }
-        }
 
         let shared_entries: Vec<_> = collected
             .iter()

--- a/crates/dcc-mcp-test-utils/Cargo.toml
+++ b/crates/dcc-mcp-test-utils/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "dcc-mcp-test-utils"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared test utilities for dcc-mcp-core workspace crates"
+
+[dependencies]
+workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/dcc-mcp-test-utils/src/lib.rs
+++ b/crates/dcc-mcp-test-utils/src/lib.rs
@@ -1,0 +1,154 @@
+//! Shared test utilities for the dcc-mcp-core workspace.
+//!
+//! # RAII environment variable guards
+//!
+//! Tests that touch process-global [`std::env::set_var`] / [`std::env::remove_var`]
+//! must use [`EnvVarGuard`] or [`EnvVarsGuard`] to safely save/restore the
+//! previous value and to serialise concurrent access within the same crate.
+//!
+//! ```ignore
+//! use dcc_mcp_test_utils::{EnvVarGuard, EnvVarsGuard};
+//!
+//! // Single var
+//! let _g = EnvVarGuard::set("MY_VAR", Some("value"));
+//!
+//! // Multiple vars
+//! let _g = EnvVarsGuard::set(&[("A", Some("1")), ("B", None)]);
+//! ```
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Global lock that serialises all env-var mutations within this crate's
+/// test binary.  Without this, concurrent tests that call `set_var` /
+/// `remove_var` race on the process-global environment table.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII guard that sets an environment variable and restores the previous
+/// value (or removes it) when dropped.
+///
+/// All mutations are serialised via [`ENV_LOCK`] so that concurrent tests
+/// in the same binary do not race.
+pub struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<String>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl EnvVarGuard {
+    /// Set `key` to `value` (or remove it when `value` is `None`), saving
+    /// the previous value so it can be restored on drop.
+    pub fn set(key: &'static str, value: Option<&str>) -> Self {
+        let lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let previous = std::env::var(key).ok();
+        // SAFETY: serialised by ENV_LOCK; the previous value is restored on
+        // drop so no other test can observe the side-effect past this guard's
+        // lifetime.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+        Self {
+            key,
+            previous,
+            _lock: lock,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: we still hold ENV_LOCK (via _lock), so this is serialised.
+        unsafe {
+            match &self.previous {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+/// RAII guard that sets multiple environment variables atomically and
+/// restores all previous values when dropped.
+pub struct EnvVarsGuard {
+    previous: Vec<(&'static str, Option<String>)>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl EnvVarsGuard {
+    /// Set each var in `vars` to its corresponding value (or remove it
+    /// when the value is `None`), saving all previous values.
+    pub fn set(vars: &[(&'static str, Option<&str>)]) -> Self {
+        let lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let previous = vars
+            .iter()
+            .map(|(key, _)| (*key, std::env::var(key).ok()))
+            .collect::<Vec<_>>();
+        // SAFETY: serialised by ENV_LOCK; previous values are restored on drop.
+        unsafe {
+            for (key, value) in vars {
+                match value {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        Self {
+            previous,
+            _lock: lock,
+        }
+    }
+}
+
+impl Drop for EnvVarsGuard {
+    fn drop(&mut self) {
+        // SAFETY: we still hold ENV_LOCK (via _lock), so this is serialised.
+        unsafe {
+            for (key, value) in &self.previous {
+                match value {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_var_set_and_restore() {
+        let _g = EnvVarGuard::set("DCC_MCP_TEST_UTILS_SINGLE", Some("hello"));
+        assert_eq!(std::env::var("DCC_MCP_TEST_UTILS_SINGLE").unwrap(), "hello");
+    }
+
+    #[test]
+    fn single_var_remove_and_restore() {
+        // Set it first so there's something to remove.
+        // SAFETY: test-only env mutation; the guard restores on drop.
+        unsafe { std::env::set_var("DCC_MCP_TEST_UTILS_REMOVE", "before") };
+        {
+            let _g = EnvVarGuard::set("DCC_MCP_TEST_UTILS_REMOVE", None);
+            assert!(std::env::var("DCC_MCP_TEST_UTILS_REMOVE").is_err());
+        }
+        assert_eq!(
+            std::env::var("DCC_MCP_TEST_UTILS_REMOVE").unwrap(),
+            "before"
+        );
+        // SAFETY: test cleanup.
+        unsafe { std::env::remove_var("DCC_MCP_TEST_UTILS_REMOVE") };
+    }
+
+    #[test]
+    fn multi_var_set_and_restore() {
+        let _g = EnvVarsGuard::set(&[
+            ("DCC_MCP_TEST_UTILS_A", Some("1")),
+            ("DCC_MCP_TEST_UTILS_B", Some("2")),
+        ]);
+        assert_eq!(std::env::var("DCC_MCP_TEST_UTILS_A").unwrap(), "1");
+        assert_eq!(std::env::var("DCC_MCP_TEST_UTILS_B").unwrap(), "2");
+    }
+}

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -20,6 +20,7 @@ axum = { version = "0.8.9", features = ["ws"] }
 axum-core = { version = "0.5.6", default-features = false, features = ["tracing"] }
 bit-set = { version = "0.8.0" }
 bit-vec = { version = "0.8.0" }
+bytemuck = { version = "1.25.0", default-features = false, features = ["derive", "extern_crate_alloc", "min_const_generics"] }
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clap_builder = { version = "4.6.0", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
@@ -103,6 +104,7 @@ axum = { version = "0.8.9", features = ["ws"] }
 axum-core = { version = "0.5.6", default-features = false, features = ["tracing"] }
 bit-set = { version = "0.8.0" }
 bit-vec = { version = "0.8.0" }
+bytemuck = { version = "1.25.0", default-features = false, features = ["derive", "extern_crate_alloc", "min_const_generics"] }
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clap_builder = { version = "4.6.0", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }


### PR DESCRIPTION
Part of PIP-1550 Phase 1.

## Summary

Eliminates ~44 `unsafe` occurrences across the workspace:

1. **pyo3 FFI → safe API** (1 block): Replace `pyo3::ffi::Py_IsInitialized()` with `pyo3::Python::is_initialized()` in the in-process script executor.
2. **Shared `dcc-mcp-test-utils` crate** (~36 blocks): Extract `EnvVarGuard` / `EnvVarsGuard` RAII pattern into a new workspace crate. All test files with ad-hoc env-var save/restore now import the shared, safe interface. 10 crates, ~20 files updated.
3. **bytemuck for shared-memory headers** (7 blocks): Derive `AnyBitPattern + NoUninit` on `RegionHeader`, use `pod_read_unaligned` / `bytes_of` instead of raw pointer operations.

## Files changed

- **New:** `crates/dcc-mcp-test-utils/` — shared RAII environment-variable guards
- **Modified:** `dcc-mcp-shm`, `dcc-mcp-skills`, `dcc-mcp-server`, `dcc-mcp-gateway-ensure`, `dcc-mcp-marketplace`, `dcc-mcp-sidecar`, `dcc-mcp-gateway`, `dcc-mcp-skill-rest`
- **Workspace:** `Cargo.toml` (add test-utils member, add bytemuck dep)

## Test plan

- [x] `cargo check --workspace` — passes
- [x] `cargo check --tests` for each affected crate — passes
- [ ] Full CI suite