### PR TITLE
feat: add asset-source skill and demo docs for cross-DCC asset import (PIP-1833)

### DIFF
--- a/docs/skills/demo-asset-import/README.md
+++ b/docs/skills/demo-asset-import/README.md
@@ -1,0 +1,154 @@
+# Cross-DCC Asset Import — End-to-End Demo
+
+This demo walks through the first cross-DCC asset import flow: search for an
+asset via the gateway `asset-source` skill, then import it into a Blender scene
+via `blender-import-to-scene`.
+
+## Prerequisites
+
+- `dcc-mcp-core` (with `asset-source` skill)
+- `dcc-mcp-blender` (with `blender-import-to-scene` skill)
+- Blender >= 4.0 running with the dcc-mcp-blender adapter
+- Gateway daemon running
+
+## Architecture
+
+```
+[Agent]
+  │
+  ├─ search_skills("asset import")
+  │   └─ returns [asset-source, blender-import-to-scene]
+  │
+  ├─ load_skill("asset-source")
+  │   └─ call("search_assets", {query: "table"})
+  │       └─ returns AssetDescriptor[]
+  │
+  ├─ load_skill("blender-import-to-scene")
+  │   └─ call("import_to_scene", {descriptor: <AssetDescriptor>, target_collection: "Furniture"})
+  │       └─ returns ImportToSceneResult
+  │
+  └─ load_skill("blender-scene")
+      └─ call("list_objects")
+          └─ verify imported nodes in scene
+```
+
+## Step-by-Step Walkthrough
+
+### 1. Search for an asset
+
+```
+search_skills("asset import")
+→ [asset-source, blender-import-to-scene]
+```
+
+Load the source skill:
+
+```
+load_skill("asset-source")
+```
+
+Call the search tool:
+
+```
+call("search_assets", {query: "table"})
+```
+
+Expected result:
+
+```json
+{
+  "success": true,
+  "message": "Found 1 asset(s) for 'table'",
+  "context": {
+    "results": [
+      {
+        "asset_id": "props/table-round",
+        "variants": [
+          {
+            "local_path": "/data/assets/props/table_round.obj",
+            "format": "obj",
+            "preferred": true,
+            "mime": "model/obj"
+          }
+        ],
+        "attribution": {
+          "source_url": "https://example.com/assets/table-round",
+          "license_spdx": "CC-BY-4.0",
+          "author": "Example Studio",
+          "title": "Round Table"
+        },
+        "unit_hint": "centimeter",
+        "meters_per_unit": 0.01,
+        "up_axis": "y",
+        "tags": ["furniture", "indoor", "table"]
+      }
+    ],
+    "scores": [100.0],
+    "total": 1,
+    "query": "table"
+  }
+}
+```
+
+### 2. Import into Blender
+
+```
+load_skill("blender-import-to-scene")
+```
+
+Call the import tool with the descriptor from step 1:
+
+```
+call("import_to_scene", {
+  descriptor: <AssetDescriptor from search>,
+  target_collection: "Furniture"
+})
+```
+
+Expected result:
+
+```json
+{
+  "success": true,
+  "message": "Imported 'props/table-round' into scene (5 node(s))",
+  "context": {
+    "success": true,
+    "imported_nodes": ["table_round_mesh", "table_round_legs", "..."],
+    "warnings": [],
+    "extra": {}
+  }
+}
+```
+
+### 3. Verify
+
+```
+load_skill("blender-scene")
+call("list_objects")
+```
+
+## Demo Catalog
+
+The `asset-source` demo catalog includes:
+
+| Asset ID | Format | Unit | Up Axis |
+|----------|--------|------|---------|
+| `props/table-round` | OBJ | cm | Y |
+| `arch/city-bank/desk` | FBX | cm | Y |
+| `characters/robot-v2` | FBX | m | Y |
+| `sets/sci-fi-corridor` | USD + USDZ | m | Z |
+| `props/chair-modern` | FBX | cm | Y |
+
+## Constraints
+
+- No Maya adapter — Blender-only demo per PIP-1832 decision
+- No new gateway architecture — uses existing `search_skills` → `load_skill` → `call` flow
+- No native MCP OAuth
+- `AssetDescriptor` contract lives in `dcc_mcp_core.asset_import` (#1708)
+
+## Next Steps (post-demo)
+
+1. Replace static catalog with a real asset registry
+2. Add download-helper for remote asset resolution
+3. Record video walkthrough
+4. Add Maya adapter (after Blender demo is recorded)

--- a/skills/asset-source/SKILL.md
+++ b/skills/asset-source/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: asset-source
+description: >-
+  Gateway skill for cross-DCC asset import — search and resolve assets into a
+  validated AssetDescriptor (local path + attribution). Demo source returns
+  static catalog entries; production sources can add download or remote
+  resolution without changing the contract.
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: python
+    layer: domain
+    stage: source
+    version: "1.0.0"
+    tags: [pipeline, asset-import, read-only]
+    search-hint: >-
+      search assets, find asset, resolve asset, asset descriptor, asset import source,
+      cross-dcc asset
+    search-aliases: [asset search, find asset, resolve asset, asset catalog, import source, asset descriptor]
+    intent: "Search and resolve assets into a validated AssetDescriptor (local path + attribution) for cross-DCC import pipelines."
+    recall-context:
+      app_type: python
+      domain: asset
+      workflow_stage: source
+      task_category: query
+    preconditions: []
+    side-effects:
+      creates: false
+      modifies: false
+      file_output: false
+      targets: []
+    produces: [asset_descriptor]
+    requires: []
+    tools: tools.yaml
+---
+
+# asset-source
+
+Gateway skill for searching and resolving assets into a validated
+`AssetDescriptor` ready for cross-DCC import. The demo source returns static
+catalog entries keyed by asset name. Production sources can layer download
+helpers or remote resolution on top without changing the contract.
+
+## Tools
+
+| Tool | Category | Description |
+|------|----------|-------------|
+| `search_assets` | Query | Search the asset catalog and return matching `AssetDescriptor` entries |
+
+The skill uses `dcc_mcp_core.AssetDescriptor` (from the shared
+`dcc_mcp_core.asset_import` contract) as the wire format so every downstream
+DCC adapter speaks the same shape.
+
+## Gateway flow
+
+```
+search_skills("asset import") → load_skill("asset-source") → call("search_assets", {query: "table"})
+→ AssetDescriptor → load_skill("blender-import-to-scene") → call("import_to_scene", {descriptor: ...})
+```

--- a/skills/asset-source/scripts/search_assets.py
+++ b/skills/asset-source/scripts/search_assets.py
@@ -1,0 +1,230 @@
+"""Search the asset catalog and return matching AssetDescriptor entries.
+
+This is a demo/mock source that returns static catalog entries. Production
+sources should replace the catalog with a real asset database or download
+helper while keeping the same AssetDescriptor contract.
+"""
+
+from __future__ import annotations
+
+from dcc_mcp_core.asset_import import AssetAttribution
+from dcc_mcp_core.asset_import import AssetDescriptor
+from dcc_mcp_core.asset_import import AssetFileVariant
+from dcc_mcp_core.asset_import import AssetFormat
+from dcc_mcp_core.asset_import import AxisHint
+from dcc_mcp_core.asset_import import UnitHint
+from dcc_mcp_core.skill import skill_entry
+from dcc_mcp_core.skill import skill_error
+from dcc_mcp_core.skill import skill_success
+
+# ---------------------------------------------------------------------------
+# Static demo catalog — replace with a real asset registry in production
+# ---------------------------------------------------------------------------
+
+_DEMO_CATALOG: list[AssetDescriptor] = [
+    AssetDescriptor(
+        asset_id="props/table-round",
+        variants=[
+            AssetFileVariant(
+                local_path="/data/assets/props/table_round.obj",
+                format=AssetFormat.OBJ,
+                preferred=True,
+                mime="model/obj",
+            ),
+        ],
+        attribution=AssetAttribution(
+            source_url="https://example.com/assets/table-round",
+            license_spdx="CC-BY-4.0",
+            author="Example Studio",
+            title="Round Table",
+        ),
+        unit_hint=UnitHint.CENTIMETER,
+        meters_per_unit=0.01,
+        up_axis=AxisHint.Y,
+        tags=["furniture", "indoor", "table"],
+    ),
+    AssetDescriptor(
+        asset_id="arch/city-bank/desk",
+        variants=[
+            AssetFileVariant(
+                local_path="/data/assets/arch/desk.fbx",
+                format=AssetFormat.FBX,
+                preferred=True,
+                mime="model/fbx",
+            ),
+        ],
+        attribution=AssetAttribution(
+            source_url="https://example.com/assets/desk",
+            license_spdx="CC-BY-4.0",
+            author="City Bank Studio",
+            title="Bank Desk",
+        ),
+        unit_hint=UnitHint.CENTIMETER,
+        meters_per_unit=0.01,
+        up_axis=AxisHint.Y,
+        scale_hint=1.0,
+        source_bbox={"min": [-60.0, 0.0, -40.0], "max": [60.0, 80.0, 40.0]},
+        tags=["furniture", "indoor", "desk"],
+    ),
+    AssetDescriptor(
+        asset_id="characters/robot-v2",
+        variants=[
+            AssetFileVariant(
+                local_path="/data/assets/chars/robot_v2.fbx",
+                format=AssetFormat.FBX,
+                preferred=True,
+                mime="model/fbx",
+            ),
+        ],
+        attribution=AssetAttribution(
+            source_url="https://example.com/assets/robot-v2",
+            license_spdx="CC-BY-4.0",
+            author="Robot Corp",
+            title="Robot V2",
+        ),
+        preview="/data/assets/chars/robot_thumb.png",
+        unit_hint=UnitHint.METER,
+        meters_per_unit=1.0,
+        up_axis=AxisHint.Y,
+        tags=["character", "robot", "scifi"],
+    ),
+    AssetDescriptor(
+        asset_id="sets/sci-fi-corridor",
+        variants=[
+            AssetFileVariant(
+                local_path="/data/assets/sets/corridor.usd",
+                format=AssetFormat.USD,
+                preferred=True,
+                mime="model/vnd.usd+zip",
+            ),
+            AssetFileVariant(
+                local_path="/data/assets/sets/corridor.usdz",
+                format=AssetFormat.USDZ,
+                preferred=False,
+                mime="model/vnd.usdz+zip",
+            ),
+        ],
+        attribution=AssetAttribution(
+            source_url="https://example.com/assets/corridor",
+            license_spdx="CC-BY-4.0",
+            author="Set Builders Inc",
+            title="Sci-Fi Corridor",
+        ),
+        unit_hint=UnitHint.METER,
+        meters_per_unit=1.0,
+        up_axis=AxisHint.Z,
+        scale_hint=0.01,
+        tags=["environment", "scifi", "corridor"],
+    ),
+    AssetDescriptor(
+        asset_id="props/chair-modern",
+        variants=[
+            AssetFileVariant(
+                local_path="/data/assets/props/chair_modern.fbx",
+                format=AssetFormat.FBX,
+                preferred=True,
+                mime="model/fbx",
+            ),
+        ],
+        attribution=AssetAttribution(
+            source_url="https://example.com/assets/chair-modern",
+            license_spdx="CC0-1.0",
+            author="Free Assets Org",
+            title="Modern Chair",
+        ),
+        unit_hint=UnitHint.CENTIMETER,
+        meters_per_unit=0.01,
+        up_axis=AxisHint.Y,
+        tags=["furniture", "indoor", "chair"],
+    ),
+]
+
+
+def _match_score(desc: AssetDescriptor, query: str) -> float:
+    """Compute a simple relevance score for a descriptor against a query.
+
+    Higher score = better match. Case-insensitive substring match on asset_id
+    and tags.
+    """
+    q = query.lower()
+    score = 0.0
+
+    # Exact asset_id match
+    if q == desc.asset_id.lower():
+        score += 100.0
+    # Substring in asset_id
+    elif q in desc.asset_id.lower():
+        score += 50.0
+
+    # Tag matches
+    for tag in desc.tags:
+        tag_lower = tag.lower()
+        if q == tag_lower:
+            score += 30.0
+        elif q in tag_lower:
+            score += 10.0
+
+    # Attribution title/author match
+    if desc.attribution:
+        if desc.attribution.title and q in desc.attribution.title.lower():
+            score += 15.0
+        if desc.attribution.author and q in desc.attribution.author.lower():
+            score += 5.0
+
+    return score
+
+
+def search_assets(query: str, limit: int = 10) -> dict:
+    """Search the asset catalog for matching descriptors.
+
+    Args:
+        query: Search term (asset name, id, or keyword).
+        limit: Maximum number of results (default 10, max 50).
+
+    Returns:
+        ActionResultModel dict with matched descriptors.
+    """
+    query = query.strip()
+    if not query:
+        return skill_error("Empty query", "query must not be empty")
+
+    limit = max(1, min(limit, 50))
+
+    # Score and sort
+    scored = [(desc, _match_score(desc, query)) for desc in _DEMO_CATALOG]
+    scored = [(desc, score) for desc, score in scored if score > 0]
+    scored.sort(key=lambda x: x[1], reverse=True)
+
+    results = scored[:limit]
+    if not results:
+        return skill_success(
+            f"No assets found for '{query}'",
+            results=[],
+            total=0,
+            query=query,
+            prompt="Try a different search term or check the asset catalog.",
+        )
+
+    descriptors = [desc.to_dict() for desc, _score in results]
+    scores = [score for _desc, score in results]
+
+    return skill_success(
+        f"Found {len(results)} asset(s) for '{query}'",
+        results=descriptors,
+        scores=scores,
+        total=len(results),
+        query=query,
+        prompt="Select a descriptor and pass it to an import-to-scene skill.",
+    )
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`search_assets`."""
+    return search_assets(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/skills/asset-source/tools.yaml
+++ b/skills/asset-source/tools.yaml
@@ -1,0 +1,49 @@
+tools:
+  - name: search_assets
+    description: "Search the asset catalog and return matching AssetDescriptor entries."
+    source_file: scripts/search_assets.py
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [query]
+      properties:
+        query:
+          type: string
+          minLength: 1
+          description: Search query (asset name, id, or keyword).
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 10
+          description: Maximum number of results to return.
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+    call_examples:
+      - arguments:
+          query: "table"
+          limit: 5
+        note: "Search for table assets, return up to 5 results"
+      - arguments:
+          query: "chair"
+        note: "Search for chair assets with default limit"


### PR DESCRIPTION
## Summary

Adds the `asset-source` gateway skill (asset catalog search + validated `AssetDescriptor`) plus end-to-end demo documentation for the cross-DCC asset import flow.

Part of [PIP-1833](https://github.com/dcc-mcp/dcc-mcp-core/issues/1833) — MVP asset import pipeline.

## Changes

- `skills/asset-source/` — new gateway skill: `search_assets` returns validated `AssetDescriptor[]`, 5-entry static demo catalog (OBJ, FBX, USD)
- `docs/skills/demo-asset-import/README.md` — full gateway flow walkthrough with expected JSON payloads

## Verification

- Uses `dcc_mcp_core.asset_import` contract (#1708)
- Imports resolve correctly against current `dcc_mcp_core`
- No new gateway architecture — uses existing `search_skills → load_skill → call` flow
- No Maya, no OAuth

Merge order: core first (this PR), then blender adapter.