### PR TITLE
fix: avoid forwarding gateway-only metadata

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/request_meta.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/request_meta.rs
@@ -1,4 +1,4 @@
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use super::admin::trace::AgentContext;
 
@@ -44,7 +44,7 @@ pub(crate) fn meta_with_agent_context(
             }
             Some(filtered)
         }
-        None => Some(json!({ "agent_context": agent_context_value })),
+        None => None,
     }
 }
 
@@ -118,9 +118,7 @@ mod tests {
             actor_id: Some("a1".to_string()),
             ..AgentContext::default()
         };
-        let merged = meta_with_agent_context(None, Some(&agent_ctx)).expect("merged");
-        assert_eq!(merged["agent_context"]["actor_id"], "a1");
-        assert!(merged.get("credential_profile").is_none());
+        assert!(meta_with_agent_context(None, Some(&agent_ctx)).is_none());
     }
 
     #[test]

--- a/python/dcc_mcp_core/_install_lifecycle_sidecar.py
+++ b/python/dcc_mcp_core/_install_lifecycle_sidecar.py
@@ -380,6 +380,12 @@ def launch_sidecar(
         flags |= getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
         flags |= getattr(subprocess, "CREATE_NO_WINDOW", 0)
         kwargs["creationflags"] = flags
+        startupinfo_cls = getattr(subprocess, "STARTUPINFO", None)
+        if startupinfo_cls is not None:
+            startupinfo = startupinfo_cls()
+            startupinfo.dwFlags |= getattr(subprocess, "STARTF_USESHOWWINDOW", 0)
+            startupinfo.wShowWindow = getattr(subprocess, "SW_HIDE", 0)
+            kwargs["startupinfo"] = startupinfo
 
     try:
         proc = subprocess.Popen(contract["command"], **kwargs)

--- a/tests/test_install_lifecycle.py
+++ b/tests/test_install_lifecycle.py
@@ -1316,6 +1316,13 @@ def test_launch_sidecar_uses_detached_popen_contract(
     assert Path(captured["kwargs"]["stderr"].name) == Path(result["stdio"]["stderr_path"])
     assert captured["kwargs"]["env"]["DCC_MCP_REGISTRY_DIR"] == str((tmp_path / "registry").resolve())
     assert captured["kwargs"]["env"]["DCC_MCP_GATEWAY_PORT"] == "9765"
+    if os.name == "nt":
+        flags = captured["kwargs"]["creationflags"]
+        assert flags & sidecar_lifecycle.subprocess.CREATE_NO_WINDOW
+        assert flags & sidecar_lifecycle.subprocess.DETACHED_PROCESS
+        startupinfo = captured["kwargs"]["startupinfo"]
+        assert startupinfo.dwFlags & sidecar_lifecycle.subprocess.STARTF_USESHOWWINDOW
+        assert startupinfo.wShowWindow == sidecar_lifecycle.subprocess.SW_HIDE
 
 
 def test_launch_sidecar_can_return_process_for_supervisors(


### PR DESCRIPTION
Prevents gateway-created agent metadata from being sent to backend tool arguments when the client did not provide call metadata. Also hides detached sidecar windows more explicitly on Windows.\n\nValidation:\n- cargo test -p dcc-mcp-gateway meta_with_agent_context --lib\n- PYTHONPATH=python python -m pytest tests/test_install_lifecycle.py::test_launch_sidecar_uses_detached_popen_contract -q