### PR TITLE
refactor: Phase 2 unsafe cleanup — Send/Sync derive, EnvVarsGuard shared

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/skill_health.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/skill_health.rs
@@ -706,15 +706,9 @@ mod skill_path_display_tests {
 
     #[test]
     fn path_tail_redacts_os_username_component() {
-        // SAFETY: scoped env mutation in a single-threaded unit test.
-        unsafe {
-            std::env::set_var("USERNAME", "alice");
-        }
+        let _g = dcc_mcp_test_utils::EnvVarGuard::set("USERNAME", Some("alice"));
         // A home-rooted path must not leak the operator's username.
         assert_eq!(safe_path_tail("C:/Users/alice/skills"), "~/skills");
-        unsafe {
-            std::env::remove_var("USERNAME");
-        }
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/traffic/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/traffic/mod.rs
@@ -561,7 +561,7 @@ fn truthy_env(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dcc_mcp_test_utils::{EnvVarGuard, EnvVarsGuard};
+    use dcc_mcp_test_utils::EnvVarsGuard;
     use serde_json::Value;
     use std::io::Write;
     use std::path::PathBuf;

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -1300,20 +1300,14 @@ mod tests {
 
     #[test]
     fn default_sources_disabled_respects_truthy_values() {
-        // EnvVarGuard saves the current value and restores it on drop.
-        // Inside the loop we mutate directly under the guard's serialised
-        // scope (edition 2024 makes set_var unsafe, but the RAII guard
-        // ensures cleanup even on panic).
-        let _guard =
-            dcc_mcp_test_utils::EnvVarGuard::set(ENV_MARKETPLACE_NO_DEFAULT_SOURCES, Some("1"));
         for v in ["1", "true", "TRUE", "yes", "YES"] {
-            // SAFETY: serialized by EnvVarGuard which restores on drop.
-            unsafe { std::env::set_var(ENV_MARKETPLACE_NO_DEFAULT_SOURCES, v) };
+            let _g =
+                dcc_mcp_test_utils::EnvVarGuard::set(ENV_MARKETPLACE_NO_DEFAULT_SOURCES, Some(v));
             assert!(default_sources_disabled(), "expected true for '{v}'");
         }
         for v in ["0", "false", "no", "", "FALSE", "NO"] {
-            // SAFETY: serialized by EnvVarGuard which restores on drop.
-            unsafe { std::env::set_var(ENV_MARKETPLACE_NO_DEFAULT_SOURCES, v) };
+            let _g =
+                dcc_mcp_test_utils::EnvVarGuard::set(ENV_MARKETPLACE_NO_DEFAULT_SOURCES, Some(v));
             assert!(!default_sources_disabled(), "expected false for '{v}'");
         }
     }

--- a/crates/dcc-mcp-server/src/event_webhooks.rs
+++ b/crates/dcc-mcp-server/src/event_webhooks.rs
@@ -704,66 +704,9 @@ mod tests {
     use axum::extract::State;
     use axum::http::StatusCode;
     use axum::routing::post;
+    use dcc_mcp_test_utils::EnvVarsGuard;
     use serde_json::Map;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
     use tokio::net::TcpListener;
-
-    struct EnvGuard {
-        previous: Vec<(&'static str, Option<String>)>,
-        _guard: MutexGuard<'static, ()>,
-    }
-
-    impl EnvGuard {
-        fn new(values: &[(&'static str, Option<&str>)]) -> Self {
-            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            const KEYS: &[&str] = &[
-                ENV_WEBHOOKS_CONFIG,
-                ENV_DCC_MCP_ETC_DIR,
-                ENV_WECOM_WEBHOOK_URL,
-                ENV_WECOM_EVENTS,
-                ENV_WECOM_TEMPLATE,
-            ];
-            let guard = ENV_LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .expect("event webhook env lock poisoned");
-            let previous = KEYS
-                .iter()
-                .map(|key| (*key, std::env::var(key).ok()))
-                .collect::<Vec<_>>();
-            // SAFETY: these tests set env vars before spawning runtime work and restore them
-            // before returning.
-            unsafe {
-                for key in KEYS {
-                    std::env::remove_var(key);
-                }
-                for (key, value) in values {
-                    match value {
-                        Some(value) => std::env::set_var(key, value),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
-            Self {
-                previous,
-                _guard: guard,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            // SAFETY: restores the process environment after the serialized test body.
-            unsafe {
-                for (key, value) in &self.previous {
-                    match value {
-                        Some(value) => std::env::set_var(key, value),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
-        }
-    }
 
     #[test]
     fn filter_rules_match_dotted_paths_and_wildcards() {
@@ -815,7 +758,13 @@ mod tests {
 
     #[test]
     fn webhook_url_interpolates_environment_variables() {
-        let _env = EnvGuard::new(&[(ENV_WECOM_WEBHOOK_URL, Some("abc123"))]);
+        let _env = EnvVarsGuard::set(&[
+            (ENV_WEBHOOKS_CONFIG, None),
+            (ENV_DCC_MCP_ETC_DIR, None),
+            (ENV_WECOM_WEBHOOK_URL, Some("abc123")),
+            (ENV_WECOM_EVENTS, None),
+            (ENV_WECOM_TEMPLATE, None),
+        ]);
         let webhook = resolve_webhook(WebhookConfig {
             name: "wecom-alerts".into(),
             url:
@@ -885,7 +834,13 @@ webhooks:
 "#,
         )?;
         let etc_dir = dir.path().to_string_lossy().to_string();
-        let _env = EnvGuard::new(&[(ENV_DCC_MCP_ETC_DIR, Some(&etc_dir))]);
+        let _env = EnvVarsGuard::set(&[
+            (ENV_WEBHOOKS_CONFIG, None),
+            (ENV_DCC_MCP_ETC_DIR, Some(&etc_dir)),
+            (ENV_WECOM_WEBHOOK_URL, None),
+            (ENV_WECOM_EVENTS, None),
+            (ENV_WECOM_TEMPLATE, None),
+        ]);
 
         let runtime = EventWebhookRuntime::from_env(EventBus::new())?;
 
@@ -928,7 +883,13 @@ webhooks:
             ),
         )?;
         let etc_dir = dir.path().to_string_lossy().to_string();
-        let _env = EnvGuard::new(&[(ENV_DCC_MCP_ETC_DIR, Some(&etc_dir))]);
+        let _env = EnvVarsGuard::set(&[
+            (ENV_WEBHOOKS_CONFIG, None),
+            (ENV_DCC_MCP_ETC_DIR, Some(&etc_dir)),
+            (ENV_WECOM_WEBHOOK_URL, None),
+            (ENV_WECOM_EVENTS, None),
+            (ENV_WECOM_TEMPLATE, None),
+        ]);
 
         let bus = EventBus::new();
         let runtime = EventWebhookRuntime::from_env(bus.clone())?
@@ -973,9 +934,12 @@ webhooks:
 "#,
         )?;
         let etc_dir = dir.path().to_string_lossy().to_string();
-        let _env = EnvGuard::new(&[
-            (ENV_DCC_MCP_ETC_DIR, Some(&etc_dir)),
+        let _env = EnvVarsGuard::set(&[
             (ENV_WEBHOOKS_CONFIG, Some("")),
+            (ENV_DCC_MCP_ETC_DIR, Some(&etc_dir)),
+            (ENV_WECOM_WEBHOOK_URL, None),
+            (ENV_WECOM_EVENTS, None),
+            (ENV_WECOM_TEMPLATE, None),
         ]);
 
         let runtime = EventWebhookRuntime::from_env(EventBus::new())?
@@ -988,7 +952,9 @@ webhooks:
 
     #[tokio::test]
     async fn runtime_loads_wecom_webhook_from_environment_without_yaml() -> Result<()> {
-        let _env = EnvGuard::new(&[
+        let _env = EnvVarsGuard::set(&[
+            (ENV_WEBHOOKS_CONFIG, None),
+            (ENV_DCC_MCP_ETC_DIR, None),
             (
                 ENV_WECOM_WEBHOOK_URL,
                 Some("https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=abc123"),

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_env.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_env.rs
@@ -8,8 +8,9 @@ use super::*;
 use dcc_mcp_test_utils::EnvVarsGuard;
 
 /// Clear the three Python-execution env vars and return a guard that restores
-/// them on drop. Individual tests may then `unsafe { set_var }` one of them
-/// under the guard's serialised scope.
+/// them on drop. Tests that need a specific value should create their own
+/// `EnvVarsGuard::set(&[...])` that includes these three clears followed by
+/// the desired override.
 fn clear_exec_env() -> EnvVarsGuard {
     EnvVarsGuard::set(&[
         ("DCC_MCP_PYTHON_EXECUTABLE", None),
@@ -50,8 +51,12 @@ fn test_execute_script_rejects_ambient_python_case_insensitive() {
 
 #[test]
 fn test_execute_script_allows_opt_out_via_env_var() {
-    let _g = clear_exec_env();
-    unsafe { std::env::set_var("DCC_MCP_ALLOW_AMBIENT_PYTHON", "1") };
+    let _g = EnvVarsGuard::set(&[
+        ("DCC_MCP_PYTHON_EXECUTABLE", None),
+        ("DCC_MCP_PYTHON_INIT_SNIPPET", None),
+        ("DCC_MCP_ALLOW_AMBIENT_PYTHON", None),
+        ("DCC_MCP_ALLOW_AMBIENT_PYTHON", Some("1")),
+    ]);
 
     let result = execute_script("/does/not/exist.py", serde_json::json!({}), Some("maya"));
     if let Err(err) = result {
@@ -64,8 +69,12 @@ fn test_execute_script_allows_opt_out_via_env_var() {
 
 #[test]
 fn test_execute_script_skips_check_when_executable_set() {
-    let _g = clear_exec_env();
-    unsafe { std::env::set_var("DCC_MCP_PYTHON_EXECUTABLE", "python") };
+    let _g = EnvVarsGuard::set(&[
+        ("DCC_MCP_PYTHON_EXECUTABLE", None),
+        ("DCC_MCP_PYTHON_INIT_SNIPPET", None),
+        ("DCC_MCP_ALLOW_AMBIENT_PYTHON", None),
+        ("DCC_MCP_PYTHON_EXECUTABLE", Some("python")),
+    ]);
 
     let result = execute_script("/does/not/exist.py", serde_json::json!({}), Some("maya"));
     if let Err(err) = result {
@@ -104,8 +113,12 @@ fn test_execute_script_no_dcc_hint_does_not_trigger_check() {
 
 #[test]
 fn test_execute_script_rejects_gui_executable_maya_exe() {
-    let _g = clear_exec_env();
-    unsafe { std::env::set_var("DCC_MCP_PYTHON_EXECUTABLE", "maya.exe") };
+    let _g = EnvVarsGuard::set(&[
+        ("DCC_MCP_PYTHON_EXECUTABLE", None),
+        ("DCC_MCP_PYTHON_INIT_SNIPPET", None),
+        ("DCC_MCP_ALLOW_AMBIENT_PYTHON", None),
+        ("DCC_MCP_PYTHON_EXECUTABLE", Some("maya.exe")),
+    ]);
 
     let result = execute_script("any_skill.py", serde_json::json!({}), None);
     let err =
@@ -122,13 +135,12 @@ fn test_execute_script_rejects_gui_executable_maya_exe() {
 
 #[test]
 fn test_execute_script_rejects_gui_executable_case_insensitive() {
-    let _g = clear_exec_env();
-    unsafe {
-        std::env::set_var(
-            "DCC_MCP_PYTHON_EXECUTABLE",
-            "/usr/autodesk/maya2024/bin/Maya",
-        )
-    };
+    let _g = EnvVarsGuard::set(&[
+        ("DCC_MCP_PYTHON_EXECUTABLE", None),
+        ("DCC_MCP_PYTHON_INIT_SNIPPET", None),
+        ("DCC_MCP_ALLOW_AMBIENT_PYTHON", None),
+        ("DCC_MCP_PYTHON_EXECUTABLE", Some("/usr/autodesk/maya2024/bin/Maya")),
+    ]);
 
     let err = execute_script("any_skill.py", serde_json::json!({}), None)
         .expect_err("must fail for GUI executable regardless of case");
@@ -140,8 +152,12 @@ fn test_execute_script_rejects_gui_executable_case_insensitive() {
 
 #[test]
 fn test_execute_script_rejects_gui_executable_blender() {
-    let _g = clear_exec_env();
-    unsafe { std::env::set_var("DCC_MCP_PYTHON_EXECUTABLE", "blender") };
+    let _g = EnvVarsGuard::set(&[
+        ("DCC_MCP_PYTHON_EXECUTABLE", None),
+        ("DCC_MCP_PYTHON_INIT_SNIPPET", None),
+        ("DCC_MCP_ALLOW_AMBIENT_PYTHON", None),
+        ("DCC_MCP_PYTHON_EXECUTABLE", Some("blender")),
+    ]);
 
     let err = execute_script("any_skill.py", serde_json::json!({}), None)
         .expect_err("must fail for blender GUI executable");
@@ -153,9 +169,12 @@ fn test_execute_script_rejects_gui_executable_blender() {
 
 #[test]
 fn test_execute_script_allows_headless_interpreter() {
-    let _g = clear_exec_env();
-    // mayapy is the headless Maya interpreter — must NOT trigger the GUI guard
-    unsafe { std::env::set_var("DCC_MCP_PYTHON_EXECUTABLE", "mayapy") };
+    let _g = EnvVarsGuard::set(&[
+        ("DCC_MCP_PYTHON_EXECUTABLE", None),
+        ("DCC_MCP_PYTHON_INIT_SNIPPET", None),
+        ("DCC_MCP_ALLOW_AMBIENT_PYTHON", None),
+        ("DCC_MCP_PYTHON_EXECUTABLE", Some("mayapy")),
+    ]);
 
     let result = execute_script("/does/not/exist.py", serde_json::json!({}), None);
     if let Err(err) = result {
@@ -168,9 +187,12 @@ fn test_execute_script_allows_headless_interpreter() {
 
 #[test]
 fn test_execute_script_allows_hython() {
-    let _g = clear_exec_env();
-    // hython is Houdini's headless interpreter
-    unsafe { std::env::set_var("DCC_MCP_PYTHON_EXECUTABLE", "hython") };
+    let _g = EnvVarsGuard::set(&[
+        ("DCC_MCP_PYTHON_EXECUTABLE", None),
+        ("DCC_MCP_PYTHON_INIT_SNIPPET", None),
+        ("DCC_MCP_ALLOW_AMBIENT_PYTHON", None),
+        ("DCC_MCP_PYTHON_EXECUTABLE", Some("hython")),
+    ]);
 
     let result = execute_script("/does/not/exist.py", serde_json::json!({}), None);
     if let Err(err) = result {

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_env.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_env.rs
@@ -139,7 +139,10 @@ fn test_execute_script_rejects_gui_executable_case_insensitive() {
         ("DCC_MCP_PYTHON_EXECUTABLE", None),
         ("DCC_MCP_PYTHON_INIT_SNIPPET", None),
         ("DCC_MCP_ALLOW_AMBIENT_PYTHON", None),
-        ("DCC_MCP_PYTHON_EXECUTABLE", Some("/usr/autodesk/maya2024/bin/Maya")),
+        (
+            "DCC_MCP_PYTHON_EXECUTABLE",
+            Some("/usr/autodesk/maya2024/bin/Maya"),
+        ),
     ]);
 
     let err = execute_script("any_skill.py", serde_json::json!({}), None)

--- a/crates/dcc-mcp-usd/src/scene_info_impl.rs
+++ b/crates/dcc-mcp-usd/src/scene_info_impl.rs
@@ -58,10 +58,8 @@ impl DccSceneInfo for UsdSceneInfoAdapter {
     }
 }
 
-// Safety: UsdStage is Send + Sync by default (all fields are Send + Sync).
-unsafe impl Send for UsdSceneInfoAdapter {}
-unsafe impl Sync for UsdSceneInfoAdapter {}
-
+// UsdSceneInfoAdapter is Send + Sync by the compiler: its only field (UsdStage)
+// is already Send + Sync.
 /// Convert a `DccResult<T>` into a `crate::UsdResult<T>`.
 fn _dcc_to_usd<T>(r: DccResult<T>) -> crate::UsdResult<T> {
     r.map_err(|e| crate::UsdError::ConversionError(e.message))


### PR DESCRIPTION
Part of PIP-1550 Phase 2. Prerequisite: Phase 1 PR #1657 (merged).

## Summary

Replaces ~28 `unsafe` occurrences across 5 files:

1. **Auto-derive Send + Sync** (dcc-mcp-usd): Remove `unsafe impl Send/Sync` — compiler derives automatically.
2. **skill_health.rs USERNAME env** (gateway admin): Switch to `EnvVarGuard`.
3. **event_webhooks.rs EnvGuard → shared** (server): Remove local `EnvGuard` (8 unsafe calls), use `EnvVarsGuard`.
4. **marketplace loop set_var** (marketplace): Per-iteration `EnvVarGuard` replaces loop body unsafe.
5. **test_execute_script_env** (skills): 7 `unsafe { set_var }` → inline `EnvVarsGuard::set`.

Also fixes unused import in gateway/traffic/mod.rs.

## Test plan

- [x] `cargo check --workspace` — passes with zero warnings
- [x] `cargo check --tests` for all affected crates — passes with zero warnings
- [ ] Full CI suite