### PR TITLE
fix(test): replace fixed sleep with polling in facade_cluster fixture

### DIFF
--- a/tests/test_gateway_facade_aggregation.py
+++ b/tests/test_gateway_facade_aggregation.py
@@ -190,8 +190,7 @@ def facade_cluster(tmp_path_factory):
             break
         if time.monotonic() > deadline:
             raise RuntimeError(
-                f"Gateway instance watcher did not discover both backends "
-                f"within timeout. Visible: {visible}"
+                f"Gateway instance watcher did not discover both backends within timeout. Visible: {visible}"
             )
         time.sleep(0.5)
 

--- a/tests/test_gateway_facade_aggregation.py
+++ b/tests/test_gateway_facade_aggregation.py
@@ -176,10 +176,24 @@ def facade_cluster(tmp_path_factory):
 
     _server_b, handle_b = _make_backend("blender", ["create_cube", "add_material"], registry_dir, gw_port)
 
-    # Let the gateway's 2-second instance watcher see both registrations.
-    time.sleep(2.2)
-
     gateway_url = f"http://127.0.0.1:{gw_port}/mcp"
+
+    # Poll until the gateway's instance watcher sees both registrations.
+    # Fixed sleeps are fragile on slower CI runners (e.g. macOS arm64).
+    deadline = time.monotonic() + 10  # generous 10-second timeout
+    while True:
+        resp = _post_mcp(gateway_url, "resources/read", {"uri": "gateway://instances"})
+        text = resp["result"]["contents"][0]["text"]
+        data = json.loads(text)
+        visible = {e["dcc_type"] for e in data.get("instances", [])}
+        if "maya" in visible and "blender" in visible:
+            break
+        if time.monotonic() > deadline:
+            raise RuntimeError(
+                f"Gateway instance watcher did not discover both backends "
+                f"within timeout. Visible: {visible}"
+            )
+        time.sleep(0.5)
 
     try:
         yield {


### PR DESCRIPTION
## Summary

- The `facade_cluster` fixture used a fixed 2.2s `time.sleep()` for the gateway's 2-second instance watcher to discover both Maya and Blender backends
- This is fragile on slower CI runners (e.g., macOS arm64) where the watcher may not have run within the fixed window
- Replaced with a polling loop: queries `gateway://instances` every 0.5s until both backends are visible, with a 10-second timeout
- On timeout, a clear `RuntimeError` reports which backends were visible

## Test plan

- [ ] Existing tests in `tests/test_gateway_facade_aggregation.py` pass on all CI platforms, including macOS arm64
- [ ] The polling logic is strictly more robust: fast platforms exit on first check (~same latency as before), slow platforms wait up to 10s