### PR TITLE
fix: harden guardian crash wait

### DIFF
--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -501,8 +501,16 @@ def test_guardian_run_continues_after_exception(monkeypatch):
 
     guardian.start()
     try:
-        assert crash_reported.wait(timeout=10.0), "Expected guardian crash status to be published"
-        assert continued_after_crash.wait(timeout=10.0), "Expected guardian loop to continue probing"
+        assert _wait_until(
+            lambda: crash_reported.is_set() or guardian.status().get("crash_count", 0) >= 1,
+            timeout=60.0,
+            interval=0.05,
+        ), "Expected guardian crash status to be published"
+        assert _wait_until(
+            lambda: continued_after_crash.is_set() or len(calls) >= 2,
+            timeout=60.0,
+            interval=0.05,
+        ), "Expected guardian loop to continue probing"
     finally:
         guardian.stop(timeout=2.0)
 


### PR DESCRIPTION
Replace bare `Event.wait(timeout=10.0)` in `test_guardian_run_continues_after_exception` with `_wait_until(...)` that polls `crash_count` / probe progress using a 60s ceiling and 50ms interval.

Root cause: the test depended on wall-clock scheduling of the guardian thread after `start()`, so CI load could delay the crash callback long enough for the 10s wait to expire even though the code path was fine.

Validation:
- `python -m pytest tests/test_gateway_guardian.py -q` (47 passed)
- targeted test repeated 5x successfully

Fixes flake observed in #1730 CI (py3.10).