### PR TITLE
fix(gateway): collapse nested if for clippy::collapsible_if

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/capability/search_cache.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/search_cache.rs
@@ -166,11 +166,11 @@ impl SearchCache {
             cache.pop(key);
             return None;
         }
-        if let Some(current_gen) = current_index_gen {
-            if entry.index_generation != current_gen {
-                cache.pop(key);
-                return None;
-            }
+        if let Some(current_gen) = current_index_gen
+            && entry.index_generation != current_gen
+        {
+            cache.pop(key);
+            return None;
         }
         Some(entry.body.clone())
     }


### PR DESCRIPTION
## Summary

Fixes the `clippy::collapsible_if` lint violation in `search_cache.rs:169`
that is blocking PR #1781 on `Rust (ubuntu-latest)`.

Collapses the nested `if` inside `if let` into `if let ... && ...`.

## Changes

- `crates/dcc-mcp-gateway/src/gateway/capability/search_cache.rs`: collapse
  nested if block to satisfy `-D clippy::collapsible-if`

## Test Plan

- [ ] CI clippy check should pass on this branch
- [ ] PR #1781 can merge after this fix is applied