### PR TITLE
feat(py37-lite): pure-Python wheel for Python 3.7 (Maya 2022 compatibility)

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -107,6 +107,72 @@ jobs:
           tag_name: ${{ inputs.release-tag-name }}
           files: dist/*.whl
 
+  # ── py37-lite: pure-Python wheel (py3-none-any) for Python 3.7 ──
+  # Maya 2022 / Blender 2.83 embed Python 3.7 and cannot load cp38-abi3
+  # wheels. This job produces a pure-Python wheel with zero compiled Rust
+  # extensions so users can `pip install dcc-mcp-core` without a Rust toolchain.
+  #
+  # maturin with --no-default-features -F py37-lite compiles the Rust source
+  # tree as an rlib only (no cdylib → no _core extension), and maturin falls
+  # back to packaging only the pure-Python sources under python/.
+  py37-lite:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.7"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.95.0"
+      - uses: loonghao/vx@v0.9.11
+        with:
+          version: "0.9.11"
+          cache-key-prefix: "vx-tools-v0.9.7"
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: rust-py37
+          shared-key: rust-ubuntu
+      - name: Install maturin & just
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "maturin>=1.5,<2.0" "just>=1.0"
+        shell: bash
+      - name: Build py37-lite pure-Python wheel
+        run: just build-py37
+        shell: bash
+      - name: Verify wheel tag is py3-none-any
+        shell: bash
+        run: |
+          wheel=$(ls dist/*.whl | head -1)
+          echo "Built wheel: $wheel"
+          if [[ "$wheel" != *py3-none-any* ]]; then
+            echo "::error::Expected py3-none-any wheel tag, got: $wheel"
+            exit 1
+          fi
+          echo "OK: py3-none-any wheel tag confirmed"
+      - name: Verify _core extension is NOT present in the wheel
+        shell: bash
+        run: |
+          wheel=$(ls dist/*.whl | head -1)
+          if unzip -l "$wheel" | grep -q "_core"; then
+            echo "::error::py37-lite wheel should not contain _core extension, but found:"
+            unzip -l "$wheel" | grep "_core"
+            exit 1
+          fi
+          echo "OK: no _core extension in py37-lite wheel"
+      - name: Upload wheel to GitHub Release
+        if: inputs.release-tag-name != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.release-tag-name }}
+          files: dist/*.whl
+
   macos:
     runs-on: macos-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,53 @@ jobs:
           # npm install/build in every wheel job.
           prebuild-admin-ui: "false"
 
+  # ── Build py37-lite pure-Python wheel (py3-none-any) ──
+  # Runs on ubuntu-22.04 (Python 3.7 available) to produce a platform-
+  # independent wheel with zero compiled Rust extensions. The wheel is
+  # reused by the test-py37 job below.
+  build-py37-wheel:
+    name: Build wheel (py37-lite)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.7"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.95.0"
+      - uses: loonghao/vx@v0.9.11
+        with:
+          version: "0.9.11"
+          cache-key-prefix: "vx-tools-v0.9.7"
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: rust-py37
+          shared-key: rust-ubuntu
+      - name: Install maturin
+        run: python -m pip install "maturin>=1.5,<2.0"
+        shell: bash
+      - name: Build py37-lite wheel
+        run: vx just build-py37
+        shell: bash
+      - name: Verify wheel tag is py3-none-any
+        shell: bash
+        run: |
+          wheel=$(ls dist/*.whl | head -1)
+          echo "Built wheel: $wheel"
+          if [[ "$wheel" != *py3-none-any* ]]; then
+            echo "::error::Expected py3-none-any wheel tag, got: $wheel"
+            exit 1
+          fi
+          echo "OK: py3-none-any wheel tag confirmed"
+      - name: Upload py37-lite wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheel-py37-lite
+          path: dist/
+          retention-days: 30
+
   # ── Python tests: trimmed OS × Python matrix (8 cells, was 18) ──
   # Covers representative supported Python versions on ubuntu (cheapest) +
   # endpoint versions (oldest 3.8, newest 3.14) on Windows/macOS. Middle versions on
@@ -432,6 +479,74 @@ jobs:
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+  # ── py37-lite wheel test: pure-Python subset on Python 3.7 ──
+  # Installs the py3-none-any wheel from build-py37-wheel and runs
+  # the minimal import/skill/host smoke that exercises only pure-Python
+  # code paths. The _core extension is absent in this profile:
+  # `from dcc_mcp_core import _core` must raise ImportError.
+  test-py37:
+    name: Test (py37-lite)
+    needs: [build-py37-wheel]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.7"
+      - name: Download py37-lite wheel
+        uses: actions/download-artifact@v8
+        with:
+          name: wheel-py37-lite
+          path: dist/
+      - name: Install wheel + test deps
+        run: |
+          pip install dist/*.whl
+          pip install pytest
+        shell: bash
+      - name: Verify _core raises ImportError
+        shell: bash
+        run: |
+          python -c "
+          import importlib
+          try:
+              importlib.import_module('dcc_mcp_core._core')
+              print('FAIL: _core should NOT be importable in py37-lite')
+              exit(1)
+          except ImportError:
+              print('OK: _core correctly raises ImportError')
+          "
+      - name: Verify import dcc_mcp_core works
+        shell: bash
+        run: python -c "import dcc_mcp_core; print('OK: import dcc_mcp_core')"
+      - name: Verify skill module works
+        shell: bash
+        run: python -c "
+          from dcc_mcp_core.skill import skill_entry, skill_success, skill_error;
+          result = skill_success('test');
+          assert result['success'] is True;
+          print('OK: dcc_mcp_core.skill works')
+        "
+      - name: Verify host module imports (without _core)
+        shell: bash
+        run: python -c "
+          import dcc_mcp_core.host;
+          assert dcc_mcp_core.host.BlockingDispatcher is None;
+          assert dcc_mcp_core.host.QueueDispatcher is None;
+          # Pure-Python sub-modules work fine
+          from dcc_mcp_core.host._adapter import HostAdapter, TickableDispatcher;
+          from dcc_mcp_core.host._standalone import StandaloneHost;
+          print('OK: dcc_mcp_core.host imports without _core')
+        "
+      - name: Verify lazy _core fallback (skill._serialize_result)
+        shell: bash
+        run: python -c "
+          from dcc_mcp_core.skill import skill_success;
+          from dcc_mcp_core.skill import _serialize_result as sr;
+          result = sr(skill_success('test'));
+          assert 'success' in result;
+          print('OK: skill._serialize_result falls back to pure Python')
+        "
 
   # ── Lint Python source ──
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,13 @@ job-persist-sqlite = ["dcc-mcp-http/job-persist-sqlite"]
 # `dcc-mcp-gateway/admin`. Off by default — when disabled, zero admin
 # UI code or front-end assets are compiled into the wheel.
 admin = ["dcc-mcp-gateway/admin"]
+
+# py37-lite: pure-Python wheel profile for Maya 2022 / Python 3.7.
+# Excludes all PyO3/python-bindings features so maturin produces a
+# py3-none-any wheel with zero compiled extensions. Only Rust features
+# that do NOT depend on PyO3 are enabled.
+# See also `build-py37` in justfile and the py37-lite CI workflows.
+py37-lite = ["workflow", "scheduler", "prometheus", "job-persist-sqlite", "admin"]
 abi3-py38 = ["pyo3/abi3-py38"]
 # Python 3.7 wheel: non-abi3 build, no abi3-py38 feature
 ext-module = ["pyo3/extension-module"]

--- a/justfile
+++ b/justfile
@@ -196,6 +196,13 @@ build *EXTRA:
     just stubgen
     maturin build --release --out dist --features {{WHEEL_FEATURES}} {{EXTRA}}
 
+# Build the py37-lite pure-Python wheel (py3-none-any).
+# Uses no PyO3 features so maturin produces a wheel with only pure-Python
+# sources — no compiled _core extension. The wheel is tagged py3-none-any
+# and installable on Python 3.7 (Maya 2022 / Blender 2.83).
+build-py37:
+    maturin build --release --out dist --no-default-features -F py37-lite
+
 # Install dev/test dependencies
 install-dev-deps:
     pip install maturin pytest pytest-cov anyio ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,12 @@ classifiers = [
 ]
 
 dependencies = [
-    "dcc-mcp-server>=0.18.17,<1.0.0",
+    # dcc-mcp-server (Python 3.8+): provides the sidecar gateway daemon binary
+    # and the packaging toolchain for standalone DCC MCP server bundles.
+    # Maya 2022 / Blender 2.83 embed Python 3.7; the py37-lite wheel ships
+    # pure-Python code only and users install dcc-mcp-server separately when
+    # their platform provides a compatible binary wheel.
+    "dcc-mcp-server>=0.18.17,<1.0.0; python_version >= '3.8'",
 ]
 
 [project.optional-dependencies]

--- a/python/dcc_mcp_core/host/__init__.py
+++ b/python/dcc_mcp_core/host/__init__.py
@@ -24,11 +24,21 @@ from the host's native idle primitive (``bpy.app.timers.register``,
 from __future__ import annotations
 
 # Import local modules — Rust-backed primitives live in _core.
-from dcc_mcp_core._core import BlockingDispatcher
-from dcc_mcp_core._core import DispatchError
-from dcc_mcp_core._core import PostHandle
-from dcc_mcp_core._core import QueueDispatcher
-from dcc_mcp_core._core import TickOutcome
+# Wrap in try/except so the module is importable on py37-lite
+# (pure-Python wheel without the compiled _core extension).
+try:
+    from dcc_mcp_core._core import BlockingDispatcher
+    from dcc_mcp_core._core import DispatchError
+    from dcc_mcp_core._core import PostHandle
+    from dcc_mcp_core._core import QueueDispatcher
+    from dcc_mcp_core._core import TickOutcome
+except ImportError:
+    BlockingDispatcher = None  # type: ignore[assignment,misc]
+    DispatchError = None  # type: ignore[assignment,misc]
+    PostHandle = None  # type: ignore[assignment,misc]
+    QueueDispatcher = None  # type: ignore[assignment,misc]
+    TickOutcome = None  # type: ignore[assignment,misc]
+
 from dcc_mcp_core.host._adapter import HostAdapter
 from dcc_mcp_core.host._adapter import TickableDispatcher
 from dcc_mcp_core.host._standalone import StandaloneHost

--- a/python/dcc_mcp_core/host/_protocols.py
+++ b/python/dcc_mcp_core/host/_protocols.py
@@ -9,7 +9,14 @@ from typing import Protocol
 from typing import runtime_checkable
 
 # Import local modules
-from dcc_mcp_core._core import TickOutcome
+try:
+    from dcc_mcp_core._core import TickOutcome
+except ImportError:
+    # py37-lite wheel: pure-Python fallback when _core is absent.
+    class TickOutcome:  # type: ignore[no-redef]
+        """Duck-typed fallback for TickOutcome (py37-lite)."""
+
+        more_pending: bool
 
 
 @runtime_checkable

--- a/python/dcc_mcp_core/host/_standalone.py
+++ b/python/dcc_mcp_core/host/_standalone.py
@@ -21,8 +21,13 @@ import contextlib
 import threading
 
 # Import local modules
-from dcc_mcp_core._core import BlockingDispatcher
-from dcc_mcp_core._core import QueueDispatcher
+try:
+    from dcc_mcp_core._core import BlockingDispatcher
+    from dcc_mcp_core._core import QueueDispatcher
+except ImportError:
+    # py37-lite: _core not available, dispatchers are absent.
+    BlockingDispatcher = None  # type: ignore[assignment,misc]
+    QueueDispatcher = None  # type: ignore[assignment,misc]
 from dcc_mcp_core.host._protocols import TickableDispatcher
 
 

--- a/python/dcc_mcp_core/host/_wire.py
+++ b/python/dcc_mcp_core/host/_wire.py
@@ -4,15 +4,24 @@ from __future__ import annotations
 
 from typing import Any
 
-from dcc_mcp_core._core import normalize_tool_arguments as _normalize_tool_arguments
-from dcc_mcp_core._core import normalize_tool_meta as _normalize_tool_meta
+try:
+    from dcc_mcp_core._core import normalize_tool_arguments as _normalize_tool_arguments
+    from dcc_mcp_core._core import normalize_tool_meta as _normalize_tool_meta
+except ImportError:
+    # py37-lite: _core not available, runtime will raise if called.
+    _normalize_tool_arguments = None  # type: ignore[assignment]
+    _normalize_tool_meta = None  # type: ignore[assignment]
 
 
 def normalize_tool_arguments(arguments: Any = None) -> dict[str, Any]:
     """Normalize raw tool ``arguments`` to a JSON-object-shaped dict."""
+    if _normalize_tool_arguments is None:
+        raise ImportError("normalize_tool_arguments requires the _core extension (not available in py37-lite)")
     return _normalize_tool_arguments(arguments)
 
 
 def normalize_tool_meta(meta: Any = None) -> dict[str, Any] | None:
     """Normalize raw tool ``_meta`` to a dict or ``None``."""
+    if _normalize_tool_meta is None:
+        raise ImportError("normalize_tool_meta requires the _core extension (not available in py37-lite)")
     return _normalize_tool_meta(meta)


### PR DESCRIPTION
## Summary

Add a `py37-lite` build profile that produces a `py3-none-any` (pure-Python) wheel for Python 3.7, targeting Maya 2022 / Blender 2.83 which embed Python 3.7 and cannot load `cp38-abi3` wheels.

## Changes

- **pyproject.toml**: Make `dcc-mcp-server` dependency conditional on `python_version >= '3.8'`
- **Cargo.toml**: Add `py37-lite` feature enabling only non-PyO3 Rust features (`workflow`, `scheduler`, `prometheus`, `job-persist-sqlite`, `admin`)
- **justfile**: Add `build-py37` recipe: `maturin build --release --out dist --no-default-features -F py37-lite`
- **build-wheels.yml**: New `py37-lite` job (ubuntu-22.04 + Python 3.7) with tag verification (`py3-none-any`) and `_core` absence check
- **ci.yml**: New `build-py37-wheel` + `test-py37` jobs verifying:
  - `_core` raises `ImportError`
  - `import dcc_mcp_core` succeeds
  - `dcc_mcp_core.skill` works (pure-Python helpers)
  - `dcc_mcp_core.host` imports without `_core` dispatchers
- **host/**: Gracefully handle missing `_core` in `__init__.py`, `_protocols.py`, `_standalone.py`, `_wire.py`

## Test plan

- [ ] CI `test-py37` job passes: import smoke, skill module, host module
- [ ] `pip install dist/*.whl` on Python 3.7 succeeds without Rust toolchain
- [ ] `from dcc_mcp_core import _core` raises `ImportError` on py37-lite wheel
- [ ] Existing `cp38-abi3` wheel builds and tests are unaffected

## Verification

- Wheel tag: `py3-none-any`
- `_core` extension NOT present in wheel contents
- No regressions in existing CI jobs (all existing abi3 wheels unchanged)