### PR TITLE
fix(ci): upgrade venv pip before installing macOS py3.7 wheel

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -244,6 +244,7 @@ jobs:
         run: |
           "${PY37}" -m venv test-env
           source test-env/bin/activate
+          pip install --upgrade "pip>=20.3"
           pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
           pip check
           python tests/test_imports.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,6 +543,7 @@ jobs:
         run: |
           "${PY37}" -m venv test-env
           source test-env/bin/activate
+          pip install --upgrade "pip>=20.3"
           pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
           pip check
           python tests/test_imports.py


### PR DESCRIPTION
## Summary

macOS py3.7 CI wheel test has been failing since 2026-06-25 on main with:
```
ERROR: Could not find a version that satisfies the requirement dcc-mcp-core
```

## Root Cause

Python 3.7.9's bundled pip (pre-20.3) fails to correctly detect platform compatibility on ARM64 macOS runners running Rosetta 2 x86_64 Python. The wheel is built correctly (`dcc_mcp_core-0.18.16-cp37-cp37m-macosx_10_12_x86_64.whl`) but the venv's old pip cannot match it to the running platform.

## Fix

Upgrade venv pip to `>=20.3` before attempting to install the wheel in two locations:
- `.github/workflows/ci.yml` — `build-wheel-py37-macos` job
- `.github/workflows/build-wheels.yml` — `macos-py37` job

## Fix History

This fix was originally committed as `23e5978b` (CI green: [run 28148640270](https://github.com/dcc-mcp/dcc-mcp-core/actions/runs/28148640270)) but was lost during branch rebasing.

## Test Plan

- [ ] CI `Build wheel (py3.7, macos-latest)` job passes on this PR