### PR TITLE
fix(ci): add CI status check to release-please PR guard

### DIFF
--- a/.github/workflows/release-please-pr-guard.yml
+++ b/.github/workflows/release-please-pr-guard.yml
@@ -4,27 +4,38 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, edited]
     branches: [main]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 permissions:
   contents: read
   pull-requests: read
+  checks: read
 
 jobs:
   validate-release-pr:
     name: Validate release PR metadata
     runs-on: ubuntu-latest
     if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      startsWith(github.event.pull_request.head.ref, 'release-please--branches--main')
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       startsWith(github.event.pull_request.head.ref, 'release-please--branches--main'))
+      ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion != 'skipped' &&
+       startsWith(github.event.workflow_run.head_branch, 'release-please--branches--main'))
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
 
       - name: Check release-please PR consistency
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PR_TITLE: ${{ github.event_name == 'pull_request' && github.event.pull_request.title || '' }}
+          PR_HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.event.workflow_run.head_branch }}
+          PR_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
         run: python scripts/ci/check_release_please_pr.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-app-ui"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "chrono",
  "hex",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "image",
  "libc",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-catalog"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "jsonschema",
  "serde",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-cli"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-db"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "axum",
  "chrono",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway-core"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "chrono",
  "dcc-mcp-gateway-search",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway-ensure"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway-search"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "nucleo-matcher",
  "serde",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-host"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-pybridge",
  "dcc-mcp-wire",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-host-rpc"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "axum",
  "axum-test",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http-py"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http-server"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "chrono",
  "dashmap",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http-types"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "base64 0.22.1",
  "dcc-mcp-gateway-core",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-job"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "chrono",
  "dashmap",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-jsonrpc"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-protocols",
  "dcc-mcp-wire",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-marketplace"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-catalog",
  "reqwest 0.13.4",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dirs",
  "pyo3",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-pybridge-derive",
  "pyo3",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge-derive"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-pybridge",
  "parking_lot",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "axum",
  "bytes",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-semantic"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "anyhow",
  "fastembed",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "ipckit",
  "libc",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sidecar"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skill-rest"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "axum",
  "axum-test",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-agent"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-protocol"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "jsonwebtoken",
  "rmp-serde",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-relay"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-updater"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-wire"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/scripts/ci/check_release_please_pr.py
+++ b/scripts/ci/check_release_please_pr.py
@@ -48,13 +48,89 @@ def remote_tag_exists(repo: str, tag_name: str) -> bool:
     fail(f"could not check remote tag {tag_name}: {result.stdout.strip()}")
 
 
+def check_ci_status(repo: str, sha: str) -> None:
+    """Block if any completed CI check runs failed for the commit."""
+    if os.environ.get("DCC_RELEASE_GUARD_SKIP_CI_CHECK") == "1":
+        return
+
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/commits/{sha}/check-runs?per_page=100"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        if "Not Found" in result.stdout:
+            print("::notice::No CI check runs found for this commit; guard continues.")
+            return
+        fail(f"could not check CI status: {result.stdout.strip()}")
+
+    data = json.loads(result.stdout or '{"check_runs": []}')
+    check_runs: list[dict] = data.get("check_runs", [])
+
+    failed: list[str] = []
+    in_progress: list[str] = []
+    for run in check_runs:
+        name = run.get("name", "unknown")
+        status = run.get("status", "")
+        conclusion = run.get("conclusion", "")
+        if status == "completed" and conclusion in (
+            "failure",
+            "timed_out",
+            "action_required",
+            "startup_failure",
+        ):
+            failed.append(f"{name} → {conclusion}")
+        elif status in ("queued", "in_progress"):
+            in_progress.append(name)
+
+    if failed:
+        fail(
+            "CI checks failed for this release PR head commit:\n"
+            + "\n".join(f"  - {f}" for f in failed)
+            + "\nFix the CI failures before merging."
+        )
+
+    passed = sum(1 for r in check_runs if r.get("status") == "completed" and r.get("conclusion") == "success")
+    skipped = sum(
+        1
+        for r in check_runs
+        if r.get("status") == "completed" and r.get("conclusion") in ("skipped", "cancelled", "neutral")
+    )
+
+    parts = [f"CI checks: {passed} passed"]
+    if skipped:
+        parts.append(f"{skipped} skipped/cancelled")
+    if in_progress:
+        preview = ", ".join(in_progress[:3])
+        more = f" +{len(in_progress) - 3} more" if len(in_progress) > 3 else ""
+        parts.append(f"{len(in_progress)} in progress ({preview}{more})")
+
+    print("; ".join(parts) + " — guard passes.")
+
+
 def main() -> None:
     """Validate the current checkout against pull request metadata."""
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
     head_ref = os.environ.get("PR_HEAD_REF", "")
-    title = os.environ.get("PR_TITLE", "").strip()
     if not head_ref.startswith("release-please--branches--main"):
         print("Not a release-please branch; skipping.")
         return
+
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    sha = os.environ.get("PR_HEAD_SHA", "")
+
+    # workflow_run events: CI-only re-check — full metadata validation
+    # already passed on the original pull_request event.
+    if event_name == "workflow_run":
+        if not repo or not sha:
+            fail("GITHUB_REPOSITORY and PR_HEAD_SHA are required")
+        check_ci_status(repo, sha)
+        return
+
+    # pull_request events: full metadata + CI validation
+    title = os.environ.get("PR_TITLE", "").strip()
 
     manifest_path = Path(".release-please-manifest.json")
     if not manifest_path.exists():
@@ -82,7 +158,6 @@ def main() -> None:
         )
 
     if os.environ.get("DCC_RELEASE_GUARD_SKIP_REMOTE") != "1":
-        repo = os.environ.get("GITHUB_REPOSITORY", "")
         if not repo:
             fail("GITHUB_REPOSITORY is required for remote tag validation")
         tag_name = f"v{manifest_version}"
@@ -93,6 +168,9 @@ def main() -> None:
             )
 
     print(f"Release PR metadata is consistent for {manifest_version}.")
+
+    if repo and sha:
+        check_ci_status(repo, sha)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds CI status check to the release-please PR guard script (`check_release_please_pr.py`), using the GitHub check-runs API to block merging when any CI check has failed
- Adds `workflow_run` trigger so the guard re-evaluates after the main CI workflow completes, catching failures that occur after the initial PR event
- CI checks that are still pending/in-progress do NOT block the guard

## Behavior

| CI state | Guard result |
|----------|-------------|
| All checks passed | Pass |
| Any check failed / timed out / startup_failure | **Block** |
| Checks pending or in progress | Pass (wait for CI) |

## Changes

- `scripts/ci/check_release_please_pr.py` — new `check_ci_status()` function; `main()` dispatches by event type (`pull_request` = full validation + CI check, `workflow_run` = CI-only re-check)
- `.github/workflows/release-please-pr-guard.yml` — `workflow_run` trigger on CI workflow completion; `checks: read` permission; event-aware env vars