### PR TITLE
fix(python): strip _-prefixed internal keys before calling Python handlers

### DIFF
--- a/crates/dcc-mcp-actions/src/pipeline/python/pipeline.rs
+++ b/crates/dcc-mcp-actions/src/pipeline/python/pipeline.rs
@@ -271,6 +271,11 @@ impl PyToolPipeline {
                 let handler = self.handler_map.get(action_name).ok_or_else(|| {
                     pyo3::exceptions::PyKeyError::new_err(format!("no handler for '{action_name}'"))
                 })?;
+                // Strip _-prefixed internal keys (e.g. _meta) before passing to Python handlers
+                // to avoid TypeError when the handler does not accept **kwargs.
+                if let Value::Object(ref mut map) = params {
+                    map.retain(|k, _| !k.starts_with('_'));
+                }
                 let py_params = value_to_py(py, &params)?;
                 let raw = handler.call1(py, (py_params,)).map_err(|e| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!("handler error: {e}"))

--- a/crates/dcc-mcp-actions/src/python/mod.rs
+++ b/crates/dcc-mcp-actions/src/python/mod.rs
@@ -397,12 +397,6 @@ impl PyToolDispatcher {
             }
         }
 
-        // 2c. Strip _meta before calling Python handlers to prevent
-        // gateway metadata from leaking into skill implementations.
-        if let Value::Object(ref mut map) = params {
-            map.remove("_meta");
-        }
-
         // 3. Call the Python handler
         if let Err(veto) = self.emit_vetoable_tool_event(
             "tool.dispatched",
@@ -420,6 +414,11 @@ impl PyToolDispatcher {
             return Err(pyo3::exceptions::PyPermissionError::new_err(message));
         }
         let handler = self.handler_map.get(action_name).expect("checked above");
+        // Strip _-prefixed internal keys (e.g. _meta) before passing to Python handlers
+        // to avoid TypeError when the handler does not accept **kwargs.
+        if let Value::Object(ref mut map) = params {
+            map.retain(|k, _| !k.starts_with('_'));
+        }
         let py_params = value_to_py(py, &params)?;
         let raw = handler.call1(py, (py_params,)).map_err(|e| {
             self.emit_tool_failed(


### PR DESCRIPTION
## Problem

When the gateway forwards MCP tool calls to DCC adapters, the Rust `ToolDispatcher` injects `_meta` into params (for Rust handler context). When these params are forwarded to Python handlers via `PyToolDispatcher`, the `_meta` key causes `TypeError` for any skill whose `main()` does not accept `**kwargs`.

This was discovered during release smoke testing (PIP-2423) where gateway REST calls to Maya skills crashed with:
```
TypeError: create_sphere() got an unexpected keyword argument '_meta'
```

## Fix

Strip all `_`-prefixed keys from params before calling Python handlers in:
- `PyToolDispatcher::dispatch()` (main dispatch path)
- `PyToolPipeline` (pipeline path)

This is the **core-level fix** that benefits all DCC adapters (Maya, 3ds Max, Blender, Houdini) automatically — a single fix instead of per-adapter workarounds.

## Affected adapters

| Adapter | Previous fix | After this PR |
|---------|-------------|---------------|
| dcc-mcp-maya | Workaround in `_executor.py` | Redundant (core handles it) |
| dcc-mcp-3dsmax | None | **Fixed** |
| dcc-mcp-blender | None | **Fixed** |
| dcc-mcp-houdini | None | **Fixed** |

## Testing

All 253 existing tests pass:
```
test result: ok. 253 passed; 0 failed; 0 ignored
```

## Related

- PIP-2423: [dcc-mcp-maya] gateway _meta leak causing TypeError
- Maya adapter fix: loonghao/dcc-mcp-maya@9cf9ea1 (redundant after this PR)