### PR TITLE
fix(release): isolate release workflow concurrency from other CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}${{ inputs.release_tag && format('-{0}', inputs.release_tag) || '' }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem

The Release workflow (`release.yml`) was cancelled by subsequent CI pushes
to main. A release run (e.g., `chore(main): release 0.18.29`) starting at
00:06:10 was cancelled by a later push (ruff format fix) at 00:15:32.

Root cause: the concurrency group `${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}`
produced the same value `Release-refs/heads/main-push` for every push to main,
and `cancel-in-progress: true` allowed the second push to preempt the first.

## Fix

1. **Isolated group name**: `release-${{ github.ref }}` — the `release-` prefix
   guarantees no collision with other workflows' concurrency groups.
2. **cancel-in-progress: false** — once a Release run starts on a given ref,
   it runs to completion regardless of subsequent pushes to the same ref.

## Testing

- [ ] The Release workflow is triggered only by `push: [main]` and
      `workflow_dispatch`. Push-triggered runs for different commits but
      the same ref (`refs/heads/main`) now queue rather than cancel one
      another.
- [ ] Workflow_dispatch runs are unaffected and also cannot be cancelled
      by push-triggered runs.