### PR TITLE
refactor: shared builtin action registration pipeline

### DIFF
--- a/python/dcc_mcp_core/_registration.py
+++ b/python/dcc_mcp_core/_registration.py
@@ -23,6 +23,7 @@ class RegistrationContext:
     include_bundled: bool = True
     minimal: bool | None = None
     strict_scan: bool | None = None
+    minimal_mode: Any | None = None
 
 
 @dataclass
@@ -94,3 +95,110 @@ def run_registration_phases(phases: Sequence[RegistrationPhase], context: Regist
                 )
             )
     return report
+
+
+class CoreBuiltinActionsPhase(RegistrationPhase):
+    """Discover skills via the core registration path."""
+
+    name = "core_builtin_actions"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._register_core_builtin_actions(context)
+
+
+class StrictSkillScanPhase(RegistrationPhase):
+    """Run strict skill validation when ``strict_scan`` is enabled."""
+
+    name = "strict_skill_scan"
+    fatal_exceptions = (ValueError,)
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._run_strict_skill_scan_phase(context)
+
+
+class MetadataDrivenToolsPhase(RegistrationPhase):
+    """Register ``recipes__*`` and ``skill_refs__*`` tools."""
+
+    name = "metadata_driven_tools"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._register_metadata_driven_tools(context)
+
+
+class IntrospectToolsPhase(RegistrationPhase):
+    """Register the four ``dcc_introspect__*`` MCP tools."""
+
+    name = "introspect_tools"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._register_introspect_tools(context)
+
+
+class FeedbackToolPhase(RegistrationPhase):
+    """Register the ``dcc_feedback__report`` MCP tool."""
+
+    name = "feedback_tool"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._register_feedback_tool(context)
+
+
+class QtUiInspectorPhase(RegistrationPhase):
+    """Register the shared ``qt_ui_inspector__*`` tools."""
+
+    name = "qt_ui_inspector"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._register_qt_ui_inspector(context)
+
+
+class CapabilityManifestPhase(RegistrationPhase):
+    """Register the ``dcc_capability_manifest`` MCP tool."""
+
+    name = "capability_manifest"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._register_capability_manifest_tool(context)
+
+
+class ProjectToolsPhase(RegistrationPhase):
+    """Register the four ``project_*`` MCP tools."""
+
+    name = "project_tools"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._attach_project_tools(context)
+
+
+class ResourcesPhase(RegistrationPhase):
+    """Publish ``scene://current`` + dynamic resource producers."""
+
+    name = "resources"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._attach_resources(context)
+
+
+class SkillCatalogReadyPhase(RegistrationPhase):
+    """Signal that the skill catalog has been populated (readiness gate)."""
+
+    name = "skill_catalog_ready"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._mark_skill_catalog_ready(context)
+
+
+def get_standard_phases() -> list[RegistrationPhase]:
+    """Return the ordered list of standard registration phases."""
+    return [
+        CoreBuiltinActionsPhase(),
+        StrictSkillScanPhase(),
+        MetadataDrivenToolsPhase(),
+        IntrospectToolsPhase(),
+        FeedbackToolPhase(),
+        QtUiInspectorPhase(),
+        CapabilityManifestPhase(),
+        ProjectToolsPhase(),
+        ResourcesPhase(),
+        SkillCatalogReadyPhase(),
+    ]

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -274,6 +274,127 @@ class DccServerBase:
             minimal_mode=minimal_mode,
         )
 
+    def run_registration(
+        self,
+        phases: Any | None = None,
+        extra_skill_paths: list[str] | None = None,
+        include_bundled: bool = True,
+        minimal: bool | None = None,
+        minimal_mode: Any | None = None,
+        strict_scan: bool | None = None,
+    ) -> Any:
+        """Execute a custom or standard registration phase pipeline.
+
+        Args:
+            phases: Optional list of phases to run. Defaults to ``get_standard_phases()``.
+            extra_skill_paths: Additional skill paths to scan.
+            include_bundled: Whether to include core bundled skills.
+            minimal: Whether minimal mode is enabled (legacy flag).
+            minimal_mode: Explicit minimal mode configuration.
+            strict_scan: Whether to fail-fast on broken skill directories.
+
+        Returns:
+            :class:`~dcc_mcp_core._registration.RegistrationReport`.
+
+        """
+        from dcc_mcp_core._registration import RegistrationContext
+        from dcc_mcp_core._registration import get_standard_phases
+        from dcc_mcp_core._registration import run_registration_phases
+
+        if phases is None:
+            phases = get_standard_phases()
+
+        context = RegistrationContext(
+            server=self,
+            extra_skill_paths=extra_skill_paths,
+            include_bundled=include_bundled,
+            minimal=minimal,
+            minimal_mode=minimal_mode,
+            strict_scan=strict_scan,
+        )
+        report = run_registration_phases(phases, context)
+        # Store report for diagnostics
+        self._registration_report = report
+        return report
+
+    # ── Builtin registration phases (PIP-689) ───────────────────────────
+
+    def _register_core_builtin_actions(self, context: Any) -> None:
+        """Discover skills via the base-class registration path (phase helper)."""
+        self.register_builtin_actions(
+            extra_skill_paths=context.extra_skill_paths,
+            include_bundled=context.include_bundled,
+            minimal_mode=context.minimal_mode,
+        )
+
+    def _run_strict_skill_scan_phase(self, context: Any) -> None:
+        """Run strict skill validation when enabled (phase helper)."""
+        # Default implementation does nothing; adapters override if they support strict scan.
+        pass
+
+    def _register_metadata_driven_tools(self, context: Any) -> None:
+        """Register ``recipes__*`` and ``skill_refs__*`` (phase helper)."""
+        try:
+            from dcc_mcp_core.metadata_registration import register_metadata_driven_tools
+        except ImportError:
+            return
+        paths = self.collect_skill_search_paths(
+            extra_paths=context.extra_skill_paths,
+            include_bundled=context.include_bundled,
+            filter_existing=True,
+        )
+        report = register_metadata_driven_tools(self._server, dcc_name=self._dcc_name, extra_paths=paths)
+        if not report.ok:
+            logger.debug(
+                "[%s] metadata_driven_tools: %d registered, %d skipped, %d failed",
+                self._dcc_name,
+                report.registered_count,
+                report.skipped_count,
+                report.failed_count,
+            )
+
+    def _register_introspect_tools(self, context: Any) -> None:
+        """Register the four ``dcc_introspect__*`` tools (phase helper)."""
+        try:
+            from dcc_mcp_core.introspect import register_introspect_tools
+        except ImportError:
+            return
+        register_introspect_tools(self._server, dcc_name=self._dcc_name)
+
+    def _register_feedback_tool(self, context: Any) -> None:
+        """Register the ``dcc_feedback__report`` MCP tool (phase helper)."""
+        try:
+            from dcc_mcp_core.feedback import register_feedback_tool
+        except ImportError:
+            return
+        register_feedback_tool(self._server, dcc_name=self._dcc_name)
+
+    def _register_qt_ui_inspector(self, context: Any) -> None:
+        """Adopt the shared core ``qt_ui_inspector__*`` tools (phase helper)."""
+        # Default does nothing; adapters override to wire their specific Qt integration.
+        pass
+
+    def _register_capability_manifest_tool(self, context: Any) -> None:
+        """Register the ``dcc_capability_manifest`` MCP tool (phase helper)."""
+        # Default does nothing; adapters override to wire their specific builder.
+        pass
+
+    def _attach_project_tools(self, context: Any) -> None:
+        """Register the four ``project_*`` MCP tools (phase helper)."""
+        # Default does nothing; adapters override if they support project tools.
+        pass
+
+    def _attach_resources(self, context: Any) -> None:
+        """Publish host-specific dynamic resource producers (phase helper)."""
+        # Default does nothing; adapters override if they support resources.
+        pass
+
+    def _mark_skill_catalog_ready(self, context: Any) -> None:
+        """Signal that the skill catalog has been populated (phase helper)."""
+        readiness = getattr(self, "_readiness", None)
+        if readiness is not None and hasattr(readiness, "mark_skill_catalog_ready"):
+            readiness.mark_skill_catalog_ready()
+
     def reload_skill_paths(
         self,
         extra_skill_paths: list[str] | None = None,

--- a/tests/test_registration_pipeline.py
+++ b/tests/test_registration_pipeline.py
@@ -1,0 +1,167 @@
+"""Tests for the shared registration phase pipeline (PIP-689).
+
+These exercise the host-agnostic core seam only: the phase base class,
+the executor's ordering / error-handling contract, and the standard phase
+list. They intentionally avoid importing ``DccServerBase`` so they stay
+stable without a built ``dcc_mcp_core._core`` binary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dcc_mcp_core._registration import RegistrationContext
+from dcc_mcp_core._registration import RegistrationPhase
+from dcc_mcp_core._registration import get_standard_phases
+from dcc_mcp_core._registration import run_registration_phases
+
+
+class _RecordingPhase(RegistrationPhase):
+    """A phase that records its invocation and can optionally fail."""
+
+    def __init__(self, name: str, calls: list, fail: type[Exception] | None = None) -> None:
+        self.name = name
+        self._calls = calls
+        self._fail = fail
+
+    def run(self, context: RegistrationContext) -> None:
+        self._calls.append(self.name)
+        if self._fail is not None:
+            raise self._fail("boom")
+
+
+class _FatalPhase(_RecordingPhase):
+    """A phase whose failures are fatal (abort the pipeline)."""
+
+    fatal_exceptions = (ValueError,)
+
+
+def test_get_standard_phases_is_ordered() -> None:
+    names = [phase.name for phase in get_standard_phases()]
+    assert names == [
+        "core_builtin_actions",
+        "strict_skill_scan",
+        "metadata_driven_tools",
+        "introspect_tools",
+        "feedback_tool",
+        "qt_ui_inspector",
+        "capability_manifest",
+        "project_tools",
+        "resources",
+        "skill_catalog_ready",
+    ]
+
+
+def test_phases_run_in_order_and_all_succeed() -> None:
+    calls: list[str] = []
+    context = RegistrationContext(server=object())
+
+    report = run_registration_phases(
+        [
+            _RecordingPhase("one", calls),
+            _RecordingPhase("two", calls),
+            _RecordingPhase("three", calls),
+        ],
+        context,
+    )
+
+    assert calls == ["one", "two", "three"]
+    assert [outcome.name for outcome in report.outcomes] == ["one", "two", "three"]
+    assert all(outcome.success for outcome in report.outcomes)
+    assert report.success is True
+
+
+def test_non_fatal_failure_continues_and_is_reported() -> None:
+    calls: list[str] = []
+    context = RegistrationContext(server=object())
+
+    report = run_registration_phases(
+        [
+            _RecordingPhase("one", calls),
+            _RecordingPhase("two", calls, fail=RuntimeError),
+            _RecordingPhase("three", calls),
+        ],
+        context,
+    )
+
+    # A non-fatal failure must not stop later phases.
+    assert calls == ["one", "two", "three"]
+    assert [outcome.success for outcome in report.outcomes] == [True, False, True]
+    assert report.success is False
+    assert report.outcomes[1].error == "boom"
+
+
+def test_fatal_failure_aborts_pipeline() -> None:
+    calls: list[str] = []
+    context = RegistrationContext(server=object())
+
+    with pytest.raises(ValueError):
+        run_registration_phases(
+            [
+                _RecordingPhase("one", calls),
+                _FatalPhase("two", calls, fail=ValueError),
+                _RecordingPhase("three", calls),
+            ],
+            context,
+        )
+
+    # The fatal phase aborts before "three" runs.
+    assert calls == ["one", "two"]
+
+
+def test_host_hook_override_is_dispatched() -> None:
+    """Verify that RegistrationPhase subclasses correctly dispatch to the server hooks."""
+
+    class MockServer:
+        def __init__(self):
+            self.calls = []
+
+        def _register_core_builtin_actions(self, context):
+            self.calls.append("core")
+
+        def _run_strict_skill_scan_phase(self, context):
+            self.calls.append("strict")
+
+        def _register_metadata_driven_tools(self, context):
+            self.calls.append("metadata")
+
+        def _register_introspect_tools(self, context):
+            self.calls.append("introspect")
+
+        def _register_feedback_tool(self, context):
+            self.calls.append("feedback")
+
+        def _register_qt_ui_inspector(self, context):
+            self.calls.append("qt")
+
+        def _register_capability_manifest_tool(self, context):
+            self.calls.append("manifest")
+
+        def _attach_project_tools(self, context):
+            self.calls.append("project")
+
+        def _attach_resources(self, context):
+            self.calls.append("resources")
+
+        def _mark_skill_catalog_ready(self, context):
+            self.calls.append("ready")
+
+    server = MockServer()
+    context = RegistrationContext(server=server)
+    phases = get_standard_phases()
+
+    for phase in phases:
+        phase.run(context)
+
+    assert server.calls == [
+        "core",
+        "strict",
+        "metadata",
+        "introspect",
+        "feedback",
+        "qt",
+        "manifest",
+        "project",
+        "resources",
+        "ready",
+    ]


### PR DESCRIPTION
This PR extracts the builtin action registration phase pipeline from host adapters into dcc-mcp-core.

**Summary**
- Unified the registration phase orchestration in dcc_mcp_core._registration.
- Added standard registration phases (CoreBuiltinActionsPhase, MetadataDrivenToolsPhase, etc.) to core.
- Added run_registration method to DccServerBase to support the shared pipeline.
- Enabled host adapters to inject custom phases while leveraging standard ones.

**Validation**
- Added unit tests in dcc-mcp-core covering registration order and error handling (fatal vs non-fatal).
- Verified that existing adapters can migrate to the shared framework with minimal changes.