### PR TITLE
feat: add cargo fmt pre-push hook + CI auto-fix for unformatted Rust

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# pre-push hook: block pushes that contain unformatted Rust code.
+# Run `just githooks-install` once to activate.
+
+set -euo pipefail
+
+echo "==> Running cargo fmt --check before push..."
+
+# Prefer `just fmt-check` when just is available, fall back to cargo directly.
+if command -v just &>/dev/null; then
+  just fmt-check
+elif command -v cargo &>/dev/null; then
+  cargo fmt --all -- --check
+else
+  echo "ERROR: neither 'just' nor 'cargo' found on PATH" >&2
+  exit 1
+fi
+
+echo "==> Rust formatting OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ on:
       - ".github/actions/build-wheel/**"
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -237,6 +237,20 @@ jobs:
       - name: Rust format check
         if: matrix.rust-validation == 'full'
         run: vx just fmt-check
+      - name: Auto-fix Rust formatting
+        if: failure() && matrix.rust-validation == 'full' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        shell: bash
+        run: |
+          git fetch origin "${{ github.head_ref }}"
+          git checkout -B "${{ github.head_ref }}" "origin/${{ github.head_ref }}"
+          cargo fmt --all
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -u
+            git commit -m "style: apply cargo fmt [skip ci]"
+            git push origin HEAD:${{ github.head_ref }}
+          fi
       - name: Clippy
         if: matrix.rust-validation == 'full'
         run: vx just clippy

--- a/justfile
+++ b/justfile
@@ -25,6 +25,13 @@ WHEEL_FEATURES_PY37 := "python-bindings,ext-module," + OPT_FEATURES
 default:
     @just --list
 
+# ── Git hooks ─────────────────────────────────────────────────────────────────
+
+# Install git hooks from .githooks/ (sets core.hooksPath).
+# Run once after clone. Also invoked automatically by `dev`.
+githooks-install:
+    git config core.hooksPath .githooks
+
 # ── Feature introspection (for CI / scripts) ──────────────────────────────────
 # CI workflows call these to pick up the canonical feature list from justfile
 # rather than hard-coding feature names in workflow YAML.
@@ -168,6 +175,7 @@ demo-gateway-photoshop:
 dev:
     #!/usr/bin/env sh
     set -eu
+    just githooks-install
     if [ ! -d .venv ]; then python -m venv .venv; fi
     .venv/bin/python -m pip install maturin 2>/dev/null || true
     just stubgen
@@ -175,6 +183,7 @@ dev:
 
 [windows]
 dev:
+    just githooks-install
     if (-not (Test-Path .venv)) { python -m venv .venv }
     & .\.venv\Scripts\python.exe -m pip install --disable-pip-version-check maturin -q
     just stubgen


### PR DESCRIPTION
## Summary

Adds two-layer defense to prevent unformatted Rust code from reaching main and failing CI `rustfmt-check`.

### Layer 1: Pre-push Hook

- `.githooks/pre-push` runs `cargo fmt --all -- --check` before push
- `just githooks-install` activates the hook via `git config core.hooksPath .githooks`
- `just dev` invokes the hook installation path

### Layer 2: CI Auto-Fix

- Adds an `Auto-fix Rust formatting` step in the Rust check job
- Runs `cargo fmt --all` after formatting failure and commits the result with `[skip ci]`
- Updates workflow permissions so the action can push the formatting fix