### PR TITLE
ci: add release-please divergence gate and version consistency check

### DIFF
--- a/.github/workflows/release-please-divergence-gate.yml
+++ b/.github/workflows/release-please-divergence-gate.yml
@@ -1,0 +1,42 @@
+name: Release Please Divergence Gate
+
+# Catches stale release-please branches before they can corrupt main.
+# Fails if the release-please branch has drifted more than 5 commits
+# ahead of origin/main.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  divergence-check:
+    name: Check branch divergence from main
+    runs-on: ubuntu-latest
+    # Only run on release-please branches
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--branches--main')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check divergence from main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git fetch origin main
+          DIVERGENCE=$(git rev-list --count origin/main..HEAD)
+          echo "Branch is ${DIVERGENCE} commit(s) ahead of origin/main"
+          if [ "${DIVERGENCE}" -gt 5 ]; then
+            echo "::error::Release-please branch diverged by ${DIVERGENCE} commits from main (max 5)." \
+                 " Close and re-open the release PR to regenerate it from the current main."
+            exit 1
+          fi
+          echo "Divergence check passed: ${DIVERGENCE}/5 commits ahead of main."

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -1,0 +1,135 @@
+name: Version Consistency Check
+
+# Verifies that all version-bearing files agree on the same version.
+# Triggers on any PR that modifies a version-bearing file:
+#   - Cargo.toml (workspace version)
+#   - pyproject.toml (Python package version)
+#   - .release-please-manifest.json (release-please source-of-truth)
+#   - Any __version__.py files
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "pyproject.toml"
+      - ".release-please-manifest.json"
+      - "**/__version__.py"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  version-consistency:
+    name: Check version consistency across files
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Check version consistency
+        run: |
+          python - <<'PY'
+          import json
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          errors = []
+          warnings = []
+
+          # Read the manifest version (source of truth for release-please)
+          manifest_path = Path(".release-please-manifest.json")
+          if not manifest_path.exists():
+              print("::warning::No .release-please-manifest.json found; skipping version check.")
+              sys.exit(0)
+
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          manifest_version = manifest.get(".")
+          if not manifest_version:
+              print("::error::Missing root package version in .release-please-manifest.json")
+              sys.exit(1)
+
+          print(f"Manifest version (source of truth): {manifest_version}")
+
+          # Check Cargo.toml workspace version
+          cargo_path = Path("Cargo.toml")
+          if cargo_path.exists():
+              cargo = tomllib.loads(cargo_path.read_text(encoding="utf-8"))
+              cargo_version = cargo.get("workspace", {}).get("package", {}).get("version")
+              if cargo_version is not None:
+                  if cargo_version != manifest_version:
+                      errors.append(
+                          f"Cargo.toml workspace.package.version={cargo_version!r} "
+                          f"!= manifest {manifest_version!r}"
+                      )
+                  else:
+                      print(f"  Cargo.toml: {cargo_version} ✓")
+
+          # Check pyproject.toml project version
+          pyproject_path = Path("pyproject.toml")
+          if pyproject_path.exists():
+              pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+              py_version = pyproject.get("project", {}).get("version")
+              if py_version is not None:
+                  if py_version != manifest_version:
+                      errors.append(
+                          f"pyproject.toml project.version={py_version!r} "
+                          f"!= manifest {manifest_version!r}"
+                      )
+                  else:
+                      print(f"  pyproject.toml: {py_version} ✓")
+
+          # Check sub-package pyproject.toml files
+          for sub_pyproject in Path("pkg").glob("*/pyproject.toml") if Path("pkg").exists() else []:
+              sub = tomllib.loads(sub_pyproject.read_text(encoding="utf-8"))
+              sub_version = sub.get("project", {}).get("version")
+              if sub_version is not None:
+                  if sub_version != manifest_version:
+                      errors.append(
+                          f"{sub_pyproject}: version={sub_version!r} != manifest {manifest_version!r}"
+                      )
+                  else:
+                      print(f"  {sub_pyproject}: {sub_version} ✓")
+
+          # Check any __version__.py files
+          for version_py in Path(".").rglob("__version__.py"):
+              if ".git" in version_py.parts:
+                  continue
+              content = version_py.read_text(encoding="utf-8")
+              # Look for __version__ = "x.y.z"
+              import re
+              match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', content)
+              if match:
+                  file_version = match.group(1)
+                  if file_version != manifest_version:
+                      warnings.append(
+                          f"{version_py}: __version__={file_version!r} != manifest {manifest_version!r}"
+                      )
+                  else:
+                      print(f"  {version_py}: {file_version} ✓")
+
+          if warnings:
+              for w in warnings:
+                  print(f"::warning::{w}")
+
+          if errors:
+              for e in errors:
+                  print(f"::error::{e}")
+              print(
+                  "::error::Version mismatch detected. All version-bearing files must agree. "
+                  "If this is a release-please PR, ensure release-please-config.json extra-files "
+                  "covers all version locations."
+              )
+              sys.exit(1)
+
+          print("Version consistency check passed.")
+          PY


### PR DESCRIPTION
## Summary

Implements CI safety gates B and C from PIP-2400.

### A. Release-Please Config Audit (no changes needed)

The existing workflow already satisfies all requirements:
- Uses `googleapis/release-please-action@v5` with `manifest-file` (PR mode, no direct push to main)
- `release-please-pr-guard.yml` already filters on `release-please--branches--main` branch prefix
- `check_release_please_pr.py` checks stale tags and PR title consistency
- `release_push_preflight.py` guards against stale release PR versions

### B. Divergence Gate (`release-please-divergence-gate.yml`)

New workflow that runs on release-please PRs and fails if the branch has drifted more than 5 commits ahead of `origin/main`. This catches stale release branches before they can corrupt main.

```bash
DIVERGENCE=$(git rev-list --count origin/main..HEAD)
# Fails if DIVERGENCE > 5
```

### C. Version Consistency Check (`version-consistency.yml`)

New workflow triggered by PRs that modify version-bearing files:
- `Cargo.toml`
- `pyproject.toml`
- `.release-please-manifest.json`
- `**/__version__.py`

Verifies that all version-bearing files agree on the same version as `.release-please-manifest.json` (source of truth).

## Testing

Both workflows are scoped correctly:
- Divergence gate only runs on `release-please--branches--main` branches
- Version consistency runs on any PR touching version files