### PR TITLE
fix(core): strip _meta from params before Python handler dispatch

### DIFF
--- a/crates/dcc-mcp-actions/src/python/mod.rs
+++ b/crates/dcc-mcp-actions/src/python/mod.rs
@@ -397,6 +397,12 @@ impl PyToolDispatcher {
             }
         }
 
+        // 2c. Strip _meta before calling Python handlers to prevent
+        // gateway metadata from leaking into skill implementations.
+        if let Value::Object(ref mut map) = params {
+            map.remove("_meta");
+        }
+
         // 3. Call the Python handler
         if let Err(veto) = self.emit_vetoable_tool_event(
             "tool.dispatched",


### PR DESCRIPTION
## Summary

Gateway `_meta` metadata injected into `params` after validation (step 2b in `PyToolDispatcher::dispatch()`) was leaking into Python skill implementations because the full `params` dict — including `_meta` — was passed directly to the Python handler.

This is the root cause of PIP-2423 (Maya adapter TypeError). Maya added a local filter in `9cf9ea1` as a workaround; this fix addresses the issue at the core layer so all adapters benefit.

## Change

`crates/dcc-mcp-actions/src/python/mod.rs` — add step 2c to strip `_meta` from `params` before `handler.call1()`.

Rust handlers (`ToolDispatcher::dispatch()`) are unaffected — they use a separate code path in `dispatcher.rs`.

## Validation

- `cargo test --lib -p dcc-mcp-actions`: 253 passed, 0 failed
- Pre-push `cargo fmt --all -- --check` passes

## Next steps

After this PR merges and a new `dcc-mcp-core` release is cut, affected adapters (3dsmax, blender, houdini) can upgrade their dependency and remove local filtering. Maya's existing local filter (`9cf9ea1`) becomes redundant.

Fixes PIP-2492.