### PR TITLE
fix(ci): install maturin before vx just build in python-matrix-full

### DIFF
--- a/.github/workflows/python-matrix-full.yml
+++ b/.github/workflows/python-matrix-full.yml
@@ -44,6 +44,9 @@ jobs:
           version: "0.9.11"
           cache-key-prefix: "vx-tools-v0.9.7"
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install maturin
+        run: pip install "maturin>=1.5,<2.0"
+        shell: bash
       - name: Build wheel
         run: vx just build
         shell: bash


### PR DESCRIPTION
## Summary
- The weekly `python-matrix-full` workflow failed on every matrix cell because the justfile `build` recipe calls `maturin` directly, but maturin was never installed before `vx just build`.
- Added `pip install "maturin>=1.5,<2.0"` step before the build step, matching the pattern used by `ci.yml` and `release.yml`.

## Test plan
- [ ] PR CI passes for the touched workflow file
- [ ] After merge, manually dispatch `python-matrix-full` workflow to confirm all cells pass