### PR TITLE
fix(gateway-ensure): add CREATE_NO_WINDOW to tasklist/taskkill subprocess calls

### DIFF
--- a/crates/dcc-mcp-gateway-ensure/src/lib.rs
+++ b/crates/dcc-mcp-gateway-ensure/src/lib.rs
@@ -291,12 +291,12 @@ pub fn is_process_alive(pid: u32) -> bool {
 
         let mut cmd = Command::new("tasklist");
         cmd.args([
-                "/FI",
-                &format!("PID eq {pid}"),
-                "/NH", // No headers
-            ])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null());
+            "/FI",
+            &format!("PID eq {pid}"),
+            "/NH", // No headers
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
         cmd.creation_flags(CREATE_NO_WINDOW);
         let output = cmd.output();
         match output {
@@ -332,7 +332,8 @@ pub fn stop_process(pid: u32) -> anyhow::Result<()> {
             .stdout(Stdio::null())
             .stderr(Stdio::null());
         cmd.creation_flags(CREATE_NO_WINDOW);
-        let status = cmd.status()
+        let status = cmd
+            .status()
             .with_context(|| format!("taskkill /PID {pid}"))?;
         if !status.success() {
             // Exit code 128 means the process was not found — that's OK.

--- a/crates/dcc-mcp-gateway-ensure/src/lib.rs
+++ b/crates/dcc-mcp-gateway-ensure/src/lib.rs
@@ -286,15 +286,19 @@ pub fn is_process_alive(pid: u32) -> bool {
         // `tasklist /FI "PID eq <pid>" /NH` returns output containing the
         // PID if the process exists, or "INFO: No tasks..." on stderr if not.
         // Exit code is always 0, so we check stdout for the PID string.
-        let output = Command::new("tasklist")
-            .args([
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+        let mut cmd = Command::new("tasklist");
+        cmd.args([
                 "/FI",
                 &format!("PID eq {pid}"),
                 "/NH", // No headers
             ])
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .output();
+            .stderr(Stdio::null());
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        let output = cmd.output();
         match output {
             Ok(out) => {
                 let stdout = String::from_utf8_lossy(&out.stdout);
@@ -320,11 +324,15 @@ pub fn is_process_alive(pid: u32) -> bool {
 pub fn stop_process(pid: u32) -> anyhow::Result<()> {
     #[cfg(windows)]
     {
-        let status = Command::new("taskkill")
-            .args(["/PID", &pid.to_string(), "/F"])
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+        let mut cmd = Command::new("taskkill");
+        cmd.args(["/PID", &pid.to_string(), "/F"])
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
+            .stderr(Stdio::null());
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        let status = cmd.status()
             .with_context(|| format!("taskkill /PID {pid}"))?;
         if !status.success() {
             // Exit code 128 means the process was not found — that's OK.


### PR DESCRIPTION
## Summary

- `is_process_alive()` polls `tasklist.exe` every 250ms in the sidecar's PID watcher loop
- `stop_process()` runs `taskkill.exe` on sidecar shutdown  
- Both were spawning these Windows console-subsystem binaries **without** `CREATE_NO_WINDOW`
- The sidecar process itself is detached (no console). When a detached process spawns a console-subsystem child without `CREATE_NO_WINDOW`, Windows allocates a **new console window**, visible to the user
- This is the root cause of the persistent terminal window reported with dcc-mcp-3dsmax

## Fix

Add `CREATE_NO_WINDOW` creation flag to both `tasklist` and `taskkill` invocations in `dcc-mcp-gateway-ensure`. Follows the same pattern already used in `launch_detached_gateway` (same file, line 381).

## Related

- User report: "安装了新版dcc-mcp-3dsmax启动后一直有个终端弹窗"
- Prior fix: `3cab75a1` fixed Python-side `CREATE_NO_WINDOW` but the Rust `is_process_alive` loop was missed