### PR TITLE
fix(ci): upgrade venv pip before installing macOS cp37 wheel

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -244,6 +244,7 @@ jobs:
         run: |
           "${PY37}" -m venv test-env
           source test-env/bin/activate
+          pip install --upgrade "pip>=20.3"
           pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
           pip check
           python tests/test_imports.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,6 +543,7 @@ jobs:
         run: |
           "${PY37}" -m venv test-env
           source test-env/bin/activate
+          pip install --upgrade "pip>=20.3"
           pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
           pip check
           python tests/test_imports.py


### PR DESCRIPTION
## Summary

Fixes recurring CI failure in `Build wheel (py3.7, macos-latest)` — flaky at latest HEAD `ea94543b`.

**Root cause:** Python 3.7.9 bundles pip 19.x which fails platform detection on ARM64 macOS runners running Rosetta 2 x86_64 Python. The old pip cannot resolve `macosx_10_12_x86_64` wheels, producing "No matching distribution found for dcc-mcp-core" in the Test wheel step.

**Fix:** Add `pip install --upgrade "pip>=20.3"` after activating the venv and before installing the wheel. Pip >= 20.3 correctly handles platform tag matching on ARM64 hosts with Rosetta 2 emulated x86_64 Python.

**Changed files:**
- `.github/workflows/ci.yml` — `build-wheel-py37-macos` → Test wheel step
- `.github/workflows/build-wheels.yml` — `macos-py37` → Test wheel step

## Test plan

- [ ] CI run on this PR: `Build wheel (py3.7, macos-latest)` passes
- [ ] No regression in other wheel build jobs