### PR TITLE
docs(architecture): fix workspace package count (43 → 47)

### DIFF
--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -52,7 +52,7 @@ DCC-MCP-Core is a Rust workspace with Python bindings via PyO3. It provides:
 
 - **Zero third-party runtime dependencies** in the Rust core
 - **Optional Python bindings** via PyO3 for DCC integration
-- **43 workspace packages** (42 functional packages + `workspace-hack`) for selective dependency usage; root `Cargo.toml` is the source of truth
+- **47 workspace packages** (46 functional packages + `workspace-hack`) for selective dependency usage; root `Cargo.toml` is the source of truth
 
 ## Crate Structure
 


### PR DESCRIPTION
## Summary

The architecture guide still referenced 43 workspace packages, but the
actual Rust workspace has grown to 47 members (46 functional +
`workspace-hack`). Updating to reflect current state.

## Test plan

- [x] Count verified against `Cargo.toml` workspace members