### PR TITLE
docs: add phase hook signature consistency check to code-review checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,6 +408,7 @@ restarts because the field is `#[serde(default)]`.
 10. **Lifecycle hooks — `off()` removes by identity (`is`), not equality** → store the handler reference; `hooks.off(event, lambda ctx: ...)` never matches (#1337)
 11. **Agent memory — `MemoryRecorder.install()` must be called** → the recorder does nothing until wired to a `LifecycleHooks` instance; forgetting `install()` means zero memory is recorded (#1334)
 12. **Agent memory — raw prompts are redacted** → never pass LLM prompts or `api_key`/`password`/`secret`/`token` keys in `MemoryEntry.payload`; the `_safe_payload` filter strips them (#1334)
+13. **Phase hook signature mismatch** → `_registration.py` calls 3 hooks with `(context)` and 7 with no args. Overriding a hook with the wrong parameter count silently fails because `run_registration_phases` catches non-fatal exceptions. Always run an integration test that calls `get_standard_phases()` against your real server class (not `MockServer`) and assert no `TypeError` (PIP-2479). See [`tests/test_phase_hook_signature_consistency.py`](tests/test_phase_hook_signature_consistency.py) for the static check.
 
 Full trap list + code examples → [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md)
 

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -574,6 +574,43 @@ assert 0.0 <= stats["summary_hit_rate"] <= 1.0
 
 ---
 
+**Phase hook signature mismatch — non-fatal, CI-invisible (PIP-2479, PIP-2468):**
+
+``_registration.py`` dispatches phase hooks with calling conventions that
+vary by phase — 3 hooks receive a ``RegistrationContext`` argument and 7
+receive nothing. If an adapter override has the wrong parameter count,
+``run_registration_phases`` catches the ``TypeError`` as non-fatal
+(``except Exception`` at line 80 of ``_registration.py``), logs it, and
+continues — the tools for that phase silently fail to register.
+
+```python
+# server_base.py — definition (DccServerBase)
+def _register_introspect_tools(self) -> None:      # ← no `context` arg
+    ...
+
+# _registration.py — call site (IntrospectToolsPhase.run)
+server._register_introspect_tools()                 # ← 0 args passed
+
+# Adapting override with wrong signature:
+def _register_introspect_tools(self, context): ...  # ← TypeError at runtime!
+# → caught as non-fatal by run_registration_phases → phase marked failed
+# → tools never registered → CI still GREEN because test uses MockServer
+```
+
+**Prevention:**
+
+1. **Static**: verify that every ``DccServerBase`` phase hook method signature
+   matches its caller in ``_registration.py`` — see
+   ``tests/test_phase_hook_signature_consistency.py`` for the automated check.
+2. **Integration**: every adapter must have at least one test that runs
+   ``get_standard_phases()`` against the real server class (not ``MockServer``)
+   and asserts no ``TypeError``.
+3. **Code review**: before approving PRs that touch registration or phase hooks,
+   check that the caller signature in ``_registration.py`` matches the hook
+   definition in ``server_base.py`` (or the adapter subclass).
+
+---
+
 ## Do and Don't — Full Reference
 
 ### Do ✅

--- a/tests/test_phase_hook_signature_consistency.py
+++ b/tests/test_phase_hook_signature_consistency.py
@@ -1,0 +1,196 @@
+"""Verify phase hook method signatures match between server_base.py and _registration.py.
+
+This prevents silent TypeError at registration time (PIP-2479, PIP-2468).
+``run_registration_phases`` catches phase exceptions as non-fatal, so a
+signature mismatch between a ``DccServerBase`` phase hook and the caller in
+``_registration.py`` does NOT fail CI — it silently skips registration for
+those tools.
+
+These tests use AST parsing and never import ``DccServerBase``, so they work
+without a built ``dcc_mcp_core._core`` binary.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SERVER_BASE = _PROJECT_ROOT / "python" / "dcc_mcp_core" / "server_base.py"
+_REGISTRATION = _PROJECT_ROOT / "python" / "dcc_mcp_core" / "_registration.py"
+
+
+def _get_method_param_count(file: Path, class_name: str, method_name: str) -> int:
+    """Return the number of positional parameters for *method_name* on *class_name*.
+
+    ``self`` is included in the count so callers know how many total
+    positional args the function expects.
+    """
+    with open(file, "rb") as f:
+        tree = ast.parse(f.read())
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                    # Count plain positional args (includes self)
+                    return len(
+                        [a for a in item.args.args if a.arg != "self"]
+                    )
+            break
+    msg = f"Method {class_name}.{method_name} not found in {file}"
+    raise ValueError(msg)
+
+
+def _get_non_self_param_count(file: Path, class_name: str, method_name: str) -> int:
+    """Return the number of required positional params excluding ``self``."""
+    with open(file, "rb") as f:
+        tree = ast.parse(f.read())
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                    defaults = item.args.defaults or []
+                    arg_names = [a.arg for a in item.args.args if a.arg != "self"]
+                    # Required = total non-self params minus default-valued ones
+                    ndefaults = len(defaults)
+                    return max(0, len(arg_names) - ndefaults)
+            break
+    msg = f"Method {class_name}.{method_name} not found in {file}"
+    raise ValueError(msg)
+
+
+# -- phase hooks called WITH a RegistrationContext argument -------------------
+
+CONTEXT_HOOKS: tuple[str, ...] = (
+    "_register_core_builtin_actions",
+    "_run_strict_skill_scan_phase",
+    "_register_metadata_driven_tools",
+)
+
+# -- phase hooks called WITH NO arguments (only self) ------------------------
+
+NO_ARG_HOOKS: tuple[str, ...] = (
+    "_register_introspect_tools",
+    "_register_feedback_tool",
+    "_register_qt_ui_inspector",
+    "_register_capability_manifest_tool",
+    "_attach_project_tools",
+    "_attach_resources",
+    "_mark_skill_catalog_ready",
+)
+
+
+class TestPhaseHookSignatureConsistency:
+    """Every ``DccServerBase`` phase hook must match its caller in ``_registration.py``.
+
+    ``_registration.py`` dispatch:
+      - ``CoreBuiltinActionsPhase``:     ``server._register_core_builtin_actions(context)``
+      - ``StrictSkillScanPhase``:        ``server._run_strict_skill_scan_phase(context)``
+      - ``MetadataDrivenToolsPhase``:    ``server._register_metadata_driven_tools(context)``
+      - ``IntrospectToolsPhase``:        ``server._register_introspect_tools()``
+      - ``FeedbackToolPhase``:           ``server._register_feedback_tool()``
+      - ``QtUiInspectorPhase``:          ``server._register_qt_ui_inspector()``
+      - ``CapabilityManifestPhase``:     ``server._register_capability_manifest_tool()``
+      - ``ProjectToolsPhase``:           ``server._attach_project_tools()``
+      - ``ResourcesPhase``:              ``server._attach_resources()``
+      - ``SkillCatalogReadyPhase``:      ``server._mark_skill_catalog_ready()``
+    """
+
+    def test_context_hooks_accept_one_arg(self) -> None:
+        """Hooks dispatched with a ``RegistrationContext`` must accept exactly one required arg."""
+        for hook_name in CONTEXT_HOOKS:
+            count = _get_non_self_param_count(_SERVER_BASE, "DccServerBase", hook_name)
+            assert count == 1, (
+                f"{hook_name} is called with (context) in _registration.py "
+                f"but its definition in DccServerBase expects {count} "
+                f"positional args (expected 1)"
+            )
+
+    def test_no_arg_hooks_accept_zero_args(self) -> None:
+        """Hooks dispatched with no arguments must not require any positional args beyond self."""
+        for hook_name in NO_ARG_HOOKS:
+            count = _get_non_self_param_count(_SERVER_BASE, "DccServerBase", hook_name)
+            assert count == 0, (
+                f"{hook_name} is called with no arguments in _registration.py "
+                f"but its definition in DccServerBase expects {count} "
+                f"positional args (expected 0)"
+            )
+
+    def test_all_standard_phase_hooks_are_covered(self) -> None:
+        """Every phase-like method on DccServerBase is listed in one of the two groups."""
+        with open(_SERVER_BASE, "rb") as f:
+            tree = ast.parse(f.read())
+
+        dcc_base_methods: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "DccServerBase":
+                for item in node.body:
+                    if isinstance(item, ast.FunctionDef):
+                        nm = item.name
+                        if nm.startswith("_register_") or nm.startswith(  # noqa: SIM114
+                            "_run_"
+                        ) or nm.startswith("_attach_") or nm.startswith("_mark_"):
+                            dcc_base_methods.add(nm)
+                break
+
+        # Explicitly exclude helpers that are not phase hooks
+        non_phase: set[str] = {"_register_builtin_skills"}
+        phase_methods = dcc_base_methods - non_phase
+        covered = set(CONTEXT_HOOKS) | set(NO_ARG_HOOKS)
+        missing = sorted(phase_methods - covered)
+        assert not missing, (
+            f"Phase hook methods {missing} are not covered by the "
+            f"signature consistency check. Either add them to the "
+            f"appropriate group in this test, or exclude them explicitly."
+        )
+
+    def test_all_registration_calls_match_dcc_server_base(self) -> None:
+        """Verify each phase in _registration.py calls with the arg count that DccServerBase defines."""
+        # Map: phase hook name → expected non-self positional parameters from _registration.py
+        registration_calls: dict[str, int] = {}
+        with open(_REGISTRATION, "rb") as f:
+            tree = ast.parse(f.read())
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            # Look for RegistrationPhase subclasses with a run() method that makes server calls
+            for item in node.body:
+                if not (isinstance(item, ast.FunctionDef) and item.name == "run"):
+                    continue
+                for child in ast.walk(item):
+                    if (
+                        isinstance(child, ast.Call)
+                        and isinstance(child.func, ast.Attribute)
+                        and isinstance(child.func.value, ast.Attribute)
+                        and child.func.value.attr == "server"
+                    ):
+                        method_name = child.func.attr
+                        n_args = len(child.args)
+                        registration_calls.setdefault(method_name, n_args)
+                        # Verify consistency: all calls to the same method should
+                        # pass the same number of arguments
+                        assert (
+                            registration_calls[method_name] == n_args
+                        ), (
+                            f"Inconsistent calls to {method_name}: "
+                            f"expected {registration_calls[method_name]} args, "
+                            f"got {n_args}"
+                        )
+
+        covered = set(CONTEXT_HOOKS) | set(NO_ARG_HOOKS)
+        for method_name, call_args in registration_calls.items():
+            # Skip methods not defined on DccServerBase (e.g. _readiness.mark_skill_catalog_ready)
+            try:
+                defined_args = _get_non_self_param_count(
+                    _SERVER_BASE, "DccServerBase", method_name
+                )
+            except ValueError:
+                continue  # method is not on DccServerBase, skip
+            assert defined_args == call_args, (
+                f"_registration.py calls {method_name} with {call_args} arg(s) "
+                f"but DccServerBase defines it with {defined_args} non-self "
+                f"param(s). This will raise TypeError at runtime."
+            )


### PR DESCRIPTION
## Summary

- Add `tests/test_phase_hook_signature_consistency.py` — static AST-based verification that every `DccServerBase` phase hook method signature matches the caller in `_registration.py`
- Add Trap #13 to `AGENTS.md` Top Traps — phase hook signature mismatch
- Add detailed trap with code example to `docs/guide/agents-reference.md`

This prevents the scenario from PIP-2468/PIP-2479 where 7 phase hooks silently fail to register because of `(self)` vs `(self, context)` signature mismatch, without failing CI (since `run_registration_phases` catches non-fatal exceptions).

## Validation

- All 4 test cases pass without requiring the Rust binary (AST-based)
- Pre-existing test suite unaffected
- `git diff` shows only the intended changes