### PR TITLE
fix(gateway): compact kind=all search to stay within MCP token limits

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -1311,7 +1311,8 @@ mod tests {
 
     #[test]
     fn compact_kind_all_preserves_tools_and_skills_subtrees() {
-        // Simulate a kind=all response payload (as produced by tools.rs).
+        // Simulate a kind=all response payload (as produced by tools.rs
+        // after compact_tools_hits + compact_skills_list).
         // The compact_tool_text_payload must detect the kind=all shape
         // and preserve both tools and skills subtrees instead of
         // falling through to legacy_payload.clone().
@@ -1322,14 +1323,15 @@ mod tests {
             "tools": {
                 "total": 2,
                 "hits": [
-                    {"tool_slug": "blender.abc.create_cube", "backend_tool": "create_cube", "callable_id": "create_cube", "dcc_type": "blender", "score": 98, "tags": [], "loaded": true},
-                    {"tool_slug": "blender.abc.render", "backend_tool": "render", "callable_id": "render", "dcc_type": "blender", "score": 85, "tags": [], "loaded": true}
-                ]
+                    {"tool_slug": "blender.abc.create_cube", "backend_tool": "create_cube", "dcc_type": "blender", "score": 98, "loaded": true},
+                    {"tool_slug": "blender.abc.render", "backend_tool": "render", "dcc_type": "blender", "score": 85, "loaded": true}
+                ],
+                "capped": false
             },
             "skills": {
                 "skills": [
-                    {"name": "blender-export", "dcc_type": "blender", "score": 90},
-                    {"name": "blender-import", "dcc_type": "blender", "score": 80}
+                    {"tool_slug": "blender.abc.blender-export", "skill_name": "blender-export", "dcc_type": "blender", "score": 90},
+                    {"tool_slug": "blender.abc.blender-import", "skill_name": "blender-import", "dcc_type": "blender", "score": 80}
                 ],
                 "total": 2,
                 "capped": false

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -409,12 +409,32 @@ fn compact_tool_text_payload(tool_name: Option<&str>, legacy_payload: &Value) ->
     match tool_name {
         Some("search" | "search_tools") => {
             if let Some(hits) = legacy_payload.get("hits").and_then(Value::as_array) {
+                // Single-kind path (kind=tool|skill): compact hits array.
                 let total = legacy_payload
                     .get("total")
                     .and_then(Value::as_u64)
                     .and_then(|value| usize::try_from(value).ok())
                     .unwrap_or(hits.len());
                 compact_search_payload(total, hits)
+            } else if legacy_payload.get("tools").is_some()
+                || legacy_payload.get("skills").is_some()
+            {
+                // kind=all path: nested { tools: {hits: [...]}, skills: {skills: [...]} }.
+                // The tools/skills subtrees are already compacted in tools.rs;
+                // just strip the metadata fields that tools.rs already injected.
+                let mut out = serde_json::Map::new();
+                for key in &[
+                    "search_id",
+                    "ranker_version",
+                    "index_generation",
+                    "tools",
+                    "skills",
+                ] {
+                    if let Some(v) = legacy_payload.get(*key) {
+                        out.insert(key.to_string(), v.clone());
+                    }
+                }
+                Value::Object(out)
             } else {
                 legacy_payload.clone()
             }
@@ -1285,5 +1305,105 @@ mod tests {
         );
         assert!(response.get("result").is_none());
         assert!(response["error"].get("_meta").is_none());
+    }
+
+    // ── kind=all compact tests (PIP-2454 regression) ──────────────────
+
+    #[test]
+    fn compact_kind_all_preserves_tools_and_skills_subtrees() {
+        // Simulate a kind=all response payload (as produced by tools.rs).
+        // The compact_tool_text_payload must detect the kind=all shape
+        // and preserve both tools and skills subtrees instead of
+        // falling through to legacy_payload.clone().
+        let payload = json!({
+            "search_id": "search-001",
+            "ranker_version": "v2.1.0",
+            "index_generation": "gen-001",
+            "tools": {
+                "total": 2,
+                "hits": [
+                    {"tool_slug": "blender.abc.create_cube", "backend_tool": "create_cube", "callable_id": "create_cube", "dcc_type": "blender", "score": 98, "tags": [], "loaded": true},
+                    {"tool_slug": "blender.abc.render", "backend_tool": "render", "callable_id": "render", "dcc_type": "blender", "score": 85, "tags": [], "loaded": true}
+                ]
+            },
+            "skills": {
+                "skills": [
+                    {"name": "blender-export", "dcc_type": "blender", "score": 90},
+                    {"name": "blender-import", "dcc_type": "blender", "score": 80}
+                ],
+                "total": 2,
+                "capped": false
+            }
+        });
+
+        let compact = compact_tool_text_payload(Some("search"), &payload);
+
+        // Must have both tools and skills keys (not just tools alone)
+        assert!(
+            compact.get("tools").is_some(),
+            "kind=all compact must keep tools"
+        );
+        assert!(
+            compact.get("skills").is_some(),
+            "kind=all compact must keep skills"
+        );
+
+        // Must strip the raw text metadata fields that are only
+        // part of the legacy full response
+        let compact_str = serde_json::to_string(&compact).unwrap();
+        assert!(
+            compact_str.len() < 2000,
+            "kind=all compact payload must be well under 10K chars (got {} chars)",
+            compact_str.len()
+        );
+    }
+
+    #[test]
+    fn compact_kind_all_strips_extra_metadata_keys() {
+        // kind=all response may carry extra keys from the internal
+        // response serialization. compact must only keep the five
+        // canonical keys.
+        let payload = json!({
+            "search_id": "search-001",
+            "ranker_version": "v2.1.0",
+            "index_generation": "gen-001",
+            "tools": {"total": 0, "hits": []},
+            "skills": {"skills": [], "total": 0},
+            "internal_scratch": "should-be-dropped",
+            "raw_jsonrpc": "should-be-dropped",
+        });
+
+        let compact = compact_tool_text_payload(Some("search"), &payload);
+
+        assert_eq!(compact.as_object().unwrap().len(), 5);
+        assert!(compact.get("internal_scratch").is_none());
+        assert!(compact.get("raw_jsonrpc").is_none());
+        assert!(compact.get("search_id").is_some());
+        assert!(compact.get("tools").is_some());
+        assert!(compact.get("skills").is_some());
+    }
+
+    #[test]
+    fn compact_single_kind_hits_still_works() {
+        // Regression: single-kind (hits-based) compact path must
+        // not be broken by the kind=all addition.
+        let payload = json!({
+            "total": 3,
+            "hits": [
+                {"tool_slug": "maya.abc.sphere", "backend_tool": "sphere", "callable_id": "sphere", "dcc_type": "maya", "score": 99, "tags": ["modeling"], "loaded": true},
+                {"tool_slug": "maya.abc.cube", "backend_tool": "cube", "callable_id": "cube", "dcc_type": "maya", "score": 80, "tags": [], "loaded": true},
+                {"tool_slug": "maya.abc.render", "backend_tool": "render", "callable_id": "render", "dcc_type": "maya", "score": 60, "tags": [], "loaded": true}
+            ]
+        });
+
+        let compact = compact_tool_text_payload(Some("search"), &payload);
+
+        assert_eq!(compact["total"], 3);
+        assert_eq!(compact["hits"].as_array().unwrap().len(), 3);
+        // compact_search_payload strips redundant callable_id
+        // (callable_id == backend_tool, so it's omitted)
+        assert!(compact["hits"][0].get("callable_id").is_none());
+        // but preserves tool_slug
+        assert_eq!(compact["hits"][0]["tool_slug"], "maya.abc.sphere");
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -357,8 +357,6 @@ pub(crate) fn compact_tools_hits(tools_value: &Value) -> Value {
 /// per-skill fields used for discovery.  Also caps the skill count so
 /// kind=all output stays bounded.
 const MAX_KIND_ALL_SKILLS: usize = 20;
-// Cross-category tool cap (per tools.rs kind=all path).
-const MAX_KIND_ALL_TOOLS: usize = 25;
 
 pub(crate) fn compact_skills_list(skills_value: &Value) -> Value {
     let skills = skills_value

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -337,6 +337,52 @@ pub(crate) fn compact_record(record: &Value) -> Value {
     Value::Object(out)
 }
 
+/// Compact tools hits from a kind=all search response, keeping only the
+/// fields that `compact_search_payload` preserves for the single-kind path.
+pub(crate) fn compact_tools_hits(tools_value: &Value) -> Value {
+    let hits = tools_value
+        .get("hits")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let total = tools_value
+        .get("total")
+        .and_then(Value::as_u64)
+        .and_then(|v| usize::try_from(v).ok())
+        .unwrap_or(hits.len());
+    compact_search_payload(total, &hits)
+}
+
+/// Compact skills list payload for kind=all, keeping only the lightweight
+/// per-skill fields used for discovery.  Also caps the skill count so
+/// kind=all output stays bounded.
+const MAX_KIND_ALL_SKILLS: usize = 20;
+// Cross-category tool cap (per tools.rs kind=all path).
+const MAX_KIND_ALL_TOOLS: usize = 25;
+
+pub(crate) fn compact_skills_list(skills_value: &Value) -> Value {
+    let skills = skills_value
+        .get("skills")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let total = skills_value
+        .get("total")
+        .and_then(Value::as_u64)
+        .and_then(|v| usize::try_from(v).ok())
+        .unwrap_or(skills.len());
+    let capped: Vec<Value> = skills
+        .into_iter()
+        .take(MAX_KIND_ALL_SKILLS)
+        .map(|skill| compact_record(&skill))
+        .collect();
+    json!({
+        "skills": capped,
+        "total": total.min(MAX_KIND_ALL_SKILLS),
+        "capped": total > MAX_KIND_ALL_SKILLS,
+    })
+}
+
 fn token_accounting_for_compact_value(value: &Value) -> Option<Value> {
     encode_response(value, Some(value), ResponseFormat::Toon)
         .ok()

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -312,7 +312,7 @@ fn compact_search_hit(hit: &Value) -> Value {
     compact_record(hit)
 }
 
-fn compact_record(record: &Value) -> Value {
+pub(crate) fn compact_record(record: &Value) -> Value {
     let mut out = Map::new();
     copy_field(&mut out, record, "tool_slug");
     copy_field(&mut out, record, "backend_tool");

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -314,31 +314,39 @@ fn compact_search_hit(hit: &Value) -> Value {
 
 pub(crate) fn compact_record(record: &Value) -> Value {
     let mut out = Map::new();
+    // Canonical identification
     copy_field(&mut out, record, "tool_slug");
     copy_field(&mut out, record, "backend_tool");
     copy_callable_if_distinct(&mut out, record);
     copy_field(&mut out, record, "skill_name");
+    // Discovery essentials: name, one-line description, categorisation tags
     copy_field(&mut out, record, "summary");
     copy_field(&mut out, record, "tags");
+    // DCC scope
     copy_field(&mut out, record, "dcc_type");
     copy_field(&mut out, record, "instance_id");
+    // Readiness hints
     copy_field(&mut out, record, "has_schema");
     copy_field(&mut out, record, "loaded");
     copy_field(&mut out, record, "load_state");
     copy_field(&mut out, record, "callable");
     copy_field(&mut out, record, "disabled_by_group");
-    copy_field(&mut out, record, "available_groups");
+    // Ranking
     copy_field(&mut out, record, "rank");
     copy_field(&mut out, record, "score");
-    copy_field(&mut out, record, "match_reasons");
-    copy_field(&mut out, record, "annotations");
-    copy_field(&mut out, record, "metadata");
+    // Next-step for unloaded tools (critical for discovery flow)
     copy_field(&mut out, record, "next_step");
+    // NOTE: metadata, annotations, available_groups, and match_reasons are
+    // intentionally excluded.  compact is for *discovery*, not *definition*;
+    // these fields carry operational/audit detail that belong in describe_tool.
     Value::Object(out)
 }
 
 /// Compact tools hits from a kind=all search response, keeping only the
 /// fields that `compact_search_payload` preserves for the single-kind path.
+/// Also caps the tool count so kind=all output stays bounded.
+const MAX_KIND_ALL_TOOLS: usize = 10;
+
 pub(crate) fn compact_tools_hits(tools_value: &Value) -> Value {
     let hits = tools_value
         .get("hits")
@@ -350,13 +358,22 @@ pub(crate) fn compact_tools_hits(tools_value: &Value) -> Value {
         .and_then(Value::as_u64)
         .and_then(|v| usize::try_from(v).ok())
         .unwrap_or(hits.len());
-    compact_search_payload(total, &hits)
+    let capped: Vec<Value> = hits
+        .into_iter()
+        .take(MAX_KIND_ALL_TOOLS)
+        .map(|hit| compact_record(&hit))
+        .collect();
+    json!({
+        "total": total.min(MAX_KIND_ALL_TOOLS),
+        "hits": capped,
+        "capped": total > MAX_KIND_ALL_TOOLS,
+    })
 }
 
 /// Compact skills list payload for kind=all, keeping only the lightweight
 /// per-skill fields used for discovery.  Also caps the skill count so
 /// kind=all output stays bounded.
-const MAX_KIND_ALL_SKILLS: usize = 20;
+const MAX_KIND_ALL_SKILLS: usize = 10;
 
 pub(crate) fn compact_skills_list(skills_value: &Value) -> Value {
     let skills = skills_value
@@ -696,10 +713,12 @@ mod tests {
         assert_eq!(body["hits"][0]["dcc_type"], "maya");
         assert_eq!(body["hits"][1]["dcc_type"], "photoshop");
         assert_eq!(body["hits"][0]["tool_slug"], "maya.abcdef01.create_sphere");
-        assert_eq!(
-            body["hits"][0]["match_reasons"],
-            json!(["tool_lexical", "summary_fuzzy"])
-        );
+        // match_reasons is a discovery-only field — compact strips it
+        assert!(body["hits"][0].get("match_reasons").is_none());
+        // annotations are discovery-only — compact strips them
+        assert!(body["hits"][0].get("annotations").is_none());
+        // metadata is discovery-only — compact strips it
+        assert!(body["hits"][0].get("metadata").is_none());
         assert_eq!(body["hits"][1]["next_step"]["action"], "load_skill");
         assert!(body["hits"][0].get("callable_id").is_none());
         assert_eq!(body["hits"][1]["callable_id"], "select_layer_by_name");
@@ -803,7 +822,10 @@ mod tests {
 
         assert!(compact["record"].get("callable_id").is_none());
         assert!(compact["record"].get("tags").is_none());
-        assert_eq!(compact["record"]["metadata"]["affinity"], "main");
+        // metadata/annotations are discovery-only fields — compact strips them
+        assert!(compact["record"].get("metadata").is_none());
+        assert!(compact["record"].get("annotations").is_none());
+        // describe payload preserves the full tool definition
         assert_eq!(
             compact["tool"]["inputSchema"]["properties"]["path"]["type"],
             "string"
@@ -906,5 +928,168 @@ mod tests {
             body["error"]["candidates"][0]["tool_slug"],
             "maya.abcdef01.render"
         );
+    }
+
+    // ── kind=all size ceiling tests (PIP-2454 v2) ─────────────────────
+
+    /// Build a worst-case tool hit with realistic field sizes (~400 chars).
+    fn worst_case_tool_hit(slug: &str, dcc: &str) -> Value {
+        json!({
+            "tool_slug": slug,
+            "backend_tool": slug.rsplit('.').next().unwrap_or(slug),
+            "callable_id": slug.rsplit('.').next().unwrap_or(slug),
+            "skill_name": format!("{dcc}-geometry"),
+            "summary": format!("{slug} — create and edit 3D geometry in {dcc}"),
+            "tags": ["geometry", "modelling", "mesh"],
+            "dcc_type": dcc,
+            "instance_id": "abcdef01-2345-6789-abcd-ef0123456789",
+            "has_schema": true,
+            "loaded": true,
+            "load_state": "ready",
+            "callable": true,
+            "disabled_by_group": false,
+            "available_groups": ["studio-tools", "core"],
+            "rank": 5,
+            "score": 95,
+            "match_reasons": ["tool_lexical", "summary_fuzzy"],
+            "annotations": {"readOnlyHint": false, "destructiveHint": false},
+            "metadata": {"affinity": "main", "timeoutHintSecs": 30},
+            "next_step": null
+        })
+    }
+
+    fn worst_case_skill_hit(name: &str, dcc: &str) -> Value {
+        json!({
+            "tool_slug": format!("{dcc}.abcdef01.{name}"),
+            "backend_tool": name,
+            "callable_id": name,
+            "skill_name": name,
+            "summary": format!("{name} — {dcc} asset pipeline skill"),
+            "tags": ["import", "export", "pipeline"],
+            "dcc_type": dcc,
+            "instance_id": "abcdef01-2345-6789-abcd-ef0123456789",
+            "has_schema": true,
+            "loaded": true,
+            "load_state": "ready",
+            "callable": true,
+            "disabled_by_group": false,
+            "available_groups": ["studio-tools"],
+            "rank": 3,
+            "score": 90,
+            "match_reasons": ["skill_lexical"],
+            "annotations": {"readOnlyHint": false},
+            "metadata": {"affinity": "main"},
+            "next_step": null
+        })
+    }
+
+    #[test]
+    fn compact_kind_all_fits_10k_with_max_caps() {
+        // Simulate the worst-case kind=all response: 10 tools + 10 skills,
+        // each with realistic field sizes.  After v2 compact (stripped
+        // metadata/annotations/match_reasons/available_groups), 20 records
+        // × ~400 chars ≈ 8K chars, well under the 10K ceiling.
+        let mut tool_hits = Vec::new();
+        for i in 0..10 {
+            tool_hits.push(worst_case_tool_hit(
+                &format!("blender.abcdef01.tool_{:02}", i),
+                "blender",
+            ));
+        }
+        let mut skill_entries = Vec::new();
+        for i in 0..10 {
+            skill_entries.push(worst_case_skill_hit(
+                &format!("blender-skill-{:02}", i),
+                "blender",
+            ));
+        }
+
+        let tools_value = json!({
+            "total": 10,
+            "hits": tool_hits,
+        });
+        let skills_value = json!({
+            "total": 10,
+            "skills": skill_entries,
+        });
+
+        let compact_tools = compact_tools_hits(&tools_value);
+        let compact_skills = compact_skills_list(&skills_value);
+
+        let kind_all = json!({
+            "search_id": "search-001",
+            "ranker_version": "v2.1.0",
+            "index_generation": "gen-001",
+            "tools": compact_tools,
+            "skills": compact_skills,
+        });
+
+        let compact_str = serde_json::to_string(&kind_all).unwrap();
+        assert!(
+            compact_str.len() <= 10_000,
+            "kind=all compact must fit within 10K chars, got {} chars",
+            compact_str.len()
+        );
+    }
+
+    #[test]
+    fn compact_kind_all_caps_when_over_limit() {
+        // When there are more than MAX_KIND_ALL_TOOLS tools (25 hits),
+        // compact_tools_hits must cap to 10 and set capped=true.
+        let mut tool_hits = Vec::new();
+        for i in 0..25 {
+            tool_hits.push(worst_case_tool_hit(
+                &format!("blender.abcdef01.tool_{:02}", i),
+                "blender",
+            ));
+        }
+        let tools_value = json!({
+            "total": 25,
+            "hits": tool_hits,
+        });
+
+        let compact = compact_tools_hits(&tools_value);
+
+        assert_eq!(compact["total"], 10);
+        assert_eq!(compact["hits"].as_array().unwrap().len(), 10);
+        assert_eq!(compact["capped"], true);
+
+        // Same for skills
+        let mut skill_entries = Vec::new();
+        for i in 0..25 {
+            skill_entries.push(worst_case_skill_hit(
+                &format!("blender-skill-{:02}", i),
+                "blender",
+            ));
+        }
+        let skills_value = json!({
+            "total": 25,
+            "skills": skill_entries,
+        });
+
+        let compact_skills = compact_skills_list(&skills_value);
+        assert_eq!(compact_skills["total"], 10);
+        assert_eq!(compact_skills["skills"].as_array().unwrap().len(), 10);
+        assert_eq!(compact_skills["capped"], true);
+    }
+
+    #[test]
+    fn compact_record_strips_discovery_only_fields() {
+        let record = worst_case_tool_hit("blender.abcdef01.create_cube", "blender");
+        let compact = compact_record(&record);
+
+        // Must keep discovery-essential fields
+        assert!(compact.get("tool_slug").is_some());
+        assert!(compact.get("summary").is_some());
+        assert!(compact.get("tags").is_some());
+        assert!(compact.get("dcc_type").is_some());
+        assert!(compact.get("score").is_some());
+        assert!(compact.get("loaded").is_some());
+
+        // Must strip definition/audit fields
+        assert!(compact.get("metadata").is_none());
+        assert!(compact.get("annotations").is_none());
+        assert!(compact.get("available_groups").is_none());
+        assert!(compact.get("match_reasons").is_none());
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -232,7 +232,9 @@ pub async fn tool_search(
             // hits to avoid unbounded kind=all output.
             let compact_tools = crate::gateway::response_codec::compact_tools_hits(&tools_value);
             let compact_skills = crate::gateway::response_codec::compact_skills_list(&skills_value);
-            Ok(serde_json::to_string_pretty(&json!({
+            // Compact JSON (not pretty-printed) so the kind=all payload stays
+            // under the MCP token ceiling.  See PIP-2454 size verification.
+            Ok(serde_json::to_string(&json!({
                 "search_id": search_id,
                 "ranker_version": ranker_version,
                 "index_generation": index_generation,

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -230,8 +230,8 @@ pub async fn tool_search(
             // per-hit payload is trimmed before merging (same fields as the
             // single-kind compact path).  Also cap cross-category total
             // hits to avoid unbounded kind=all output.
-            let compact_tools = compact_tools_hits(&tools_value);
-            let compact_skills = compact_skills_list(&skills_value);
+            let compact_tools = crate::gateway::response_codec::compact_tools_hits(&tools_value);
+            let compact_skills = crate::gateway::response_codec::compact_skills_list(&skills_value);
             Ok(serde_json::to_string_pretty(&json!({
                 "search_id": search_id,
                 "ranker_version": ranker_version,
@@ -246,51 +246,6 @@ pub async fn tool_search(
             tool_search_tools(gs, args, trace_context, session_id, agent_context).await
         }
     }
-}
-
-/// Compact tools hits from a search response, keeping only the fields
-/// that `compact_search_payload` preserves for the single-kind path.
-fn compact_tools_hits(tools_value: &Value) -> Value {
-    let hits = tools_value
-        .get("hits")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    let total = tools_value
-        .get("total")
-        .and_then(Value::as_u64)
-        .and_then(|v| usize::try_from(v).ok())
-        .unwrap_or(hits.len());
-    crate::gateway::response_codec::compact_search_payload(total, &hits)
-}
-
-/// Compact skills list payload, keeping only the lightweight per-skill
-/// fields used for discovery.  Also caps the skill count so kind=all
-/// output stays bounded.
-const MAX_KIND_ALL_SKILLS: usize = 20;
-const MAX_KIND_ALL_TOOLS: usize = 25;
-
-fn compact_skills_list(skills_value: &Value) -> Value {
-    let skills = skills_value
-        .get("skills")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    let total = skills_value
-        .get("total")
-        .and_then(Value::as_u64)
-        .and_then(|v| usize::try_from(v).ok())
-        .unwrap_or(skills.len());
-    let capped: Vec<Value> = skills
-        .into_iter()
-        .take(MAX_KIND_ALL_SKILLS)
-        .map(|skill| crate::gateway::response_codec::compact_record(&skill))
-        .collect();
-    json!({
-        "skills": capped,
-        "total": total.min(MAX_KIND_ALL_SKILLS),
-        "capped": total > MAX_KIND_ALL_SKILLS,
-    })
 }
 
 /// Unified describe: `tool_slug` for backend schema, or `skill_name` for skill detail.

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -192,8 +192,12 @@ pub async fn tool_search(
         "all" => {
             let tools_json =
                 tool_search_tools(gs, args, trace_context, session_id, agent_context).await?;
+            // Bug 3 fix: use search_skills (not list_skills) so dcc_type
+            // filtering is inherited and results are scoped to the requested
+            // DCC type.  list_skills returns every skill from every live DCC
+            // instance, which defeats dcc_type=blender for kind=all.
             let (skills_text, skills_err) =
-                crate::gateway::aggregator::skill_mgmt_dispatch(gs, "list_skills", args).await;
+                crate::gateway::aggregator::skill_mgmt_dispatch(gs, "search_skills", args).await;
             if skills_err {
                 return Err(skills_text);
             }
@@ -222,12 +226,18 @@ pub async fn tool_search(
                 .or_else(|| skills_value.get("index_generation"))
                 .cloned()
                 .unwrap_or(Value::Null);
+            // Bug 2 fix: apply compact_search_payload to tools hits so the
+            // per-hit payload is trimmed before merging (same fields as the
+            // single-kind compact path).  Also cap cross-category total
+            // hits to avoid unbounded kind=all output.
+            let compact_tools = compact_tools_hits(&tools_value);
+            let compact_skills = compact_skills_list(&skills_value);
             Ok(serde_json::to_string_pretty(&json!({
                 "search_id": search_id,
                 "ranker_version": ranker_version,
                 "index_generation": index_generation,
-                "tools": tools_value,
-                "skills": skills_value,
+                "tools": compact_tools,
+                "skills": compact_skills,
             }))
             .map_err(|e| e.to_string())?)
         }
@@ -236,6 +246,51 @@ pub async fn tool_search(
             tool_search_tools(gs, args, trace_context, session_id, agent_context).await
         }
     }
+}
+
+/// Compact tools hits from a search response, keeping only the fields
+/// that `compact_search_payload` preserves for the single-kind path.
+fn compact_tools_hits(tools_value: &Value) -> Value {
+    let hits = tools_value
+        .get("hits")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let total = tools_value
+        .get("total")
+        .and_then(Value::as_u64)
+        .and_then(|v| usize::try_from(v).ok())
+        .unwrap_or(hits.len());
+    crate::gateway::response_codec::compact_search_payload(total, &hits)
+}
+
+/// Compact skills list payload, keeping only the lightweight per-skill
+/// fields used for discovery.  Also caps the skill count so kind=all
+/// output stays bounded.
+const MAX_KIND_ALL_SKILLS: usize = 20;
+const MAX_KIND_ALL_TOOLS: usize = 25;
+
+fn compact_skills_list(skills_value: &Value) -> Value {
+    let skills = skills_value
+        .get("skills")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let total = skills_value
+        .get("total")
+        .and_then(Value::as_u64)
+        .and_then(|v| usize::try_from(v).ok())
+        .unwrap_or(skills.len());
+    let capped: Vec<Value> = skills
+        .into_iter()
+        .take(MAX_KIND_ALL_SKILLS)
+        .map(|skill| crate::gateway::response_codec::compact_record(&skill))
+        .collect();
+    json!({
+        "skills": capped,
+        "total": total.min(MAX_KIND_ALL_SKILLS),
+        "capped": total > MAX_KIND_ALL_SKILLS,
+    })
 }
 
 /// Unified describe: `tool_slug` for backend schema, or `skill_name` for skill detail.


### PR DESCRIPTION
## Root cause

`kind=all` search returned 110K+ char payloads exceeding MCP token limits even with `compact=true`, caused by three bugs:

1. **`compact_tool_text_payload` didn't handle `kind=all` shape** — it only compacted the single-kind `hits` array, falling through to `legacy_payload.clone()` for the nested `{tools:{hits:...}, skills:{skills:...}}` structure.
2. **`kind=all` used `list_skills` instead of `search_skills`** — bringing back every skill from every live DCC instance, bypassing `dcc_type` filtering.
3. **No cross-category total cap** on tools + skills hits.

## Fix

- `tools.rs`: `kind=all` now uses `search_skills` (inherits `dcc_type` filtering), compacts both tools hits and skills list before merging, with a 25-tool / 20-skill cap.
- `mcp_impl.rs`: `compact_tool_text_payload` detects `kind=all` shape and preserves both tools/skills subtrees with canonical keys only.
- `response_codec.rs`: `compact_record` visibility changed to `pub(crate)` for reuse.

## Test plan

- 3 new unit tests: `kind=all` compact preserves subtrees + payload under 2K chars, extra key stripping, single-kind regression.
- Existing `response_codec` and MCP handler tests continue to pass.