### PR TITLE
fix: add CREATE_NO_WINDOW to subprocess calls that spawn console-subsystem binaries

### DIFF
--- a/python/dcc_mcp_core/_install_lifecycle_sidecar.py
+++ b/python/dcc_mcp_core/_install_lifecycle_sidecar.py
@@ -528,6 +528,7 @@ def _probe_server_binary_version(
             capture_output=True,
             text=True,
             timeout=SERVER_BINARY_VERSION_TIMEOUT_SECS,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0,
         )
     except Exception as exc:
         return None, f"running --version failed: {exc}"

--- a/python/dcc_mcp_core/daemon_launch.py
+++ b/python/dcc_mcp_core/daemon_launch.py
@@ -229,6 +229,7 @@ class Daemon:
         flags = 0
         flags |= getattr(subprocess, "DETACHED_PROCESS", 0x0000_0008)
         flags |= getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x0000_0200)
+        flags |= getattr(subprocess, "CREATE_NO_WINDOW", 0)
 
         child = subprocess.Popen(
             args,

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -500,12 +500,18 @@ def test_guardian_run_continues_after_exception(monkeypatch):
     )
 
     guardian.start()
+    time.sleep(0.1)  # yield to daemon thread on slow runners
     try:
         assert _wait_until(
             lambda: crash_reported.is_set() or guardian.status().get("crash_count", 0) >= 1,
-            timeout=30.0,
+            timeout=60.0,
+            interval=0.05,
         ), "Expected guardian crash status to be published"
-        assert _wait_until(lambda: continued_after_crash.is_set() or len(calls) >= 2), (
+        assert _wait_until(
+            lambda: continued_after_crash.is_set() or len(calls) >= 2,
+            timeout=60.0,
+            interval=0.05,
+        ), (
             "Expected guardian loop to continue probing"
         )
     finally:

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -511,9 +511,7 @@ def test_guardian_run_continues_after_exception(monkeypatch):
             lambda: continued_after_crash.is_set() or len(calls) >= 2,
             timeout=60.0,
             interval=0.05,
-        ), (
-            "Expected guardian loop to continue probing"
-        )
+        ), "Expected guardian loop to continue probing"
     finally:
         guardian.stop(timeout=2.0)
 

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -500,18 +500,9 @@ def test_guardian_run_continues_after_exception(monkeypatch):
     )
 
     guardian.start()
-    time.sleep(0.1)  # yield to daemon thread on slow runners
     try:
-        assert _wait_until(
-            lambda: crash_reported.is_set() or guardian.status().get("crash_count", 0) >= 1,
-            timeout=60.0,
-            interval=0.05,
-        ), "Expected guardian crash status to be published"
-        assert _wait_until(
-            lambda: continued_after_crash.is_set() or len(calls) >= 2,
-            timeout=60.0,
-            interval=0.05,
-        ), "Expected guardian loop to continue probing"
+        assert crash_reported.wait(timeout=10.0), "Expected guardian crash status to be published"
+        assert continued_after_crash.wait(timeout=10.0), "Expected guardian loop to continue probing"
     finally:
         guardian.stop(timeout=2.0)
 


### PR DESCRIPTION
## Summary

Two `subprocess` calls in core lack `CREATE_NO_WINDOW`, causing CMD black boxes to flash on 3ds Max startup:

1. **`_probe_server_binary_version()`** — runs `dcc-mcp-server --version` on every sidecar launch. The Rust binary is console-subsystem; without the flag Windows briefly shows a CMD window.

2. **`Daemon._daemonize_windows()`** — same missing flag, while `detached_popen_kwargs()` in the same file already sets it.