### PR TITLE
fix(gateway): strip meta from mcp.arguments in suggested_post_load_next_step

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -821,12 +821,16 @@ fn suggested_post_load_next_step(
         if compact_schema.is_some() {
             let mut arguments = json!({ "tool_slug": tool_slug, "arguments": {} });
             attach_search_meta(&mut arguments, search_id, index_generation);
+            let mut mcp_arguments = arguments.clone();
+            if let Some(obj) = mcp_arguments.as_object_mut() {
+                obj.remove("meta");
+            }
             return json!({
                 "action": "call",
                 "arguments": arguments.clone(),
                 "mcp": {
                     "tool": "call",
-                    "arguments": arguments.clone(),
+                    "arguments": mcp_arguments,
                     "_meta": arguments.get("meta").cloned().unwrap_or(Value::Null),
                 },
                 "rest": {
@@ -844,12 +848,16 @@ fn suggested_post_load_next_step(
         {
             let mut arguments = json!({ "tool_slug": tool_slug, "arguments": {} });
             attach_search_meta(&mut arguments, search_id, index_generation);
+            let mut mcp_arguments = arguments.clone();
+            if let Some(obj) = mcp_arguments.as_object_mut() {
+                obj.remove("meta");
+            }
             return json!({
                 "action": "call",
                 "arguments": arguments.clone(),
                 "mcp": {
                     "tool": "call",
-                    "arguments": arguments.clone(),
+                    "arguments": mcp_arguments,
                     "_meta": arguments.get("meta").cloned().unwrap_or(Value::Null),
                 },
                 "rest": {
@@ -862,12 +870,16 @@ fn suggested_post_load_next_step(
 
         let mut arguments = json!({ "tool_slug": tool_slug });
         attach_search_meta(&mut arguments, search_id, index_generation);
+        let mut mcp_arguments = arguments.clone();
+        if let Some(obj) = mcp_arguments.as_object_mut() {
+            obj.remove("meta");
+        }
         return json!({
             "action": "describe",
             "arguments": arguments.clone(),
             "mcp": {
                 "tool": "describe",
-                "arguments": arguments.clone(),
+                "arguments": mcp_arguments,
                 "_meta": arguments.get("meta").cloned().unwrap_or(Value::Null),
             },
             "rest": {
@@ -886,12 +898,16 @@ fn suggested_post_load_next_step(
         "loaded_only": true,
     });
     attach_search_meta(&mut arguments, search_id, index_generation);
+    let mut mcp_arguments = arguments.clone();
+    if let Some(obj) = mcp_arguments.as_object_mut() {
+        obj.remove("meta");
+    }
     json!({
         "action": "search",
         "arguments": arguments.clone(),
         "mcp": {
             "tool": "search",
-            "arguments": arguments.clone(),
+            "arguments": mcp_arguments,
             "_meta": arguments.get("meta").cloned().unwrap_or(Value::Null),
         },
         "rest": {


### PR DESCRIPTION
## Root Cause

`attach_search_meta` writes a `meta` object into the arguments map (search_id, ranker_version, index_generation). `suggested_post_load_next_step` was cloning those arguments directly into `mcp.arguments` — leaking the meta object into backend tool kwargs.

## Fix

Strip `meta` from the clone before passing it into `mcp.arguments`, so only tool arguments reach the backend. The meta object is still available via the separate `_meta` key.

Applied to all 5 return paths in `suggested_post_load_next_step` (2 call paths with arguments, 1 call path without arguments, 1 describe path, 1 search path).

## Test Plan

- `cargo check` passes
- `cargo test` passes (all tests green)
- Manual verification: MCP `arguments` field no longer contains `meta` key when skill suggestions are returned

Fixes #1717