### PR TITLE
docs: fix stale package counts, Python version range, and version examples

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -317,8 +317,8 @@ print(f'Loaded: {[s.name for s in skills]}')
 └──────────────────────┬──────────────────────────────┘
                        │ PyO3 bindings
 ┌──────────────────────▼──────────────────────────────┐
-│        Rust Workspace (35 members total)             │
-│        34 functional crates + workspace-hack         │
+│        Rust Workspace (47 members total)             │
+│        46 functional crates + workspace-hack         │
 │  naming → models → actions → skills → protocols     │
 │  gateway/http-types/http-server/http-py/http         │
 │  host → transport → process → sandbox → telemetry   │

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,7 +545,7 @@ If a split is genuinely out-of-scope for the current PR:
 ## Repo Layout (What Lives Where)
 
 ```
-crates/          # Rust workspace — 43 packages (42 functional packages + workspace-hack); `Cargo.toml` is source of truth
+crates/          # Rust workspace — 47 packages (46 functional packages + workspace-hack); `Cargo.toml` is source of truth
 python/dcc_mcp_core/__init__.py  # ← top-level Python public re-exports
 python/dcc_mcp_core/result_envelope.py  # ← typed ToolResult dataclass (#487)
 python/dcc_mcp_core/constants.py        # ← metadata key / layer / category constants (#487)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ vx just test
 
 - **Formatter**: `ruff format` (line length: 120)
 - **Linter**: `ruff check` (includes import sorting via `I` rules)
-- **Target**: Python 3.7+ (CI tests 3.7–3.13)
+- **Target**: Python 3.7+ (CI tests 3.8–3.14)
 - **Quotes**: Double quotes (`"`)
 - **Docstrings**: Google-style
 

--- a/README.md
+++ b/README.md
@@ -356,13 +356,13 @@ plane CLI into `PATH`.
 Pin a release or install somewhere custom:
 
 ```bash
-export DCC_MCP_VERSION=v0.17.44
+export DCC_MCP_VERSION=v0.x.y
 export DCC_MCP_INSTALL_DIR="$HOME/bin"
 curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | bash
 ```
 
 ```powershell
-$env:DCC_MCP_VERSION = "v0.17.44"
+$env:DCC_MCP_VERSION = "v0.x.y"
 $env:DCC_MCP_INSTALL_DIR = "$env:USERPROFILE\bin"
 irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex
 ```
@@ -727,9 +727,9 @@ tools/list response (Maya session, nothing loaded yet):
 
 ---
 
-## Architecture Overview — 43 Workspace Packages
+## Architecture Overview — 47 Workspace Packages
 
-`dcc-mcp-core` is organised as a **Rust workspace of 43 packages** (42 functional packages + `workspace-hack`). Most library crates compile into the native Python extension (`_core`) via PyO3 / maturin, while operator-facing crates such as `dcc-mcp-cli`, `dcc-mcp-server`, and tunnel binaries also ship as release assets. The root `Cargo.toml` is the source of truth for membership. Selected crates:
+`dcc-mcp-core` is organised as a **Rust workspace of 47 packages** (46 functional packages + `workspace-hack`). Most library crates compile into the native Python extension (`_core`) via PyO3 / maturin, while operator-facing crates such as `dcc-mcp-cli`, `dcc-mcp-server`, and tunnel binaries also ship as release assets. The root `Cargo.toml` is the source of truth for membership. Selected crates:
 
 | Crate | Responsibility | Key Types |
 |---|---|---|

--- a/README_zh.md
+++ b/README_zh.md
@@ -289,13 +289,13 @@ powershell -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/s
 也可以固定版本或自定义安装目录：
 
 ```bash
-export DCC_MCP_VERSION=v0.17.44
+export DCC_MCP_VERSION=v0.x.y
 export DCC_MCP_INSTALL_DIR="$HOME/bin"
 curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | bash
 ```
 
 ```powershell
-$env:DCC_MCP_VERSION = "v0.17.44"
+$env:DCC_MCP_VERSION = "v0.x.y"
 $env:DCC_MCP_INSTALL_DIR = "$env:USERPROFILE\bin"
 irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex
 ```
@@ -650,9 +650,9 @@ tools/list 响应（Maya 会话、尚未加载任何 skill）：
 
 ---
 
-## 架构总览 —— 41 个 Workspace 包
+## 架构总览 —— 47 个 Workspace 包
 
-`dcc-mcp-core` 组织为 **41 个包的 Rust workspace**（40 个功能包 + `workspace-hack`）。大多数库 crate 通过 PyO3 / maturin 编译进原生 Python 扩展（`_core`），`dcc-mcp-cli`、`dcc-mcp-server` 与 tunnel 二进制也会作为面向用户的 release assets 发布。根 `Cargo.toml` 是 workspace 成员列表的唯一来源。精选 crate：
+`dcc-mcp-core` 组织为 **47 个包的 Rust workspace**（46 个功能包 + `workspace-hack`）。大多数库 crate 通过 PyO3 / maturin 编译进原生 Python 扩展（`_core`），`dcc-mcp-cli`、`dcc-mcp-server` 与 tunnel 二进制也会作为面向用户的 release assets 发布。根 `Cargo.toml` 是 workspace 成员列表的唯一来源。精选 crate：
 
 | Crate | 职责 | 关键类型 |
 |---|---|---|


### PR DESCRIPTION
## Summary

Audit-driven docs fixes for dcc-mcp-core (PIP-1746). Corrects stale numeric values found during documentation synchronization audit.

- **Package count**: README 43→47, README_zh 41→47, AGENTS.md 43→47, SKILL.md 35→47 (verified against Cargo.toml [workspace.members])
- **Python range**: CONTRIBUTING.md CI tests now cover 3.8–3.14 (was 3.7–3.13)
- **Version example**: Both READMEs use `v0.x.y` placeholder instead of hardcoded `v0.17.44`

## Test plan

- [x] All changes are comments/documentation text only
- [x] Counts verified against Cargo.toml
- [x] No code changes — no build/test needed