### PR TITLE
fix: ignore RUSTSEC-2026-0176/0177 pyo3 advisories in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -25,7 +25,15 @@ exclude-dev = true
 version = 2
 yanked = "warn"
 unmaintained = "workspace"
-ignore = []
+ignore = [
+    # RUSTSEC-2026-0176: PyO3 0.24.0 Iterator::nth/nth_back integer overflow.
+    # Fixed in pyo3 >= 0.29.0. Upgrade tracked in PIP-2153 (separate from
+    # the current feature PR to avoid coupling a security upgrade with new code).
+    "RUSTSEC-2026-0176",
+    # RUSTSEC-2026-0177: PyO3 PyCFunction::new_closure missing Sync bound.
+    # Fixed in pyo3 >= 0.29.0. Upgrade tracked in PIP-2153.
+    "RUSTSEC-2026-0177",
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary

cargo-deny `advisories` check is failing on main because the RustSec advisory database published two new advisories for pyo3 < 0.29.0:

- **RUSTSEC-2026-0176**: Iterator::nth/nth_back integer overflow in PyO3 0.24.0
- **RUSTSEC-2026-0177**: PyCFunction::new_closure missing Sync bound

Both are fixed in pyo3 >= 0.29.0. The workspace pins `pyo3 = "0.28"` with `multiple-pymethods`, so these advisories fire for every crate that depends on pyo3.

## Fix

Add both advisories to the `ignore` list in `deny.toml` with comments explaining the rationale.

## Follow-up

The pyo3 0.28→0.29 upgrade is tracked separately in PIP-2153 and should be done as a standalone change with its own CI verification.

Refs: PIP-2153