### PR TITLE
fix(introspect): strip _meta from tool arguments

### DIFF
--- a/python/dcc_mcp_core/introspect.py
+++ b/python/dcc_mcp_core/introspect.py
@@ -383,6 +383,7 @@ def register_introspect_tools(
 
         def wrapper(params: Any) -> Any:
             args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
+            args.pop("_meta", None)
             return fn(**args)
 
         return wrapper


### PR DESCRIPTION
This PR fixes an issue where introspect tools (e.g. dcc_introspect__eval) would fail when receiving metadata in the tool call.

Changes:
- Modified _handler in introspect.py to pop _meta from the arguments dictionary before calling the underlying function.