### PR TITLE
Fix GH-1665: dcc-mcp-core-semantic stable embedder API and diagnostics

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/diagnostics.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/diagnostics.rs
@@ -16,9 +16,11 @@ pub const PROCESS_URI: &str = "gateway://diagnostics/process";
 pub const AUDIT_URI: &str = "gateway://diagnostics/audit";
 /// URI for the gateway-native tool metrics summary.
 pub const METRICS_URI: &str = "gateway://diagnostics/metrics";
+/// URI for the gateway-native search and capability index diagnostics.
+pub const SEARCH_URI: &str = "gateway://diagnostics/search";
 
 /// Resource pointers emitted in `resources/list`.
-pub fn pointers() -> [Value; 3] {
+pub fn pointers() -> [Value; 4] {
     [
         json!({
             "uri":         PROCESS_URI,
@@ -38,6 +40,12 @@ pub fn pointers() -> [Value; 3] {
             "description": "Local gateway tool count, live backend count, and dispatch timeouts.",
             "mimeType":    "application/json"
         }),
+        json!({
+            "uri":         SEARCH_URI,
+            "name":        "Gateway search & capability diagnostics",
+            "description": "Capability index health and semantic ranking provider status.",
+            "mimeType":    "application/json"
+        }),
     ]
 }
 
@@ -50,6 +58,8 @@ pub enum Query {
     Audit,
     /// Tool metrics summary (no parameters).
     Metrics,
+    /// Search and semantic ranking status.
+    Search,
 }
 
 /// Recognise a `gateway://diagnostics/*` URI. Returns `None` when the URI
@@ -65,6 +75,7 @@ pub fn parse(uri: &str) -> Option<Query> {
         }
         AUDIT_URI => Some(Query::Audit),
         METRICS_URI => Some(Query::Metrics),
+        SEARCH_URI => Some(Query::Search),
         _ => None,
     }
 }
@@ -155,6 +166,24 @@ pub async fn build_payload(
                 }
             }))
         }
+        Query::Search => {
+            let total_records = gs.capability_index.total_records();
+            let unloaded = gs.capability_index.unloaded_count();
+            Ok(json!({
+                "success": true,
+                "message": "Gateway search and capability diagnostics",
+                "semantic_provider": {
+                    "active": false,
+                    "backend": "dcc-mcp-gateway-search (lexical only)",
+                    "note": "Semantic ranking is not yet supported in the Rust gateway daemon.",
+                },
+                "capability_index": {
+                    "total_records": total_records,
+                    "unloaded_records": unloaded,
+                    "empty": total_records == 0 && unloaded == 0,
+                }
+            }))
+        }
     }
 }
 
@@ -191,6 +220,11 @@ mod tests {
     }
 
     #[test]
+    fn parse_search() {
+        assert_eq!(parse("gateway://diagnostics/search"), Some(Query::Search));
+    }
+
+    #[test]
     fn parse_returns_none_for_unrelated_uris() {
         assert_eq!(parse("gateway://instances"), None);
         assert_eq!(parse("gateway://diagnostics"), None);
@@ -199,11 +233,12 @@ mod tests {
     }
 
     #[test]
-    fn pointers_cover_all_three_uris() {
+    fn pointers_cover_all_four_uris() {
         let ps = pointers();
         let uris: Vec<&str> = ps.iter().filter_map(|p| p["uri"].as_str()).collect();
         assert!(uris.contains(&PROCESS_URI));
         assert!(uris.contains(&AUDIT_URI));
         assert!(uris.contains(&METRICS_URI));
+        assert!(uris.contains(&SEARCH_URI));
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/mod.rs
@@ -52,7 +52,7 @@ use super::state::GatewayState;
 ///
 /// Order is stable: instances first, then diagnostics, then catalog, then docs.
 pub fn pointers_for_list() -> Vec<Value> {
-    let mut out = Vec::with_capacity(6);
+    let mut out = Vec::with_capacity(7);
     out.push(instances::pointer());
     out.extend(diagnostics::pointers());
     out.push(catalog::pointer());
@@ -134,6 +134,7 @@ mod tests {
             "gateway://diagnostics/process",
             "gateway://diagnostics/audit",
             "gateway://diagnostics/metrics",
+            "gateway://diagnostics/search",
         ] {
             assert!(
                 matches!(Request::parse(uri), Some(Request::Diagnostics(_))),
@@ -169,9 +170,10 @@ mod tests {
         assert!(uris.contains(&diagnostics::PROCESS_URI));
         assert!(uris.contains(&diagnostics::AUDIT_URI));
         assert!(uris.contains(&diagnostics::METRICS_URI));
+        assert!(uris.contains(&diagnostics::SEARCH_URI));
         assert!(uris.contains(&catalog::ROOT_URI));
         assert!(uris.contains(&agent_workflows::ROOT_URI));
-        assert_eq!(ps.len(), 6);
+        assert_eq!(ps.len(), 7);
     }
 
     #[test]

--- a/pkg/dcc-mcp-core-semantic/python/dcc_mcp_core_semantic/__init__.py
+++ b/pkg/dcc-mcp-core-semantic/python/dcc_mcp_core_semantic/__init__.py
@@ -22,6 +22,10 @@ Re-exports:
 from __future__ import annotations
 
 from dcc_mcp_core_semantic import _native as native
+from dcc_mcp_core_semantic._native import NativeEmbedder
 
-__all__ = ["native"]
+# Compatibility alias for earlier versions that exposed the Python wrapper here
+OnnxEmbedder = NativeEmbedder
+
+__all__ = ["NativeEmbedder", "OnnxEmbedder", "native"]
 __version__ = native.__version__

--- a/tests/test_semantic_api.py
+++ b/tests/test_semantic_api.py
@@ -1,0 +1,20 @@
+import pytest
+
+def test_semantic_public_api():
+    """Ensure the expected public API is available for dcc_mcp_core_semantic."""
+    try:
+        import dcc_mcp_core_semantic
+    except ImportError:
+        pytest.skip("dcc-mcp-core-semantic not installed")
+
+    # NativeEmbedder should be available at the top level
+    assert hasattr(dcc_mcp_core_semantic, "NativeEmbedder")
+    
+    # OnnxEmbedder should be available as a compatibility alias
+    assert hasattr(dcc_mcp_core_semantic, "OnnxEmbedder")
+    
+    # They should be the same class
+    assert dcc_mcp_core_semantic.NativeEmbedder is dcc_mcp_core_semantic.OnnxEmbedder
+    
+    # Try instantiating it if possible (may require downloading model, so we skip the actual init or catch exceptions)
+    # The issue just asks for an import path smoke test.

--- a/tests/test_semantic_api.py
+++ b/tests/test_semantic_api.py
@@ -10,12 +10,12 @@ def test_semantic_public_api():
 
     # NativeEmbedder should be available at the top level
     assert hasattr(dcc_mcp_core_semantic, "NativeEmbedder")
-    
+
     # OnnxEmbedder should be available as a compatibility alias
     assert hasattr(dcc_mcp_core_semantic, "OnnxEmbedder")
-    
+
     # They should be the same class
     assert dcc_mcp_core_semantic.NativeEmbedder is dcc_mcp_core_semantic.OnnxEmbedder
-    
+
     # Try instantiating it if possible (may require downloading model, so we skip the actual init or catch exceptions)
     # The issue just asks for an import path smoke test.

--- a/tests/test_semantic_api.py
+++ b/tests/test_semantic_api.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 def test_semantic_public_api():
     """Ensure the expected public API is available for dcc_mcp_core_semantic."""
     try:


### PR DESCRIPTION
## Summary
Fixes https://github.com/dcc-mcp/dcc-mcp-core/issues/1665

- Re-export \NativeEmbedder\ as the stable public API at the top-level of \dcc_mcp_core_semantic\
- Expose \OnnxEmbedder\ as a compatibility alias
- Add a new Rust gateway diagnostic resource (\gateway://diagnostics/search\) that reports capability index health and explicitly notes that semantic ranking is not supported in the Rust gateway.
- Add an API smoke test.
