### PR TITLE
fix(ci): install maturin before building wheel in python-matrix-full

### DIFF
--- a/.github/workflows/python-matrix-full.yml
+++ b/.github/workflows/python-matrix-full.yml
@@ -44,6 +44,9 @@ jobs:
           version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install maturin
+        run: python -m pip install "maturin>=1.5,<2.0"
+        shell: bash
       - name: Build wheel
         run: vx just build
         shell: bash


### PR DESCRIPTION
The nightly Python Matrix (full, nightly) workflow was missing `pip install maturin` before calling `vx just build`, causing `maturin: not found` (exit 127) on all platforms.

All other workflows (`ci.yml`, `build-wheels.yml`, `release.yml`, `dcc-integration.yml`) explicitly install maturin before invoking it.

Failed run: https://github.com/dcc-mcp/dcc-mcp-core/actions/runs/27945489880

Fixes PIP-1963.