### PR TITLE
fix(ci): resolve cargo fmt and macos-py37 wheel test failures

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -244,6 +244,7 @@ jobs:
         run: |
           "${PY37}" -m venv test-env
           source test-env/bin/activate
+          python -m pip install --upgrade "pip>=24.0"
           pip install --force-reinstall dist/*.whl
           pip check
           python tests/test_imports.py

--- a/crates/dcc-mcp-http-server/Cargo.toml
+++ b/crates/dcc-mcp-http-server/Cargo.toml
@@ -55,3 +55,8 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"
 [features]
 default = []
 prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus"]
+## Enable MCP 2026-07-28 stateless protocol support (ADR-010 Phase 1).
+## Adds `stateless::StatelessMcpService` and propagates the flag to
+## `dcc-mcp-jsonrpc` so `2026-07-28` appears in `SUPPORTED_PROTOCOL_VERSIONS`.
+## Off by default; will become default at Phase 2 (0.21.0).
+mcp-2026-07-28 = ["dcc-mcp-jsonrpc/mcp-2026-07-28"]

--- a/crates/dcc-mcp-http-server/src/lib.rs
+++ b/crates/dcc-mcp-http-server/src/lib.rs
@@ -40,6 +40,12 @@ pub mod rmcp_tool_call_async;
 pub mod rmcp_tool_call_dispatch;
 pub mod thread_routed_invoker;
 
+/// Stateless MCP service path for protocol version 2026-07-28 (ADR-010 Phase 1).
+///
+/// Enabled by the `mcp-2026-07-28` Cargo feature flag.
+#[cfg(feature = "mcp-2026-07-28")]
+pub mod stateless;
+
 pub use dynamic_tools::{
     DYNAMIC_TOOL_PREFIX, DynamicToolEntry, DynamicToolError, SessionDynamicTools, ToolSpec,
     build_deregister_tool_descriptor, build_list_dynamic_tools_descriptor,

--- a/crates/dcc-mcp-http-server/src/stateless/meta.rs
+++ b/crates/dcc-mcp-http-server/src/stateless/meta.rs
@@ -1,0 +1,97 @@
+//! Parse per-request client metadata from the `_meta` field (MCP 2026-07-28).
+//!
+//! In the 2026-07-28 stateless protocol each request is self-contained.
+//! Client identity, protocol version, and capabilities that were previously
+//! exchanged during `initialize` are now conveyed in `_meta` on every
+//! request.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Client information extracted from `_meta` on a 2026-07-28 request.
+#[derive(Debug, Clone, Default)]
+pub struct RequestMeta {
+    /// Protocol version declared by the client (`_meta.protocolVersion`).
+    pub protocol_version: Option<String>,
+    /// Human-readable client name (`_meta.clientInfo.name`).
+    pub client_name: Option<String>,
+    /// Client version string (`_meta.clientInfo.version`).
+    pub client_version: Option<String>,
+    /// Progress token for long-running tool calls (`_meta.progressToken`).
+    pub progress_token: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawMeta {
+    #[serde(default)]
+    protocol_version: Option<String>,
+    #[serde(default)]
+    client_info: Option<RawClientInfo>,
+    #[serde(default)]
+    progress_token: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawClientInfo {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+}
+
+impl RequestMeta {
+    /// Extract [`RequestMeta`] from a JSON-RPC `params._meta` value.
+    ///
+    /// Returns a zeroed struct if `meta` is `None` or cannot be decoded —
+    /// stateless requests are valid even without a populated `_meta`.
+    pub fn from_value(meta: Option<&Value>) -> Self {
+        let Some(meta) = meta else {
+            return Self::default();
+        };
+        let Ok(raw) = serde_json::from_value::<RawMeta>(meta.clone()) else {
+            return Self::default();
+        };
+        Self {
+            protocol_version: raw.protocol_version,
+            client_name: raw.client_info.as_ref().and_then(|c| c.name.clone()),
+            client_version: raw.client_info.as_ref().and_then(|c| c.version.clone()),
+            progress_token: raw.progress_token,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_full_meta() {
+        let meta = json!({
+            "protocolVersion": "2026-07-28",
+            "clientInfo": {"name": "TestClient", "version": "1.2.3"},
+            "progressToken": "tok-1"
+        });
+        let m = RequestMeta::from_value(Some(&meta));
+        assert_eq!(m.protocol_version.as_deref(), Some("2026-07-28"));
+        assert_eq!(m.client_name.as_deref(), Some("TestClient"));
+        assert_eq!(m.client_version.as_deref(), Some("1.2.3"));
+        assert_eq!(m.progress_token, Some(json!("tok-1")));
+    }
+
+    #[test]
+    fn handles_missing_meta() {
+        let m = RequestMeta::from_value(None);
+        assert!(m.protocol_version.is_none());
+        assert!(m.client_name.is_none());
+    }
+
+    #[test]
+    fn handles_partial_meta() {
+        let meta = json!({"protocolVersion": "2026-07-28"});
+        let m = RequestMeta::from_value(Some(&meta));
+        assert_eq!(m.protocol_version.as_deref(), Some("2026-07-28"));
+        assert!(m.client_name.is_none());
+    }
+}

--- a/crates/dcc-mcp-http-server/src/stateless/mod.rs
+++ b/crates/dcc-mcp-http-server/src/stateless/mod.rs
@@ -1,0 +1,32 @@
+//! Stateless MCP service path for protocol version 2026-07-28 (ADR-010 Phase 1).
+//!
+//! This module is compiled only when the `mcp-2026-07-28` feature flag is
+//! enabled.  It provides a request-handling layer that:
+//!
+//! - Does **not** create sessions or read `Mcp-Session-Id`.
+//! - Handles `server/discover` in place of `initialize`.
+//! - Routes tool calls to the existing [`crate::rmcp_tool_call_dispatch`]
+//!   pipeline with `session_id = None` (Tool Registry / Dispatcher / Catalog
+//!   are not modified).
+//! - Reads `_meta` on every request for per-request client context.
+//!
+//! ## Usage
+//!
+//! The caller (typically an axum handler or integration test) detects the
+//! `MCP-Protocol-Version: 2026-07-28` request header, constructs a
+//! [`StatelessMcpService`] with the shared [`ServerState`] and
+//! [`RegistryContext`], and calls [`StatelessMcpService::handle_request`].
+//!
+//! ```rust,ignore
+//! # use std::sync::Arc;
+//! # use dcc_mcp_http_server::stateless::StatelessMcpService;
+//! # use dcc_mcp_http_server::server_state::ServerState;
+//! # use dcc_mcp_http_server::rmcp_registry_context::RegistryContext;
+//! let service = StatelessMcpService::new(state, registry_context);
+//! let response = service.handle_request(&jsonrpc_req).await;
+//! ```
+
+mod meta;
+mod service;
+
+pub use service::StatelessMcpService;

--- a/crates/dcc-mcp-http-server/src/stateless/service.rs
+++ b/crates/dcc-mcp-http-server/src/stateless/service.rs
@@ -1,0 +1,370 @@
+//! Stateless MCP service for protocol version 2026-07-28 (ADR-010 Phase 1).
+//!
+//! [`StatelessMcpService`] handles JSON-RPC requests for the 2026-07-28
+//! stateless protocol path:
+//!
+//! - No session is created or read.
+//! - `Mcp-Session-Id` header is completely ignored.
+//! - Every request is self-contained; client identity lives in `_meta`.
+//! - `server/discover` replaces `initialize`.
+//! - Tool calls route to the existing [`dispatch_rmcp_tool_call`] — the
+//!   Tool Registry, Dispatcher, and Catalog are **not** modified.
+//!
+//! # Feature gate
+//!
+//! This module is compiled only when the `mcp-2026-07-28` feature is enabled.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use tracing::debug;
+
+use dcc_mcp_jsonrpc::{
+    DiscoverResult, JsonRpcRequest, JsonRpcResponse, MCP_PROTOCOL_VERSION_2026_07_28,
+    PromptsCapability, ResourcesCapability, ServerInfo, StatelessServerCapabilities,
+    TasksCapability, ToolsCapability, error_codes,
+};
+
+use crate::mcp_tool_list_builder::{assemble_full_tool_list, slice_tools_page};
+use crate::rmcp_registry_context::RegistryContext;
+use crate::rmcp_tool_call_dispatch::dispatch_rmcp_tool_call;
+use crate::server_state::ServerState;
+
+use super::meta::RequestMeta;
+
+/// Stateless MCP service (2026-07-28 protocol path).
+///
+/// Clone-cheap: all heavy state is behind `Arc`.
+#[derive(Clone)]
+pub struct StatelessMcpService {
+    state: ServerState,
+    registry_context: Arc<RegistryContext>,
+}
+
+impl StatelessMcpService {
+    /// Create a new service backed by the given server state.
+    #[must_use]
+    pub fn new(state: ServerState, registry_context: Arc<RegistryContext>) -> Self {
+        Self {
+            state,
+            registry_context,
+        }
+    }
+
+    /// Handle one JSON-RPC request and return a response value.
+    ///
+    /// Notifications (requests with no `id`) should be handled by the caller
+    /// and not forwarded here; they return `null`.
+    pub async fn handle_request(&self, req: &JsonRpcRequest) -> Option<Value> {
+        let id = req.id.clone()?;
+        let meta = req
+            .params
+            .as_ref()
+            .and_then(|p| p.get("_meta"))
+            .cloned();
+        let _request_meta = RequestMeta::from_value(meta.as_ref());
+
+        let response = match req.method.as_str() {
+            "server/discover" => self.handle_discover(id),
+            "ping" => json!({"jsonrpc": "2.0", "id": id, "result": {}}),
+            "tools/list" => self.handle_tools_list(id, req).await,
+            "tools/call" => self.handle_tools_call(id, req).await,
+            "resources/list" => self.handle_resources_list(id).await,
+            "prompts/list" => self.handle_prompts_list(id).await,
+            other => {
+                debug!(method = other, "stateless: method not found");
+                let error = JsonRpcResponse::method_not_found(Some(id), other);
+                serde_json::to_value(error).unwrap_or_else(|_| json!(null))
+            }
+        };
+        Some(response)
+    }
+
+    /// `server/discover` — returns server capabilities without creating a session.
+    ///
+    /// Equivalent to `initialize` in the 2026-07-28 stateless model (SEP-2575).
+    fn handle_discover(&self, id: Value) -> Value {
+        let caps = self.build_stateless_capabilities();
+        let result = DiscoverResult {
+            protocol_version: MCP_PROTOCOL_VERSION_2026_07_28.to_string(),
+            server_info: ServerInfo {
+                name: self.state.server_name.clone(),
+                version: self.state.server_version.clone(),
+            },
+            capabilities: caps,
+            instructions: Some(
+                "Direct DCC workflow: search_tools(query) → load_skill → tools/call. \
+                 tools/list is paginated; follow nextCursor if you list it."
+                    .to_string(),
+            ),
+        };
+        let result_value =
+            serde_json::to_value(result).unwrap_or_else(|_| json!({"error": "serialize_failed"}));
+        json!({"jsonrpc": "2.0", "id": id, "result": result_value})
+    }
+
+    fn build_stateless_capabilities(&self) -> StatelessServerCapabilities {
+        StatelessServerCapabilities {
+            tools: Some(ToolsCapability { list_changed: true }),
+            resources: if self.state.enable_resources {
+                Some(ResourcesCapability {
+                    subscribe: true,
+                    list_changed: true,
+                })
+            } else {
+                None
+            },
+            prompts: if self.state.enable_prompts {
+                Some(PromptsCapability { list_changed: true })
+            } else {
+                None
+            },
+            // Tasks are a first-class capability in 2026-07-28.
+            tasks: Some(TasksCapability {}),
+            experimental: None,
+        }
+    }
+
+    /// `tools/list` — returns the paginated tool list.
+    ///
+    /// No session context: session_id is always `None` in stateless mode.
+    async fn handle_tools_list(&self, id: Value, req: &JsonRpcRequest) -> Value {
+        let full = assemble_full_tool_list(&self.state, true, None);
+        let cursor = req
+            .params
+            .as_ref()
+            .and_then(|p| p.get("cursor"))
+            .and_then(Value::as_str);
+        let (page, next_cursor) = slice_tools_page(full, cursor);
+        let tools: Vec<Value> = page
+            .iter()
+            .map(|t| serde_json::to_value(t).unwrap_or(Value::Null))
+            .collect();
+        let mut result = json!({"tools": tools});
+        if let Some(c) = next_cursor {
+            result["nextCursor"] = Value::String(c);
+        }
+        debug!(count = tools.len(), "stateless: tools/list");
+        json!({"jsonrpc": "2.0", "id": id, "result": result})
+    }
+
+    /// `tools/call` — routes to the existing dispatch pipeline (zero registry changes).
+    async fn handle_tools_call(&self, id: Value, req: &JsonRpcRequest) -> Value {
+        let params = match req.params.as_ref() {
+            Some(p) => p,
+            None => {
+                return json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "error": {"code": error_codes::INVALID_PARAMS, "message": "Missing params"}
+                });
+            }
+        };
+
+        let tool_name = match params.get("name").and_then(Value::as_str) {
+            Some(n) if !n.is_empty() => n.to_string(),
+            _ => {
+                return json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "error": {"code": error_codes::INVALID_PARAMS, "message": "Missing tool name"}
+                });
+            }
+        };
+
+        let arguments = params.get("arguments").cloned();
+
+        // Extract _meta for async dispatch / progress routing.
+        let call_meta: Option<dcc_mcp_jsonrpc::CallToolMeta> = params
+            .get("_meta")
+            .and_then(|m| serde_json::from_value(m.clone()).ok());
+
+        debug!(tool = %tool_name, "stateless: tools/call");
+
+        // Stateless path: no session_id.
+        let dispatch_result = dispatch_rmcp_tool_call(
+            &self.state,
+            &self.registry_context,
+            None,
+            &tool_name,
+            arguments,
+            call_meta.as_ref(),
+        )
+        .await;
+
+        match dispatch_result {
+            Ok(result) => {
+                let result_value = serde_json::to_value(&result)
+                    .unwrap_or_else(|_| json!({"isError": true, "content": []}));
+                json!({"jsonrpc": "2.0", "id": id, "result": result_value})
+            }
+            Err(msg) => {
+                json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "error": {"code": error_codes::INVALID_PARAMS, "message": msg}
+                })
+            }
+        }
+    }
+
+    /// `resources/list` — returns an empty list when resources are disabled.
+    async fn handle_resources_list(&self, id: Value) -> Value {
+        if !self.state.enable_resources {
+            return json!({
+                "jsonrpc": "2.0", "id": id,
+                "error": {
+                    "code": error_codes::METHOD_NOT_FOUND,
+                    "message": "Resources not enabled"
+                }
+            });
+        }
+        // Stateless path: no resource provider wiring yet (Phase 1).
+        json!({"jsonrpc": "2.0", "id": id, "result": {"resources": []}})
+    }
+
+    /// `prompts/list` — returns an empty list when prompts are disabled.
+    async fn handle_prompts_list(&self, id: Value) -> Value {
+        if !self.state.enable_prompts {
+            return json!({
+                "jsonrpc": "2.0", "id": id,
+                "result": {"prompts": []}
+            });
+        }
+        json!({"jsonrpc": "2.0", "id": id, "result": {"prompts": []}})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
+    use dcc_mcp_skill_rest::StaticReadiness;
+    use dcc_mcp_skills::SkillCatalog;
+    use serde_json::json;
+
+    fn make_service() -> StatelessMcpService {
+        let registry = Arc::new(ToolRegistry::new());
+        let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+        let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+            Arc::clone(&registry),
+            Arc::clone(&dispatcher),
+        ));
+        let state = ServerState::builder(registry, dispatcher, catalog).build();
+        let registry_context = Arc::new(RegistryContext {
+            resource_provider: None,
+            prompt_provider: None,
+            readiness: Arc::new(StaticReadiness::fully_ready()),
+            on_skill_catalog_mutated: Arc::new(|| {}),
+        });
+        StatelessMcpService::new(state, registry_context)
+    }
+
+    fn make_request(method: &str, id: Value, params: Option<Value>) -> JsonRpcRequest {
+        JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(id),
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    #[tokio::test]
+    async fn server_discover_returns_capabilities() {
+        let svc = make_service();
+        let req = make_request("server/discover", json!(1), None);
+        let resp = svc.handle_request(&req).await.expect("has id");
+
+        assert_eq!(resp["jsonrpc"], "2.0");
+        assert_eq!(resp["id"], 1);
+        let result = &resp["result"];
+        assert_eq!(result["protocolVersion"], MCP_PROTOCOL_VERSION_2026_07_28);
+        assert_eq!(result["serverInfo"]["name"], "dcc-mcp-http");
+        assert!(result["capabilities"]["tools"].is_object());
+        assert!(result["capabilities"]["tasks"].is_object());
+        assert!(result["instructions"].is_string());
+    }
+
+    #[tokio::test]
+    async fn server_discover_has_no_session_artifacts() {
+        let svc = make_service();
+        let req = make_request("server/discover", json!("disc"), None);
+        let resp = svc.handle_request(&req).await.expect("has id");
+
+        // Must not include session-scoped fields.
+        let result = &resp["result"];
+        assert!(result.get("sessionId").is_none());
+        assert!(result["capabilities"].get("elicitation").is_none());
+        assert!(result["capabilities"].get("logging").is_none());
+    }
+
+    #[tokio::test]
+    async fn tools_list_returns_paginated_result() {
+        let svc = make_service();
+        let req = make_request("tools/list", json!(2), None);
+        let resp = svc.handle_request(&req).await.expect("has id");
+
+        let tools = resp["result"]["tools"].as_array().expect("tools array");
+        // Core tools are always present (search_tools, load_skill, etc.)
+        assert!(!tools.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unknown_method_returns_method_not_found() {
+        let svc = make_service();
+        let req = make_request("initialize", json!(3), None);
+        let resp = svc.handle_request(&req).await.expect("has id");
+
+        assert_eq!(resp["error"]["code"], error_codes::METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn ping_returns_empty_result() {
+        let svc = make_service();
+        let req = make_request("ping", json!(4), None);
+        let resp = svc.handle_request(&req).await.expect("has id");
+
+        assert_eq!(resp["result"], json!({}));
+    }
+
+    #[tokio::test]
+    async fn notification_returns_none() {
+        let svc = make_service();
+        // Notifications have no id.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            method: "notifications/initialized".to_string(),
+            params: None,
+        };
+        let resp = svc.handle_request(&req).await;
+        assert!(resp.is_none());
+    }
+
+    #[tokio::test]
+    async fn tools_call_missing_name_returns_invalid_params() {
+        let svc = make_service();
+        let req = make_request(
+            "tools/call",
+            json!(5),
+            Some(json!({"arguments": {}})),
+        );
+        let resp = svc.handle_request(&req).await.expect("has id");
+        assert_eq!(resp["error"]["code"], error_codes::INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn tools_call_unknown_tool_returns_error_result() {
+        let svc = make_service();
+        let req = make_request(
+            "tools/call",
+            json!(6),
+            Some(json!({"name": "non_existent_tool_xyz", "arguments": {}})),
+        );
+        let resp = svc.handle_request(&req).await.expect("has id");
+        // dispatch_rmcp_tool_call returns Ok(CallToolResult { is_error: true })
+        // for unknown tools rather than Err.
+        let result = &resp["result"];
+        assert_eq!(result["isError"], true);
+    }
+}

--- a/crates/dcc-mcp-http-server/src/stateless/service.rs
+++ b/crates/dcc-mcp-http-server/src/stateless/service.rs
@@ -57,11 +57,7 @@ impl StatelessMcpService {
     /// and not forwarded here; they return `null`.
     pub async fn handle_request(&self, req: &JsonRpcRequest) -> Option<Value> {
         let id = req.id.clone()?;
-        let meta = req
-            .params
-            .as_ref()
-            .and_then(|p| p.get("_meta"))
-            .cloned();
+        let meta = req.params.as_ref().and_then(|p| p.get("_meta")).cloned();
         let _request_meta = RequestMeta::from_value(meta.as_ref());
 
         let response = match req.method.as_str() {
@@ -344,11 +340,7 @@ mod tests {
     #[tokio::test]
     async fn tools_call_missing_name_returns_invalid_params() {
         let svc = make_service();
-        let req = make_request(
-            "tools/call",
-            json!(5),
-            Some(json!({"arguments": {}})),
-        );
+        let req = make_request("tools/call", json!(5), Some(json!({"arguments": {}})));
         let resp = svc.handle_request(&req).await.expect("has id");
         assert_eq!(resp["error"]["code"], error_codes::INVALID_PARAMS);
     }

--- a/crates/dcc-mcp-jsonrpc/Cargo.toml
+++ b/crates/dcc-mcp-jsonrpc/Cargo.toml
@@ -14,3 +14,10 @@ dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[features]
+default = []
+## Enable MCP 2026-07-28 stateless protocol support (ADR-010 Phase 1).
+## When enabled, `2026-07-28` is added to `SUPPORTED_PROTOCOL_VERSIONS`.
+## Off by default; will become default at Phase 2 (0.21.0).
+mcp-2026-07-28 = []

--- a/crates/dcc-mcp-jsonrpc/src/lib.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lib.rs
@@ -35,10 +35,11 @@ pub use jsonrpc::{
     JsonRpcResponse, error_codes,
 };
 pub use lifecycle::{
-    ClientCapabilities, ClientInfo, ClientRoot, ElicitationCapability, ElicitationCreateParams,
-    ElicitationCreateResult, InitializeParams, InitializeResult, LoggingCapability,
-    LoggingSetLevelParams, PromptsCapability, ResourcesCapability, RootsListResult,
-    ServerCapabilities, ServerInfo, ToolsCapability,
+    ClientCapabilities, ClientInfo, ClientRoot, DiscoverResult, ElicitationCapability,
+    ElicitationCreateParams, ElicitationCreateResult, InitializeParams, InitializeResult,
+    LoggingCapability, LoggingSetLevelParams, PromptsCapability, ResourcesCapability,
+    RootsListResult, ServerCapabilities, ServerInfo, StatelessServerCapabilities, TasksCapability,
+    ToolsCapability,
 };
 pub use notification_builder::{JsonRpcRequestBuilder, NotificationBuilder};
 pub use prompts::{
@@ -60,7 +61,23 @@ pub use tools::{
 /// MCP protocol version this server implements (default / latest).
 pub const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
 
+/// MCP 2026-07-28 protocol version constant (ADR-010 Phase 1, SEP-2575).
+///
+/// This version introduces stateless sessions: no `initialize` handshake,
+/// no `Mcp-Session-Id`, every request self-contained via `_meta`.
+pub const MCP_PROTOCOL_VERSION_2026_07_28: &str = "2026-07-28";
+
 /// All protocol versions this server can speak, newest first.
+///
+/// `2026-07-28` is listed when the `mcp-2026-07-28` feature flag is enabled
+/// (ADR-010 Phase 1).  At Phase 2 it will become the default; at Phase 3
+/// only `2026-07-28` will remain.
+#[cfg(feature = "mcp-2026-07-28")]
+pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
+    &["2026-07-28", "2025-06-18", "2025-03-26"];
+
+/// All protocol versions this server can speak (feature flag disabled).
+#[cfg(not(feature = "mcp-2026-07-28"))]
 pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26"];
 
 /// Negotiate the protocol version to use for a session.

--- a/crates/dcc-mcp-jsonrpc/src/lib.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lib.rs
@@ -73,8 +73,7 @@ pub const MCP_PROTOCOL_VERSION_2026_07_28: &str = "2026-07-28";
 /// (ADR-010 Phase 1).  At Phase 2 it will become the default; at Phase 3
 /// only `2026-07-28` will remain.
 #[cfg(feature = "mcp-2026-07-28")]
-pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
-    &["2026-07-28", "2025-06-18", "2025-03-26"];
+pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2026-07-28", "2025-06-18", "2025-03-26"];
 
 /// All protocol versions this server can speak (feature flag disabled).
 #[cfg(not(feature = "mcp-2026-07-28"))]

--- a/crates/dcc-mcp-jsonrpc/src/lifecycle.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lifecycle.rs
@@ -1,5 +1,7 @@
 //! MCP lifecycle messages: `initialize`, capabilities, `roots/list`,
 //! `logging/setLevel`, `elicitation/create`.
+//!
+//! Also includes `server/discover` types for MCP 2026-07-28 (ADR-010 Phase 1).
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -126,4 +128,54 @@ pub struct ElicitationCreateResult {
 pub struct ServerInfo {
     pub name: String,
     pub version: String,
+}
+
+// ── MCP 2026-07-28: server/discover (ADR-010 Phase 1) ───────────────────────
+
+/// Tasks capability (MCP 2026-07-28, SEP-2663).
+///
+/// Tasks become a first-class capability in 2026-07-28, replacing the
+/// experimental `tasks` field in `ServerCapabilities`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TasksCapability {}
+
+/// `ServerCapabilities` for MCP 2026-07-28 stateless sessions.
+///
+/// Differs from the session-based [`ServerCapabilities`] in that:
+/// - `tasks` is a first-class field (not experimental)
+/// - `elicitation` is absent (handled via `InputRequiredResult` multi-turn)
+/// - `logging` is omitted (deprecated in 2026-07-28)
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct StatelessServerCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<ToolsCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<ResourcesCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompts: Option<PromptsCapability>,
+    /// Tasks are a first-class capability in 2026-07-28 (SEP-2663).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tasks: Option<TasksCapability>,
+    /// Vendor-extension capabilities.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<serde_json::Value>,
+}
+
+/// Result payload for `server/discover` (MCP 2026-07-28, SEP-2575).
+///
+/// Replaces `initialize` in the 2026-07-28 stateless protocol.  Every
+/// request is self-contained (no session), so the client calls
+/// `server/discover` once (or caches the result) to learn server capabilities.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverResult {
+    /// The protocol version this server is speaking (`"2026-07-28"`).
+    pub protocol_version: String,
+    /// Server name and version.
+    pub server_info: ServerInfo,
+    /// Server capabilities under the 2026-07-28 model.
+    pub capabilities: StatelessServerCapabilities,
+    /// Optional human-readable workflow hint for AI agents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
 }


### PR DESCRIPTION
## Summary

Fixes two CI failures from PR #1730:

### 1. Rust format check (ubuntu-latest)
`cargo fmt --all -- --check` failed on 3 locations across 2 files:
- `crates/dcc-mcp-http-server/src/stateless/service.rs` (lines 57, 344)
- `crates/dcc-mcp-jsonrpc/src/lib.rs` (line 73)

**Fix**: Ran `cargo fmt --all` to apply correct formatting.

### 2. Build wheel (py3.7, macos-latest) — Test wheel
The wheel built successfully for x86_64-apple-darwin, but the test step failed:
```
ERROR: dcc_mcp_core-0.18.38-cp37-cp37m-macosx_10_12_x86_64.whl is not a supported wheel on this platform.
```

**Root cause**: The macos-py37 job runs on an ARM64 runner (macos-latest), cross-compiling the Rust extension for x86_64-apple-darwin. The bundled pip 20.1.1 in Python 3.7's venv fails to recognize the x86_64 wheel tag on an ARM64 host.

**Fix**: Added `python -m pip install --upgrade "pip>=24.0"` after venv activation and before wheel installation.

## CI Links
- Failed run: https://github.com/dcc-mcp/dcc-mcp-core/actions/runs/28117073291