### PR TITLE
fix: align skill version diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/crates/dcc-mcp-http-server/Cargo.toml
+++ b/crates/dcc-mcp-http-server/Cargo.toml
@@ -49,6 +49,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 rmcp = { workspace = true }
 
 [dev-dependencies]
+tempfile = "3"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 
 [features]

--- a/crates/dcc-mcp-http-server/src/handlers/tool_builder_core.rs
+++ b/crates/dcc-mcp-http-server/src/handlers/tool_builder_core.rs
@@ -54,10 +54,10 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
         },
         McpTool {
             name: "list_skills".to_string(),
-            description: "Lists every discovered skill on this server with its current load status (loaded, unloaded, or error).\n\n\
-                          When to use: Use to browse what is available or to audit which skills are currently active. For keyword lookup, call search_skills instead — list_skills is a flat dump with no ranking.\n\n\
+            description: "Lists discovered skills with load status (loaded, unloaded, error, skipped).\n\n\
+                          When to use: Browse availability or audit active skills. For ranked lookup, call search_skills instead.\n\n\
                           How to use:\n\
-                          - Pass status='loaded' to inspect the active tool surface, 'unloaded' to find candidates to load.\n\
+                          - Pass status='loaded' for active skills, 'unloaded' for load candidates, or 'skipped' for rejected package diagnostics.\n\
                           - Follow up with get_skill_info(skill_name=...) or load_skill(skill_name=...)."
                 .to_string(),
             input_schema: json!({
@@ -65,9 +65,14 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
                 "properties": {
                     "status": {
                         "type": "string",
-                        "enum": ["all", "loaded", "unloaded", "error"],
+                        "enum": ["all", "loaded", "unloaded", "error", "skipped"],
                         "default": "all",
-                        "description": "Load-status filter; 'all' returns every discovered skill."
+                        "description": "Load-status filter; 'all' returns skills, 'skipped' returns rejected package diagnostics."
+                    },
+                    "include_skipped": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Include skipped skill diagnostics with stable reason codes and suggested fixes."
                     },
                     "limit": {
                         "type": "integer",
@@ -198,7 +203,7 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
         },
         McpTool {
             name: "search_skills".to_string(),
-            description: "Unified skill discovery. Ranks skills against query across name, description, search-hint, tags, and tool names; filters by tags/dcc/scope.\n\n\
+            description: "Unified skill discovery. Ranks skills against query across name, description, search-hint, tags, and tool names; filters by tags/dcc/scope. Matching skipped skill directories are returned in `skipped` with diagnostics.\n\n\
                           When to use: Start here when you need a capability but don't know the skill name. Call with no args to browse by trust scope (Admin>System>User>Repo).\n\n\
                           How to use:\n\
                           - Keep query short (2-4 keywords); combine with tags/dcc/scope.\n\

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/skills.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/skills.rs
@@ -29,11 +29,74 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_list_skills(
     arguments: &Value,
 ) -> CallToolResult {
     let status = arguments.get("status").and_then(Value::as_str);
+    let include_skipped = arguments
+        .get("include_skipped")
+        .or_else(|| arguments.get("include_skipped_diagnostics"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || status == Some("skipped");
+    if status == Some("skipped") {
+        let skipped = state.catalog.skipped_skill_diagnostics(None, None);
+        let payload = build_list_skipped_skills_response(skipped, arguments);
+        let text = serde_json::to_string_pretty(&payload).unwrap_or_default();
+        return CallToolResult::text(text);
+    }
+
     let results = state.catalog.list_skills(status);
-    let payload =
+    let mut payload =
         dcc_mcp_skills::catalog::list_projection::build_list_skills_response(results, arguments);
+    let skipped_count = state.catalog.skipped_count();
+    if let Some(obj) = payload.as_object_mut() {
+        obj.insert("skipped_count".to_string(), json!(skipped_count));
+        if include_skipped {
+            let skipped = state.catalog.skipped_skill_diagnostics(None, None);
+            obj.insert("skipped".to_string(), json!(skipped));
+        }
+    }
     let text = serde_json::to_string_pretty(&payload).unwrap_or_default();
     CallToolResult::text(text)
+}
+
+fn parse_list_offset(arguments: &Value) -> usize {
+    arguments.get("offset").and_then(Value::as_u64).unwrap_or(0) as usize
+}
+
+fn parse_list_limit(arguments: &Value) -> Option<usize> {
+    arguments.get("limit").and_then(Value::as_u64).map(|n| {
+        let n = n as usize;
+        if n == 0 {
+            0
+        } else {
+            n.min(dcc_mcp_skills::catalog::list_projection::MAX_LIST_SKILLS_LIMIT)
+        }
+    })
+}
+
+fn build_list_skipped_skills_response(
+    mut skipped: Vec<dcc_mcp_skills::SkippedSkillDiagnostic>,
+    arguments: &Value,
+) -> Value {
+    skipped.sort_by(|a, b| a.skill_name.cmp(&b.skill_name));
+    let total = skipped.len();
+    let offset = parse_list_offset(arguments).min(total);
+    let limit = parse_list_limit(arguments);
+    let end = match limit {
+        Some(limit) => (offset + limit).min(total),
+        None => total,
+    };
+    let page = skipped[offset..end].to_vec();
+    let truncated = limit.is_some() && end < total;
+    let response_limit = limit.unwrap_or(page.len());
+
+    json!({
+        "skills": [],
+        "total": total,
+        "limit": response_limit,
+        "offset": offset,
+        "truncated": truncated,
+        "skipped_count": total,
+        "skipped": page,
+    })
 }
 
 pub(in crate::rmcp_tool_call_dispatch) fn handle_get_skill_info(
@@ -52,7 +115,22 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_get_skill_info(
             let text = serde_json::to_string_pretty(&info).unwrap_or_default();
             CallToolResult::text(text)
         }
-        None => CallToolResult::error(format!("Skill '{skill_name}' not found")),
+        None => {
+            if let Some(diagnostic) = state.catalog.skipped_skill_diagnostic(skill_name) {
+                let payload = json!({
+                    "error": "skill_skipped",
+                    "message": format!(
+                        "Skill '{skill_name}' was skipped during discovery: {}",
+                        diagnostic.message
+                    ),
+                    "skipped": diagnostic,
+                });
+                return CallToolResult::error(
+                    serde_json::to_string_pretty(&payload).unwrap_or_default(),
+                );
+            }
+            CallToolResult::error(format!("Skill '{skill_name}' not found"))
+        }
     }
 }
 
@@ -301,12 +379,23 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_search_skills(
         .clamp(1, MAX_LIMIT);
 
     let query_opt = if query.is_empty() { None } else { Some(query) };
+    let scope_label = scope_filter.map(|scope| scope.label());
     let matches =
         state
             .catalog
             .search_skills(query_opt, &tags, dcc_filter, scope_filter, Some(limit));
+    let remaining = limit.saturating_sub(matches.len());
+    let skipped_matches: Vec<_> = state
+        .catalog
+        .skipped_skill_diagnostics(query_opt, None)
+        .into_iter()
+        .filter(|diagnostic| {
+            skipped_diagnostic_matches_filters(diagnostic, &tags, dcc_filter, scope_label)
+        })
+        .take(remaining)
+        .collect();
 
-    if matches.is_empty() {
+    if matches.is_empty() && skipped_matches.is_empty() {
         let text = if query.is_empty()
             && tags.is_empty()
             && dcc_filter.is_none()
@@ -345,12 +434,54 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_search_skills(
         .collect();
 
     let result = json!({
-        "total": matches.len(),
+        "total": matches.len() + skipped_matches.len(),
+        "skill_total": matches.len(),
+        "skipped_count": skipped_matches.len(),
         "query": query,
-        "skills": compact_skills
+        "skills": compact_skills,
+        "skipped": skipped_matches
     });
 
     CallToolResult::text(serde_json::to_string(&result).unwrap_or_default())
+}
+
+fn skipped_diagnostic_matches_filters(
+    diagnostic: &dcc_mcp_skills::SkippedSkillDiagnostic,
+    tags: &[&str],
+    dcc_filter: Option<&str>,
+    scope_label: Option<&str>,
+) -> bool {
+    if let Some(dcc) = dcc_filter
+        && !dcc.is_empty()
+        && !diagnostic
+            .dcc
+            .as_deref()
+            .is_some_and(|value| value.eq_ignore_ascii_case(dcc))
+    {
+        return false;
+    }
+
+    if !tags.is_empty()
+        && !tags.iter().all(|tag| {
+            diagnostic
+                .tags
+                .iter()
+                .any(|value| value.eq_ignore_ascii_case(tag))
+        })
+    {
+        return false;
+    }
+
+    if let Some(scope) = scope_label
+        && !diagnostic
+            .scope
+            .as_deref()
+            .is_some_and(|value| value.eq_ignore_ascii_case(scope))
+    {
+        return false;
+    }
+
+    true
 }
 
 pub(in crate::rmcp_tool_call_dispatch) fn handle_activate_tool_group(

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/mod.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/mod.rs
@@ -256,7 +256,8 @@ mod tests {
     use dcc_mcp_actions::ToolDispatcher;
     use dcc_mcp_actions::registry::{ToolMeta, ToolRegistry};
     use dcc_mcp_job::job::JobStatus;
-    use dcc_mcp_models::{ExecutionMode, ThreadAffinity};
+    use dcc_mcp_jsonrpc::ToolContent;
+    use dcc_mcp_models::{ExecutionMode, SkillScope, ThreadAffinity};
     use dcc_mcp_skill_rest::StaticReadiness;
     use dcc_mcp_skills::SkillCatalog;
     use serde_json::json;
@@ -282,6 +283,199 @@ mod tests {
             readiness: Arc::new(StaticReadiness::fully_ready()),
             on_skill_catalog_mutated: Arc::new(|| {}),
         }
+    }
+
+    fn result_text_json(result: &dcc_mcp_jsonrpc::CallToolResult) -> Value {
+        serde_json::from_str(result_text(result)).expect("handler text should be JSON")
+    }
+
+    fn result_text(result: &dcc_mcp_jsonrpc::CallToolResult) -> &str {
+        let Some(ToolContent::Text { text }) = result.content.first() else {
+            panic!("expected text content, got {result:?}");
+        };
+        text
+    }
+
+    #[tokio::test]
+    async fn skipped_skill_diagnostics_are_visible_through_mcp_discovery() {
+        let temp = tempfile::tempdir().unwrap();
+        let skill_dir = temp.path().join("maya-mgear");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join(dcc_mcp_skills::constants::SKILL_METADATA_FILE),
+            "---\nname: maya-mgear\ndescription: mGear integration\nversion: \"1.0.0\"\n---\n# body\n",
+        )
+        .unwrap();
+
+        let registry = Arc::new(ToolRegistry::new());
+        let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+        let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+            Arc::clone(&registry),
+            Arc::clone(&dispatcher),
+        ));
+        let roots = vec![temp.path().to_string_lossy().to_string()];
+        catalog.discover(Some(&roots), Some("maya"));
+        let state = ServerState::builder(registry, dispatcher, catalog).build();
+
+        let search = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "search_skills",
+            Some(json!({"query": "mgear"})),
+            None,
+        )
+        .await
+        .expect("search_skills dispatch should succeed");
+        assert!(!search.is_error);
+        let search_payload = result_text_json(&search);
+        assert_eq!(search_payload["skipped_count"], 1);
+        assert_eq!(search_payload["skipped"][0]["skill_name"], "maya-mgear");
+        assert!(
+            search_payload["skipped"][0]["suggested_fix"]
+                .as_str()
+                .unwrap()
+                .contains("metadata.dcc-mcp.version")
+        );
+
+        let listed = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "list_skills",
+            Some(json!({"status": "skipped"})),
+            None,
+        )
+        .await
+        .expect("list_skills dispatch should succeed");
+        let list_payload = result_text_json(&listed);
+        assert_eq!(list_payload["skipped_count"], 1);
+        assert_eq!(
+            list_payload["skipped"][0]["reason_code"],
+            "non_spec_top_level_keys"
+        );
+
+        let info = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "get_skill_info",
+            Some(json!({"skill_name": "maya-mgear"})),
+            None,
+        )
+        .await
+        .expect("get_skill_info dispatch should succeed");
+        assert!(info.is_error);
+        let info_payload = result_text_json(&info);
+        assert_eq!(info_payload["error"], "skill_skipped");
+        assert!(
+            !info_payload
+                .to_string()
+                .contains(temp.path().to_string_lossy().as_ref())
+        );
+    }
+
+    #[tokio::test]
+    async fn skipped_skill_diagnostics_obey_search_filters_and_pagination() {
+        let temp = tempfile::tempdir().unwrap();
+        let maya_dir = temp.path().join("maya-broken");
+        let blender_dir = temp.path().join("blender-broken");
+        std::fs::create_dir_all(&maya_dir).unwrap();
+        std::fs::create_dir_all(&blender_dir).unwrap();
+        std::fs::write(
+            maya_dir.join(dcc_mcp_skills::constants::SKILL_METADATA_FILE),
+            "---\nname: maya-broken\ndescription: Broken Maya skill\nversion: \"1.0.0\"\nmetadata:\n  dcc-mcp:\n    dcc: maya\n    tags: [rigging]\n---\n# body\n",
+        )
+        .unwrap();
+        std::fs::write(
+            blender_dir.join(dcc_mcp_skills::constants::SKILL_METADATA_FILE),
+            "---\nname: blender-broken\ndescription: Broken Blender skill\nversion: \"1.0.0\"\nmetadata:\n  dcc-mcp:\n    dcc: blender\n    tags: [modeling]\n---\n# body\n",
+        )
+        .unwrap();
+
+        let registry = Arc::new(ToolRegistry::new());
+        let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+        let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+            Arc::clone(&registry),
+            Arc::clone(&dispatcher),
+        ));
+        let roots = vec![temp.path().to_string_lossy().to_string()];
+        catalog.discover_scoped(&[(SkillScope::System, roots)], None);
+        let state = ServerState::builder(registry, dispatcher, catalog).build();
+
+        let filtered = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "search_skills",
+            Some(json!({
+                "query": "broken",
+                "dcc": "blender",
+                "scope": "system",
+                "limit": 1
+            })),
+            None,
+        )
+        .await
+        .expect("search_skills dispatch should succeed");
+        let filtered_payload = result_text_json(&filtered);
+        assert_eq!(filtered_payload["total"], 1);
+        assert_eq!(filtered_payload["skill_total"], 0);
+        assert_eq!(filtered_payload["skipped_count"], 1);
+        assert_eq!(
+            filtered_payload["skipped"][0]["skill_name"],
+            "blender-broken"
+        );
+        assert_eq!(filtered_payload["skipped"][0]["dcc"], "blender");
+        assert_eq!(filtered_payload["skipped"][0]["scope"], "system");
+
+        let tag_filtered = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "search_skills",
+            Some(json!({"query": "broken", "tags": ["rigging"], "limit": 20})),
+            None,
+        )
+        .await
+        .expect("search_skills dispatch should succeed");
+        let tag_payload = result_text_json(&tag_filtered);
+        assert_eq!(tag_payload["skipped_count"], 1);
+        assert_eq!(tag_payload["skipped"][0]["skill_name"], "maya-broken");
+
+        let wrong_scope = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "search_skills",
+            Some(json!({"query": "broken", "scope": "repo"})),
+            None,
+        )
+        .await
+        .expect("search_skills dispatch should succeed");
+        assert_eq!(
+            result_text(&wrong_scope),
+            "No skills found matching 'broken'."
+        );
+
+        let listed = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "list_skills",
+            Some(json!({"status": "skipped", "limit": 1, "offset": 1})),
+            None,
+        )
+        .await
+        .expect("list_skills dispatch should succeed");
+        let list_payload = result_text_json(&listed);
+        assert_eq!(list_payload["total"], 2);
+        assert_eq!(list_payload["skipped_count"], 2);
+        assert_eq!(list_payload["limit"], 1);
+        assert_eq!(list_payload["offset"], 1);
+        assert_eq!(list_payload["truncated"], false);
+        assert_eq!(list_payload["skipped"].as_array().unwrap().len(), 1);
+        assert_eq!(list_payload["skills"].as_array().unwrap().len(), 0);
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-skills/src/catalog/catalog.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog.rs
@@ -140,6 +140,44 @@ impl SkillCatalog {
             .collect()
     }
 
+    /// Return safe diagnostics for skill directories that were scanned but
+    /// rejected by the loader.
+    pub fn skipped_skill_diagnostics(
+        &self,
+        query: Option<&str>,
+        limit: Option<usize>,
+    ) -> Vec<SkippedSkillDiagnostic> {
+        let mut diagnostics: Vec<SkippedSkillDiagnostic> = self
+            .skipped
+            .iter()
+            .filter(|entry| entry.value().matches_query(query))
+            .map(|entry| entry.value().clone())
+            .collect();
+        diagnostics.sort_by(|a, b| a.skill_name.cmp(&b.skill_name));
+        if let Some(limit) = limit {
+            diagnostics.truncate(limit);
+        }
+        diagnostics
+    }
+
+    /// Return a skipped diagnostic for an exact skill name or directory name.
+    pub fn skipped_skill_diagnostic(&self, skill_name: &str) -> Option<SkippedSkillDiagnostic> {
+        if let Some(entry) = self.skipped.get(skill_name) {
+            return Some(entry.value().clone());
+        }
+        let wanted = skill_name.trim();
+        self.skipped
+            .iter()
+            .find(|entry| entry.directory_name.eq_ignore_ascii_case(wanted))
+            .map(|entry| entry.value().clone())
+    }
+
+    /// Number of skipped skill diagnostics currently retained by the catalog.
+    #[must_use]
+    pub fn skipped_count(&self) -> usize {
+        self.skipped.len()
+    }
+
     /// Get detailed information about a specific skill.
     pub fn get_skill_info(&self, skill_name: &str) -> Option<SkillDetail> {
         self.entries.get(skill_name).map(|entry| {

--- a/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::path::Path;
 
 fn dependency_state_for(
     metadata: &SkillMetadata,
@@ -40,6 +41,7 @@ impl SkillCatalog {
     pub fn new(registry: Arc<ToolRegistry>) -> Self {
         Self {
             entries: DashMap::new(),
+            skipped: DashMap::new(),
             loaded: DashSet::new(),
             registry,
             dispatcher: None,
@@ -61,6 +63,7 @@ impl SkillCatalog {
         let event_bus = dispatcher.event_bus();
         Self {
             entries: DashMap::new(),
+            skipped: DashMap::new(),
             loaded: DashSet::new(),
             registry,
             dispatcher: Some(dispatcher),
@@ -226,6 +229,7 @@ impl SkillCatalog {
         let mut new_count = 0;
         for (skill, path_source) in result.skills {
             let name = skill.name.clone();
+            self.skipped.remove(&name);
             if !self.entries.contains_key(&name) {
                 self.entries.insert(
                     name,
@@ -243,6 +247,7 @@ impl SkillCatalog {
         self.refresh_dependency_states();
 
         if !result.skipped.is_empty() {
+            self.record_skipped_diagnostics(&result.skipped, SkillScope::Repo);
             tracing::warn!(
                 count = result.skipped.len(),
                 skipped = ?result.skipped,
@@ -273,10 +278,12 @@ impl SkillCatalog {
         };
 
         let mut seen = std::collections::HashSet::new();
+        self.skipped.clear();
         let mut added = 0usize;
 
         for (skill, path_source) in result.skills {
             let name = skill.name.clone();
+            self.skipped.remove(&name);
             seen.insert(name.clone());
             if let Some(mut entry) = self.entries.get_mut(&name) {
                 entry.metadata = skill;
@@ -313,6 +320,7 @@ impl SkillCatalog {
         self.refresh_dependency_states();
 
         if !result.skipped.is_empty() {
+            self.record_skipped_diagnostics(&result.skipped, SkillScope::Repo);
             tracing::warn!(
                 count = result.skipped.len(),
                 skipped = ?result.skipped,
@@ -332,6 +340,7 @@ impl SkillCatalog {
     /// Add a single skill to the catalog (e.g. from SkillWatcher).
     pub fn add_skill(&self, metadata: SkillMetadata) {
         let name = metadata.name.clone();
+        self.skipped.remove(&name);
         if let Some(mut entry) = self.entries.get_mut(&name) {
             if entry.state != SkillState::Loaded {
                 entry.metadata = metadata;
@@ -372,6 +381,7 @@ impl SkillCatalog {
                 };
 
             if !result.skipped.is_empty() {
+                self.record_skipped_diagnostics(&result.skipped, *scope);
                 tracing::warn!(
                     scope = %scope,
                     count = result.skipped.len(),
@@ -382,6 +392,7 @@ impl SkillCatalog {
 
             for skill in result.skills {
                 let name = skill.name.clone();
+                self.skipped.remove(&name);
                 if !self.entries.contains_key(&name) {
                     self.entries.insert(
                         name,
@@ -404,6 +415,22 @@ impl SkillCatalog {
             scoped_paths.len()
         );
         total_new
+    }
+
+    fn record_skipped_diagnostics(&self, skipped_dirs: &[String], scope: SkillScope) {
+        for dir in skipped_dirs {
+            let diagnostic =
+                loader::diagnose_skipped_skill_dir(Path::new(dir)).with_scope(scope.label());
+            tracing::warn!(
+                skill_name = %diagnostic.skill_name,
+                reason_code = %diagnostic.reason_code,
+                suggested_fix = %diagnostic.suggested_fix,
+                "SkillCatalog: skipped skill diagnostic: {}",
+                diagnostic.message,
+            );
+            self.skipped
+                .insert(diagnostic.skill_name.clone(), diagnostic);
+        }
     }
 
     /// Discover user-level and team-level accumulated skills from environment variables.

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -264,7 +264,14 @@ impl SkillCatalog {
         let metadata = match self.entries.get(skill_name) {
             Some(entry) => entry.metadata.clone(),
             None => {
-                let err = format!("Skill '{skill_name}' not found in catalog");
+                let err = if let Some(diagnostic) = self.skipped_skill_diagnostic(skill_name) {
+                    format!(
+                        "Skill '{skill_name}' not found in catalog, but a matching skill directory was skipped because {} Suggested fix: {}",
+                        diagnostic.message, diagnostic.suggested_fix
+                    )
+                } else {
+                    format!("Skill '{skill_name}' not found in catalog")
+                };
                 self.emit_skill_event(
                     "skill.validation_failed",
                     skill_name,
@@ -670,6 +677,7 @@ impl SkillCatalog {
         if self.loaded.contains(skill_name) {
             let _ = self.unload_skill(skill_name);
         }
+        self.skipped.remove(skill_name);
         let removed = self.entries.remove(skill_name).is_some();
         if removed {
             self.refresh_dependency_states();
@@ -688,6 +696,7 @@ impl SkillCatalog {
             let _ = self.unload_skill(&name);
         }
         self.entries.clear();
+        self.skipped.clear();
     }
 
     /// Replay a persisted set of loaded skills + active groups (#1405).

--- a/crates/dcc-mcp-skills/src/catalog/list_projection.rs
+++ b/crates/dcc-mcp-skills/src/catalog/list_projection.rs
@@ -183,6 +183,16 @@ pub fn project_list_skills_payload(mut payload: Value, args: &Value) -> Value {
             .as_object_mut()
             .map(|obj| obj.insert("instances".into(), instances.clone()));
     }
+    if let Some(skipped_count) = payload.get("skipped_count") {
+        projected
+            .as_object_mut()
+            .map(|obj| obj.insert("skipped_count".into(), skipped_count.clone()));
+    }
+    if let Some(skipped) = payload.get("skipped") {
+        projected
+            .as_object_mut()
+            .map(|obj| obj.insert("skipped".into(), skipped.clone()));
+    }
     projected
 }
 

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -63,6 +63,7 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 
 use crate::loader;
+use crate::loader::SkippedSkillDiagnostic;
 
 #[allow(clippy::module_inception)]
 mod catalog;
@@ -113,6 +114,9 @@ pub type AfterGroupChangeFn = dyn Fn(&str, bool) -> Result<(), String> + Send + 
 pub struct SkillCatalog {
     /// All discovered skill entries, keyed by skill name.
     pub(super) entries: DashMap<String, SkillEntry>,
+    /// Skill directories that were scanned but rejected by the loader, keyed
+    /// by best-effort skill name. Values are safe to surface through MCP.
+    pub(super) skipped: DashMap<String, SkippedSkillDiagnostic>,
     /// Set of skill names currently loaded.
     pub(super) loaded: DashSet<String>,
     /// Reference to ToolRegistry for registering/unregistering tools.
@@ -154,6 +158,7 @@ impl std::fmt::Debug for SkillCatalog {
             .field("discovered", &discovered)
             .field("loaded", &loaded)
             .field("total", &self.entries.len())
+            .field("skipped", &self.skipped.len())
             .finish()
     }
 }
@@ -184,7 +189,9 @@ pub(crate) fn group_default_active(groups: &[SkillGroup], group_name: &str) -> b
 /// dedicated methods (`add_skill`, `load_skill`, `remove_skill`, …) instead.
 impl Registry<SkillEntry> for SkillCatalog {
     fn register(&self, entry: SkillEntry) {
-        self.entries.insert(entry.key(), entry);
+        let key = entry.key();
+        self.skipped.remove(&key);
+        self.entries.insert(key, entry);
         self.refresh_dependency_states();
     }
 
@@ -197,6 +204,7 @@ impl Registry<SkillEntry> for SkillCatalog {
     }
 
     fn remove(&self, key: &str) -> bool {
+        self.skipped.remove(key);
         let removed = self.entries.remove(key).is_some();
         if removed {
             self.refresh_dependency_states();

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
@@ -23,6 +23,45 @@ fn test_catalog_new_is_empty() {
     assert!(catalog.is_empty());
     assert_eq!(catalog.len(), 0);
     assert_eq!(catalog.loaded_count(), 0);
+    assert_eq!(catalog.skipped_count(), 0);
+}
+
+#[test]
+fn test_discovery_surfaces_skipped_skill_diagnostics() {
+    let tmp = tempfile::tempdir().unwrap();
+    let skill_dir = tmp.path().join("maya-mgear");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join(crate::constants::SKILL_METADATA_FILE),
+        "---\nname: maya-mgear\ndescription: mGear integration\nversion: \"1.0.0\"\n---\n# body\n",
+    )
+    .unwrap();
+
+    let catalog = make_test_catalog();
+    let roots = vec![tmp.path().to_string_lossy().to_string()];
+
+    catalog.discover(Some(&roots), Some("maya"));
+    assert_eq!(catalog.skipped_count(), 1);
+
+    let diagnostics = catalog.skipped_skill_diagnostics(Some("mgear"), None);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].skill_name, "maya-mgear");
+    assert_eq!(diagnostics[0].reason_code, "non_spec_top_level_keys");
+    assert!(
+        diagnostics[0]
+            .suggested_fix
+            .contains("metadata.dcc-mcp.version")
+    );
+    assert!(
+        !diagnostics[0]
+            .message
+            .contains(tmp.path().to_string_lossy().as_ref())
+    );
+
+    let err = catalog.load_skill("maya-mgear").unwrap_err();
+    assert!(err.contains("matching skill directory was skipped"));
+    assert!(err.contains("metadata.dcc-mcp.version"));
+    assert!(!err.contains(tmp.path().to_string_lossy().as_ref()));
 }
 
 #[test]
@@ -115,7 +154,10 @@ fn test_rediscover_removes_missing_skill_and_registered_tools() {
     let paths = vec![tmp.path().to_string_lossy().to_string()];
     let changed = catalog.rediscover(Some(&paths), Some("maya"));
 
-    assert_eq!(changed, 2, "expected one add and one remove");
+    assert!(
+        changed >= 2,
+        "expected at least one add and one remove; local installed skills may also be discovered"
+    );
     assert!(catalog.get_skill_info("fresh-skill").is_some());
     assert!(catalog.get_skill_info("stale-skill").is_none());
     assert!(!catalog.is_loaded("stale-skill"));
@@ -658,7 +700,7 @@ fn test_get_skill_info_includes_skill_markdown() {
 
     let catalog = make_test_catalog();
     let paths = vec![tmp.path().to_string_lossy().to_string()];
-    assert_eq!(catalog.rediscover(Some(&paths), Some("maya")), 1);
+    assert!(catalog.rediscover(Some(&paths), Some("maya")) >= 1);
 
     let info = catalog.get_skill_info("review-skill").unwrap();
     assert!(

--- a/crates/dcc-mcp-skills/src/lib.rs
+++ b/crates/dcc-mcp-skills/src/lib.rs
@@ -20,7 +20,8 @@ pub use catalog::{SkillCatalog, SkillDetail, SkillState, SkillSummary};
 pub use feedback::{SkillFeedback, get_skill_feedback, record_skill_feedback};
 pub use gui_executable::{GuiExecutableHint, correct_python_executable, is_gui_executable};
 pub use loader::{
-    LoadResult, LoadResultWithSources, parse_skill_md, scan_and_load, scan_and_load_lenient,
+    LoadResult, LoadResultWithSources, SkippedSkillDiagnostic, diagnose_skipped_skill_dir,
+    parse_skill_md, parse_skill_md_with_diagnostic, scan_and_load, scan_and_load_lenient,
     scan_and_load_lenient_with_sources, scan_and_load_strict, scan_and_load_team,
     scan_and_load_team_lenient, scan_and_load_user, scan_and_load_user_lenient,
 };

--- a/crates/dcc-mcp-skills/src/loader/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/mod.rs
@@ -27,6 +27,108 @@ const AGENTSKILLS_SPEC_KEYS: &[&str] = &[
     "allowed_tools",
 ];
 
+/// Diagnostic captured when a skill directory is scanned but cannot be loaded.
+///
+/// The payload intentionally carries only a directory basename, not the
+/// absolute path. Full paths remain available in local logs and in the legacy
+/// `LoadResult.skipped` vector for callers that already opted into local
+/// filesystem details.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SkippedSkillDiagnostic {
+    /// Best-effort skill name, read from frontmatter when possible and falling
+    /// back to the directory name otherwise.
+    pub skill_name: String,
+    /// Directory basename, safe to surface through MCP discovery.
+    pub directory_name: String,
+    /// Stable machine-readable reason code.
+    pub reason_code: String,
+    /// Human-readable reason with no absolute path.
+    pub message: String,
+    /// Actionable migration or repair hint.
+    pub suggested_fix: String,
+    /// Best-effort DCC filter metadata from frontmatter when it can be
+    /// parsed safely.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dcc: Option<String>,
+    /// Best-effort tag filter metadata from frontmatter when it can be
+    /// parsed safely.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    /// Catalog scope that found the skipped directory, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    /// Non-spec frontmatter keys that caused rejection, when applicable.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub offending_keys: Vec<String>,
+}
+
+impl SkippedSkillDiagnostic {
+    fn new(
+        skill_dir: &Path,
+        skill_name: Option<String>,
+        reason_code: impl Into<String>,
+        message: impl Into<String>,
+        suggested_fix: impl Into<String>,
+    ) -> Self {
+        let directory_name = skill_dir
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let skill_name = skill_name
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| directory_name.clone());
+        Self {
+            skill_name,
+            directory_name,
+            reason_code: reason_code.into(),
+            message: message.into(),
+            suggested_fix: suggested_fix.into(),
+            dcc: None,
+            tags: Vec::new(),
+            scope: None,
+            offending_keys: Vec::new(),
+        }
+    }
+
+    pub fn with_scope(mut self, scope: impl Into<String>) -> Self {
+        self.scope = Some(scope.into());
+        self
+    }
+
+    fn with_filter_metadata(mut self, dcc: Option<String>, tags: Vec<String>) -> Self {
+        self.dcc = dcc.filter(|value| !value.trim().is_empty());
+        self.tags = tags;
+        self
+    }
+
+    fn with_offending_keys(mut self, offending_keys: Vec<String>) -> Self {
+        self.offending_keys = offending_keys;
+        self
+    }
+
+    /// Return true when this diagnostic should be surfaced for a discovery
+    /// query. Matching is deliberately simple and local: agents need "why did
+    /// maya-mgear disappear?", not a second BM25 index.
+    pub fn matches_query(&self, query: Option<&str>) -> bool {
+        let q = query.map(str::trim).unwrap_or_default();
+        if q.is_empty() {
+            return true;
+        }
+        let q = q.to_ascii_lowercase();
+        let haystack = format!(
+            "{} {} {} {} {} {}",
+            self.skill_name,
+            self.directory_name,
+            self.reason_code,
+            self.message,
+            self.suggested_fix,
+            self.offending_keys.join(" ")
+        )
+        .to_ascii_lowercase();
+        haystack.contains(&q)
+    }
+}
+
 mod files;
 mod scan;
 
@@ -44,22 +146,50 @@ pub use scan::{
 /// Parse a SKILL.md file from a skill directory.
 #[must_use]
 pub fn parse_skill_md(skill_dir: &Path) -> Option<SkillMetadata> {
+    parse_skill_md_with_diagnostic(skill_dir).ok()
+}
+
+/// Parse a SKILL.md file from a skill directory, returning a structured
+/// skipped diagnostic when the loader rejects it.
+pub fn parse_skill_md_with_diagnostic(
+    skill_dir: &Path,
+) -> Result<SkillMetadata, Box<SkippedSkillDiagnostic>> {
     let skill_md_path = skill_dir.join(SKILL_METADATA_FILE);
     if !skill_md_path.is_file() {
         tracing::warn!("SKILL.md not found at: {}", skill_md_path.display());
-        return None;
+        return Err(Box::new(SkippedSkillDiagnostic::new(
+            skill_dir,
+            None,
+            "missing_skill_md",
+            "SKILL.md not found",
+            "Create a SKILL.md file with agentskills.io frontmatter.",
+        )));
     }
 
     let content = match std::fs::read_to_string(&skill_md_path) {
         Ok(c) => c,
         Err(e) => {
             tracing::warn!("Error reading {}: {}", skill_md_path.display(), e);
-            return None;
+            return Err(Box::new(SkippedSkillDiagnostic::new(
+                skill_dir,
+                None,
+                "read_error",
+                format!("Cannot read SKILL.md: {e}"),
+                "Fix file permissions or encoding, then rescan the skill directory.",
+            )));
         }
     };
 
     // Extract YAML frontmatter between --- delimiters
-    let frontmatter = extract_frontmatter(&content)?;
+    let frontmatter = extract_frontmatter(&content).ok_or_else(|| {
+        Box::new(SkippedSkillDiagnostic::new(
+            skill_dir,
+            None,
+            "missing_frontmatter",
+            "SKILL.md missing YAML frontmatter",
+            "Start SKILL.md with a YAML frontmatter block delimited by ---.",
+        ))
+    })?;
 
     // Parse once into a raw YAML value so we can validate top-level keys
     // before handing off to serde. All dcc-mcp-core extensions must live
@@ -73,7 +203,13 @@ pub fn parse_skill_md(skill_dir: &Path) -> Option<SkillMetadata> {
                 skill_md_path.display(),
                 e
             );
-            return None;
+            return Err(Box::new(SkippedSkillDiagnostic::new(
+                skill_dir,
+                None,
+                "invalid_frontmatter_yaml",
+                format!("Invalid YAML frontmatter: {e}"),
+                "Fix the YAML frontmatter syntax, then rescan the skill directory.",
+            )));
         }
     };
 
@@ -81,21 +217,36 @@ pub fn parse_skill_md(skill_dir: &Path) -> Option<SkillMetadata> {
     // 1.0 spec. This replaces the pre-0.15 dual-read path that silently
     // accepted legacy top-level extension keys.
     if let Some(map) = raw_value.as_mapping() {
-        let mut offending: Vec<&str> = map
+        let mut offending: Vec<String> = map
             .iter()
             .filter_map(|(k, _)| k.as_str())
             .filter(|k| !AGENTSKILLS_SPEC_KEYS.contains(k))
+            .map(str::to_string)
             .collect();
         if !offending.is_empty() {
             offending.sort_unstable();
             offending.dedup();
+            let suggested_fix = non_spec_top_level_suggestion(&offending);
             tracing::error!(
                 "skill at {}: non-spec top-level key(s) {:?}; move them under metadata.dcc-mcp.* \
                  (see docs/guide/skills.md#migrating-pre-015-skillmd)",
                 skill_md_path.display(),
                 offending,
             );
-            return None;
+            return Err(Box::new(
+                SkippedSkillDiagnostic::new(
+                    skill_dir,
+                    raw_skill_name(&raw_value, skill_dir),
+                    "non_spec_top_level_keys",
+                    format!(
+                        "SKILL.md uses non-spec top-level key(s) {:?}; dcc-mcp-core extensions must live under metadata.dcc-mcp.*.",
+                        offending
+                    ),
+                    suggested_fix,
+                )
+                .with_frontmatter_filter_metadata(&raw_value)
+                .with_offending_keys(offending),
+            ));
         }
     }
 
@@ -107,7 +258,14 @@ pub fn parse_skill_md(skill_dir: &Path) -> Option<SkillMetadata> {
                 skill_md_path.display(),
                 e
             );
-            return None;
+            return Err(Box::new(SkippedSkillDiagnostic::new(
+                skill_dir,
+                raw_skill_name(&raw_value, skill_dir),
+                "invalid_frontmatter_shape",
+                format!("Cannot deserialize frontmatter into SkillMetadata: {e}"),
+                "Keep top-level fields to name, description, license, compatibility, metadata, and allowed-tools.",
+            )
+            .with_frontmatter_filter_metadata(&raw_value)));
         }
     };
 
@@ -159,7 +317,120 @@ pub fn parse_skill_md(skill_dir: &Path) -> Option<SkillMetadata> {
     // Merge depends from metadata/depends.md if present
     merge_depends_from_metadata(skill_dir, &mut meta);
 
-    Some(meta)
+    Ok(meta)
+}
+
+/// Re-run the loader in diagnostic mode for a directory that was skipped by a
+/// scan. If the directory now parses successfully, return a generic stale
+/// diagnostic so callers can refresh their catalog state.
+#[must_use]
+pub fn diagnose_skipped_skill_dir(skill_dir: &Path) -> SkippedSkillDiagnostic {
+    match parse_skill_md_with_diagnostic(skill_dir) {
+        Ok(meta) => SkippedSkillDiagnostic::new(
+            skill_dir,
+            Some(meta.name.clone()),
+            "stale_skip_record",
+            "Skill now parses successfully but the catalog still has a skipped record.",
+            "Rediscover skills to refresh the catalog state.",
+        )
+        .with_filter_metadata((!meta.dcc.is_empty()).then_some(meta.dcc), meta.tags),
+        Err(diagnostic) => *diagnostic,
+    }
+}
+
+impl SkippedSkillDiagnostic {
+    fn with_frontmatter_filter_metadata(self, raw: &serde_yaml_ng::Value) -> Self {
+        let (dcc, tags) = frontmatter_filter_metadata(raw);
+        self.with_filter_metadata(dcc, tags)
+    }
+}
+
+fn raw_skill_name(raw: &serde_yaml_ng::Value, skill_dir: &Path) -> Option<String> {
+    raw.as_mapping()
+        .and_then(|map| map.get(serde_yaml_ng::Value::String("name".to_string())))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .or_else(|| {
+            skill_dir
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+}
+
+fn frontmatter_filter_metadata(raw: &serde_yaml_ng::Value) -> (Option<String>, Vec<String>) {
+    let mut dcc = None;
+    let mut tags = Vec::new();
+
+    for (key, value) in collect_dcc_mcp_overrides(raw) {
+        match key.as_str() {
+            "dcc" if dcc.is_none() => {
+                dcc = value.as_str().map(str::to_string);
+            }
+            "tags" if tags.is_empty() => {
+                tags = parse_csv_or_list(&value);
+            }
+            _ => {}
+        }
+    }
+
+    let Some(map) = raw.as_mapping() else {
+        return (dcc, tags);
+    };
+    if dcc.is_none() {
+        dcc = map
+            .get(serde_yaml_ng::Value::String("dcc".to_string()))
+            .and_then(|value| value.as_str())
+            .map(str::to_string);
+    }
+    if tags.is_empty()
+        && let Some(value) = map.get(serde_yaml_ng::Value::String("tags".to_string()))
+    {
+        tags = parse_csv_or_list(value);
+    }
+
+    (dcc, tags)
+}
+
+fn non_spec_top_level_suggestion(offending: &[String]) -> String {
+    let mut replacements = Vec::new();
+    for key in offending {
+        let replacement = match key.as_str() {
+            "dcc" => "metadata.dcc-mcp.dcc",
+            "version" => "metadata.dcc-mcp.version",
+            "tags" => "metadata.dcc-mcp.tags",
+            "tools" => "metadata.dcc-mcp.tools: tools.yaml",
+            "groups" => "metadata.dcc-mcp.groups",
+            "prompts" => "metadata.dcc-mcp.prompts",
+            "resources" => "metadata.dcc-mcp.resources",
+            "depends" => "metadata.dcc-mcp.depends",
+            "layer" => "metadata.dcc-mcp.layer",
+            "stage" => "metadata.dcc-mcp.stage",
+            "search-hint" | "search_hint" => "metadata.dcc-mcp.search-hint",
+            "search-aliases" | "search_aliases" | "aliases" => "metadata.dcc-mcp.search-aliases",
+            "products" => "metadata.dcc-mcp.products",
+            "allow-implicit-invocation" | "allow_implicit_invocation" => {
+                "metadata.dcc-mcp.allow-implicit-invocation"
+            }
+            "external-deps" | "external_deps" => "metadata.dcc-mcp.external-deps",
+            "runtimes" | "runtime-deps" | "optional-runtimes" => "metadata.dcc-mcp.runtimes",
+            "recipes" => "metadata.dcc-mcp.recipes",
+            "introspection" => "metadata.dcc-mcp.introspection",
+            "branding" => "metadata.dcc-mcp.branding",
+            "links" => "metadata.dcc-mcp.links",
+            "example-prompts" | "example_prompts" => "metadata.dcc-mcp.example-prompts",
+            _ => "metadata.dcc-mcp.<key>",
+        };
+        replacements.push(format!("{key} -> {replacement}"));
+    }
+
+    if replacements.is_empty() {
+        "Move dcc-mcp-core extensions under metadata.dcc-mcp.*.".to_string()
+    } else {
+        format!(
+            "Move unsupported top-level key(s): {}. For version metadata, use metadata.dcc-mcp.version: \"1.0.0\".",
+            replacements.join(", ")
+        )
+    }
 }
 
 // ── Issue #356: agentskills.io-compliant metadata.dcc-mcp.* support ──

--- a/crates/dcc-mcp-skills/src/loader/scan.rs
+++ b/crates/dcc-mcp-skills/src/loader/scan.rs
@@ -7,7 +7,7 @@ use crate::catalog::scoring::SkillPathSource;
 use crate::resolver::{self, ResolveError};
 use crate::scanner::SkillScanner;
 
-use super::parse_skill_md;
+use super::parse_skill_md_with_diagnostic;
 
 /// Result of a full scan-and-load pipeline.
 #[derive(Debug, Clone)]
@@ -218,14 +218,16 @@ pub(crate) fn load_all_skills(dirs: &[String]) -> (Vec<SkillMetadata>, Vec<Strin
 
     for dir_str in dirs {
         let dir = Path::new(dir_str);
-        match parse_skill_md(dir) {
-            Some(meta) => skills.push(meta),
-            None => {
+        match parse_skill_md_with_diagnostic(dir) {
+            Ok(meta) => skills.push(meta),
+            Err(diagnostic) => {
                 tracing::warn!(
                     directory = %dir_str,
-                    "Skipping skill directory: SKILL.md missing or failed validation \
-                     (see preceding parse warnings for the specific cause). \
-                     Use scan_and_load_strict() to fail-fast on such directories."
+                    reason_code = %diagnostic.reason_code,
+                    skill_name = %diagnostic.skill_name,
+                    suggested_fix = %diagnostic.suggested_fix,
+                    "Skipping skill directory: {}. Use scan_and_load_strict() to fail-fast on such directories.",
+                    diagnostic.message
                 );
                 skipped.push(dir_str.clone());
             }

--- a/crates/dcc-mcp-skills/src/loader/tests/test_metadata_compat.rs
+++ b/crates/dcc-mcp-skills/src/loader/tests/test_metadata_compat.rs
@@ -23,6 +23,34 @@ fn legacy_top_level_keys_are_rejected() {
 }
 
 #[test]
+fn top_level_version_rejection_reports_nested_replacement() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("maya-mgear");
+    write_skill(
+        &dir,
+        "---\nname: maya-mgear\ndescription: mGear tools\nversion: \"1.0.0\"\n---\n# body\n",
+    );
+
+    let diagnostic = parse_skill_md_with_diagnostic(&dir).unwrap_err();
+
+    assert_eq!(diagnostic.skill_name, "maya-mgear");
+    assert_eq!(diagnostic.directory_name, "maya-mgear");
+    assert_eq!(diagnostic.reason_code, "non_spec_top_level_keys");
+    assert_eq!(diagnostic.offending_keys, vec!["version".to_string()]);
+    assert!(diagnostic.message.contains("non-spec top-level key"));
+    assert!(
+        diagnostic
+            .suggested_fix
+            .contains("metadata.dcc-mcp.version")
+    );
+    assert!(
+        !diagnostic
+            .message
+            .contains(tmp.path().to_string_lossy().as_ref())
+    );
+}
+
+#[test]
 fn legacy_flat_form_does_not_populate_typed_fields() {
     // The pre-0.15 flat shorthand is no longer parsed into
     // `SkillMetadata` typed fields; the skill parses (the YAML itself

--- a/crates/dcc-mcp-skills/src/validator/rules.rs
+++ b/crates/dcc-mcp-skills/src/validator/rules.rs
@@ -77,6 +77,7 @@ pub fn validate_skill_dir(skill_dir: &Path) -> SkillValidationReport {
 
     let non_spec = detect_non_spec_top_level_fields(&raw_value);
     if !non_spec.is_empty() {
+        let migration_hint = non_spec_top_level_migration_hint(&non_spec);
         report.issues.push(SkillValidationIssue::error(
             IssueCategory::Frontmatter,
             format!(
@@ -84,8 +85,8 @@ pub fn validate_skill_dir(skill_dir: &Path) -> SkillValidationReport {
                  The loader rejects any key outside the agentskills.io 1.0 \
                  spec (name, description, license, compatibility, metadata, \
                  allowed-tools). Move dcc-mcp-core extensions under \
-                 metadata.dcc-mcp.*.",
-                non_spec
+                 metadata.dcc-mcp.*. {migration_hint}",
+                non_spec,
             ),
         ));
     }
@@ -511,6 +512,47 @@ fn detect_non_spec_top_level_fields(root: &serde_yaml_ng::Value) -> Vec<String> 
         }
     }
     out
+}
+
+fn non_spec_top_level_migration_hint(keys: &[String]) -> String {
+    let mut replacements = Vec::new();
+    for key in keys {
+        let replacement = match key.as_str() {
+            "dcc" => "metadata.dcc-mcp.dcc",
+            "version" => "metadata.dcc-mcp.version",
+            "tags" => "metadata.dcc-mcp.tags",
+            "tools" => "metadata.dcc-mcp.tools: tools.yaml",
+            "groups" => "metadata.dcc-mcp.groups",
+            "prompts" => "metadata.dcc-mcp.prompts",
+            "resources" => "metadata.dcc-mcp.resources",
+            "depends" => "metadata.dcc-mcp.depends",
+            "layer" => "metadata.dcc-mcp.layer",
+            "stage" => "metadata.dcc-mcp.stage",
+            "search-hint" | "search_hint" => "metadata.dcc-mcp.search-hint",
+            "search-aliases" | "search_aliases" | "aliases" => "metadata.dcc-mcp.search-aliases",
+            "products" => "metadata.dcc-mcp.products",
+            "allow-implicit-invocation" | "allow_implicit_invocation" => {
+                "metadata.dcc-mcp.allow-implicit-invocation"
+            }
+            "external-deps" | "external_deps" => "metadata.dcc-mcp.external-deps",
+            "runtimes" | "runtime-deps" | "optional-runtimes" => "metadata.dcc-mcp.runtimes",
+            "recipes" => "metadata.dcc-mcp.recipes",
+            "introspection" => "metadata.dcc-mcp.introspection",
+            "branding" => "metadata.dcc-mcp.branding",
+            "links" => "metadata.dcc-mcp.links",
+            "example-prompts" | "example_prompts" => "metadata.dcc-mcp.example-prompts",
+            _ => "metadata.dcc-mcp.<key>",
+        };
+        replacements.push(format!("{key} -> {replacement}"));
+    }
+    if replacements.is_empty() {
+        "Use metadata.dcc-mcp.<key> for dcc-mcp-core extensions.".to_string()
+    } else {
+        format!(
+            "Accepted replacement shape(s): {}. Example: metadata.dcc-mcp.version: \"1.0.0\".",
+            replacements.join(", ")
+        )
+    }
 }
 
 fn is_valid_version(version: &str) -> bool {

--- a/crates/dcc-mcp-skills/src/validator/tests.rs
+++ b/crates/dcc-mcp-skills/src/validator/tests.rs
@@ -160,6 +160,27 @@ fn test_non_spec_top_level_keys_error() {
 }
 
 #[test]
+fn test_top_level_version_error_includes_actionable_replacement() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = make_skill_dir(
+        &tmp,
+        "maya-mgear",
+        "---\nname: maya-mgear\ndescription: test\nversion: \"1.0.0\"\n---\n",
+    );
+    let report = validate_skill_dir(&dir);
+
+    let message = report
+        .issues
+        .iter()
+        .find(|issue| issue.severity == IssueSeverity::Error && issue.message.contains("version"))
+        .map(|issue| issue.message.as_str())
+        .expect("top-level version must be reported as an error");
+
+    assert!(message.contains("metadata.dcc-mcp.version"));
+    assert!(message.contains("metadata.dcc-mcp.version: \"1.0.0\""));
+}
+
+#[test]
 fn test_duplicate_tool_names() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = make_skill_dir(

--- a/docs/api/skills.md
+++ b/docs/api/skills.md
@@ -97,7 +97,7 @@ Lightweight summary returned by `SkillCatalog.search_skills()` and `list_skills(
 | `search_hint` | `str` | Keyword hint for search (from `search-hint:` in SKILL.md; falls back to `description`) |
 | `tags` | `List[str]` | Skill tags |
 | `dcc` | `str` | Target DCC (e.g. `"maya"`) |
-| `version` | `str` | Skill version |
+| `version` | `str` | Skill package version projected from `metadata.dcc-mcp.version`; top-level `version` in SKILL.md is rejected |
 | `tool_count` | `int` | Number of declared tools |
 | `tool_names` | `List[str]` | Names of declared tools |
 | `loaded` | `bool` | Whether the skill is currently loaded |

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -63,6 +63,12 @@ tools:
     source_file: scripts/export_fbx.bat
 ```
 
+`metadata.dcc-mcp.version` is the canonical skill package version field and
+is projected into `SkillMetadata.version`. Do not put `version` at the
+frontmatter root: top-level `version` is outside the agentskills.io 1.0 key
+set and the strict loader rejects it with a diagnostic that points to
+`metadata.dcc-mcp.version: "1.0.0"`.
+
 The `metadata.dcc-mcp.search-hint` field provides comma-separated keywords for efficient skill discovery via `search_skills` without loading full tool schemas. Use bounded `metadata.dcc-mcp.search-aliases` and per-tool `search_aliases` in `tools.yaml` for domain synonyms, localized terms, or common user phrases that should improve gateway/per-DCC search recall without changing tool names, summaries, tags, or dispatch inputs.
 
 Optional adapter runtimes can be declared without turning skill discovery into
@@ -1620,7 +1626,7 @@ The `tags` and `dcc` filter arguments are applied *before* scoring.
 
 ## Migrating pre-0.15 SKILL.md
 
-Starting with dcc-mcp-core 0.15 (issue [#356](https://github.com/dcc-mcp/dcc-mcp-core/issues/356)), dcc-mcp-core-specific extension keys (`dcc`, `version`, `tags`, `tools`, …) MUST live under the agentskills.io-compliant nested `metadata.dcc-mcp` namespace rather than at the top level of SKILL.md frontmatter. The strict v0.15+ loader also no longer promotes the pre-0.15 flat dotted form (`metadata: { "dcc-mcp.dcc": ... }`) into typed fields. A SKILL.md with legacy top-level keys fails to load and emits a `tracing::error!`.
+Starting with dcc-mcp-core 0.15 (issue [#356](https://github.com/dcc-mcp/dcc-mcp-core/issues/356)), dcc-mcp-core-specific extension keys (`dcc`, `version`, `tags`, `tools`, ...) MUST live under the agentskills.io-compliant nested `metadata.dcc-mcp` namespace rather than at the top level of SKILL.md frontmatter. The strict v0.15+ loader also no longer promotes the pre-0.15 flat dotted form (`metadata: { "dcc-mcp.dcc": ... }`) into typed fields. A SKILL.md with legacy top-level keys fails to load and emits a `tracing::error!`; MCP `list_skills(status="skipped")`, `search_skills`, and `load_skill` now surface the skipped reason and suggested replacement so operators do not need startup logs to diagnose a missing skill.
 
 ### Before (pre-0.15 legacy form — no longer accepted)
 

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -111,6 +111,8 @@ Generated `tools.yaml` entries follow the modern contract:
 
 - Local tool names are snake_case and client-safe. Do not use dotted names.
 - Loaded tools are published as `<skill-name>__<tool_name>` when namespacing is needed.
+- Skill package version metadata lives at `metadata.dcc-mcp.version` in
+  `SKILL.md`; a top-level `version` key is rejected by the strict loader.
 - `input_schema` and `output_schema` are declared explicitly.
 - Keep MCP-facing `input_schema` shapes simple: prefer a top-level object with
   `properties`, `required`, primitive `type`, bounds, and descriptions. Put
@@ -133,6 +135,14 @@ Generated `tools.yaml` entries follow the modern contract:
 6. Put long examples, recipes, and host-specific notes under `references/`.
 7. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before loading it in an adapter.
 8. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.
+
+When reviewing existing skills, reject top-level DCC-MCP extension keys such
+as `dcc`, `version`, `tags`, `tools`, `groups`, `depends`, `search-hint`,
+`runtimes`, `prompts`, and `resources`. Move them under
+`metadata.dcc-mcp.*`; for version metadata, use
+`metadata.dcc-mcp.version: "1.0.0"`. Validate the installable skill directory
+that contains the `SKILL.md` loaded by adapters, not only mirrored repository
+docs or marketplace metadata.
 
 Read [AUTHORING_WORKFLOW.md](references/AUTHORING_WORKFLOW.md) and
 [DCC_TOOL_CONTRACTS.md](references/DCC_TOOL_CONTRACTS.md) before changing a
@@ -211,4 +221,7 @@ The validator checks:
 - **Sidecar files**: `metadata.dcc-mcp.tools/groups/prompts` references exist
 - **Dependencies**: `metadata.dcc-mcp.depends` consistency
 - **Spec compliance**: non-standard top-level keys are frontmatter errors; dcc-mcp-core extensions must live under `metadata.dcc-mcp.*` and point to sibling files
+- **Version metadata**: `metadata.dcc-mcp.version` is accepted and projected
+  to `SkillMetadata.version`; top-level `version` fails with an actionable
+  migration hint
 - **Skill helper adoption**: `validate_skill_dir` emits `skill-helper-adoption` warnings when scripts import avoidable dependencies covered by `dcc_mcp_core.skills_helper`, such as `requests`, `httpx`, PyYAML, or local JSON/HTTP/file/path helper modules

--- a/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
+++ b/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
@@ -27,6 +27,14 @@ DCC-MCP extension pointers such as `tools`, `prompts`, `recipes`, `workflows`,
 and `depends` under `metadata.dcc-mcp.*`. Use `references/` for long-form docs,
 recipes, examples, and notes that agents should load only when needed.
 
+Skill package version metadata is also a DCC-MCP extension: declare it as
+`metadata.dcc-mcp.version: "1.0.0"`. Do not put `version` at the top level of
+`SKILL.md`; the strict loader rejects that agentskills.io-incompatible shape.
+When modernizing a skill, migrate top-level `dcc`, `version`, `tags`, `tools`,
+`groups`, `depends`, `search-hint`, `runtimes`, `prompts`, and `resources`
+under `metadata.dcc-mcp.*`, then run creator validation against the actual
+installable skill directory.
+
 ### Gateway-Facing Tags (`metadata.dcc-mcp.tags`)
 
 Gateway search treats `tags` as a narrowing filter. Declare `tags` under

--- a/skills/dcc-mcp-skills-creator/scripts/validate_skill_dir.py
+++ b/skills/dcc-mcp-skills-creator/scripts/validate_skill_dir.py
@@ -1,4 +1,4 @@
-"""Validate a skill directory using dcc_mcp_core.validate_skill."""
+"""Validate an installable skill directory using dcc_mcp_core.validate_skill."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ def validate_skill_dir(skill_dir: str) -> dict:
     """Validate a skill directory and return a structured report.
 
     Args:
-        skill_dir: Path to the skill directory.
+        skill_dir: Path to the installable skill directory containing SKILL.md.
 
     Returns:
         Dict with 'skill_dir', 'is_clean', 'has_errors', and 'issues' list.

--- a/tests/test_dcc_mcp_skills_creator_validation.py
+++ b/tests/test_dcc_mcp_skills_creator_validation.py
@@ -1,0 +1,64 @@
+"""Regression tests for the bundled dcc-mcp-skills-creator validation script."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from conftest import REPO_ROOT
+import dcc_mcp_core
+
+
+def _load_creator_validator():
+    script = REPO_ROOT / "skills" / "dcc-mcp-skills-creator" / "scripts" / "validate_skill_dir.py"
+    spec = importlib.util.spec_from_file_location("creator_validate_skill_dir", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_skill(skill_dir: Path, frontmatter: str) -> None:
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(f"---\n{frontmatter}\n---\n# Skill\n", encoding="utf-8")
+
+
+def test_creator_validation_rejects_mgear_like_top_level_version(tmp_path: Path) -> None:
+    module = _load_creator_validator()
+    skill_dir = tmp_path / "maya-mgear"
+    _write_skill(
+        skill_dir,
+        'name: maya-mgear\ndescription: mGear integration\nversion: "1.0.0"',
+    )
+
+    result = module.validate_skill_dir(str(skill_dir))
+
+    assert result["has_errors"] is True
+    messages = [issue["message"] for issue in result["issues"]]
+    assert any("Non-spec top-level" in message for message in messages)
+    assert any("metadata.dcc-mcp.version" in message for message in messages)
+
+
+def test_creator_validation_accepts_nested_version_metadata(tmp_path: Path) -> None:
+    module = _load_creator_validator()
+    skill_dir = tmp_path / "maya-mgear"
+    _write_skill(
+        skill_dir,
+        "\n".join(
+            [
+                "name: maya-mgear",
+                "description: mGear integration",
+                "metadata:",
+                "  dcc-mcp:",
+                "    dcc: maya",
+                '    version: "1.0.0"',
+            ]
+        ),
+    )
+
+    result = module.validate_skill_dir(str(skill_dir))
+    meta = dcc_mcp_core.parse_skill_md(str(skill_dir))
+
+    assert result["has_errors"] is False
+    assert meta is not None
+    assert meta.version == "1.0.0"


### PR DESCRIPTION
Summary:
- Align loader, validator, docs, and skills-creator guidance on canonical metadata.dcc-mcp.version.
- Store safe skipped skill diagnostics in the catalog and surface them through MCP list/search/get/load flows.
- Add Rust and Python regressions for top-level version rejection and nested version compatibility.

Validation:
- DCC_MCP_DISABLE_ACCUMULATED_SKILLS=1 vx cargo test -p dcc-mcp-skills --lib
- vx cargo test -p dcc-mcp-http-server --lib
- .\.venv\Scripts\python.exe -m pytest tests\test_tool_descriptions.py tests\test_dcc_mcp_skills_creator_validation.py -q --tb=short --show-capture=no

Fixes #1675
Fixes #1676
Fixes #1677