### PR TITLE
refactor: registration helpers and capability plumbing

### DIFF
--- a/python/dcc_mcp_core/_registration.py
+++ b/python/dcc_mcp_core/_registration.py
@@ -162,7 +162,7 @@ class IntrospectToolsPhase(RegistrationPhase):
 
     def run(self, context: RegistrationContext) -> None:
         if hasattr(context.server, "_register_introspect_tools"):
-            context.server._register_introspect_tools()
+            context.server._register_introspect_tools(context)
         else:
             try:
                 from dcc_mcp_core.introspect import register_introspect_tools
@@ -178,7 +178,7 @@ class FeedbackToolPhase(RegistrationPhase):
 
     def run(self, context: RegistrationContext) -> None:
         if hasattr(context.server, "_register_feedback_tool"):
-            context.server._register_feedback_tool()
+            context.server._register_feedback_tool(context)
         else:
             try:
                 from dcc_mcp_core.feedback import register_feedback_tool
@@ -194,7 +194,7 @@ class QtUiInspectorPhase(RegistrationPhase):
 
     def run(self, context: RegistrationContext) -> None:
         if hasattr(context.server, "_register_qt_ui_inspector"):
-            context.server._register_qt_ui_inspector()
+            context.server._register_qt_ui_inspector(context)
 
 
 class CapabilityManifestPhase(RegistrationPhase):
@@ -204,7 +204,7 @@ class CapabilityManifestPhase(RegistrationPhase):
 
     def run(self, context: RegistrationContext) -> None:
         if hasattr(context.server, "_register_capability_manifest_tool"):
-            context.server._register_capability_manifest_tool()
+            context.server._register_capability_manifest_tool(context)
 
 
 class ProjectToolsPhase(RegistrationPhase):
@@ -214,7 +214,7 @@ class ProjectToolsPhase(RegistrationPhase):
 
     def run(self, context: RegistrationContext) -> None:
         if hasattr(context.server, "_attach_project_tools"):
-            context.server._attach_project_tools()
+            context.server._attach_project_tools(context)
 
 
 class ResourcesPhase(RegistrationPhase):
@@ -224,7 +224,7 @@ class ResourcesPhase(RegistrationPhase):
 
     def run(self, context: RegistrationContext) -> None:
         if hasattr(context.server, "_attach_resources"):
-            context.server._attach_resources()
+            context.server._attach_resources(context)
 
 
 class SkillCatalogReadyPhase(RegistrationPhase):
@@ -236,7 +236,7 @@ class SkillCatalogReadyPhase(RegistrationPhase):
         if hasattr(context.server, "_readiness") and hasattr(context.server._readiness, "mark_skill_catalog_ready"):
             context.server._readiness.mark_skill_catalog_ready()
         elif hasattr(context.server, "_mark_skill_catalog_ready"):
-            context.server._mark_skill_catalog_ready()
+            context.server._mark_skill_catalog_ready(context)
 
 
 def get_standard_phases() -> list[RegistrationPhase]:

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -353,7 +353,7 @@ class DccServerBase:
                 report.failed_count,
             )
 
-    def _register_introspect_tools(self) -> None:
+    def _register_introspect_tools(self, context: Any | None = None) -> None:
         """Register the four ``dcc_introspect__*`` tools (phase helper)."""
         try:
             from dcc_mcp_core.introspect import register_introspect_tools
@@ -361,7 +361,7 @@ class DccServerBase:
             return
         register_introspect_tools(self._server, dcc_name=self._dcc_name)
 
-    def _register_feedback_tool(self) -> None:
+    def _register_feedback_tool(self, context: Any | None = None) -> None:
         """Register the ``dcc_feedback__report`` MCP tool (phase helper)."""
         try:
             from dcc_mcp_core.feedback import register_feedback_tool
@@ -369,27 +369,27 @@ class DccServerBase:
             return
         register_feedback_tool(self._server, dcc_name=self._dcc_name)
 
-    def _register_qt_ui_inspector(self) -> None:
+    def _register_qt_ui_inspector(self, context: Any | None = None) -> None:
         """Adopt the shared core ``qt_ui_inspector__*`` tools (phase helper)."""
         # Default does nothing; adapters override to wire their specific Qt integration.
         pass
 
-    def _register_capability_manifest_tool(self) -> None:
+    def _register_capability_manifest_tool(self, context: Any | None = None) -> None:
         """Register the ``dcc_capability_manifest`` MCP tool (phase helper)."""
         # Default does nothing; adapters override to wire their specific builder.
         pass
 
-    def _attach_project_tools(self) -> None:
+    def _attach_project_tools(self, context: Any | None = None) -> None:
         """Register the four ``project_*`` MCP tools (phase helper)."""
         # Default does nothing; adapters override if they support project tools.
         pass
 
-    def _attach_resources(self) -> None:
+    def _attach_resources(self, context: Any | None = None) -> None:
         """Publish host-specific dynamic resource producers (phase helper)."""
         # Default does nothing; adapters override if they support resources.
         pass
 
-    def _mark_skill_catalog_ready(self) -> None:
+    def _mark_skill_catalog_ready(self, context: Any | None = None) -> None:
         """Signal that the skill catalog has been populated (phase helper)."""
         readiness = getattr(self, "_readiness", None)
         if readiness is not None and hasattr(readiness, "mark_skill_catalog_ready"):

--- a/tests/test_registration_pipeline.py
+++ b/tests/test_registration_pipeline.py
@@ -165,3 +165,39 @@ def test_host_hook_override_is_dispatched() -> None:
         "resources",
         "ready",
     ]
+
+
+def test_standard_phases_accept_real_dcc_server_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default ``DccServerBase`` hooks must keep the phase dispatcher contract."""
+    from dcc_mcp_core.server_base import DccServerBase
+
+    class MinimalServer(DccServerBase):
+        pass
+
+    server = MinimalServer.__new__(MinimalServer)
+    server._dcc_name = "maya"
+    server._server = object()
+
+    monkeypatch.setattr(DccServerBase, "register_builtin_actions", lambda self, **kwargs: None)
+    monkeypatch.setattr(DccServerBase, "collect_skill_search_paths", lambda self, **kwargs: [])
+
+    import dcc_mcp_core.feedback as feedback
+    import dcc_mcp_core.introspect as introspect
+    import dcc_mcp_core.metadata_registration as metadata_registration
+
+    class _MetadataReport:
+        ok = True
+        registered_count = 0
+        skipped_count = 0
+        failed_count = 0
+
+    monkeypatch.setattr(
+        metadata_registration, "register_metadata_driven_tools", lambda *args, **kwargs: _MetadataReport()
+    )
+    monkeypatch.setattr(introspect, "register_introspect_tools", lambda *args, **kwargs: None)
+    monkeypatch.setattr(feedback, "register_feedback_tool", lambda *args, **kwargs: None)
+
+    report = run_registration_phases(get_standard_phases(), RegistrationContext(server=server))
+
+    assert report.success is True
+    assert [outcome.success for outcome in report.outcomes] == [True] * len(report.outcomes)

--- a/tests/test_registration_pipeline.py
+++ b/tests/test_registration_pipeline.py
@@ -125,25 +125,25 @@ def test_host_hook_override_is_dispatched() -> None:
         def _register_metadata_driven_tools(self, context):
             self.calls.append("metadata")
 
-        def _register_introspect_tools(self):
+        def _register_introspect_tools(self, context):
             self.calls.append("introspect")
 
-        def _register_feedback_tool(self):
+        def _register_feedback_tool(self, context):
             self.calls.append("feedback")
 
-        def _register_qt_ui_inspector(self):
+        def _register_qt_ui_inspector(self, context):
             self.calls.append("qt")
 
-        def _register_capability_manifest_tool(self):
+        def _register_capability_manifest_tool(self, context):
             self.calls.append("manifest")
 
-        def _attach_project_tools(self):
+        def _attach_project_tools(self, context):
             self.calls.append("project")
 
-        def _attach_resources(self):
+        def _attach_resources(self, context):
             self.calls.append("resources")
 
-        def _mark_skill_catalog_ready(self):
+        def _mark_skill_catalog_ready(self, context):
             self.calls.append("ready")
 
     server = MockServer()


### PR DESCRIPTION
Restore the registration helper contract so the standard phases can call the default DccServerBase hooks again.

Validation:
- pytest tests/test_registration_pipeline.py tests/test_introspect.py tests/test_feedback_and_rationale.py

Notes:
- This branch also carries the broader capability/project extraction already present in the diff.