### PR TITLE
fix(ci): make cargo-deny advisory check non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,15 @@ jobs:
   # openssl-sys regressions (the v0.17.45/0.17.46 manylinux2014 OpenSSL 1.0.2
   # break), unmaintained / yanked deps, and license drift. Configuration
   # lives in `deny.toml` at the repo root.
+  #
+  # Advisory check is non-blocking (continue-on-error) to prevent the
+  # recurring pattern where every new RUSTSEC publication immediately
+  # fails all PRs requiring manual ignore-list entries.
+  # Advisories are still visible in CI output so the team can assess
+  # and act, but they don't gate merges.
+  # Bans, licenses, and sources checks remain blocking — these catch
+  # real regressions (native-tls/openssl-sys reintroduction, license
+  # drift, unknown registries).
   cargo-deny:
     name: cargo-deny
     runs-on: ubuntu-latest
@@ -286,8 +295,11 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-deny
-      - name: cargo deny check
-        run: cargo deny --all-features check
+      - name: cargo deny check advisories
+        continue-on-error: true
+        run: cargo deny --all-features check advisories
+      - name: cargo deny check (bans licenses sources)
+        run: cargo deny --all-features check bans licenses sources
 
   server-binary-dependency-policy:
     name: Server binary dependency policy


### PR DESCRIPTION
## Summary

Split the `cargo-deny` CI job so RUSTSEC advisories don't block PR merges while bans, licenses, and sources checks remain gating.

## Problem

New RUSTSEC publications immediately fail all CI runs, requiring manual `deny.toml` ignore entries. This happened at least twice recently (RUSTSEC-2026-0176/0177 for pyo3), consuming maintainer time on duplicate fixes across branches.

Under cargo-deny v2 schema, the `vulnerability` severity field is hardcoded to `deny` and cannot be configured per-severity — the only mitigation is the `ignore` list, which is inherently reactive.

## Fix

- Advisory check: `continue-on-error: true` — visible in CI output, non-blocking
- Bans, licenses, sources check: blocking — catches real regressions (native-tls/openssl-sys reintroduction, license drift, unknown registries)

## Test plan

- [x] `cargo deny check advisories` passes locally
- [x] `cargo deny check bans licenses sources` passes locally (warnings only, no errors)
- [ ] CI run on this PR confirms both steps work and the job passes