### PR TITLE
fix(gateway): resolve gateway/app-ui DCC tool contract bugs (PIP-2420)

### DIFF
--- a/crates/dcc-mcp-gateway-core/src/capability/record.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/record.rs
@@ -289,6 +289,13 @@ pub struct CapabilityRecord {
     /// is always callable when `loaded=true`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_group: Option<String>,
+    /// True when this tool is a discovery-only meta-tool that must
+    /// NOT be dispatched via sidecar `tools/call` (e.g.
+    /// `dcc_capability_manifest`). Discovery-only tools are still
+    /// searchable and describable, but `is_callable()` returns false
+    /// regardless of load state.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub discovery_only: bool,
 }
 
 impl CapabilityRecord {
@@ -333,6 +340,7 @@ impl CapabilityRecord {
             metadata: None,
             available_groups: Vec::new(),
             tool_group,
+            discovery_only: false,
         }
     }
 
@@ -365,6 +373,14 @@ impl CapabilityRecord {
     #[must_use]
     pub fn with_search_tokens(mut self, tokens: Vec<String>) -> Self {
         self.search_tokens = normalise_search_tokens(tokens);
+        self
+    }
+
+    /// Mark this record as a discovery-only meta-tool that must not be
+    /// dispatched via sidecar `tools/call`.
+    #[must_use]
+    pub fn with_discovery_only(mut self, discovery_only: bool) -> Self {
+        self.discovery_only = discovery_only;
         self
     }
 
@@ -405,6 +421,7 @@ impl CapabilityRecord {
             metadata: None,
             available_groups: Vec::new(),
             tool_group,
+            discovery_only: false,
         }
     }
 
@@ -415,6 +432,9 @@ impl CapabilityRecord {
     /// - the tool either has no group, or its group is active.
     #[must_use]
     pub fn is_callable(&self) -> bool {
+        if self.discovery_only {
+            return false;
+        }
         if !self.loaded {
             return false;
         }
@@ -715,5 +735,67 @@ mod unit_tests {
         );
         let s = serde_json::to_string(&bare).unwrap();
         assert!(!s.contains("\"tags\""), "bare record JSON: {s}");
+    }
+
+    // ── discovery_only (PIP-2420) ─────────────────────────────────────────
+
+    #[test]
+    fn discovery_only_tool_is_not_callable() {
+        let mut rec = CapabilityRecord::new(
+            "maya.abcdef01.dcc_capability_manifest".into(),
+            "dcc_capability_manifest".into(),
+            "dcc_capability_manifest".into(),
+            None,
+            "Discovery manifest",
+            Vec::new(),
+            "maya".into(),
+            Uuid::nil(),
+            true,
+            true,
+            None,
+        );
+        rec.discovery_only = true;
+        assert!(!rec.is_callable());
+    }
+
+    #[test]
+    fn discovery_only_false_serializes_as_default() {
+        let rec = CapabilityRecord::new(
+            "x.abcdef01.a".into(),
+            "a".into(),
+            "a".into(),
+            None,
+            "",
+            Vec::new(),
+            "x".into(),
+            Uuid::nil(),
+            false,
+            false,
+            None,
+        );
+        let s = serde_json::to_string(&rec).unwrap();
+        assert!(!s.contains("discovery_only"), "default false should not serialize");
+    }
+
+    #[test]
+    fn discovery_only_true_is_serialized() {
+        let mut rec = CapabilityRecord::new(
+            "x.abcdef01.a".into(),
+            "a".into(),
+            "a".into(),
+            None,
+            "",
+            Vec::new(),
+            "x".into(),
+            Uuid::nil(),
+            false,
+            false,
+            None,
+        );
+        rec.discovery_only = true;
+        let s = serde_json::to_string(&rec).unwrap();
+        assert!(s.contains("discovery_only"), "true must serialize: {s}");
+        let back: CapabilityRecord = serde_json::from_str(&s).unwrap();
+        assert!(back.discovery_only);
     }
 }

--- a/crates/dcc-mcp-gateway-core/src/capability/record.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/record.rs
@@ -774,7 +774,10 @@ mod unit_tests {
             None,
         );
         let s = serde_json::to_string(&rec).unwrap();
-        assert!(!s.contains("discovery_only"), "default false should not serialize");
+        assert!(
+            !s.contains("discovery_only"),
+            "default false should not serialize"
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -102,6 +102,7 @@ pub fn build_records_from_backend(input: BuildInput<'_>) -> BuildOutcome {
         let slug = tool_slug(input.dcc_type, &input.instance_id, &callable_id);
         let tool_group = extract_tool_group_from_meta(tool.meta.as_ref());
         let available_groups = extract_available_groups_from_meta(tool.meta.as_ref());
+        let discovery_only = is_discovery_only_tool(&tool.name);
         records.push(
             CapabilityRecord::new(
                 slug,
@@ -121,7 +122,8 @@ pub fn build_records_from_backend(input: BuildInput<'_>) -> BuildOutcome {
                 extract_metadata(tool.meta.as_ref()),
             )
             .with_available_groups(available_groups)
-            .with_search_tokens(search_tokens),
+            .with_search_tokens(search_tokens)
+            .with_discovery_only(discovery_only),
         );
     }
 
@@ -156,6 +158,18 @@ fn should_skip(name: &str) -> bool {
         return true;
     }
     false
+}
+
+/// Return `true` when the tool is a discovery-only meta-tool that
+/// must NOT be dispatched via sidecar `tools/call`.
+///
+/// Discovery-only tools (e.g. `dcc_capability_manifest`) are still
+/// searchable and describable, but `is_callable()` returns false.
+fn is_discovery_only_tool(backend_tool: &str) -> bool {
+    let lower = backend_tool.to_ascii_lowercase();
+    // dcc_capability_manifest is served by the discovery MCP
+    // endpoint, not the sidecar tools/call dispatch path.
+    lower == "dcc_capability_manifest"
 }
 
 /// Pull the `(skill_name, bare_tool)` pair out of a backend tool name.
@@ -868,5 +882,28 @@ mod unit_tests {
         assert_eq!(meta.execution.as_deref(), Some("sync"));
         assert_eq!(meta.timeout_hint_secs, Some(5));
         assert_eq!(meta.risk.as_deref(), Some("mutation"));
+    }
+
+    // ── discovery_only (PIP-2420) ─────────────────────────────────────────
+
+    #[test]
+    fn discovery_only_tool_is_marked() {
+        let iid = Uuid::from_u128(99);
+        let tools = vec![
+            tool("dcc_capability_manifest", "DCC capability manifest", json!({"type": "object"})),
+            tool("create_sphere", "make a sphere", json!({"type": "object"})),
+        ];
+        let out = build_records_from_backend(BuildInput {
+            instance_id: iid,
+            dcc_type: "3dsmax",
+            backend_tools: &tools,
+        });
+        let by_name: std::collections::HashMap<_, _> = out
+            .records
+            .iter()
+            .map(|r| (r.backend_tool.as_str(), r))
+            .collect();
+        assert!(by_name["dcc_capability_manifest"].discovery_only);
+        assert!(!by_name["create_sphere"].discovery_only);
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -890,7 +890,11 @@ mod unit_tests {
     fn discovery_only_tool_is_marked() {
         let iid = Uuid::from_u128(99);
         let tools = vec![
-            tool("dcc_capability_manifest", "DCC capability manifest", json!({"type": "object"})),
+            tool(
+                "dcc_capability_manifest",
+                "DCC capability manifest",
+                json!({"type": "object"}),
+            ),
             tool("create_sphere", "make a sphere", json!({"type": "object"})),
         ];
         let out = build_records_from_backend(BuildInput {

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -509,6 +509,21 @@ pub async fn call_service(
 ) -> Result<Value, ServiceError> {
     let record = describe_service(&gs.capability_index, slug)?;
     enforce_record_policy(&gs.policy, GatewayPolicyOperation::Call, &record)?;
+    // Discovery-only tools (e.g. dcc_capability_manifest) must not be
+    // dispatched via sidecar tools/call — they are served by the discovery
+    // MCP endpoint. Return a clear error so callers get actionable guidance
+    // instead of a cryptic backend failure (PIP-2420).
+    if record.discovery_only {
+        return Err(ServiceError::new(
+            "discovery-only-tool",
+            format!(
+                "tool '{}' is a discovery-only meta-tool and cannot be called directly; \
+                 use describe_tool to inspect its schema or query the discovery MCP endpoint",
+                record.callable_id,
+            ),
+        )
+        .with_instance_provenance("discovery_only", Some(record.instance_id)));
+    }
     // Resolve the backend endpoint using the live registry — the
     // capability record's `instance_id` is authoritative even if the
     // backend's port changed since indexing, because we always
@@ -1481,6 +1496,66 @@ mod unit_tests {
         assert_eq!(row["load_state"], "loaded");
         assert!(row.get("disabled_by_group").is_none());
         assert_eq!(row["next_step"]["action"], "describe");
+    }
+
+    // ── discovery_only guard (PIP-2420) ──────────────────────────────────
+
+    #[test]
+    fn discovery_only_search_hit_is_not_callable_and_has_describe_next_step() {
+        let iid = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        let mut rec = CapabilityRecord::new(
+            "maya.abcdef0123456789abcdef0123456789.dcc_capability_manifest".into(),
+            "dcc_capability_manifest".into(),
+            "dcc_capability_manifest".into(),
+            None,
+            "DCC capability manifest",
+            Vec::new(),
+            "maya".into(),
+            iid,
+            false,
+            true, // loaded
+            None,
+        );
+        rec.discovery_only = true;
+        let hit = SearchHit {
+            record: rec,
+            rank: 1,
+            score: 10,
+            match_reasons: vec![],
+        };
+        let row = search_hit_to_value(hit);
+        assert_eq!(row["callable"], false, "discovery_only must not be callable");
+        assert_eq!(row["load_state"], "loaded");
+        assert_eq!(row["discovery_only"], true);
+        assert_eq!(
+            row["next_step"]["action"], "describe",
+            "next_step should be describe, not call"
+        );
+    }
+
+    #[test]
+    fn describe_service_exposes_discovery_only_record() {
+        let idx = CapabilityIndex::new();
+        let iid = Uuid::from_u128(0xabcd_1234);
+        let mut rec = CapabilityRecord::new(
+            tool_slug("maya", &iid, "dcc_capability_manifest"),
+            "dcc_capability_manifest".into(),
+            "dcc_capability_manifest".into(),
+            None,
+            "",
+            Vec::new(),
+            "maya".into(),
+            iid,
+            false,
+            true,
+            None,
+        );
+        rec.discovery_only = true;
+        idx.upsert_instance(iid, vec![rec], InstanceFingerprint(1));
+        let slug = tool_slug("maya", &iid, "dcc_capability_manifest");
+        let found = describe_service(&idx, &slug).expect("should find record");
+        assert!(found.discovery_only);
+        assert!(!found.is_callable());
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -244,7 +244,10 @@ pub fn search_hit_to_value_with_context(
         }
     } else if hit.record.loaded {
         value["load_state"] = json!("loaded");
-        if let Some(group_name) = hit.record.disabled_by_group() {
+        if hit.record.discovery_only {
+            value["discovery_only"] = json!(true);
+            value["next_step"] = describe_next_step(&hit.record.tool_slug, context);
+        } else if let Some(group_name) = hit.record.disabled_by_group() {
             // Tool is loaded but its progressive group is inactive.
             value["disabled_by_group"] = json!(group_name);
             // Provide an activate_tool_group next_step (MCP only —
@@ -527,13 +530,14 @@ pub async fn call_service(
     drop(reg);
 
     let call_result = if entry_uses_sidecar_dispatch(&entry) {
-        let mut params = json!({
+        // _meta is intentionally NOT forwarded into sidecar params.
+        // The sidecar tools/call contract expects only {name, arguments};
+        // injecting _meta at the params level leaks gateway-internal
+        // metadata into adapter tool kwargs (PIP-2420).
+        let params = json!({
             "name": &record.callable_id,
             "arguments": arguments,
         });
-        if let Some(meta) = meta_with_agent_context(meta, agent_context) {
-            params["_meta"] = meta;
-        }
         call_backend_with_observability(
             &gs.http_client,
             &url,

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -1524,7 +1524,10 @@ mod unit_tests {
             match_reasons: vec![],
         };
         let row = search_hit_to_value(hit);
-        assert_eq!(row["callable"], false, "discovery_only must not be callable");
+        assert_eq!(
+            row["callable"], false,
+            "discovery_only must not be callable"
+        );
         assert_eq!(row["load_state"], "loaded");
         assert_eq!(row["discovery_only"], true);
         assert_eq!(

--- a/crates/dcc-mcp-gateway/src/gateway/instance_diagnostics.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/instance_diagnostics.rs
@@ -83,13 +83,13 @@ impl InstanceDiagnosticsStore {
     }
 }
 
-/// Host-execution readiness summary (issue #1331).
+/// Host-execution readiness summary (issue #1331, #2420).
 ///
-/// `ready` when every bit required to dispatch a host-thread action is green
-/// (`dispatcher`, `dcc`, `host_execution_bridge`, `main_thread_executor`);
-/// `not_ready` when at least one of those bits is red but readiness was
-/// probed; `unknown` when no readiness probe data has been observed yet
-/// (e.g. a pre-#660 backend that only exposes `GET /health`).
+/// `ready` when every bit required to dispatch an action is green.
+/// For sidecar-dispatch instances (e.g. 3ds Max per_dcc_sidecar),
+/// only `dispatcher` and `dcc` are required — sidecar dispatch does
+/// not need `host_execution_bridge` or `main_thread_executor`.
+/// For non-sidecar instances, all four bits must be green.
 ///
 /// Lifted to the top level of the instance JSON so admin / agent surfaces
 /// can distinguish "online but execution bridge not attached" from
@@ -113,16 +113,22 @@ impl HostExecutionStatus {
     }
 
     /// Derive the summary from a cached [`InstanceDiagnostics`] entry.
+    ///
+    /// When `uses_sidecar` is true, only `dispatcher` and `dcc` are
+    /// required — sidecar dispatch does not need host execution bridge
+    /// or main thread executor (PIP-2420).
     #[must_use]
-    pub fn from_diagnostics(diag: Option<&InstanceDiagnostics>) -> Self {
+    pub fn from_diagnostics(diag: Option<&InstanceDiagnostics>, uses_sidecar: bool) -> Self {
         let Some(report) = diag.and_then(|d| d.readiness.as_ref()) else {
             return Self::Unknown;
         };
-        if report.dispatcher
-            && report.dcc
-            && report.host_execution_bridge
-            && report.main_thread_executor
-        {
+        if !report.dispatcher || !report.dcc {
+            return Self::NotReady;
+        }
+        if uses_sidecar {
+            // Sidecar dispatch only needs dispatcher + dcc.
+            Self::Ready
+        } else if report.host_execution_bridge && report.main_thread_executor {
             Self::Ready
         } else {
             Self::NotReady
@@ -132,8 +138,12 @@ impl HostExecutionStatus {
     /// Bounded list of readiness bits that are currently red, for the
     /// admin/debug remediation hint. Empty when status is `Ready` or
     /// `Unknown`.
+    ///
+    /// When `uses_sidecar` is true, `host_execution_bridge` and
+    /// `main_thread_executor` are intentionally excluded from the
+    /// missing-bits list because sidecar dispatch does not require them.
     #[must_use]
-    pub fn missing_bits(diag: Option<&InstanceDiagnostics>) -> Vec<&'static str> {
+    pub fn missing_bits(diag: Option<&InstanceDiagnostics>, uses_sidecar: bool) -> Vec<&'static str> {
         let Some(report) = diag.and_then(|d| d.readiness.as_ref()) else {
             return Vec::new();
         };
@@ -144,11 +154,13 @@ impl HostExecutionStatus {
         if !report.dcc {
             out.push("dcc");
         }
-        if !report.host_execution_bridge {
-            out.push("host_execution_bridge");
-        }
-        if !report.main_thread_executor {
-            out.push("main_thread_executor");
+        if !uses_sidecar {
+            if !report.host_execution_bridge {
+                out.push("host_execution_bridge");
+            }
+            if !report.main_thread_executor {
+                out.push("main_thread_executor");
+            }
         }
         out
     }
@@ -249,11 +261,11 @@ mod tests {
     #[test]
     fn host_execution_status_unknown_without_probe() {
         assert_eq!(
-            HostExecutionStatus::from_diagnostics(None),
+            HostExecutionStatus::from_diagnostics(None, false),
             HostExecutionStatus::Unknown
         );
         assert_eq!(HostExecutionStatus::Unknown.label(), "unknown");
-        assert!(HostExecutionStatus::missing_bits(None).is_empty());
+        assert!(HostExecutionStatus::missing_bits(None, false).is_empty());
     }
 
     #[test]
@@ -267,11 +279,11 @@ mod tests {
             main_thread_executor: true,
         });
         assert_eq!(
-            HostExecutionStatus::from_diagnostics(Some(&diag)),
+            HostExecutionStatus::from_diagnostics(Some(&diag), false),
             HostExecutionStatus::Ready
         );
         assert_eq!(HostExecutionStatus::Ready.label(), "ready");
-        assert!(HostExecutionStatus::missing_bits(Some(&diag)).is_empty());
+        assert!(HostExecutionStatus::missing_bits(Some(&diag), false).is_empty());
     }
 
     #[test]
@@ -285,11 +297,11 @@ mod tests {
             main_thread_executor: true,
         });
         assert_eq!(
-            HostExecutionStatus::from_diagnostics(Some(&diag)),
+            HostExecutionStatus::from_diagnostics(Some(&diag), false),
             HostExecutionStatus::NotReady
         );
         assert_eq!(HostExecutionStatus::NotReady.label(), "not_ready");
-        let missing = HostExecutionStatus::missing_bits(Some(&diag));
+        let missing = HostExecutionStatus::missing_bits(Some(&diag), false);
         assert_eq!(missing, vec!["dcc", "host_execution_bridge"]);
     }
 
@@ -305,8 +317,46 @@ mod tests {
             main_thread_executor: true,
         });
         assert_eq!(
-            HostExecutionStatus::from_diagnostics(Some(&diag)),
+            HostExecutionStatus::from_diagnostics(Some(&diag), false),
             HostExecutionStatus::Ready
         );
+    }
+
+    #[test]
+    fn sidecar_ready_without_host_execution_bits() {
+        // Sidecar-dispatch instances don't need host_execution_bridge
+        // or main_thread_executor (PIP-2420).
+        let diag = diag_with(ReadinessReport {
+            process: true,
+            dcc: true,
+            skill_catalog: true,
+            dispatcher: true,
+            host_execution_bridge: false,
+            main_thread_executor: false,
+        });
+        assert_eq!(
+            HostExecutionStatus::from_diagnostics(Some(&diag), true),
+            HostExecutionStatus::Ready
+        );
+        let missing = HostExecutionStatus::missing_bits(Some(&diag), true);
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn sidecar_not_ready_when_dispatcher_missing() {
+        let diag = diag_with(ReadinessReport {
+            process: true,
+            dcc: true,
+            skill_catalog: true,
+            dispatcher: false,
+            host_execution_bridge: true,
+            main_thread_executor: true,
+        });
+        assert_eq!(
+            HostExecutionStatus::from_diagnostics(Some(&diag), true),
+            HostExecutionStatus::NotReady
+        );
+        let missing = HostExecutionStatus::missing_bits(Some(&diag), true);
+        assert_eq!(missing, vec!["dispatcher"]);
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/instance_diagnostics.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/instance_diagnostics.rs
@@ -143,7 +143,10 @@ impl HostExecutionStatus {
     /// `main_thread_executor` are intentionally excluded from the
     /// missing-bits list because sidecar dispatch does not require them.
     #[must_use]
-    pub fn missing_bits(diag: Option<&InstanceDiagnostics>, uses_sidecar: bool) -> Vec<&'static str> {
+    pub fn missing_bits(
+        diag: Option<&InstanceDiagnostics>,
+        uses_sidecar: bool,
+    ) -> Vec<&'static str> {
         let Some(report) = diag.and_then(|d| d.readiness.as_ref()) else {
             return Vec::new();
         };

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -809,8 +809,12 @@ pub fn entry_to_json(
     // dispatcher + dcc; host_execution_bridge and main_thread_executor are
     // not required for sidecar dispatch (PIP-2420).
     let uses_sidecar = super::http_registration::entry_uses_sidecar_dispatch(e);
-    let host_exec = super::instance_diagnostics::HostExecutionStatus::from_diagnostics(diagnostics, uses_sidecar);
-    let missing_bits = super::instance_diagnostics::HostExecutionStatus::missing_bits(diagnostics, uses_sidecar);
+    let host_exec = super::instance_diagnostics::HostExecutionStatus::from_diagnostics(
+        diagnostics,
+        uses_sidecar,
+    );
+    let missing_bits =
+        super::instance_diagnostics::HostExecutionStatus::missing_bits(diagnostics, uses_sidecar);
     row["host_execution"] = json!({
         "status": host_exec.label(),
         "missing_bits": missing_bits,

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -799,16 +799,22 @@ pub fn entry_to_json(
         },
         "stale":           stale,
     });
-    // ── host execution readiness (issue #1331) ────────────────────────────
+    // ── host execution readiness (issue #1331, #2420) ──────────────────────
     //
     // Always include this summary so admin/agent surfaces can branch on a
     // single string without parsing the nested `diagnostics.readiness`
     // block. Status is `unknown` when no readiness probe has reported yet.
-    let host_exec = super::instance_diagnostics::HostExecutionStatus::from_diagnostics(diagnostics);
-    let missing_bits = super::instance_diagnostics::HostExecutionStatus::missing_bits(diagnostics);
+    //
+    // Sidecar-dispatch instances (e.g. 3ds Max per_dcc_sidecar) only need
+    // dispatcher + dcc; host_execution_bridge and main_thread_executor are
+    // not required for sidecar dispatch (PIP-2420).
+    let uses_sidecar = super::http_registration::entry_uses_sidecar_dispatch(e);
+    let host_exec = super::instance_diagnostics::HostExecutionStatus::from_diagnostics(diagnostics, uses_sidecar);
+    let missing_bits = super::instance_diagnostics::HostExecutionStatus::missing_bits(diagnostics, uses_sidecar);
     row["host_execution"] = json!({
         "status": host_exec.label(),
         "missing_bits": missing_bits,
+        "uses_sidecar_dispatch": uses_sidecar,
     });
     if let Some(diag) = diagnostics.filter(|d| {
         d.readiness.is_some() || d.last_error.is_some() || d.probed_at_unix_secs.is_some()


### PR DESCRIPTION
## Summary

Fixes three contract bugs exposed by the latest release smoke test:

### Fix 1: _meta reserved field leaking into adapter kwargs
Remove  injection from sidecar dispatch params. The sidecar  contract expects only ;  is gateway-internal metadata and must not enter adapter tool kwargs.

### Fix 2: Discovery-only tool routing
- `CapabilityRecord` gains a `discovery_only: bool` field (default false, skipped when false in JSON)
- `is_callable()` returns false for `discovery_only` tools
- `build_records_from_backend()` auto-marks `dcc_capability_manifest` as discovery-only
- Search results show `callable=false`, `next_step.action=describe`, `discovery_only=true`
- **New in this PR**: `call_service` now rejects discovery-only tools with a clear `discovery-only-tool` error instead of a cryptic backend failure

### Fix 3: Admin readiness false positives for sidecar instances
`HostExecutionStatus` gains a `uses_sidecar` parameter. Sidecar-dispatch instances (e.g. 3ds Max per-dcc-sidecar) only need `dispatcher + dcc`; they no longer report `not_ready` due to absent `host_execution_bridge` / `main_thread_executor`. Instance JSON gains `uses_sidecar_dispatch` field.

## Files changed (5 → 6 files, +288/-34)
- `crates/dcc-mcp-gateway-core/src/capability/record.rs`
- `crates/dcc-mcp-gateway/src/gateway/capability/builder.rs`
- `crates/dcc-mcp-gateway/src/gateway/capability_service.rs`
- `crates/dcc-mcp-gateway/src/gateway/instance_diagnostics.rs`
- `crates/dcc-mcp-gateway/src/gateway/state.rs`

## Tests
11 new unit tests added. All 470 lib tests pass.