### PR TITLE
fix: suppress cargo-deny advisory RUSTSEC-2026-{0002,0176,0177}

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,15 @@ ignore = [
     # anyhow 1.0.x (≤1.0.102): `Error::downcast_mut()` UB with nested context.
     # Tracked in https://github.com/dtolnay/anyhow/issues/451; fix expected in 1.0.103+.
     "RUSTSEC-2026-0190",
+    # lru 0.15.0: `IterMut` violates Stacked Borrows (unsound).
+    # Upstream fix tracked at https://github.com/jeromefroe/lru-rs/issues/203.
+    "RUSTSEC-2026-0002",
+    # pyo3 0.28.3: `PyList`/`PyTuple` iterator OOB read in `nth`/`nth_back` (vulnerability).
+    # Fixed in pyo3 0.28.4; pinned dep on fastembed-side.
+    "RUSTSEC-2026-0176",
+    # pyo3 0.28.3: `PyCFunction::new_closure` missing `Sync` bound (vulnerability).
+    # Fixed in pyo3 0.28.4; pinned dep on fastembed-side.
+    "RUSTSEC-2026-0177",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Add 3 cargo-deny advisory ignores to unblock main CI and release PR #1776:

- `RUSTSEC-2026-0002` — lru `IterMut` Stacked Borrows (unsound)
- `RUSTSEC-2026-0176` — pyo3 `PyList`/`PyTuple` iterator OOB read (vulnerability)
- `RUSTSEC-2026-0177` — pyo3 `PyCFunction::new_closure` missing `Sync` bound (vulnerability)

All three are upstream dependency issues (lru 0.15.0 + pyo3 0.28.3) with no code-level fix in dcc-mcp-core. Follows the PIP-2153 pattern (commit `888827e1`).

## Test plan

- [x] cargo fmt --check passed in pre-push hook
- [x] Main CI should go green after merge, unblocking PR #1776