### PR TITLE
docs: document CLI standalone ZIP bundle (#1651 follow-up)

### DIFF
--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -19,6 +19,9 @@ powershell -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/s
 Pin a release by setting `DCC_MCP_VERSION=v0.17.17` or passing
 `--version v0.17.17` to the install script.
 
+A standalone CLI-only ZIP (`dcc-mcp-cli-<version>-<platform>.zip`) is
+also published as a GitHub Release asset alongside the server bundle.
+
 | Binary | Role | Source |
 |---|---|---|
 | [`dcc-mcp-cli`](#dcc-mcp-cli) | User/CI control plane for local or remote DCC-MCP REST endpoints. | `crates/dcc-mcp-cli/` |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -14,6 +14,10 @@ powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc
 This installs the standalone `dcc-mcp-cli` control-plane binary from the
 latest GitHub Release. Pin a release with `DCC_MCP_VERSION=v0.17.17`.
 
+The CLI is also available as a standalone ZIP archive
+(`dcc-mcp-cli-<version>-<platform>.zip`) from each
+[GitHub Release](https://github.com/dcc-mcp/dcc-mcp-core/releases).
+
 ### From PyPI
 
 ```bash

--- a/docs/guide/production-deployment.md
+++ b/docs/guide/production-deployment.md
@@ -53,6 +53,9 @@ GitHub Releases attach deployable bundles named
 `dcc-mcp-server` and `dcc-mcp-cli` at its root (`.exe` on Windows), so a
 deployment host can unpack one archive and put both binaries on `PATH`.
 
+A CLI-only ZIP (`dcc-mcp-cli-<version>-<platform>.zip`) is published
+alongside the server bundle for environments that only need the CLI binary.
+
 ### Install Location
 
 Pick **one** location consistently per machine:

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -14,6 +14,9 @@ powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc
 这会从最新 GitHub Release 安装独立的 `dcc-mcp-cli` 控制面二进制。
 需要固定版本时设置 `DCC_MCP_VERSION=v0.17.17`。
 
+CLI 也提供了独立 ZIP 包（`dcc-mcp-cli-<version>-<platform>.zip`），
+可从每个 [GitHub Release](https://github.com/dcc-mcp/dcc-mcp-core/releases) 下载。
+
 ### 从 PyPI 安装
 
 ```bash

--- a/docs/zh/guide/production-deployment.md
+++ b/docs/zh/guide/production-deployment.md
@@ -53,6 +53,9 @@ GitHub Release 会附带可直接解压部署的
 `dcc-mcp-server` 和 `dcc-mcp-cli` 两个二进制（Windows 上带 `.exe`），
 部署机器只需要解压一次，再把两个二进制所在目录加入 `PATH`。
 
+同时还会发布仅含 CLI 的 ZIP 包（`dcc-mcp-cli-<version>-<platform>.zip`），
+供仅需 CLI 二进制的环境使用。
+
 ### 安装路径
 
 每台机器上选定一个**唯一**位置：


### PR DESCRIPTION
## Summary

PR #1651 added a CLI-only ZIP bundle (`dcc-mcp-cli-<version>-<platform>.zip`)
to the release pipeline, but its availability was not documented in the
human-facing guides. This PR fills that gap.

### Changes

- `getting-started.md`: mention standalone CLI ZIP download alternative
- `cli-reference.md`: mention CLI ZIP alongside the install script
- `production-deployment.md`: mention CLI-only ZIP alongside the server bundle
- `docs/zh/guide/*`: sync zh-CN translations for the same changes

### Verification

- `npm run docs:build` passes clean

### Related

Follow-up to #1651.