### PR TITLE
fix(ci): retry ClawHub skill publish on transient embedding failures

### DIFF
--- a/scripts/clawhub_sync.py
+++ b/scripts/clawhub_sync.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+import time
 from typing import Any
 
 import dcc_mcp_core
@@ -17,7 +18,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
 DEFAULT_CLI = os.environ.get("CLAWHUB_CLI_PACKAGE", "clawhub@0.17.0")
 CLAWHUB_LICENSE = "MIT-0"
+MAX_RETRIES = 3
 VERSION_EXISTS_RE = re.compile(r"\bVersion(?:\s+\S+)?\s+already exists\b")
+RETRYABLE_RE = re.compile(
+    r"\b(?:Embedding failed|Please try again|reset in \d+s)\b",
+    re.IGNORECASE,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -96,6 +102,12 @@ def version_already_exists(proc: subprocess.CompletedProcess[str]) -> bool:
     return VERSION_EXISTS_RE.search(output) is not None
 
 
+def is_retryable(proc: subprocess.CompletedProcess[str]) -> bool:
+    """Return True when ClawHub output indicates a transient retryable failure."""
+    output = "\n".join(part for part in (proc.stdout, proc.stderr) if part)
+    return RETRYABLE_RE.search(output) is not None
+
+
 def publish_one(
     entry: dict[str, Any],
     *,
@@ -147,11 +159,24 @@ def publish_one(
         return 0
 
     print(f"Publishing {slug}@{version} from {skill_dir} ...", flush=True)
-    proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
-    print_completed_process_output(proc)
-    if proc.returncode != 0 and version_already_exists(proc):
-        print(f"{slug}@{version} already exists on ClawHub; skipping.")
-        return 0
+    for attempt in range(1, MAX_RETRIES + 1):
+        proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        print_completed_process_output(proc)
+        if proc.returncode == 0:
+            return 0
+        if version_already_exists(proc):
+            print(f"{slug}@{version} already exists on ClawHub; skipping.")
+            return 0
+        if attempt < MAX_RETRIES and is_retryable(proc):
+            wait = 2 ** attempt
+            print(
+                f"Transient ClawHub error for {slug}@{version}; "
+                f"retrying in {wait}s (attempt {attempt}/{MAX_RETRIES}) ...",
+                flush=True,
+            )
+            time.sleep(wait)
+        else:
+            return int(proc.returncode)
     return int(proc.returncode)
 
 

--- a/scripts/clawhub_sync.py
+++ b/scripts/clawhub_sync.py
@@ -168,7 +168,7 @@ def publish_one(
             print(f"{slug}@{version} already exists on ClawHub; skipping.")
             return 0
         if attempt < MAX_RETRIES and is_retryable(proc):
-            wait = 2 ** attempt
+            wait = 2**attempt
             print(
                 f"Transient ClawHub error for {slug}@{version}; "
                 f"retrying in {wait}s (attempt {attempt}/{MAX_RETRIES}) ...",

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -140,7 +140,9 @@ class TestClawhubSync:
         assert "retrying in 2s" in captured.out
         assert "Published example@1.2.3" in captured.out
 
-    def test_publish_retries_embedding_failure_then_treats_existing_as_success(self, tmp_path, monkeypatch, capsys) -> None:
+    def test_publish_retries_embedding_failure_then_treats_existing_as_success(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
         sync = load_sync_module()
         skill_dir = tmp_path / "skills" / "example"
         skill_dir.mkdir(parents=True)
@@ -268,7 +270,6 @@ class TestClawhubSync:
 
         assert rc == 1
         assert len(calls) == 1
-
 
     def test_clawhub_skill_versions_follow_release_please(self) -> None:
         entries = json.loads(MANIFEST.read_text(encoding="utf-8"))

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -90,6 +90,186 @@ class TestClawhubSync:
         assert "Version 1.2.3 already exists" in captured.err
         assert "example@1.2.3 already exists on ClawHub; skipping." in captured.out
 
+    def test_publish_retries_on_embedding_failure_then_succeeds(self, tmp_path, monkeypatch, capsys) -> None:
+        sync = load_sync_module()
+        skill_dir = tmp_path / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+
+        class CleanReport:
+            is_clean = True
+            issues: tuple[str, ...] = ()
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *, check, capture_output, text):
+            assert check is False
+            assert capture_output is True
+            assert text is True
+            calls.append(cmd)
+            if len(calls) == 1:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    1,
+                    stdout="- Preparing example@1.2.3\n",
+                    stderr="Error: Embedding failed. Please try again. (reset in 22s)\n",
+                )
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="- Published example@1.2.3\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(sync, "skill_version", lambda _skill_dir: "1.2.3")
+        monkeypatch.setattr(sync, "skill_license", lambda _skill_dir: sync.CLAWHUB_LICENSE)
+        monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
+        monkeypatch.setattr(sync.subprocess, "run", fake_run)
+        monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
+
+        rc = sync.publish_one(
+            {"path": "skills/example", "slug": "example"},
+            dry_run=False,
+            cli="clawhub@test",
+        )
+
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert len(calls) == 2
+        assert "Embedding failed" in captured.err
+        assert "retrying in 2s" in captured.out
+        assert "Published example@1.2.3" in captured.out
+
+    def test_publish_retries_embedding_failure_then_treats_existing_as_success(self, tmp_path, monkeypatch, capsys) -> None:
+        sync = load_sync_module()
+        skill_dir = tmp_path / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+
+        class CleanReport:
+            is_clean = True
+            issues: tuple[str, ...] = ()
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *, check, capture_output, text):
+            assert check is False
+            assert capture_output is True
+            assert text is True
+            calls.append(cmd)
+            if len(calls) == 1:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    1,
+                    stdout="- Preparing example@1.2.3\n",
+                    stderr="Error: Embedding failed. Please try again.\n",
+                )
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                stdout="- Preparing example@1.2.3\n",
+                stderr="Error: Uncaught ConvexError: Version 1.2.3 already exists\n",
+            )
+
+        monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(sync, "skill_version", lambda _skill_dir: "1.2.3")
+        monkeypatch.setattr(sync, "skill_license", lambda _skill_dir: sync.CLAWHUB_LICENSE)
+        monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
+        monkeypatch.setattr(sync.subprocess, "run", fake_run)
+        monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
+
+        rc = sync.publish_one(
+            {"path": "skills/example", "slug": "example"},
+            dry_run=False,
+            cli="clawhub@test",
+        )
+
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert len(calls) == 2
+        assert "example@1.2.3 already exists on ClawHub; skipping." in captured.out
+
+    def test_publish_retries_exhausted_on_embedding_failure(self, tmp_path, monkeypatch, capsys) -> None:
+        sync = load_sync_module()
+        skill_dir = tmp_path / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+
+        class CleanReport:
+            is_clean = True
+            issues: tuple[str, ...] = ()
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *, check, capture_output, text):
+            assert check is False
+            assert capture_output is True
+            assert text is True
+            calls.append(cmd)
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                stdout="- Preparing example@1.2.3\n",
+                stderr="Error: Embedding failed. Please try again. (reset in 22s)\n",
+            )
+
+        monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(sync, "skill_version", lambda _skill_dir: "1.2.3")
+        monkeypatch.setattr(sync, "skill_license", lambda _skill_dir: sync.CLAWHUB_LICENSE)
+        monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
+        monkeypatch.setattr(sync.subprocess, "run", fake_run)
+        monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
+
+        rc = sync.publish_one(
+            {"path": "skills/example", "slug": "example"},
+            dry_run=False,
+            cli="clawhub@test",
+        )
+
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert len(calls) == sync.MAX_RETRIES
+        assert "retrying in 2s" in captured.out
+        assert "retrying in 4s" in captured.out
+
+    def test_publish_no_retry_on_permanent_error(self, tmp_path, monkeypatch, capsys) -> None:
+        sync = load_sync_module()
+        skill_dir = tmp_path / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+
+        class CleanReport:
+            is_clean = True
+            issues: tuple[str, ...] = ()
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *, check, capture_output, text):
+            assert check is False
+            assert capture_output is True
+            assert text is True
+            calls.append(cmd)
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                stdout="- Preparing example@1.2.3\n",
+                stderr="Error: Unknown permanent error\n",
+            )
+
+        monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(sync, "skill_version", lambda _skill_dir: "1.2.3")
+        monkeypatch.setattr(sync, "skill_license", lambda _skill_dir: sync.CLAWHUB_LICENSE)
+        monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
+        monkeypatch.setattr(sync.subprocess, "run", fake_run)
+        monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
+
+        rc = sync.publish_one(
+            {"path": "skills/example", "slug": "example"},
+            dry_run=False,
+            cli="clawhub@test",
+        )
+
+        assert rc == 1
+        assert len(calls) == 1
+
+
     def test_clawhub_skill_versions_follow_release_please(self) -> None:
         entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
         release_version = json.loads(RELEASE_MANIFEST.read_text(encoding="utf-8"))["."]


### PR DESCRIPTION
## Problem

The `publish-clawhub-skills` job in the release workflow failed on v0.19.1 with exit code 1 during the `Publish skills to ClawHub` step.

Root cause: ClawHub returned a transient embedding failure for `dcc-mcp-creator@0.19.1`:

```
✖ Embedding failed. Please try again. (reset in 22s)
Error: Embedding failed. Please try again. (reset in 22s)
```

The first two skills (`dcc-cli-gateway`, `dcc-mcp-skills-creator`) were already published and correctly skipped via the existing "version already exists" handling, but the third skill failed the whole job.

## Fix

Add retry logic to `scripts/clawhub_sync.py`:

- Retry up to `MAX_RETRIES = 3` times on transient ClawHub errors such as `Embedding failed`, `Please try again`, or rate-limit reset hints (`reset in 22s`).
- Use exponential backoff (`2^attempt` seconds) between retries to give the embedding service time to recover.
- Treat "version already exists" as success on any attempt, so a retry that discovers the first attempt actually succeeded does not fail the job.
- Permanent / non-retryable errors fail immediately without retrying.

## Tests

Added four focused unit tests in `tests/test_clawhub_sync.py`:

- Retry on embedding failure then succeed.
- Retry on embedding failure then treat "already exists" as success.
- Retry exhausted on repeated embedding failures.
- No retry on permanent errors.

## Notes

- The Node 20 deprecation warnings for `actions/setup-python@v5` and `actions/upload-artifact@v4` are non-blocking and intentionally left out of this PR to keep the fix minimal.
- Skill versions remain managed by release-please (`x-release-please-version`); no hardcoded version changes were made.
