### PR TITLE
Support skill resource metadata declarations

### DIFF
--- a/crates/dcc-mcp-http/src/resources/skill_resources.rs
+++ b/crates/dcc-mcp-http/src/resources/skill_resources.rs
@@ -134,9 +134,22 @@ where
 }
 
 fn resources_reference(md: &dcc_mcp_models::SkillMetadata) -> Option<&str> {
+    if let Some(reference) = md
+        .resources_file
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        return Some(reference);
+    }
+
     md.metadata
         .pointer("/dcc-mcp/resources")
         .and_then(|value| value.as_str())
+        .or_else(|| {
+            md.metadata
+                .get("dcc-mcp.resources")
+                .and_then(|value| value.as_str())
+        })
         .filter(|value| !value.is_empty())
 }
 

--- a/crates/dcc-mcp-http/src/resources/tests.rs
+++ b/crates/dcc-mcp-http/src/resources/tests.rs
@@ -172,7 +172,7 @@ resources:
     let metadata = dcc_mcp_models::SkillMetadata {
         name: "maya-docs".to_string(),
         skill_path: tmp.path().to_string_lossy().into_owned(),
-        metadata: json!({"dcc-mcp": {"resources": "resources/"}}),
+        resources_file: Some("resources/".to_string()),
         ..Default::default()
     };
     reg.sync_skill_resources(|visit| visit(&metadata));

--- a/crates/dcc-mcp-models/src/python/skill_metadata.rs
+++ b/crates/dcc-mcp-models/src/python/skill_metadata.rs
@@ -78,6 +78,7 @@ impl SkillMetadata {
             runtimes,
             groups: Vec::new(),
             prompts_file: None,
+            resources_file: None,
             layer: None,
             stage: None,
             // Recall metadata extensions (#1335) and capability-graph fields

--- a/crates/dcc-mcp-models/src/skill_metadata/mod.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/mod.rs
@@ -106,6 +106,7 @@ use serde_impl::{
         runtimes: Vec<crate::skill_metadata::SkillRuntimeDescriptor> => [get(clone), set],
         layer: Option<String> => [get(clone), set],
         stage: Option<String> => [get(clone), set],
+        resources_file: Option<String> => [get(clone), set],
         branding: Option<crate::skill_metadata::SkillBranding> => [get(clone), set],
         links: Option<crate::skill_metadata::SkillLinks> => [get(clone), set],
         example_prompts: Vec<String> => [get(clone), set],
@@ -288,6 +289,15 @@ pub struct SkillMetadata {
     /// scan / load time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompts_file: Option<String>,
+
+    /// Sibling-file reference for the MCP resources primitive.
+    ///
+    /// Set from `metadata.dcc-mcp.resources` in SKILL.md frontmatter. The value
+    /// is a path relative to the skill root — either a single YAML file, a
+    /// directory containing `*.resource.yaml` entries, or a glob-like reference
+    /// whose non-glob parent directory is scanned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources_file: Option<String>,
 
     /// Architectural layer for skill routing and search partitioning.
     ///

--- a/crates/dcc-mcp-models/src/skill_metadata/tests.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tests.rs
@@ -429,6 +429,7 @@ fn test_skill_metadata_serde_round_trip() {
         runtimes: Vec::new(),
         groups: Vec::new(),
         prompts_file: None,
+        resources_file: None,
         layer: Some("domain".to_string()),
         stage: Some("authoring".to_string()),
         recipes_file: None,

--- a/crates/dcc-mcp-skills/src/loader/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/mod.rs
@@ -530,6 +530,16 @@ fn apply_dcc_mcp_metadata_overrides(
                     meta.prompts_file = Some(s.to_string());
                 }
             }
+            "resources" => {
+                // Sibling-file reference for the MCP resources primitive.
+                // Parsing is deferred; the HTTP/MCP resource registry loads
+                // sidecar YAML files lazily when resources are synchronized.
+                if let Some(s) = value.as_str()
+                    && !s.is_empty()
+                {
+                    meta.resources_file = Some(s.to_string());
+                }
+            }
             "layer" => {
                 // Architectural layer for skill routing and search partitioning.
                 // Valid values: "infrastructure", "domain", "example".

--- a/crates/dcc-mcp-skills/src/loader/tests/test_metadata_compat.rs
+++ b/crates/dcc-mcp-skills/src/loader/tests/test_metadata_compat.rs
@@ -185,6 +185,23 @@ metadata:
 }
 
 #[test]
+fn nested_form_resources_file_reference_resolves() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("resources-sidecar");
+    let body = r#"---
+name: resources-sidecar
+metadata:
+  dcc-mcp:
+    resources: resources/
+---
+# body
+"#;
+    write_skill(&dir, body);
+    let meta = parse_skill_md(&dir).expect("parsed");
+    assert_eq!(meta.resources_file.as_deref(), Some("resources/"));
+}
+
+#[test]
 fn nested_form_parses_optional_runtime_descriptors() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = tmp.path().join("runtime");


### PR DESCRIPTION
## Summary
- add a typed SkillMetadata field for metadata.dcc-mcp.resources
- parse resources sidecar references in the SKILL.md loader
- let the resource registry read the typed field while preserving legacy metadata compatibility

## Tests
- cargo test -p dcc-mcp-models test_skill_metadata_serde_round_trip
- cargo test -p dcc-mcp-skills nested_form_resources_file_reference_resolves
- cargo test -p dcc-mcp-http skill_resources_list_and_read_text_and_binary_files
- cargo test -p dcc-mcp-http malformed_skill_resource_yaml_is_skipped