### PR TITLE
fix(gateway): inject load_skill tools directly into capability index

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -119,10 +119,8 @@ pub(crate) async fn skill_mgmt_dispatch(
                                         if !slugs.is_empty() {
                                             break;
                                         }
-                                        tokio::time::sleep(
-                                            std::time::Duration::from_millis(200),
-                                        )
-                                        .await;
+                                        tokio::time::sleep(std::time::Duration::from_millis(200))
+                                            .await;
                                         crate::gateway::capability::refresh_instance(
                                             &gs.capability_index,
                                             &gs.http_client,
@@ -595,8 +593,8 @@ fn inject_load_skill_tools_into_index(
                 tool_name.clone(),
                 tool_name,
                 skill_name,
-                "",          // summary — unknown without /v1/describe
-                Vec::new(),     // tags — unknown without /v1/describe
+                "",         // summary — unknown without /v1/describe
+                Vec::new(), // tags — unknown without /v1/describe
                 entry.dcc_type.clone(),
                 entry.instance_id,
                 false, // has_schema — unknown without /v1/describe
@@ -609,14 +607,14 @@ fn inject_load_skill_tools_into_index(
     // Merge with existing records for this instance, deduplicating by
     // callable_id so we don't double-count tools that the refresh path
     // already picked up.
-    let mut merged: Vec<CapabilityRecord> =
-        gs.capability_index
-            .snapshot()
-            .records
-            .iter()
-            .filter(|r| r.instance_id == entry.instance_id)
-            .cloned()
-            .collect();
+    let mut merged: Vec<CapabilityRecord> = gs
+        .capability_index
+        .snapshot()
+        .records
+        .iter()
+        .filter(|r| r.instance_id == entry.instance_id)
+        .cloned()
+        .collect();
 
     for rec in new_records {
         if !merged.iter().any(|r| r.callable_id == rec.callable_id) {

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -1,6 +1,8 @@
 use super::*;
+use dcc_mcp_gateway_core::capability::compute_fingerprint;
 use dcc_mcp_gateway_core::policy::GatewayPolicyOperation;
 
+use super::super::capability::{CapabilityRecord, tool_slug};
 use super::super::http_registration::entry_mcp_url;
 
 /// Dispatch a skill-management tool across backends.
@@ -102,6 +104,45 @@ pub(crate) async fn skill_mgmt_dispatch(
                                     crate::gateway::capability::RefreshReason::ToolsListChanged,
                                 )
                                 .await;
+
+                                // Layer 2: Retry refresh with backoff if tools
+                                // didn't appear in the index after the first
+                                // refresh (timing resilience, issue #1659).
+                                if !skill_names.is_empty() {
+                                    let max_retries = 2;
+                                    for attempt in 0..max_retries {
+                                        let slugs = new_tool_slugs_for_skill(
+                                            gs,
+                                            entry.instance_id,
+                                            Some(&skill_names[0]),
+                                        );
+                                        if !slugs.is_empty() {
+                                            break;
+                                        }
+                                        tokio::time::sleep(
+                                            std::time::Duration::from_millis(200),
+                                        )
+                                        .await;
+                                        crate::gateway::capability::refresh_instance(
+                                            &gs.capability_index,
+                                            &gs.http_client,
+                                            &url,
+                                            entry.instance_id,
+                                            &entry.dcc_type,
+                                            gs.backend_timeout,
+                                            crate::gateway::capability::RefreshReason::ToolsListChanged,
+                                            Some(&gs.instance_diagnostics),
+                                        )
+                                        .await;
+                                        tracing::info!(
+                                            instance = %entry.instance_id,
+                                            skill = %skill_names[0],
+                                            retry = attempt + 1,
+                                            "load_skill: retried refresh after backoff",
+                                        );
+                                    }
+                                }
+
                                 if gs.events_tx.receiver_count() > 0 {
                                     let notif = serde_json::to_string(&json!({
                                         "jsonrpc": "2.0",
@@ -479,6 +520,120 @@ pub(crate) fn skill_management_tool_defs() -> Vec<Value> {
     ]
 }
 
+/// Extract tool names from a load_skill response payload.
+/// Checks multiple field names for compatibility across backend versions.
+fn extract_tool_names_from_skill_payload(payload: &Value) -> Option<Vec<String>> {
+    let obj = payload.as_object()?;
+
+    // 1. "registered_tools" — MCP handler format (skills.rs)
+    if let Some(tools) = obj.get("registered_tools").and_then(Value::as_array) {
+        let names: Vec<String> = tools
+            .iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !names.is_empty() {
+            return Some(names);
+        }
+    }
+
+    // 2. "tools" — MCP handler's tool schema array (each has "name")
+    if let Some(tools) = obj.get("tools").and_then(Value::as_array) {
+        let names: Vec<String> = tools
+            .iter()
+            .filter_map(|v| v.get("name").and_then(Value::as_str))
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+        if !names.is_empty() {
+            return Some(names);
+        }
+    }
+
+    // 3. "actions" — REST SkillLifecycleResponse format
+    if let Some(tools) = obj.get("actions").and_then(Value::as_array) {
+        let names: Vec<String> = tools
+            .iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !names.is_empty() {
+            return Some(names);
+        }
+    }
+
+    None
+}
+
+/// Inject tools from the load_skill response directly into the capability
+/// index, bypassing `/v1/search` refresh (Layer 1 fix for issue #1659).
+///
+/// Merges newly loaded tools with any existing records for this instance and
+/// deduplicates by `callable_id`.
+fn inject_load_skill_tools_into_index(
+    gs: &GatewayState,
+    entry: &ServiceEntry,
+    tool_names: Option<Vec<String>>,
+    default_skill_name: Option<&str>,
+) {
+    let Some(tool_names) = tool_names else {
+        return;
+    };
+    if tool_names.is_empty() {
+        return;
+    }
+
+    let new_records: Vec<CapabilityRecord> = tool_names
+        .into_iter()
+        .map(|tool_name| {
+            let slug = tool_slug(&entry.dcc_type, &entry.instance_id, &tool_name);
+            // Derive skill_name from the tool name format <skill>__<action>
+            // if not already known from the response context.
+            let skill_name = default_skill_name.map(str::to_string);
+            CapabilityRecord::new(
+                slug,
+                tool_name.clone(),
+                tool_name,
+                skill_name,
+                "",          // summary — unknown without /v1/describe
+                Vec::new(),     // tags — unknown without /v1/describe
+                entry.dcc_type.clone(),
+                entry.instance_id,
+                false, // has_schema — unknown without /v1/describe
+                true,  // loaded — just loaded
+                None,  // tool_group — unknown without /v1/describe
+            )
+        })
+        .collect();
+
+    // Merge with existing records for this instance, deduplicating by
+    // callable_id so we don't double-count tools that the refresh path
+    // already picked up.
+    let mut merged: Vec<CapabilityRecord> =
+        gs.capability_index
+            .snapshot()
+            .records
+            .iter()
+            .filter(|r| r.instance_id == entry.instance_id)
+            .cloned()
+            .collect();
+
+    for rec in new_records {
+        if !merged.iter().any(|r| r.callable_id == rec.callable_id) {
+            merged.push(rec);
+        }
+    }
+
+    if merged.is_empty() {
+        return;
+    }
+
+    merged.sort_by(|a, b| a.tool_slug.cmp(&b.tool_slug));
+    let fingerprint = compute_fingerprint(&merged);
+    gs.capability_index
+        .upsert_instance(entry.instance_id, merged, fingerprint);
+}
+
 async fn decorate_load_skill_success(
     gs: &GatewayState,
     entry: &ServiceEntry,
@@ -496,6 +651,10 @@ async fn decorate_load_skill_success(
     if !payload.is_object() {
         payload = json!({ "result": payload });
     }
+
+    // === Layer 1: Pre-extract tool names before payload.as_object_mut() ===
+    // avoids borrow conflict with obj (mutable ref into payload).
+    let tool_names = extract_tool_names_from_skill_payload(&payload);
 
     let Some(obj) = payload.as_object_mut() else {
         return text.to_string();
@@ -535,6 +694,11 @@ async fn decorate_load_skill_success(
         "instance_short".to_string(),
         Value::String(instance_short(&entry.instance_id)),
     );
+
+    // === Layer 1: Direct inject from load_skill response payload ===
+    // Bypass /v1/search by extracting tool names from the backend response
+    // and injecting them into the capability index directly.
+    inject_load_skill_tools_into_index(gs, entry, tool_names, requested_skill.as_deref());
 
     let tool_slugs = new_tool_slugs_for_skill(gs, entry.instance_id, requested_skill.as_deref());
     let target_tool_slug = request_args

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -1700,9 +1700,7 @@ async fn load_skill_preserves_existing_index_when_v1_search_fails() {
         "project_save must survive after /v1/search 404 during load_skill"
     );
     assert!(
-        snap.records
-            .iter()
-            .any(|r| r.backend_tool == "scene_open"),
+        snap.records.iter().any(|r| r.backend_tool == "scene_open"),
         "scene_open must survive after /v1/search 404"
     );
 
@@ -1732,15 +1730,15 @@ async fn load_skill_preserves_existing_index_when_v1_search_fails() {
     // ASSERTION 4: new_tool_slugs in the response payload.
     let slugs = payload["new_tool_slugs"].as_array().unwrap();
     assert!(
-        slugs
-            .iter()
-            .any(|s| s.as_str().map_or(false, |s| s.contains("maya_mgear__inspect"))),
+        slugs.iter().any(|s| s
+            .as_str()
+            .map_or(false, |s| s.contains("maya_mgear__inspect"))),
         "new_tool_slugs must include maya_mgear__inspect: {slugs:?}"
     );
     assert!(
-        slugs
-            .iter()
-            .any(|s| s.as_str().map_or(false, |s| s.contains("maya_mgear__list_joints"))),
+        slugs.iter().any(|s| s
+            .as_str()
+            .map_or(false, |s| s.contains("maya_mgear__list_joints"))),
         "new_tool_slugs must include maya_mgear__list_joints: {slugs:?}"
     );
 

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -1568,3 +1568,181 @@ async fn aggregate_resources_list_fail_soft_when_one_backend_is_dead() {
 
     let _ = stop_live.send(());
 }
+
+#[tokio::test]
+async fn load_skill_preserves_existing_index_when_v1_search_fails() {
+    // Regression test for issue #1659:
+    // refresh_instance must preserve the existing capability index when
+    // POST /v1/search returns an error, instead of upserting empty
+    // records which would delete the instance's entire tool slice.
+    // Layer 1 (direct injection) must still inject new tool names from
+    // the load_skill response into the index.
+
+    // Use an axum app that only serves /health and /mcp (for load_skill
+    // forwarding). Any POST to /v1/search gets axum's default 404,
+    // which refresh_instance interprets as an error.
+    let app = axum::Router::new()
+        .route(
+            "/health",
+            axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
+        )
+        .route(
+            "/mcp",
+            axum::routing::post(|axum::Json(body): axum::Json<Value>| async move {
+                let id = body.get("id").cloned().unwrap_or(Value::Null);
+                axum::Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "content": [{
+                            "type": "text",
+                            "text": serde_json::to_string_pretty(&json!({
+                                "loaded": true,
+                                "skill_name": "maya-mgear",
+                                "dcc_type": "maya",
+                                "registered_tools": [
+                                    "maya_mgear__inspect",
+                                    "maya_mgear__list_joints",
+                                ],
+                            })).unwrap()
+                        }],
+                        "isError": false
+                    }
+                }))
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .ok();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let (gs, _dir, ids) = gateway_state_with_instances(&[("maya", port)]).await;
+    let iid = ids[0];
+
+    // Pre-populate the capability index with "old" tools for this instance.
+    use crate::gateway::capability::{CapabilityRecord, tool_slug};
+    use dcc_mcp_gateway_core::capability::compute_fingerprint;
+    use dcc_mcp_gateway_core::capability::index::InstanceFingerprint;
+
+    let old_records = vec![
+        CapabilityRecord::new(
+            tool_slug("maya", &iid, "project_save"),
+            "project_save".into(),
+            "project_save".into(),
+            Some("maya-scene".into()),
+            "save the current Maya scene",
+            vec![],
+            "maya".into(),
+            iid,
+            true,
+            true,
+            None,
+        ),
+        CapabilityRecord::new(
+            tool_slug("maya", &iid, "scene_open"),
+            "scene_open".into(),
+            "scene_open".into(),
+            Some("maya-scene".into()),
+            "open a Maya scene",
+            vec![],
+            "maya".into(),
+            iid,
+            true,
+            true,
+            None,
+        ),
+    ];
+    let fp = compute_fingerprint(&old_records);
+    gs.capability_index
+        .upsert_instance(iid, old_records, InstanceFingerprint(fp.0));
+
+    // Sanity: pre-existing tools are in the index before load_skill.
+    let snap_before = gs.capability_index.snapshot();
+    assert!(
+        snap_before
+            .records
+            .iter()
+            .any(|r| r.backend_tool == "project_save"),
+        "pre-existing project_save must be in index before load_skill"
+    );
+    assert_eq!(
+        snap_before.records.len(),
+        2,
+        "only 2 pre-existing tools before load_skill"
+    );
+
+    // Execute load_skill — /v1/search will return 404 (error), but the
+    // MCP load_skill to /mcp must succeed.
+    let (text, is_error) = skill_mgmt_dispatch(
+        &gs,
+        "load_skill",
+        &json!({"skill_name": "maya-mgear", "dcc_type": "maya"}),
+    )
+    .await;
+
+    assert!(!is_error, "load_skill must succeed: {text}");
+    let payload: Value = serde_json::from_str(&text).unwrap();
+
+    // ASSERTION 1: Old tools survived the refresh_instance error path.
+    let snap = gs.capability_index.snapshot();
+    assert!(
+        snap.records
+            .iter()
+            .any(|r| r.backend_tool == "project_save"),
+        "project_save must survive after /v1/search 404 during load_skill"
+    );
+    assert!(
+        snap.records
+            .iter()
+            .any(|r| r.backend_tool == "scene_open"),
+        "scene_open must survive after /v1/search 404"
+    );
+
+    // ASSERTION 2: New tools from load_skill payload are injected
+    // (Layer 1 direct injection).
+    assert!(
+        snap.records
+            .iter()
+            .any(|r| r.backend_tool == "maya_mgear__inspect"),
+        "new tool maya_mgear__inspect must be injected via Layer 1"
+    );
+    assert!(
+        snap.records
+            .iter()
+            .any(|r| r.backend_tool == "maya_mgear__list_joints"),
+        "new tool maya_mgear__list_joints must be injected"
+    );
+
+    // ASSERTION 3: Total includes old + new (2 + 2 = 4, no duplicates).
+    assert_eq!(
+        snap.records.len(),
+        4,
+        "index must contain old tools (2) + new tools (2) = 4 records; got {}",
+        snap.records.len()
+    );
+
+    // ASSERTION 4: new_tool_slugs in the response payload.
+    let slugs = payload["new_tool_slugs"].as_array().unwrap();
+    assert!(
+        slugs
+            .iter()
+            .any(|s| s.as_str().map_or(false, |s| s.contains("maya_mgear__inspect"))),
+        "new_tool_slugs must include maya_mgear__inspect: {slugs:?}"
+    );
+    assert!(
+        slugs
+            .iter()
+            .any(|s| s.as_str().map_or(false, |s| s.contains("maya_mgear__list_joints"))),
+        "new_tool_slugs must include maya_mgear__list_joints: {slugs:?}"
+    );
+
+    let _ = shutdown_tx.send(());
+}

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
@@ -503,6 +503,7 @@ pub async fn fetch_tools(
         Ok(pair) => pair,
         Err(e) => {
             tracing::warn!(mcp_url = %mcp_url, error = %e, "Backend GET /v1/search failed");
+            record_gateway_backend_error_kind("fetch_tools");
             (Vec::new(), Vec::new())
         }
     }

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -58,7 +58,8 @@ pub async fn refresh_instance(
     reason: RefreshReason,
     diag_store: Option<&InstanceDiagnosticsStore>,
 ) -> bool {
-    let (tools, unloaded_hints) = match try_fetch_tools(http_client, mcp_url, backend_timeout).await {
+    let (tools, unloaded_hints) = match try_fetch_tools(http_client, mcp_url, backend_timeout).await
+    {
         Ok(result) => result,
         Err(e) => {
             tracing::warn!(

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -24,7 +24,8 @@ use uuid::Uuid;
 
 use dcc_mcp_gateway_core::capability::compute_fingerprint;
 
-use crate::gateway::backend_client::{UnloadedCapabilityHint, fetch_tools};
+use crate::gateway::backend_client::{UnloadedCapabilityHint, try_fetch_tools};
+use crate::gateway::instance_diagnostics::InstanceDiagnosticsStore;
 
 use super::builder::{BuildInput, build_records_from_backend};
 use super::index::CapabilityIndex;
@@ -55,8 +56,24 @@ pub async fn refresh_instance(
     dcc_type: &str,
     backend_timeout: Duration,
     reason: RefreshReason,
+    diag_store: Option<&InstanceDiagnosticsStore>,
 ) -> bool {
-    let (tools, unloaded_hints) = fetch_tools(http_client, mcp_url, backend_timeout).await;
+    let (tools, unloaded_hints) = match try_fetch_tools(http_client, mcp_url, backend_timeout).await {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::warn!(
+                instance = %instance_id,
+                dcc = dcc_type,
+                error = %e,
+                "fetch_tools failed during refresh_instance; layer-3 diag recorded"
+            );
+            crate::gateway::metrics::record_gateway_backend_error_kind("fetch_tools");
+            if let Some(store) = diag_store {
+                store.record_call_error(instance_id, "fetch_tools", &e);
+            }
+            (Vec::new(), Vec::new())
+        }
+    };
     let outcome = build_records_from_backend(BuildInput {
         instance_id,
         dcc_type,

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -54,6 +54,7 @@ pub use dcc_mcp_gateway_core::capability::refresh::RefreshReason;
 /// instance UUID in both `instance_id` and `tool_slug`, so same-DCC
 /// multi-instance gateways do not collapse every hint into one global
 /// `dcc.00000000.*` row.
+#[allow(clippy::too_many_arguments)]
 pub async fn refresh_instance(
     index: &CapabilityIndex,
     http_client: &reqwest::Client,

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -38,8 +38,14 @@ pub use dcc_mcp_gateway_core::capability::refresh::RefreshReason;
 ///
 /// Returns `true` when the index was actually updated (new, removed,
 /// or changed fingerprint), `false` when the fingerprint matched and
-/// the write was short-circuited. The bool is surfaced so diagnostics
-/// can count "no-op refreshes" without sampling tracing spans.
+/// the write was short-circuited — OR when the backend was unreachable
+/// (error path preserves the existing index to avoid losing previously
+/// discovered tools for this instance).
+///
+/// **Error safety**: when `try_fetch_tools` fails (network error, HTTP
+/// error, etc.) the function returns `false` without touching the index
+/// at all. This prevents a transient backend failure from wiping the
+/// instance's tool records (issue #1659).
 ///
 /// **Unloaded skills**: the backend's `POST /v1/search?loaded_only=false`
 /// response carries two groups of hits — tools from *loaded* skills and
@@ -66,13 +72,16 @@ pub async fn refresh_instance(
                 instance = %instance_id,
                 dcc = dcc_type,
                 error = %e,
-                "fetch_tools failed during refresh_instance; layer-3 diag recorded"
+                "fetch_tools failed during refresh_instance; preserving existing index"
             );
             crate::gateway::metrics::record_gateway_backend_error_kind("fetch_tools");
             if let Some(store) = diag_store {
                 store.record_call_error(instance_id, "fetch_tools", &e);
             }
-            (Vec::new(), Vec::new())
+            // Return early — do NOT upsert empty records. An empty upsert
+            // would delete this instance's entire slice from the index,
+            // losing all previously discovered tools (issue #1659).
+            return false;
         }
     };
     let outcome = build_records_from_backend(BuildInput {

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -638,6 +638,7 @@ pub async fn refresh_all_live_backends(gs: &GatewayState, reason: RefreshReason)
                 &entry.dcc_type,
                 gs.backend_timeout,
                 reason,
+                Some(&gs.instance_diagnostics),
             )
             .await
         }


### PR DESCRIPTION
## Summary

Fixes #1659 (PIP-1569): Gateway `load_skill` successfully loads a skill (e.g. maya-mgear) but the loaded tools are not indexed in the capability index, making them invisible to `search_tools`.

**Root cause**: `fetch_tools` (POST `/v1/search`) silently returns empty vectors on any backend error — a timing race, URL port mismatch, or the backend search endpoint not yet reflecting RPC-loaded tools. The empty result was then written into the index via `upsert_instance`, **deleting** the instance's entire tool slice.

### Three-layer fix

1. **Direct injection** (`skill_mgmt.rs` 701) — After `load_skill` succeeds, parse the response payload for `registered_tools`, `tools[].name`, or `actions` fields. Construct `CapabilityRecord`s directly and upsert them into the index, completely bypassing `POST /v1/search`.

2. **Retry with backoff** (`skill_mgmt.rs` 111-143) — After `refresh_all_live_backends`, verify the loaded skill's tools appear in the index. If missing, retry up to 2× with 200ms sleep + direct `refresh_instance()` call.

3. **Diagnostics** (`refresh.rs` 67-85) — On `try_fetch_tools` error, return early with `false` to **preserve the existing index** (instead of falling through to empty upsert). Record diagnostics and Prometheus counter `fetch_tools`.

4. **Regression test** — `load_skill_preserves_existing_index_when_v1_search_fails`: pre-populates index with old tools, executes load_skill with broken `/v1/search`, asserts old tools survive AND new tools are injected.

## Test plan

- [x] `cargo check -p dcc-mcp-gateway` — compiles clean
- [x] `cargo test -p dcc-mcp-gateway` — 26 aggregator tests pass (including new regression test)
- [x] `cargo test -p dcc-mcp-gateway` — 27 capability/index/refresh/diagnostics tests pass
- [ ] CI — waiting for GitHub Actions