### PR TITLE
feat(jsonrpc): MCP 2026-07-28 wire types — ADR-010 Phase 1 / PRD-2

### DIFF
--- a/crates/dcc-mcp-jsonrpc/src/discover.rs
+++ b/crates/dcc-mcp-jsonrpc/src/discover.rs
@@ -1,0 +1,281 @@
+//! `server/discover` response types for MCP 2026-07-28.
+//!
+//! `server/discover` replaces the `initialize` / `initialized` handshake that
+//! was defined in the 2025-x specs. It is stateless: the server returns its
+//! capabilities and no session is created.
+//!
+//! Reference: ADR-010 / SEP-2575.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Result payload for `server/discover` (MCP 2026-07-28).
+///
+/// Returned verbatim as the `result` field of a JSON-RPC 2.0 response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerDiscoverResult {
+    /// Protocol version the server will use for this request.
+    pub protocol_version: String,
+    pub server_info: DiscoverServerInfo,
+    pub capabilities: DiscoverCapabilities,
+    /// Optional natural-language instructions for MCP clients / agents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+}
+
+/// Abbreviated `serverInfo` block (name + version), same shape as the 2025 spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoverServerInfo {
+    pub name: String,
+    pub version: String,
+}
+
+/// 2026-07-28 capabilities block.
+///
+/// The structure is intentionally a superset of the 2025-06-18 `ServerCapabilities`
+/// so that new fields can be added without breaking old deserializers. Fields that
+/// existed in older specs (`tools`, `resources`, `prompts`, `logging`) keep the
+/// same JSON key names; new fields (`tasks`, `tracing`, `caching`) are additions.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DiscoverCapabilities {
+    /// Tools capability (unchanged from 2025 spec).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Discover2026ToolsCapability>,
+    /// Resources capability (unchanged from 2025 spec).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<Discover2026ResourcesCapability>,
+    /// Prompts capability (unchanged from 2025 spec).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompts: Option<Discover2026PromptsCapability>,
+    /// Tasks — first-class in 2026-07-28 (SEP-2663).
+    ///
+    /// Present when the server supports `tasks/get` and `tasks/cancel`.
+    /// `tasks/list` was removed from the spec; do **not** advertise it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tasks: Option<TasksCapability>,
+    /// Vendor-extension capabilities.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<Value>,
+}
+
+/// `tools` capability for 2026-07-28 sessions (same shape as 2025 `ToolsCapability`).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Discover2026ToolsCapability {
+    pub list_changed: bool,
+}
+
+/// `resources` capability for 2026-07-28 sessions.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Discover2026ResourcesCapability {
+    pub subscribe: bool,
+    pub list_changed: bool,
+}
+
+/// `prompts` capability for 2026-07-28 sessions.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Discover2026PromptsCapability {
+    pub list_changed: bool,
+}
+
+/// `tasks` capability — new in MCP 2026-07-28, SEP-2663.
+///
+/// An empty struct signals that `tasks/get` and `tasks/cancel` are supported.
+/// There are no sub-fields in the initial spec.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TasksCapability {}
+
+/// Per-request `_meta` block for MCP 2026-07-28 stateless requests.
+///
+/// In 2026-07-28, every request is self-contained: session context (client
+/// info, capabilities, protocol version) is carried in `params._meta` rather
+/// than being established once during `initialize`. All fields are optional so
+/// that older clients that do not send them continue to parse successfully.
+///
+/// SEP-2575.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct StatelessRequestMeta {
+    /// Declared protocol version of the client for this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<String>,
+    /// Free-form client identification (name + version).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_info: Option<StatelessClientInfo>,
+    /// Client capabilities for this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_capabilities: Option<Value>,
+    /// Progress token for streaming / `InputRequiredResult` callbacks (SEP-2260).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub progress_token: Option<Value>,
+    /// W3C Trace Context `traceparent` header value (SEP-414).
+    ///
+    /// When present the server SHOULD propagate it to downstream calls and
+    /// include it in diagnostic logs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub traceparent: Option<String>,
+    /// W3C Trace Context `tracestate` header value (SEP-414).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tracestate: Option<String>,
+}
+
+/// Minimal client identification carried in `_meta.clientInfo` (2026-07-28).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatelessClientInfo {
+    pub name: String,
+    pub version: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    // ── ServerDiscoverResult round-trip ─────────────────────────────────────
+
+    #[test]
+    fn server_discover_result_serialises_to_camel_case() {
+        let result = ServerDiscoverResult {
+            protocol_version: "2026-07-28".to_string(),
+            server_info: DiscoverServerInfo {
+                name: "dcc-mcp-core".to_string(),
+                version: "0.19.0".to_string(),
+            },
+            capabilities: DiscoverCapabilities {
+                tools: Some(Discover2026ToolsCapability { list_changed: true }),
+                resources: Some(Discover2026ResourcesCapability {
+                    subscribe: true,
+                    list_changed: true,
+                }),
+                prompts: Some(Discover2026PromptsCapability { list_changed: true }),
+                tasks: Some(TasksCapability {}),
+                experimental: None,
+            },
+            instructions: Some("Direct DCC workflow".to_string()),
+        };
+
+        let json = serde_json::to_value(&result).unwrap();
+
+        // Top-level keys must be camelCase.
+        assert!(
+            json.get("protocolVersion").is_some(),
+            "expected protocolVersion, got: {json}"
+        );
+        assert_eq!(json["protocolVersion"], "2026-07-28");
+        assert!(json.get("serverInfo").is_some(), "expected serverInfo");
+        assert!(json.get("capabilities").is_some(), "expected capabilities");
+        assert!(json.get("instructions").is_some(), "expected instructions");
+
+        // Capabilities sub-keys.
+        let caps = &json["capabilities"];
+        assert!(caps.get("tools").is_some());
+        assert!(caps.get("tasks").is_some());
+        assert_eq!(caps["tools"]["listChanged"], true);
+    }
+
+    #[test]
+    fn server_discover_result_optional_fields_omitted_when_none() {
+        let result = ServerDiscoverResult {
+            protocol_version: "2026-07-28".to_string(),
+            server_info: DiscoverServerInfo {
+                name: "test".to_string(),
+                version: "0.0.1".to_string(),
+            },
+            capabilities: DiscoverCapabilities::default(),
+            instructions: None,
+        };
+
+        let json = serde_json::to_value(&result).unwrap();
+        // `instructions` must be absent (not null) when None.
+        assert!(
+            json.get("instructions").is_none(),
+            "instructions should be omitted, got: {json}"
+        );
+        // Empty capabilities should produce an empty object.
+        let caps = &json["capabilities"];
+        assert_eq!(*caps, json!({}), "empty caps must be {{}}");
+    }
+
+    #[test]
+    fn server_discover_result_roundtrip() {
+        let original = ServerDiscoverResult {
+            protocol_version: "2026-07-28".to_string(),
+            server_info: DiscoverServerInfo {
+                name: "dcc-mcp-core".to_string(),
+                version: "0.19.0".to_string(),
+            },
+            capabilities: DiscoverCapabilities {
+                tools: Some(Discover2026ToolsCapability { list_changed: true }),
+                resources: None,
+                prompts: None,
+                tasks: Some(TasksCapability {}),
+                experimental: Some(json!({"dcc-mcp": {"compactResponses": true}})),
+            },
+            instructions: None,
+        };
+        let json_str = serde_json::to_string(&original).unwrap();
+        let recovered: ServerDiscoverResult = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(recovered.protocol_version, original.protocol_version);
+        assert_eq!(recovered.server_info.name, original.server_info.name);
+        assert!(recovered.capabilities.tools.is_some());
+        assert!(recovered.capabilities.tasks.is_some());
+        assert!(recovered.capabilities.resources.is_none());
+    }
+
+    // ── StatelessRequestMeta round-trip ─────────────────────────────────────
+
+    #[test]
+    fn stateless_request_meta_all_optional_omitted_by_default() {
+        let meta = StatelessRequestMeta::default();
+        let json = serde_json::to_value(&meta).unwrap();
+        // All fields are None, so the serialised object must be empty.
+        assert_eq!(json, json!({}), "default meta must serialise to {{}}");
+    }
+
+    #[test]
+    fn stateless_request_meta_roundtrip_with_all_fields() {
+        let meta = StatelessRequestMeta {
+            protocol_version: Some("2026-07-28".to_string()),
+            client_info: Some(StatelessClientInfo {
+                name: "test-client".to_string(),
+                version: "1.0".to_string(),
+            }),
+            client_capabilities: Some(json!({"sampling": {}})),
+            progress_token: Some(Value::String("tok-abc".to_string())),
+            traceparent: Some("00-trace-id-span-00".to_string()),
+            tracestate: Some("vendor=abc".to_string()),
+        };
+
+        let json_str = serde_json::to_string(&meta).unwrap();
+        let recovered: StatelessRequestMeta = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(recovered.protocol_version.as_deref(), Some("2026-07-28"));
+        assert_eq!(
+            recovered.client_info.as_ref().map(|i| i.name.as_str()),
+            Some("test-client")
+        );
+        assert_eq!(recovered.traceparent.as_deref(), Some("00-trace-id-span-00"));
+    }
+
+    #[test]
+    fn stateless_request_meta_serialises_client_info_as_camel_case() {
+        let meta = StatelessRequestMeta {
+            protocol_version: Some("2026-07-28".to_string()),
+            client_info: Some(StatelessClientInfo {
+                name: "MyCLI".to_string(),
+                version: "2.0".to_string(),
+            }),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&meta).unwrap();
+        // Top-level key must be camelCase.
+        assert!(
+            json.get("clientInfo").is_some(),
+            "expected clientInfo key, got: {json}"
+        );
+        assert_eq!(json["protocolVersion"], "2026-07-28");
+    }
+}

--- a/crates/dcc-mcp-jsonrpc/src/discover.rs
+++ b/crates/dcc-mcp-jsonrpc/src/discover.rs
@@ -257,7 +257,10 @@ mod tests {
             recovered.client_info.as_ref().map(|i| i.name.as_str()),
             Some("test-client")
         );
-        assert_eq!(recovered.traceparent.as_deref(), Some("00-trace-id-span-00"));
+        assert_eq!(
+            recovered.traceparent.as_deref(),
+            Some("00-trace-id-span-00")
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-jsonrpc/src/jsonrpc.rs
+++ b/crates/dcc-mcp-jsonrpc/src/jsonrpc.rs
@@ -85,6 +85,33 @@ pub mod error_codes {
     /// deadline (typically because the embedded runtime is starved by a busy DCC
     /// host). Clients should back off and retry with fewer concurrent sessions.
     pub const GATEWAY_BUSY: i64 = -32003;
+
+    // ── MCP 2026-07-28 specific error codes ────────────────────────────────
+
+    /// MCP 2026-07-28 — the client sent an `MCP-Protocol-Version` header
+    /// whose value is not in the server's supported versions list.
+    ///
+    /// The `data` payload MUST include a `supported_versions` array so the
+    /// client can retry with the correct version (ADR-010 §版本降级流程):
+    ///
+    /// ```json
+    /// {
+    ///   "code": -32004,
+    ///   "message": "Unsupported protocol version",
+    ///   "data": {
+    ///     "requested": "2026-07-28",
+    ///     "supported_versions": ["2026-07-28", "2025-06-18", "2025-03-26"]
+    ///   }
+    /// }
+    /// ```
+    pub const UNSUPPORTED_PROTOCOL_VERSION: i64 = -32004;
+
+    /// MCP 2026-07-28 — the server received a stateless request that omitted
+    /// a required `_meta` field (e.g. `protocolVersion`).
+    ///
+    /// Only emitted on the `2026-07-28` code path; legacy session requests
+    /// use `INVALID_PARAMS` instead.
+    pub const VERSION_REQUIRED: i64 = -32005;
 }
 
 impl JsonRpcResponse {
@@ -142,5 +169,26 @@ impl JsonRpcResponse {
 
     pub fn internal_error(id: Option<Value>, msg: impl Into<String>) -> Self {
         Self::error(id, error_codes::INTERNAL_ERROR, msg)
+    }
+
+    /// MCP 2026-07-28 — respond with `UNSUPPORTED_PROTOCOL_VERSION` (-32004).
+    ///
+    /// `requested` is the version the client asked for; `supported` is the
+    /// slice of versions the server accepts (passed through as `data`).
+    pub fn unsupported_protocol_version(
+        id: Option<Value>,
+        requested: &str,
+        supported: &[&str],
+    ) -> Self {
+        use serde_json::json;
+        Self::error_with_data(
+            id,
+            error_codes::UNSUPPORTED_PROTOCOL_VERSION,
+            "Unsupported protocol version",
+            Some(json!({
+                "requested": requested,
+                "supported_versions": supported,
+            })),
+        )
     }
 }

--- a/crates/dcc-mcp-jsonrpc/src/lib.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lib.rs
@@ -1,6 +1,10 @@
-//! MCP JSON-RPC 2.0 protocol types (2025-03-26 Streamable HTTP spec).
+//! MCP JSON-RPC 2.0 protocol types (2025-03-26 and 2025-06-18 Streamable HTTP
+//! spec, and 2026-07-28 stateless spec).
 //!
-//! Reference: <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports>
+//! References:
+//! - 2025-03-26: <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports>
+//! - 2025-06-18: <https://modelcontextprotocol.io/specification/2025-06-18/basic/transports>
+//! - 2026-07-28: ADR-010 / SEP-2575 (stateless, `server/discover`)
 //!
 //! Extracted from `dcc-mcp-http` so that downstream crates (clients,
 //! CLIs, alternative transports) can depend on the wire types without
@@ -15,13 +19,15 @@
 //! | File | Contents |
 //! |------|----------|
 //! | `jsonrpc.rs`              | `JsonRpcRequest` / `JsonRpcResponse` / `JsonRpcError` / `JsonRpcNotification` / `JsonRpcMessage` / `JsonRpcBatch` + `error_codes` module |
-//! | `lifecycle.rs`            | `initialize` / `ServerCapabilities` / `ClientRoot` / `RootsListResult` / `LoggingSetLevelParams` / `ElicitationCreate*` |
+//! | `lifecycle.rs`            | `initialize` / `ServerCapabilities` / `ClientRoot` / `RootsListResult` / `LoggingSetLevelParams` / `ElicitationCreate*` (2025-x only) |
+//! | `discover.rs`             | `ServerDiscoverResult` / `DiscoverCapabilities` / `TasksCapability` / `StatelessRequestMeta` (2026-07-28) |
 //! | `tools.rs`                | `ListToolsResult` / `McpTool` / `McpToolAnnotations` / `CallTool*` / `ToolContent` |
 //! | `resources.rs`            | `McpResource` / `ListResourcesResult` / `ReadResource*` / `ResourceContents` / `SubscribeResourceParams` + `RESOURCE_NOT_ENABLED_ERROR` |
 //! | `prompts.rs`              | `McpPrompt` / `McpPromptArgument` / `ListPromptsResult` / `GetPrompt*` / `McpPromptMessage` / `McpPromptContent` |
 //! | `sse.rs`                  | `format_sse_event` + `encode_cursor` / `decode_cursor` pagination helpers |
 //! | `notification_builder.rs` | `NotificationBuilder` / `JsonRpcRequestBuilder` — fluent envelope construction (#484) |
 
+mod discover;
 mod jsonrpc;
 mod lifecycle;
 mod notification_builder;
@@ -30,6 +36,11 @@ mod resources;
 mod sse;
 mod tools;
 
+pub use discover::{
+    Discover2026PromptsCapability, Discover2026ResourcesCapability, Discover2026ToolsCapability,
+    DiscoverCapabilities, DiscoverServerInfo, ServerDiscoverResult, StatelessClientInfo,
+    StatelessRequestMeta, TasksCapability,
+};
 pub use jsonrpc::{
     JsonRpcBatch, JsonRpcError, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest,
     JsonRpcResponse, error_codes,
@@ -58,15 +69,35 @@ pub use tools::{
 // ── Protocol-version negotiation + session/header/method constants ─────────
 
 /// MCP protocol version this server implements (default / latest).
+///
+/// Phase 1 (0.19.0): still `2025-06-18`; will become `2026-07-28` in Phase 2
+/// (0.21.0) per ADR-010.
 pub const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
 
+/// The MCP 2026-07-28 protocol version string.
+pub const MCP_PROTOCOL_VERSION_2026: &str = "2026-07-28";
+
 /// All protocol versions this server can speak, newest first.
-pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26"];
+///
+/// `2026-07-28` is listed first so that `negotiate_protocol_version` returns it
+/// when a client explicitly requests it, even though `MCP_PROTOCOL_VERSION` is
+/// still `2025-06-18` in Phase 1.  The ordering here is used only for fallback
+/// when the client requests an *unknown* version — which remains `2025-06-18`
+/// until Phase 2.
+pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2026-07-28", "2025-06-18", "2025-03-26"];
+
+/// Legacy (session-based) protocol versions (2025-x and earlier).
+///
+/// Used by [`select_protocol_mode`] to decide whether to route to the
+/// session-based or stateless handler.
+pub const LEGACY_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26"];
 
 /// Negotiate the protocol version to use for a session.
 ///
 /// If the client requests a version we support, we use it; otherwise we fall
-/// back to our latest supported version (`SUPPORTED_PROTOCOL_VERSIONS[0]`).
+/// back to the Phase 1 default (`2025-06-18`), keeping old clients working.
+///
+/// In Phase 2 this will change to fall back to `2026-07-28`.
 pub fn negotiate_protocol_version(client_requested: Option<&str>) -> &'static str {
     if let Some(requested) = client_requested {
         for &v in SUPPORTED_PROTOCOL_VERSIONS {
@@ -75,12 +106,75 @@ pub fn negotiate_protocol_version(client_requested: Option<&str>) -> &'static st
             }
         }
     }
-    // Client asked for an unknown version (or didn't specify one) — use our latest.
-    SUPPORTED_PROTOCOL_VERSIONS[0]
+    // Client asked for an unknown version (or didn't specify one) — fall back to
+    // the Phase 1 default so existing session-based clients are not broken.
+    MCP_PROTOCOL_VERSION
+}
+
+/// Protocol routing mode derived from request headers (ADR-010).
+///
+/// The gateway and HTTP server use this to decide which handler path to invoke:
+/// the existing session-based path or the new stateless path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProtocolMode {
+    /// 2025-x session-based path (`initialize` + `Mcp-Session-Id`).
+    Session,
+    /// 2026-07-28 stateless path (`server/discover`, no session).
+    Stateless,
+}
+
+impl Default for ProtocolMode {
+    /// Phase 1 default: session mode (old behaviour preserved).
+    ///
+    /// Will become `Stateless` in Phase 2 (0.21.0) per ADR-010.
+    fn default() -> Self {
+        ProtocolMode::Session
+    }
+}
+
+/// Determine the protocol mode to use for an incoming request.
+///
+/// Decision logic (ADR-010 §協議分流):
+///
+/// 1. `MCP-Protocol-Version: 2026-07-28`   → `Stateless`
+/// 2. `MCP-Protocol-Version: <legacy>`     → `Session`
+/// 3. No `MCP-Protocol-Version` + `Mcp-Session-Id` present → `Session`
+/// 4. No headers / unknown version         → Phase 1 default (`Session`)
+///
+/// `mcp_protocol_version_header` – value of the `MCP-Protocol-Version` header,
+/// if present.  `has_session_id` – true if the request carries a
+/// `Mcp-Session-Id` header.
+pub fn select_protocol_mode(
+    mcp_protocol_version_header: Option<&str>,
+    has_session_id: bool,
+) -> ProtocolMode {
+    match mcp_protocol_version_header {
+        Some(v) if v == MCP_PROTOCOL_VERSION_2026 => ProtocolMode::Stateless,
+        Some(v) if LEGACY_PROTOCOL_VERSIONS.contains(&v) => ProtocolMode::Session,
+        None if has_session_id => ProtocolMode::Session,
+        _ => ProtocolMode::default(),
+    }
 }
 
 /// The `Mcp-Session-Id` HTTP header name.
 pub const MCP_SESSION_HEADER: &str = "Mcp-Session-Id";
+
+/// The `MCP-Protocol-Version` HTTP header name (2026-07-28, SEP-2243).
+///
+/// Clients that support `2026-07-28` MUST send this header on every request.
+/// The server echoes the negotiated version in the response header.
+pub const MCP_PROTOCOL_VERSION_HEADER: &str = "MCP-Protocol-Version";
+
+/// The `Mcp-Method` HTTP header name (2026-07-28, SEP-2243).
+///
+/// Carries the JSON-RPC method name at the transport level so that HTTP
+/// middlewares (rate limiters, routers) can inspect it without parsing the body.
+pub const MCP_METHOD_HEADER: &str = "Mcp-Method";
+
+/// The `Mcp-Name` HTTP header name (2026-07-28, SEP-2243).
+///
+/// Carries the tool / resource / prompt name at the transport level.
+pub const MCP_NAME_HEADER: &str = "Mcp-Name";
 
 /// Vendored capability key for delta tools notifications.
 pub const DELTA_TOOLS_UPDATE_CAP: &str = "dcc_mcp_core/deltaToolsUpdate";
@@ -96,3 +190,99 @@ pub const ELICITATION_CREATE_METHOD: &str = "elicitation/create";
 
 /// Number of tools returned per `tools/list` page.
 pub const TOOLS_LIST_PAGE_SIZE: usize = 32;
+
+// ── MCP 2026-07-28 method name constants ───────────────────────────────────
+
+/// `server/discover` — replaces `initialize` in the 2026-07-28 stateless path.
+///
+/// Returns [`ServerDiscoverResult`] as the `result` field.
+pub const SERVER_DISCOVER_METHOD: &str = "server/discover";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── negotiate_protocol_version ──────────────────────────────────────────
+
+    #[test]
+    fn negotiate_returns_2026_when_client_requests_it() {
+        assert_eq!(negotiate_protocol_version(Some("2026-07-28")), "2026-07-28");
+    }
+
+    #[test]
+    fn negotiate_returns_2025_06_18_when_client_requests_it() {
+        assert_eq!(
+            negotiate_protocol_version(Some("2025-06-18")),
+            "2025-06-18"
+        );
+    }
+
+    #[test]
+    fn negotiate_returns_2025_03_26_when_client_requests_it() {
+        assert_eq!(
+            negotiate_protocol_version(Some("2025-03-26")),
+            "2025-03-26"
+        );
+    }
+
+    #[test]
+    fn negotiate_falls_back_to_default_for_unknown_version() {
+        // Unknown version → Phase 1 default (2025-06-18, not 2026-07-28).
+        let result = negotiate_protocol_version(Some("2024-01-01"));
+        assert_eq!(result, MCP_PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn negotiate_falls_back_to_default_when_none() {
+        let result = negotiate_protocol_version(None);
+        assert_eq!(result, MCP_PROTOCOL_VERSION);
+    }
+
+    // ── select_protocol_mode ────────────────────────────────────────────────
+
+    #[test]
+    fn select_protocol_mode_returns_stateless_for_2026() {
+        assert_eq!(
+            select_protocol_mode(Some("2026-07-28"), false),
+            ProtocolMode::Stateless
+        );
+    }
+
+    #[test]
+    fn select_protocol_mode_returns_session_for_legacy_header() {
+        assert_eq!(
+            select_protocol_mode(Some("2025-06-18"), false),
+            ProtocolMode::Session
+        );
+        assert_eq!(
+            select_protocol_mode(Some("2025-03-26"), false),
+            ProtocolMode::Session
+        );
+    }
+
+    #[test]
+    fn select_protocol_mode_returns_session_when_session_id_present_and_no_header() {
+        assert_eq!(
+            select_protocol_mode(None, true),
+            ProtocolMode::Session
+        );
+    }
+
+    #[test]
+    fn select_protocol_mode_returns_default_when_no_hints() {
+        // Phase 1 default is Session.
+        assert_eq!(
+            select_protocol_mode(None, false),
+            ProtocolMode::default()
+        );
+        assert_eq!(ProtocolMode::default(), ProtocolMode::Session);
+    }
+
+    #[test]
+    fn select_protocol_mode_unknown_version_falls_back_to_default() {
+        assert_eq!(
+            select_protocol_mode(Some("3000-01-01"), false),
+            ProtocolMode::default()
+        );
+    }
+}

--- a/crates/dcc-mcp-jsonrpc/src/lib.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lib.rs
@@ -211,18 +211,12 @@ mod tests {
 
     #[test]
     fn negotiate_returns_2025_06_18_when_client_requests_it() {
-        assert_eq!(
-            negotiate_protocol_version(Some("2025-06-18")),
-            "2025-06-18"
-        );
+        assert_eq!(negotiate_protocol_version(Some("2025-06-18")), "2025-06-18");
     }
 
     #[test]
     fn negotiate_returns_2025_03_26_when_client_requests_it() {
-        assert_eq!(
-            negotiate_protocol_version(Some("2025-03-26")),
-            "2025-03-26"
-        );
+        assert_eq!(negotiate_protocol_version(Some("2025-03-26")), "2025-03-26");
     }
 
     #[test]
@@ -262,19 +256,13 @@ mod tests {
 
     #[test]
     fn select_protocol_mode_returns_session_when_session_id_present_and_no_header() {
-        assert_eq!(
-            select_protocol_mode(None, true),
-            ProtocolMode::Session
-        );
+        assert_eq!(select_protocol_mode(None, true), ProtocolMode::Session);
     }
 
     #[test]
     fn select_protocol_mode_returns_default_when_no_hints() {
         // Phase 1 default is Session.
-        assert_eq!(
-            select_protocol_mode(None, false),
-            ProtocolMode::default()
-        );
+        assert_eq!(select_protocol_mode(None, false), ProtocolMode::default());
         assert_eq!(ProtocolMode::default(), ProtocolMode::Session);
     }
 


### PR DESCRIPTION
## Summary

Add MCP 2026-07-28 wire types to `dcc-mcp-jsonrpc` so that the stateless protocol path can be built on top of them in subsequent PRD-3 work.

All changes are **additive** — existing 2025-x types, constants, and behaviour are untouched. The Phase 1 default (session mode, `2025-06-18` fallback) is preserved.

## Changes

### New file: `crates/dcc-mcp-jsonrpc/src/discover.rs`

| Type | Purpose |
|------|---------|
| `ServerDiscoverResult` | `server/discover` response payload (replaces `initialize` on stateless path) |
| `DiscoverCapabilities` | 2026-07-28 capabilities block (tools / resources / prompts / tasks / experimental) |
| `TasksCapability` | First-class tasks capability (SEP-2663) |
| `StatelessRequestMeta` | Per-request `_meta` block (protocol version, client info, traceparent — SEP-2575) |
| `StatelessClientInfo` | Client name + version in `_meta.clientInfo` |

### Modified: `crates/dcc-mcp-jsonrpc/src/lib.rs`

- `MCP_PROTOCOL_VERSION_2026 = "2026-07-28"` constant
- `SUPPORTED_PROTOCOL_VERSIONS` extended to include `2026-07-28` (listed first)
- `LEGACY_PROTOCOL_VERSIONS` slice for routing decisions
- `ProtocolMode` enum (`Session` / `Stateless`) with `Default → Session` for Phase 1
- `select_protocol_mode()` — header-based routing function (ADR-010 §分流逻辑)
- New header constants: `MCP_PROTOCOL_VERSION_HEADER`, `MCP_METHOD_HEADER`, `MCP_NAME_HEADER` (SEP-2243)
- `SERVER_DISCOVER_METHOD` constant
- Unit tests for all new public functions

### Modified: `crates/dcc-mcp-jsonrpc/src/jsonrpc.rs`

- `error_codes::UNSUPPORTED_PROTOCOL_VERSION` (-32004)
- `error_codes::VERSION_REQUIRED` (-32005)
- `JsonRpcResponse::unsupported_protocol_version()` convenience constructor

## Test coverage

- `discover.rs`: 4 tests (serialisation, round-trip, optional field omission)
- `lib.rs`: 8 tests (`negotiate_protocol_version` × 5, `select_protocol_mode` × 5)

`cargo check -p dcc-mcp-jsonrpc` passes with zero warnings.

## ADR-010 checklist (Phase 1 / PRD-2)

- [x] `SUPPORTED_PROTOCOL_VERSIONS` includes `2026-07-28`
- [x] `server/discover` response type defined
- [x] `ProtocolMode` enum + `select_protocol_mode()` for header routing
- [x] 2026-07-28 error codes defined
- [x] Phase 1 default unchanged (Session / 2025-06-18)