### PR TITLE
docs: fix markdownlint errors in asset-import-contract.md

### DIFF
--- a/docs/guide/asset-import-contract.md
+++ b/docs/guide/asset-import-contract.md
@@ -135,7 +135,9 @@ at the top of `import_to_scene`.
 
 ### String constant enums
 
-**`AssetFormat`** — well-known interchange format identifiers:
+### AssetFormat string constants
+
+Well-known interchange format identifiers:
 
 | Constant | Value |
 |----------|-------|
@@ -149,7 +151,7 @@ at the top of `import_to_scene`.
 | `AssetFormat.BLEND` | `"blend"` |
 | `AssetFormat.UNKNOWN` | `"unknown"` |
 
-**`UnitHint`**:
+### UnitHint values
 
 | Constant | Value |
 |----------|-------|
@@ -158,7 +160,7 @@ at the top of `import_to_scene`.
 | `UnitHint.INCH` | `"inch"` |
 | `UnitHint.UNITLESS` | `"unitless"` |
 
-**`AxisHint`**:
+### AxisHint values
 
 | Constant | Value |
 |----------|-------|
@@ -195,7 +197,7 @@ into the host DCC scene, and returns an `ImportToSceneResult`.
 | `error_message` | `Optional[str]` | No | Human-readable error when `success` is `False`. |
 | `extra` | `Dict[str, Any]` | No | Free-form DCC-specific enrichments. |
 
-#### `MaterialMode`
+#### MaterialMode values
 
 | Constant | Value | Meaning |
 |----------|-------|---------|
@@ -255,20 +257,20 @@ prefix avoids collisions with DCC-native and other-plugin attributes.
 
 ### ImportWarning codes
 
-Warning code | Meaning
--------------|--------
-`missing_textures` | Texture files referenced by the asset were not found on disk.
-`missing_plugin` | A required DCC plugin or format handler is not installed.
-`scale_clamped` | Import scale was clamped to the adapter's supported range.
-`rotation_clamped` | Rotation values were clamped to the adapter's supported range.
-`non_uniform_scale_baked` | Non-uniform scaling was baked into the geometry.
-`degenerate_geometry_skipped` | Zero-area faces or zero-length edges were dropped.
-`hierarchy_flattened` | The original scene hierarchy was collapsed (e.g. USD to OBJ fallback).
-`names_collided` | Object names conflicted with existing scene objects; suffixes were appended.
-`material_fallback` | Materials were downgraded (e.g. PBR → standard).
-`animation_stripped` | Animation data was discarded (format or adapter limitation).
-`unsupported_feature` | A specific feature in the file is not supported by this adapter.
-`unknown` | An unrecognised warning that does not fit any other code.
+| Warning code | Meaning |
+|--------------|---------|
+| `missing_textures` | Texture files referenced by the asset were not found on disk. |
+| `missing_plugin` | A required DCC plugin or format handler is not installed. |
+| `scale_clamped` | Import scale was clamped to the adapter's supported range. |
+| `rotation_clamped` | Rotation values were clamped to the adapter's supported range. |
+| `non_uniform_scale_baked` | Non-uniform scaling was baked into the geometry. |
+| `degenerate_geometry_skipped` | Zero-area faces or zero-length edges were dropped. |
+| `hierarchy_flattened` | The original scene hierarchy was collapsed (e.g. USD to OBJ fallback). |
+| `names_collided` | Object names conflicted with existing scene objects; suffixes were appended. |
+| `material_fallback` | Materials were downgraded (e.g. PBR → standard). |
+| `animation_stripped` | Animation data was discarded (format or adapter limitation). |
+| `unsupported_feature` | A specific feature in the file is not supported by this adapter. |
+| `unknown` | An unrecognised warning that does not fit any other code. |
 
 Each warning is an `ImportWarning(code, message, detail?)` frozen dataclass.
 Consumers should match on `code`, not on `message`.

--- a/docs/guide/asset-import-contract.md
+++ b/docs/guide/asset-import-contract.md
@@ -91,9 +91,9 @@ desc.validate()  # raises AssetImportValidationError on violation
 | `variants` | `List[AssetFileVariant]` | Yes (≥1) | File formats available. At least one variant with a non-empty `local_path`. |
 | `attribution` | `Optional[AssetAttribution]` | No | Legal attribution metadata (see [table below](#attribution-metadata-fields)). |
 | `preview` | `Optional[str]` | No | Path to a preview image / thumbnail. |
-| `unit_hint` | `str` | No (default `unitless`) | Native unit hint from [`UnitHint`](#unit-hint-values). |
+| `unit_hint` | `str` | No (default `unitless`) | Native unit hint from [`UnitHint`](#unithint-values). |
 | `meters_per_unit` | `float` | No (default `1.0`) | Conversion factor from asset units to meters. |
-| `up_axis` | `str` | No (default `"y"`) | Source asset up-axis from [`AxisHint`](#axis-hint-values). |
+| `up_axis` | `str` | No (default `"y"`) | Source asset up-axis from [`AxisHint`](#axishint-values). |
 | `scale_hint` | `Optional[float]` | No | Suggested import scale multiplier. |
 | `source_bbox` | `Optional[Dict]` | No | Bounding box from the source tool. **Always cm, Y-up.** Shape: `{"min": [x, y, z], "max": [x, y, z]}`. |
 | `tags` | `List[str]` | No | Free-form tags for categorisation / search. |
@@ -181,7 +181,7 @@ into the host DCC scene, and returns an `ImportToSceneResult`.
 | Field | Type | Required | Meaning |
 |-------|------|----------|---------|
 | `descriptor` | `AssetDescriptor` | Yes | The asset to import (from source skill). |
-| `material_mode` | `str` | No (default `as_authored`) | Material handling strategy from [`MaterialMode`](#material-mode-values). |
+| `material_mode` | `str` | No (default `as_authored`) | Material handling strategy from [`MaterialMode`](#materialmode-values). |
 | `placement` | `Optional[PlacementHint]` | No | Position, rotation, scale override. |
 | `target_collection` | `Optional[str]` | No | Name of the collection / layer to import into. |
 | `skip_existing` | `bool` | No (default `False`) | Skip import when the `asset_id` is already in the scene. |


### PR DESCRIPTION
Fixes MD051 (anchor links) and MD055 (table pipes) in `docs/guide/asset-import-contract.md` which were blocking the 0.19.1 release PR #1764.

Addresses PIP-2433.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author