### PR TITLE
Guide skill dependency authoring

### DIFF
--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -113,6 +113,9 @@ Generated `tools.yaml` entries follow the modern contract:
 - Loaded tools are published as `<skill-name>__<tool_name>` when namespacing is needed.
 - Skill package version metadata lives at `metadata.dcc-mcp.version` in
   `SKILL.md`; a top-level `version` key is rejected by the strict loader.
+- Inter-skill dependencies live at `metadata.dcc-mcp.depends` as skill names,
+  not repo names or prose-only instructions. Use it when one skill must be
+  discovered or loaded before another, for example `depends: ["qt-ui-inspector"]`.
 - `input_schema` and `output_schema` are declared explicitly.
 - Keep MCP-facing `input_schema` shapes simple: prefer a top-level object with
   `properties`, `required`, primitive `type`, bounds, and descriptions. Put
@@ -131,7 +134,7 @@ Generated `tools.yaml` entries follow the modern contract:
 2. Give the skill a kebab-case name and each local tool a snake_case name.
 3. Keep host API calls inside scripts, with lazy imports so discovery works without the host running.
 4. Import dependency-light runtime helpers from `dcc_mcp_core.skills_helper` first: JSON/YAML codecs, bounded HTTP helpers, safe file/path helpers, validation, cancellation checks, and result helpers.
-5. Declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`. For high-frequency tools, add `call_examples` so agents can copy argument payloads without trial-and-error.
+5. Declare `metadata.dcc-mcp.depends` for prerequisite skills, then declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`. For high-frequency tools, add `call_examples` so agents can copy argument payloads without trial-and-error.
 6. Put long examples, recipes, and host-specific notes under `references/`.
 7. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before loading it in an adapter.
 8. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.

--- a/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
+++ b/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
@@ -35,6 +35,37 @@ When modernizing a skill, migrate top-level `dcc`, `version`, `tags`, `tools`,
 under `metadata.dcc-mcp.*`, then run creator validation against the actual
 installable skill directory.
 
+### Dependency-Aware Skills
+
+Use machine-readable dependencies whenever one skill must run after another.
+Do not rely on prose such as "use after qt-ui-inspector" as the only signal:
+
+```yaml
+metadata:
+  dcc-mcp:
+    dcc: python
+    layer: infrastructure
+    depends: ["qt-ui-inspector"]
+    search-hint: "qt ui actions after qt-ui-inspector, click widget, trigger QAction"
+    tools: tools.yaml
+```
+
+Rules:
+- `depends` values are `SKILL.md` `name` values, not repository names,
+  marketplace package names, tool slugs, or Python packages.
+- Keep dependency chains small and acyclic. Split only when the prerequisite
+  has reusable value on its own, such as read-only UI inspection before mutating
+  UI actions.
+- Put runtime library requirements under `metadata.dcc-mcp.runtimes`, not
+  `depends`; `depends` is for other DCC-MCP skills.
+- Mention the prerequisite in `search-hint` and in the first paragraph of the
+  body, but treat that as human guidance. `metadata.dcc-mcp.depends` is the
+  agent-readable contract.
+- Validate the installable skill directory, then test the load path: search the
+  dependent skill, call `load_skill`, and confirm `new_tool_slugs` or a follow-up
+  search shows the expected callable tools. If loading reports pending
+  dependencies, install or discover the missing skill and retry.
+
 ### Gateway-Facing Tags (`metadata.dcc-mcp.tags`)
 
 Gateway search treats `tags` as a narrowing filter. Declare `tags` under

--- a/skills/dcc-mcp-skills-creator/scripts/create_skill.py
+++ b/skills/dcc-mcp-skills-creator/scripts/create_skill.py
@@ -40,6 +40,16 @@ def _stage_line(stage: str) -> str:
     return f"    stage: {stage}\n" if stage else ""
 
 
+def _depends_line(depends) -> str:
+    deps = [dep.strip() for dep in (depends or []) if dep and dep.strip()]
+    for dep in deps:
+        _validate_skill_name(dep)
+    if not deps:
+        return ""
+    quoted = ", ".join(f'"{dep}"' for dep in deps)
+    return f"    depends: [{quoted}]\n"
+
+
 def create_skill(
     name: str,
     parent_dir: str,
@@ -48,6 +58,7 @@ def create_skill(
     tool_name: str = "example_tool",
     layer: str = "thin-harness",
     stage: str = "",
+    depends=None,
     affinity: str = "any",
     execution: str = "sync",
 ) -> str:
@@ -60,6 +71,7 @@ def create_skill(
         tool_name: First generated tool name. Must be snake_case, never dotted.
         layer: Skill taxonomy layer, usually thin-harness, infrastructure, domain, or example.
         stage: Optional progressive-loading stage such as scene, authoring, or pipeline.
+        depends: Optional iterable of prerequisite DCC-MCP skill names.
         affinity: Tool thread affinity. Use "main" for host API / scene work.
         execution: "sync" or "async".
 
@@ -73,6 +85,7 @@ def create_skill(
     stage = stage.strip()
     affinity = affinity.strip().lower() or "any"
     execution = execution.strip().lower() or "sync"
+    depends_line = _depends_line(depends)
 
     _validate_skill_name(name)
     _validate_dcc_name(dcc)
@@ -106,7 +119,7 @@ metadata:
     dcc: {dcc}
     version: "0.1.0"
     layer: {layer}
-{_stage_line(stage)}    tags: ["generated", "{dcc}"]
+{_stage_line(stage)}{depends_line}    tags: ["generated", "{dcc}"]
     search-hint: "TODO: add search keywords for this skill"
     tools: tools.yaml
 ---
@@ -114,7 +127,8 @@ metadata:
 # {title}
 
 Keep instructions focused on when an agent should use this skill, what each
-tool returns, and what to inspect after success or failure.
+tool returns, prerequisite skills to load first, and what to inspect after
+success or failure.
 
 Tool names must stay client-safe (`^[A-Za-z0-9_-]{{1,64}}$`). Use local
 snake_case tool names in `tools.yaml`; dcc-mcp-core publishes them as

--- a/skills/dcc-mcp-skills-creator/scripts/skill_template.py
+++ b/skills/dcc-mcp-skills-creator/scripts/skill_template.py
@@ -17,6 +17,7 @@ metadata:
     layer: thin-harness
     stage: authoring
     tags: ["modeling", "animation", "example"]
+    # depends: ["base-skill"]
     search-hint: "create object, inspect scene, export asset"
     tools: tools.yaml
 ---
@@ -26,6 +27,7 @@ metadata:
 Write concise instructions for the AI agent:
 
 - when to load this skill;
+- which prerequisite skill to load first, if `metadata.dcc-mcp.depends` is set;
 - what each tool changes or reads;
 - what to verify after success;
 - what diagnostic tool to call after failure.

--- a/skills/dcc-mcp-skills-creator/tools.yaml
+++ b/skills/dcc-mcp-skills-creator/tools.yaml
@@ -31,6 +31,12 @@ tools:
         stage:
           type: string
           description: "Optional progressive-loading stage, for example scene or authoring."
+        depends:
+          type: array
+          items:
+            type: string
+            pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          description: "Optional prerequisite DCC-MCP skill names for metadata.dcc-mcp.depends."
         affinity:
           type: string
           enum: [any, main]


### PR DESCRIPTION
## Summary
- Document `metadata.dcc-mcp.depends` as the machine-readable contract for inter-skill prerequisites.
- Add dependency-aware authoring guidance for creator skills.
- Let the skill scaffold/template expose optional prerequisite skill names.

## Validation
- `vx python .\skills\dcc-mcp-skills-creator\scripts\validate_skill_dir.py .\skills\dcc-mcp-skills-creator`
- `create_skill` dependency self-check
- `vx git diff --check`

## Notes
- No core loader change needed; existing dependency resolution and load diagnostics already cover this path.
