### PR TITLE
fix: avoid runtime schema introspection

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -457,7 +457,7 @@ entries:
         let entries = sample_entries();
         let mut hits = search_hits(&entries, "");
         // Reverse: houdini (idx 2), blender (idx 1), maya (idx 0)
-        hits.sort_by(|a, b| b.index.cmp(&a.index));
+        hits.sort_by_key(|h| std::cmp::Reverse(h.index));
         let page = materialise_page(&entries, &hits);
         assert_eq!(page[0].name, "dcc-mcp-houdini-vfx");
         assert_eq!(page[1].name, "dcc-mcp-blender-skills");

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -666,9 +666,10 @@ impl SkillCatalogSource for CatalogSource {
             });
         }
 
-        // Discovered-but-unloaded skills: expose every tools.yaml declaration
-        // with its full input_schema so gateway `describe_tool` / POST
-        // `/v1/describe` work before `load_skill` (issue #992 class).
+        // Discovered-but-unloaded skills: expose tools.yaml declarations.
+        // Runtime stays manifest-first: if a tool omits input_schema, describe
+        // returns a permissive object schema unless Python introspection is
+        // explicitly enabled for development/migration.
         for summary in summaries {
             if self.catalog.is_loaded(&summary.name) {
                 continue;
@@ -687,9 +688,6 @@ impl SkillCatalogSource for CatalogSource {
                     tool_decl.description.clone()
                 };
                 let input_schema = if tool_decl.input_schema.is_null() {
-                    // Try to generate schema from Python script signature so
-                    // describe returns real inputSchema before load_skill
-                    // (same logic as load_skill_metadata in catalog_loading.rs).
                     let skill_path = std::path::Path::new(&detail.skill_path);
                     let script_path = dcc_mcp_skills::catalog::resolve_tool_script(
                         tool_decl,
@@ -697,12 +695,14 @@ impl SkillCatalogSource for CatalogSource {
                         skill_path,
                     );
                     if let Some(ref sp) = script_path {
-                        dcc_mcp_skills::catalog::schema_gen::generate_input_schema(sp, None)
-                            .unwrap_or_else(|| {
-                                // Only warn once per (skill, tool) pair per
-                                // process lifetime — `list_actions` is called
-                                // on every read request and repeated warnings
-                                // flood the Admin logs panel.
+                        dcc_mcp_skills::catalog::schema_gen::generate_input_schema_if_enabled(
+                            sp, None,
+                        )
+                        .unwrap_or_else(|| {
+                            // Only warn once per (skill, tool) pair per process lifetime when
+                            // opt-in introspection fails. `list_actions` is called on every read
+                            // request, so repeated warnings flood the Admin logs panel.
+                            if dcc_mcp_skills::catalog::schema_gen::schema_introspection_enabled() {
                                 let key = (detail.name.clone(), tool_decl.name.clone());
                                 let mut warned = self.schema_warned.lock();
                                 if warned.insert(key) {
@@ -712,8 +712,9 @@ impl SkillCatalogSource for CatalogSource {
                                         tool_decl.name
                                     );
                                 }
-                                serde_json::json!({"type": "object"})
-                            })
+                            }
+                            serde_json::json!({"type": "object"})
+                        })
                     } else {
                         serde_json::json!({"type": "object"})
                     }

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -507,6 +507,125 @@ fn describe_returns_schema_when_asked() {
 }
 
 #[test]
+fn missing_tool_schema_does_not_run_python_by_default() {
+    use dcc_mcp_actions::ToolRegistry;
+    use dcc_mcp_skills::SkillCatalog;
+    use std::sync::Arc;
+
+    struct TempSkillDir {
+        root: std::path::PathBuf,
+    }
+
+    impl Drop for TempSkillDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    let skill_dir = TempSkillDir {
+        root: std::env::temp_dir().join(format!(
+            "dcc-mcp-rest-missing-schema-{}",
+            uuid::Uuid::new_v4()
+        )),
+    };
+    std::fs::create_dir_all(skill_dir.root.join("scripts")).unwrap();
+    let counter = skill_dir.root.join("counter.txt");
+    std::fs::write(&counter, "0").unwrap();
+    std::fs::write(
+        skill_dir.root.join("SKILL.md"),
+        r#"---
+name: auto-schema-skill
+description: Generates schema from a Python signature.
+allowed-tools: python
+metadata:
+  dcc-mcp:
+    dcc: maya
+    version: "1.0.0"
+    tools: tools.yaml
+---
+
+# Auto Schema Skill
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        skill_dir.root.join("tools.yaml"),
+        r#"tools:
+  - name: set_timeline
+    description: Set the playback timeline range.
+    source_file: scripts/set_timeline.py
+"#,
+    )
+    .unwrap();
+    let counter_literal = counter.to_string_lossy().replace('\\', "/");
+    std::fs::write(
+        skill_dir.root.join("scripts").join("set_timeline.py"),
+        format!(
+            r#"
+from pathlib import Path
+
+counter = Path(r"{counter_literal}")
+counter.write_text(str(int(counter.read_text() or "0") + 1))
+
+
+def main(start_frame: int, end_frame: int, playback: bool = False):
+    """Set the playback timeline range."""
+    pass
+"#
+        ),
+    )
+    .unwrap();
+
+    let _introspection_env =
+        dcc_mcp_test_utils::EnvVarGuard::set("DCC_MCP_ENABLE_SCHEMA_INTROSPECTION", None);
+    let registry = Arc::new(ToolRegistry::new());
+    let catalog = Arc::new(SkillCatalog::new(registry));
+    let path = skill_dir.root.to_string_lossy().into_owned();
+    assert!(catalog.discover(Some(&[path]), Some("maya")) > 0);
+
+    let catalog_src = Arc::new(CatalogSource::new(catalog));
+    let actions = catalog_src.list_actions();
+    let action = actions
+        .iter()
+        .find(|a| a.action_name == "auto_schema_skill__set_timeline")
+        .expect("missing-schema tool should still be discoverable");
+    assert!(!action.loaded);
+    assert_eq!(action.input_schema, serde_json::json!({"type": "object"}));
+
+    let svc = SkillRestService::new(catalog_src, Arc::new(FakeInvoker::default()));
+    for _ in 0..2 {
+        let search = svc.search(&SearchRequest {
+            query: Some("set_timeline".into()),
+            dcc_type: Some("maya".into()),
+            loaded_only: false,
+            ..Default::default()
+        });
+        let hit = search
+            .hits
+            .iter()
+            .find(|hit| hit.action == "auto_schema_skill__set_timeline")
+            .expect("search should surface the missing-schema tool");
+        assert!(!hit.has_schema);
+    }
+
+    let desc = svc
+        .describe(&DescribeRequest {
+            tool_slug: ToolSlug::build(
+                "maya",
+                "auto-schema-skill",
+                "auto_schema_skill__set_timeline",
+            ),
+            include_schema: true,
+        })
+        .unwrap();
+    assert_eq!(
+        desc.input_schema,
+        Some(serde_json::json!({"type": "object"}))
+    );
+    assert_eq!(std::fs::read_to_string(counter).unwrap(), "0");
+}
+
+#[test]
 fn catalog_source_lists_discovered_tools_with_input_schema() {
     use dcc_mcp_actions::ToolRegistry;
     use dcc_mcp_skills::SkillCatalog;

--- a/crates/dcc-mcp-skill-rest/src/tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/tests.rs
@@ -15,7 +15,6 @@
 //! 4. **Enterprise controls** (#660): auth gate, audit sink,
 //!    readiness — each behaves as specified.
 
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use axum::Router;
@@ -98,33 +97,6 @@ fn build_server(service: SkillRestService) -> (TestServer, Arc<VecAuditSink>) {
     (server, sink)
 }
 
-struct TempSkillDir {
-    root: PathBuf,
-}
-
-impl TempSkillDir {
-    fn new() -> Self {
-        let root =
-            std::env::temp_dir().join(format!("dcc-mcp-rest-schema-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(root.join("scripts")).unwrap();
-        Self { root }
-    }
-
-    fn path_string(&self) -> String {
-        self.root.to_string_lossy().into_owned()
-    }
-}
-
-impl Drop for TempSkillDir {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.root);
-    }
-}
-
-fn write(path: &Path, body: &str) {
-    std::fs::write(path, body).unwrap();
-}
-
 // ── High-value scenarios ─────────────────────────────────────────────
 
 /// Goal #1 — agent flow: search then describe then call, with a real
@@ -170,110 +142,6 @@ async fn search_describe_call_round_trip() {
     assert_eq!(out["slug"], slug);
     assert_eq!(out["output"]["name"], "pSphere1");
     assert_eq!(out["output"]["radius"], 2.5);
-}
-
-#[tokio::test]
-async fn repeated_search_does_not_regenerate_missing_tool_schema() {
-    let skill_dir = TempSkillDir::new();
-    let counter = skill_dir.root.join("counter.txt");
-    write(&counter, "0");
-    write(
-        &skill_dir.root.join("SKILL.md"),
-        r#"---
-name: auto-schema-skill
-description: Generates schema from a Python signature.
-allowed-tools: python
-metadata:
-  dcc-mcp:
-    dcc: maya
-    version: "1.0.0"
-    tools: tools.yaml
----
-
-# Auto Schema Skill
-"#,
-    );
-    write(
-        &skill_dir.root.join("tools.yaml"),
-        r#"tools:
-  - name: set_timeline
-    description: Set the playback timeline range.
-    source_file: scripts/set_timeline.py
-"#,
-    );
-    write(
-        &skill_dir.root.join("scripts").join("set_timeline.py"),
-        r#"
-import os
-from pathlib import Path
-
-counter = Path(os.environ["DCC_MCP_E2E_SCHEMA_COUNTER"])
-counter.write_text(str(int(counter.read_text() or "0") + 1))
-
-
-def main(start_frame: int, end_frame: int, playback: bool = False):
-    """Set the playback timeline range."""
-    pass
-"#,
-    );
-
-    let _counter_env =
-        dcc_mcp_test_utils::EnvVarGuard::set("DCC_MCP_E2E_SCHEMA_COUNTER", counter.to_str());
-
-    let registry = Arc::new(ToolRegistry::new());
-    let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
-    let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
-        registry,
-        dispatcher.clone(),
-    ));
-    assert!(catalog.discover(Some(&[skill_dir.path_string()]), Some("maya")) > 0);
-    assert!(catalog.get_skill_info("auto-schema-skill").is_some());
-    let service = SkillRestService::from_catalog_and_dispatcher(catalog, dispatcher);
-    let (server, _) = build_server(service);
-
-    let mut slug = String::new();
-    for _ in 0..2 {
-        let resp = server
-            .post("/v1/search")
-            .json(&json!({
-                "query": "set_timeline",
-                "dcc_type": "maya",
-                "loaded_only": false,
-                "limit": 5
-            }))
-            .await;
-        resp.assert_status_ok();
-        let body: Value = resp.json();
-        let hit = body["hits"]
-            .as_array()
-            .and_then(|hits| {
-                hits.iter()
-                    .find(|hit| hit["action"] == "auto_schema_skill__set_timeline")
-            })
-            .unwrap_or_else(|| panic!("expected auto schema hit, got {body}"));
-        assert_eq!(hit["has_schema"], true);
-        assert!(hit.get("input_schema").is_none());
-        slug = hit["slug"].as_str().expect("slug").to_string();
-    }
-
-    let resp = server
-        .post("/v1/describe")
-        .json(&json!({"tool_slug": slug}))
-        .await;
-    resp.assert_status_ok();
-    let body: Value = resp.json();
-    assert!(
-        body["input_schema"]["properties"]["start_frame"].is_object(),
-        "describe must expose generated schema properties: {body}"
-    );
-    assert!(
-        body["input_schema"]["required"]
-            .as_array()
-            .is_some_and(|required| required.contains(&json!("start_frame"))
-                && required.contains(&json!("end_frame"))),
-        "describe must expose generated required params: {body}"
-    );
-    assert_eq!(std::fs::read_to_string(counter).unwrap(), "1");
 }
 
 /// Goal #2 — MCP and REST must yield identical envelopes for the same

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -427,11 +427,12 @@ impl SkillCatalog {
                 return Err(err);
             }
 
-            // Generate input_schema: prefer tools.yaml if present, otherwise derive from Python signature
+            // Prefer manifest schemas. Runtime Python introspection is opt-in
+            // because importing arbitrary skill scripts during discovery can
+            // spawn DCC host Python processes and run module-level side effects.
             let input_schema = if tool_decl.input_schema.is_null() {
-                // Try to generate schema from Python script signature
                 if let Some(ref script_path) = script_path {
-                    crate::catalog::schema_gen::generate_input_schema(script_path, None)
+                    crate::catalog::schema_gen::generate_input_schema_if_enabled(script_path, None)
                         .unwrap_or_else(|| serde_json::json!({"type": "object"}))
                 } else {
                     serde_json::json!({"type": "object"})
@@ -533,9 +534,8 @@ impl SkillCatalog {
                     .unwrap_or("unknown");
                 let action_name = format!("{}__{}", skill_base, stem.replace('-', "_"));
 
-                // Try to generate schema from Python script signature
                 let input_schema =
-                    crate::catalog::schema_gen::generate_input_schema(script_path, None)
+                    crate::catalog::schema_gen::generate_input_schema_if_enabled(script_path, None)
                         .unwrap_or_else(|| serde_json::json!({"type": "object"}));
 
                 let meta = ToolMeta {

--- a/crates/dcc-mcp-skills/src/catalog/schema_gen.rs
+++ b/crates/dcc-mcp-skills/src/catalog/schema_gen.rs
@@ -1,19 +1,22 @@
-//! Generate JSON Schema from Python script signatures.
+//! Opt-in JSON Schema generation from Python script signatures.
 //!
-//! This module provides functionality to introspect Python scripts and generate
-//! JSON Schema compatible `inputSchema` for MCP tools. It uses a helper Python
-//! script to extract function signatures, type annotations, defaults, and
-//! docstring parameter descriptions.
+//! Runtime skill discovery is manifest-first and does not import or execute
+//! Python scripts unless `DCC_MCP_ENABLE_SCHEMA_INTROSPECTION=1` is set. The
+//! helper path remains for development and migration tooling that needs to
+//! derive `inputSchema` from a script signature before committing it to
+//! `tools.yaml`.
 
 use parking_lot::Mutex;
 use serde_json::Value as JsonValue;
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::DefaultHasher};
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
 use std::time::UNIX_EPOCH;
 
 const HELPER_SOURCE: &str = include_str!("../../scripts/generate_input_schema.py");
+const ENABLE_SCHEMA_INTROSPECTION_ENV: &str = "DCC_MCP_ENABLE_SCHEMA_INTROSPECTION";
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct SchemaCacheKey {
@@ -73,22 +76,46 @@ pub fn generate_input_schema<P: AsRef<Path>>(
     schema
 }
 
+/// Return true when runtime Python schema introspection is explicitly enabled.
+///
+/// The default runtime path is manifest-first: skill authors declare
+/// `input_schema` in `tools.yaml`, like FastMCP/LangChain keep schemas attached
+/// to registered tools. Importing arbitrary skill scripts during discovery is
+/// kept as a development escape hatch because it can spawn DCC host Python
+/// processes and run module-level side effects.
+pub fn schema_introspection_enabled() -> bool {
+    std::env::var(ENABLE_SCHEMA_INTROSPECTION_ENV).is_ok_and(|value| {
+        matches!(
+            value.to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+/// Generate a script-derived schema only when explicitly enabled.
+pub fn generate_input_schema_if_enabled<P: AsRef<Path>>(
+    script_path: P,
+    function_name: Option<&str>,
+) -> Option<JsonValue> {
+    if !schema_introspection_enabled() {
+        return None;
+    }
+    generate_input_schema(script_path, function_name)
+}
+
 fn generate_input_schema_uncached(
     script_path: &Path,
     function_name: Option<&str>,
 ) -> Option<JsonValue> {
     // Try to find Python interpreter (try python first, then python3)
     let python_cmd = find_python_interpreter()?;
+    let helper_path = schema_helper_script_path()?;
 
-    // Build command: python -c <embedded helper> <script_path> [function_name]
-    let mut cmd = Command::new(python_cmd);
-    cmd.arg("-c");
-    cmd.arg(HELPER_SOURCE);
-    cmd.arg(script_path);
-
-    if let Some(func_name) = function_name {
-        cmd.arg(func_name);
-    }
+    // Build command: python <materialized helper> <script_path> [function_name].
+    // Keeping the helper source out of argv prevents DCC process inspectors from
+    // accumulating huge repeated command lines during skill scans.
+    let mut cmd =
+        build_schema_helper_command(&python_cmd, &helper_path, script_path, function_name);
 
     // Execute and capture output
     let output = match cmd.output() {
@@ -133,10 +160,60 @@ fn generate_input_schema_uncached(
     }
 }
 
+fn schema_helper_script_path() -> Option<PathBuf> {
+    static HELPER_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+    HELPER_PATH.get_or_init(materialize_schema_helper).clone()
+}
+
+fn materialize_schema_helper() -> Option<PathBuf> {
+    let mut hasher = DefaultHasher::new();
+    HELPER_SOURCE.hash(&mut hasher);
+    let helper_hash = hasher.finish();
+    let dir = std::env::temp_dir().join("dcc-mcp-core");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!(
+            "Failed to create schema helper temp directory '{}': {}",
+            dir.display(),
+            e
+        );
+        return None;
+    }
+
+    let path = dir.join(format!(
+        "generate_input_schema-{helper_hash:x}-{}.py",
+        std::process::id()
+    ));
+    if let Err(e) = std::fs::write(&path, HELPER_SOURCE) {
+        tracing::warn!(
+            "Failed to materialize schema helper script '{}': {}",
+            path.display(),
+            e
+        );
+        return None;
+    }
+    Some(path)
+}
+
+fn build_schema_helper_command(
+    python_cmd: &str,
+    helper_path: &Path,
+    script_path: &Path,
+    function_name: Option<&str>,
+) -> Command {
+    let mut cmd = Command::new(python_cmd);
+    cmd.arg(helper_path);
+    cmd.arg(script_path);
+    if let Some(func_name) = function_name {
+        cmd.arg(func_name);
+    }
+    cmd
+}
+
 /// Find available Python interpreter.
 ///
-/// The result is cached in a `OnceLock` — the shell-out to `python
-/// --version` only happens once per process lifetime.
+/// `DCC_MCP_PYTHON_EXECUTABLE` is honored first so DCC hosts can use mayapy,
+/// hython, or another host interpreter. The result is cached in a `OnceLock`;
+/// set the env var before the server starts.
 fn find_python_interpreter() -> Option<String> {
     static PYTHON_CMD: OnceLock<Option<String>> = OnceLock::new();
     PYTHON_CMD
@@ -145,6 +222,23 @@ fn find_python_interpreter() -> Option<String> {
 }
 
 fn find_python_interpreter_uncached() -> Option<String> {
+    if let Ok(cmd) = std::env::var("DCC_MCP_PYTHON_EXECUTABLE")
+        && !cmd.trim().is_empty()
+    {
+        if crate::gui_executable::is_gui_executable(Path::new(&cmd)).is_some() {
+            tracing::warn!(
+                "Ignoring DCC_MCP_PYTHON_EXECUTABLE for schema generation because it points to a GUI DCC executable: {}",
+                cmd
+            );
+        } else if Command::new(&cmd)
+            .arg("--version")
+            .output()
+            .is_ok_and(|output| output.status.success())
+        {
+            return Some(cmd);
+        }
+    }
+
     // List of possible Python commands to try (in order of preference)
     let candidates = ["python", "python3", "py"];
 
@@ -181,6 +275,10 @@ pub fn validate_schema_drift(
     defined_schema: &JsonValue,
     script_path: Option<&str>,
 ) -> bool {
+    if !schema_introspection_enabled() {
+        return true;
+    }
+
     let Some(script_path) = script_path else {
         return true; // No script to validate against
     };
@@ -239,6 +337,7 @@ pub fn validate_schema_drift(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dcc_mcp_test_utils::EnvVarsGuard;
     use std::env;
     use std::io::Write;
     use tempfile::NamedTempFile;
@@ -421,24 +520,100 @@ def main(value: int):
 "#,
         );
 
-        let old_counter = env::var_os("DCC_MCP_SCHEMA_COUNTER");
-        unsafe {
-            env::set_var("DCC_MCP_SCHEMA_COUNTER", &counter);
-        }
+        let counter_value = counter.to_string_lossy().into_owned();
+        let _env = EnvVarsGuard::set(&[("DCC_MCP_SCHEMA_COUNTER", Some(counter_value.as_str()))]);
         let first = generate_input_schema(script.path(), Some("main"));
         let second = generate_input_schema(script.path(), Some("main"));
-        if let Some(value) = old_counter {
-            unsafe {
-                env::set_var("DCC_MCP_SCHEMA_COUNTER", value);
-            }
-        } else {
-            unsafe {
-                env::remove_var("DCC_MCP_SCHEMA_COUNTER");
-            }
-        }
 
         assert!(first.is_some());
         assert_eq!(first, second);
+        assert_eq!(std::fs::read_to_string(counter).unwrap(), "1");
+    }
+
+    #[test]
+    fn test_schema_helper_command_uses_materialized_script() {
+        let helper_path = schema_helper_script_path().expect("helper script should materialize");
+        assert!(helper_path.is_file());
+        assert_eq!(
+            std::fs::read_to_string(&helper_path).unwrap(),
+            HELPER_SOURCE
+        );
+
+        let script_path = Path::new("tool.py");
+        let cmd = build_schema_helper_command("python", &helper_path, script_path, Some("main"));
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert!(!args.iter().any(|arg| arg == "-c"));
+        assert!(!args.iter().any(|arg| arg.contains("Generate JSON Schema")));
+        assert_eq!(args[0], helper_path.to_string_lossy());
+        assert_eq!(args[1], script_path.to_string_lossy());
+        assert_eq!(args[2], "main");
+    }
+
+    #[test]
+    fn test_schema_introspection_is_opt_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let counter = dir.path().join("counter.txt");
+        std::fs::write(&counter, "0").unwrap();
+        let script = create_test_script(
+            r#"
+import os
+from pathlib import Path
+
+counter = Path(os.environ["DCC_MCP_SCHEMA_COUNTER"])
+counter.write_text(str(int(counter.read_text() or "0") + 1))
+
+
+def main(value: int):
+    pass
+"#,
+        );
+
+        let counter_value = counter.to_string_lossy().into_owned();
+        let _env = EnvVarsGuard::set(&[
+            ("DCC_MCP_ENABLE_SCHEMA_INTROSPECTION", None),
+            ("DCC_MCP_SCHEMA_COUNTER", Some(counter_value.as_str())),
+        ]);
+
+        assert!(generate_input_schema_if_enabled(script.path(), Some("main")).is_none());
+        assert_eq!(std::fs::read_to_string(counter).unwrap(), "0");
+    }
+
+    #[test]
+    fn test_schema_introspection_opt_in_runs_helper() {
+        if Command::new("python").arg("--version").output().is_err() {
+            eprintln!("Skipping test: Python interpreter not found in PATH");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let counter = dir.path().join("counter.txt");
+        std::fs::write(&counter, "0").unwrap();
+        let script = create_test_script(
+            r#"
+import os
+from pathlib import Path
+
+counter = Path(os.environ["DCC_MCP_SCHEMA_COUNTER"])
+counter.write_text(str(int(counter.read_text() or "0") + 1))
+
+
+def main(value: int):
+    pass
+"#,
+        );
+
+        let counter_value = counter.to_string_lossy().into_owned();
+        let _env = EnvVarsGuard::set(&[
+            ("DCC_MCP_ENABLE_SCHEMA_INTROSPECTION", Some("1")),
+            ("DCC_MCP_SCHEMA_COUNTER", Some(counter_value.as_str())),
+        ]);
+
+        let schema = generate_input_schema_if_enabled(script.path(), Some("main"));
+        assert!(schema.is_some());
         assert_eq!(std::fs::read_to_string(counter).unwrap(), "1");
     }
 }

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -324,6 +324,13 @@ decl = ToolDeclaration(
 | `defer_loading` | `bool` | `False` | Accepts `defer-loading` / `defer_loading` in SKILL.md and marks the declaration as discovery-oriented |
 | `source_file` | `str` | `""` | Explicit path to the script (relative to skill dir) |
 
+Runtime discovery is manifest-first: if `input_schema` is omitted, loaded and
+unloaded tool metadata falls back to `{"type": "object"}`. Core does not import
+or execute tool scripts to infer schemas during normal DCC startup, search, or
+describe calls. Set `DCC_MCP_ENABLE_SCHEMA_INTROSPECTION=1` only as a
+development/migration aid, then copy the generated schema into `tools.yaml` or
+register it through `ToolSpec`.
+
 ### Deriving `input_schema` / `output_schema` from Python types (#242)
 
 Hand-writing JSON Schema is error-prone — agent-authored actions drift,
@@ -388,6 +395,10 @@ spell containers and unions with `typing.List`, `typing.Dict`,
 The core package still imports without third-party Python library dependencies. Unsupported
 types raise `TypeError` with a clear escape hatch: pass an explicit
 `input_schema=...` dict or use pydantic's `MyModel.model_json_schema()`.
+
+This helper is for Python registration-time authoring (`ToolSpec`) and offline
+schema generation. It is not part of the default file-based skill discovery
+path, which intentionally avoids importing arbitrary DCC scripts.
 
 ::: tip Why not pydantic?
 We intentionally stay free of third-party Python library dependencies. Adding `pydantic` for this one

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -117,6 +117,9 @@ Generated `tools.yaml` entries follow the modern contract:
   not repo names or prose-only instructions. Use it when one skill must be
   discovered or loaded before another, for example `depends: ["qt-ui-inspector"]`.
 - `input_schema` and `output_schema` are declared explicitly.
+- Runtime discovery never imports or executes tool scripts to infer missing
+  schemas by default. Treat Python-derived schemas as an authoring-time helper:
+  generate them before publishing, then commit the JSON Schema to `tools.yaml`.
 - Keep MCP-facing `input_schema` shapes simple: prefer a top-level object with
   `properties`, `required`, primitive `type`, bounds, and descriptions. Put
   mutually exclusive forms, conditional requirements, and cross-field rules in
@@ -134,7 +137,7 @@ Generated `tools.yaml` entries follow the modern contract:
 2. Give the skill a kebab-case name and each local tool a snake_case name.
 3. Keep host API calls inside scripts, with lazy imports so discovery works without the host running.
 4. Import dependency-light runtime helpers from `dcc_mcp_core.skills_helper` first: JSON/YAML codecs, bounded HTTP helpers, safe file/path helpers, validation, cancellation checks, and result helpers.
-5. Declare `metadata.dcc-mcp.depends` for prerequisite skills, then declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`. For high-frequency tools, add `call_examples` so agents can copy argument payloads without trial-and-error.
+5. Declare `metadata.dcc-mcp.depends` for prerequisite skills, then declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`. Do not rely on runtime Python introspection for missing schemas. For high-frequency tools, add `call_examples` so agents can copy argument payloads without trial-and-error.
 6. Put long examples, recipes, and host-specific notes under `references/`.
 7. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before loading it in an adapter.
 8. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.

--- a/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
+++ b/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
@@ -14,6 +14,11 @@ Use this checklist for every `tools.yaml` entry.
 - `timeout_hint_secs`: realistic upper bound for dispatch and UX.
 - `annotations`: MCP safety hints.
 
+Runtime discovery is manifest-first. Missing `input_schema` falls back to a
+permissive `{"type": "object"}` instead of importing or executing the script.
+If you derive schemas from Python annotations, do it while authoring and write
+the result into `tools.yaml`.
+
 ## Recovery Chains
 
 Domain tools should include `next-tools.on-failure` entries that point to


### PR DESCRIPTION
## Summary
- make runtime skill discovery manifest-first for missing tool schemas
- gate Python schema introspection behind DCC_MCP_ENABLE_SCHEMA_INTROSPECTION=1
- materialize the schema helper script instead of passing it through python -c
- update skill authoring guidance and regression coverage

## Validation
- vx cargo fmt --check
- vx cargo test -p dcc-mcp-skill-rest --lib
- vx cargo test -p dcc-mcp-skills --lib
- pre-commit cargo clippy