### PR TITLE
feat(py37-lite): decouple DccServerBase HTTP server to dcc-mcp-server sidecar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,35 +518,38 @@ jobs:
           "
       - name: Verify import dcc_mcp_core works
         shell: bash
-        run: python -c "import dcc_mcp_core; print('OK: import dcc_mcp_core')"
+        run: |
+          python -c "import dcc_mcp_core; print('OK: import dcc_mcp_core')"
       - name: Verify skill module works
         shell: bash
-        run: python -c "
-          from dcc_mcp_core.skill import skill_entry, skill_success, skill_error;
-          result = skill_success('test');
-          assert result['success'] is True;
+        run: |
+          python -c "
+          from dcc_mcp_core.skill import skill_entry, skill_success, skill_error
+          result = skill_success('test')
+          assert result['success'] is True
           print('OK: dcc_mcp_core.skill works')
-        "
+          "
       - name: Verify host module imports (without _core)
         shell: bash
-        run: python -c "
-          import dcc_mcp_core.host;
-          assert dcc_mcp_core.host.BlockingDispatcher is None;
-          assert dcc_mcp_core.host.QueueDispatcher is None;
-          # Pure-Python sub-modules work fine
-          from dcc_mcp_core.host._adapter import HostAdapter, TickableDispatcher;
-          from dcc_mcp_core.host._standalone import StandaloneHost;
+        run: |
+          python -c "
+          import dcc_mcp_core.host
+          assert dcc_mcp_core.host.BlockingDispatcher is None
+          assert dcc_mcp_core.host.QueueDispatcher is None
+          from dcc_mcp_core.host._adapter import HostAdapter, TickableDispatcher
+          from dcc_mcp_core.host._standalone import StandaloneHost
           print('OK: dcc_mcp_core.host imports without _core')
-        "
+          "
       - name: Verify lazy _core fallback (skill._serialize_result)
         shell: bash
-        run: python -c "
-          from dcc_mcp_core.skill import skill_success;
-          from dcc_mcp_core.skill import _serialize_result as sr;
-          result = sr(skill_success('test'));
-          assert 'success' in result;
+        run: |
+          python -c "
+          from dcc_mcp_core.skill import skill_success
+          from dcc_mcp_core.skill import _serialize_result as sr
+          result = sr(skill_success('test'))
+          assert 'success' in result
           print('OK: skill._serialize_result falls back to pure Python')
-        "
+          "
       - name: Run py37 sidecar factory tests (source tree)
         shell: bash
         run: PYTHONPATH=python pytest tests/test_py37_sidecar_server_factory.py -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,9 @@ jobs:
           assert 'success' in result;
           print('OK: skill._serialize_result falls back to pure Python')
         "
+      - name: Run py37 sidecar factory tests (source tree)
+        shell: bash
+        run: PYTHONPATH=python pytest tests/test_py37_sidecar_server_factory.py -q
 
   # ── Lint Python source ──
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ keywords = ["dcc", "mcp", "maya", "blender", "houdini", "pyo3"]
 [lib]
 name = "_core"
 crate-type = ["cdylib", "rlib"]
+required-features = ["python-bindings"]
 
 [dependencies]
 # Internal crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,11 +263,10 @@ job-persist-sqlite = ["dcc-mcp-http/job-persist-sqlite"]
 admin = ["dcc-mcp-gateway/admin"]
 
 # py37-lite: pure-Python wheel profile for Maya 2022 / Python 3.7.
-# Excludes all PyO3/python-bindings features so maturin produces a
-# py3-none-any wheel with zero compiled extensions. Only Rust features
-# that do NOT depend on PyO3 are enabled.
+# Intentionally empty: ``build-py37`` only packages ``python/`` sources and
+# must not compile Rust (see ``scripts/build_py37_pure_wheel.py``).
 # See also `build-py37` in justfile and the py37-lite CI workflows.
-py37-lite = ["workflow", "scheduler", "prometheus", "job-persist-sqlite", "admin"]
+py37-lite = []
 abi3-py38 = ["pyo3/abi3-py38"]
 # Python 3.7 wheel: non-abi3 build, no abi3-py38 feature
 ext-module = ["pyo3/extension-module"]

--- a/justfile
+++ b/justfile
@@ -201,7 +201,7 @@ build *EXTRA:
 # sources — no compiled _core extension. The wheel is tagged py3-none-any
 # and installable on Python 3.7 (Maya 2022 / Blender 2.83).
 build-py37:
-    maturin build --release --out dist --no-default-features -F py37-lite
+    python scripts/build_py37_pure_wheel.py
 
 # Install dev/test dependencies
 install-dev-deps:

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -79,7 +79,7 @@ _LAZY: dict[str, str] = {
     "IntWrapper": "dcc_mcp_core._core",
     "IpcChannelAdapter": "dcc_mcp_core._core",
     "LoggingMiddleware": "dcc_mcp_core._core",
-    "McpHttpConfig": "dcc_mcp_core._core",
+    "McpHttpConfig": "dcc_mcp_core._runtime.config_bridge",
     "McpHttpServer": "dcc_mcp_core._core",
     "McpServerHandle": "dcc_mcp_core._core",
     "ObjectTransform": "dcc_mcp_core._core",

--- a/python/dcc_mcp_core/_runtime/__init__.py
+++ b/python/dcc_mcp_core/_runtime/__init__.py
@@ -8,5 +8,5 @@ __all__ = [
     "resolve_mcp_http_config_class",
 ]
 
-from dcc_mcp_core._runtime.core_availability import is_core_extension_available
 from dcc_mcp_core._runtime.config_bridge import resolve_mcp_http_config_class
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available

--- a/python/dcc_mcp_core/_runtime/__init__.py
+++ b/python/dcc_mcp_core/_runtime/__init__.py
@@ -1,0 +1,12 @@
+"""Runtime helpers for py37-lite and sidecar-backed HTTP/MCP serving."""
+
+from __future__ import annotations
+
+__all__ = [
+    "create_adapter_server",
+    "is_core_extension_available",
+    "resolve_mcp_http_config_class",
+]
+
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+from dcc_mcp_core._runtime.config_bridge import resolve_mcp_http_config_class

--- a/python/dcc_mcp_core/_runtime/config_bridge.py
+++ b/python/dcc_mcp_core/_runtime/config_bridge.py
@@ -1,0 +1,22 @@
+"""Resolve the active ``McpHttpConfig`` implementation for the current wheel."""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Type
+
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+
+
+def resolve_mcp_http_config_class() -> Type[Any]:
+    """Return PyO3 ``McpHttpConfig`` when available, else the pure-Python dataclass."""
+    if is_core_extension_available():
+        from dcc_mcp_core._core import McpHttpConfig as CoreMcpHttpConfig
+
+        return CoreMcpHttpConfig
+    from dcc_mcp_core._runtime.mcp_http_config import McpHttpConfig as PureMcpHttpConfig
+
+    return PureMcpHttpConfig
+
+
+McpHttpConfig = resolve_mcp_http_config_class()

--- a/python/dcc_mcp_core/_runtime/config_bridge.py
+++ b/python/dcc_mcp_core/_runtime/config_bridge.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Type
 
 from dcc_mcp_core._runtime.core_availability import is_core_extension_available
 
 
-def resolve_mcp_http_config_class() -> Type[Any]:
+def resolve_mcp_http_config_class() -> type[Any]:
     """Return PyO3 ``McpHttpConfig`` when available, else the pure-Python dataclass."""
     if is_core_extension_available():
         from dcc_mcp_core._core import McpHttpConfig as CoreMcpHttpConfig

--- a/python/dcc_mcp_core/_runtime/core_availability.py
+++ b/python/dcc_mcp_core/_runtime/core_availability.py
@@ -1,0 +1,27 @@
+"""Detect whether the compiled ``dcc_mcp_core._core`` extension is loadable."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+_CORE_AVAILABLE: bool | None = None
+
+
+def is_core_extension_available() -> bool:
+    """Return ``True`` when the PyO3 ``_core`` extension can be imported."""
+    global _CORE_AVAILABLE
+    if _CORE_AVAILABLE is not None:
+        return _CORE_AVAILABLE
+
+    if sys.version_info < (3, 8):
+        _CORE_AVAILABLE = False
+        return _CORE_AVAILABLE
+
+    try:
+        importlib.import_module("dcc_mcp_core._core")
+    except ImportError:
+        _CORE_AVAILABLE = False
+    else:
+        _CORE_AVAILABLE = True
+    return _CORE_AVAILABLE

--- a/python/dcc_mcp_core/_runtime/core_availability.py
+++ b/python/dcc_mcp_core/_runtime/core_availability.py
@@ -13,7 +13,6 @@ def is_core_extension_available() -> bool:
     if _CORE_AVAILABLE is not None:
         return _CORE_AVAILABLE
 
-
     try:
         importlib.import_module("dcc_mcp_core._core")
     except ImportError:

--- a/python/dcc_mcp_core/_runtime/core_availability.py
+++ b/python/dcc_mcp_core/_runtime/core_availability.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib
-import sys
 
 _CORE_AVAILABLE: bool | None = None
 
@@ -14,9 +13,6 @@ def is_core_extension_available() -> bool:
     if _CORE_AVAILABLE is not None:
         return _CORE_AVAILABLE
 
-    if sys.version_info < (3, 8):
-        _CORE_AVAILABLE = False
-        return _CORE_AVAILABLE
 
     try:
         importlib.import_module("dcc_mcp_core._core")

--- a/python/dcc_mcp_core/_runtime/mcp_http_config.py
+++ b/python/dcc_mcp_core/_runtime/mcp_http_config.py
@@ -1,0 +1,90 @@
+"""Pure-Python ``McpHttpConfig`` for py37-lite and sidecar-backed adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+
+def _default_server_version() -> str:
+    try:
+        from importlib import metadata as importlib_metadata
+    except ImportError:
+        try:
+            import importlib_metadata  # type: ignore[import-not-found]
+        except ImportError:
+            return "0.0.0-dev"
+    try:
+        return importlib_metadata.version("dcc-mcp-core")
+    except Exception:
+        return "0.0.0-dev"
+
+
+@dataclass
+class McpHttpConfig:
+    """Python-visible MCP HTTP server configuration without PyO3."""
+
+    port: int = 8765
+    server_name: str = "dcc-mcp"
+    server_version: str = field(default_factory=_default_server_version)
+    host: str = "127.0.0.1"
+    endpoint_path: str = "/mcp"
+    enable_cors: bool = False
+    request_timeout_ms: int = 30000
+    session_ttl_secs: int = 3600
+    enable_tool_cache: bool = False
+    enable_prometheus: bool = False
+    gateway_port: int = 9765
+    registry_dir: Optional[str] = None
+    dcc_version: str = ""
+    scene: str = ""
+    dcc_type: str = ""
+    instance_metadata: Dict[str, str] = field(default_factory=dict)
+    standalone_main_thread_execution: bool = False
+    exclude_skill_stubs_from_tools_list: bool = False
+    exclude_group_stubs_from_tools_list: bool = False
+    job_storage_path: Optional[str] = None
+    sandbox_policy: Any = None
+
+    def __init__(
+        self,
+        port: int = 8765,
+        server_name: Optional[str] = None,
+        server_version: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.port = int(port)
+        self.server_name = server_name if server_name is not None else "dcc-mcp"
+        self.server_version = server_version if server_version is not None else _default_server_version()
+        self.host = str(kwargs.pop("host", "127.0.0.1"))
+        self.endpoint_path = str(kwargs.pop("endpoint_path", "/mcp"))
+        self.enable_cors = bool(kwargs.pop("enable_cors", False))
+        self.request_timeout_ms = int(kwargs.pop("request_timeout_ms", 30000))
+        self.session_ttl_secs = int(kwargs.pop("session_ttl_secs", 3600))
+        self.enable_tool_cache = bool(kwargs.pop("enable_tool_cache", False))
+        self.enable_prometheus = bool(kwargs.pop("enable_prometheus", False))
+        self.gateway_port = int(kwargs.pop("gateway_port", 9765))
+        self.registry_dir = kwargs.pop("registry_dir", None)
+        self.dcc_version = str(kwargs.pop("dcc_version", ""))
+        self.scene = str(kwargs.pop("scene", ""))
+        self.dcc_type = str(kwargs.pop("dcc_type", ""))
+        metadata = kwargs.pop("instance_metadata", None)
+        self.instance_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        self.standalone_main_thread_execution = bool(kwargs.pop("standalone_main_thread_execution", False))
+        self.exclude_skill_stubs_from_tools_list = bool(kwargs.pop("exclude_skill_stubs_from_tools_list", False))
+        self.exclude_group_stubs_from_tools_list = bool(kwargs.pop("exclude_group_stubs_from_tools_list", False))
+        self.job_storage_path = kwargs.pop("job_storage_path", None)
+        self.sandbox_policy = kwargs.pop("sandbox_policy", None)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def __repr__(self) -> str:
+        return (
+            "McpHttpConfig("
+            f"port={self.port}, "
+            f"server_name={self.server_name!r}, "
+            f"server_version={self.server_version!r})"
+        )

--- a/python/dcc_mcp_core/_runtime/mcp_http_config.py
+++ b/python/dcc_mcp_core/_runtime/mcp_http_config.py
@@ -81,8 +81,5 @@ class McpHttpConfig:
 
     def __repr__(self) -> str:
         return (
-            "McpHttpConfig("
-            f"port={self.port}, "
-            f"server_name={self.server_name!r}, "
-            f"server_version={self.server_version!r})"
+            f"McpHttpConfig(port={self.port}, server_name={self.server_name!r}, server_version={self.server_version!r})"
         )

--- a/python/dcc_mcp_core/_runtime/mcp_http_config.py
+++ b/python/dcc_mcp_core/_runtime/mcp_http_config.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
-from typing import Dict
-from typing import Optional
 
 
 def _default_server_version() -> str:
@@ -38,22 +36,22 @@ class McpHttpConfig:
     enable_tool_cache: bool = False
     enable_prometheus: bool = False
     gateway_port: int = 9765
-    registry_dir: Optional[str] = None
+    registry_dir: str | None = None
     dcc_version: str = ""
     scene: str = ""
     dcc_type: str = ""
-    instance_metadata: Dict[str, str] = field(default_factory=dict)
+    instance_metadata: dict[str, str] = field(default_factory=dict)
     standalone_main_thread_execution: bool = False
     exclude_skill_stubs_from_tools_list: bool = False
     exclude_group_stubs_from_tools_list: bool = False
-    job_storage_path: Optional[str] = None
+    job_storage_path: str | None = None
     sandbox_policy: Any = None
 
     def __init__(
         self,
         port: int = 8765,
-        server_name: Optional[str] = None,
-        server_version: Optional[str] = None,
+        server_name: str | None = None,
+        server_version: str | None = None,
         **kwargs: Any,
     ) -> None:
         self.port = int(port)

--- a/python/dcc_mcp_core/_runtime/server_factory.py
+++ b/python/dcc_mcp_core/_runtime/server_factory.py
@@ -1,0 +1,60 @@
+"""Factory for adapter-local MCP servers (embedded _core or sidecar binary)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from typing import Optional
+
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+from dcc_mcp_core._runtime.sidecar_skill_server import SidecarBackedSkillServer
+
+
+def create_adapter_server(
+    dcc_name: str,
+    config: Any,
+    options: Optional[Any] = None,
+) -> Any:
+    """Create the inner server object used by :class:`DccServerBase`."""
+    if is_core_extension_available():
+        from dcc_mcp_core._core import create_skill_server
+
+        return create_skill_server(dcc_name, config)
+
+    sidecar = getattr(options, "sidecar", None) if options is not None else None
+    host_rpc = _resolve_host_rpc(sidecar)
+    return SidecarBackedSkillServer(
+        dcc_name,
+        config,
+        host_rpc=host_rpc,
+        watch_pid=_resolve_watch_pid(options),
+        adapter_version=getattr(sidecar, "adapter_version", None) if sidecar is not None else None,
+        display_name=getattr(sidecar, "display_name", None) if sidecar is not None else None,
+        wait_ready_timeout_secs=_resolve_wait_ready(sidecar),
+    )
+
+
+def _resolve_host_rpc(sidecar: Any) -> str:
+    if sidecar is not None:
+        value = getattr(sidecar, "host_rpc", None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return str(os.environ.get("DCC_MCP_HOST_RPC", "")).strip()
+
+
+def _resolve_watch_pid(options: Optional[Any]) -> Optional[int]:
+    if options is None:
+        return None
+    diagnostics = getattr(options, "diagnostics", None)
+    if diagnostics is not None and getattr(diagnostics, "dcc_pid", None) is not None:
+        return int(diagnostics.dcc_pid)
+    return None
+
+
+def _resolve_wait_ready(sidecar: Any) -> float:
+    if sidecar is None:
+        return 15.0
+    value = getattr(sidecar, "wait_ready_timeout_secs", None)
+    if value is None:
+        return 15.0
+    return float(value)

--- a/python/dcc_mcp_core/_runtime/server_factory.py
+++ b/python/dcc_mcp_core/_runtime/server_factory.py
@@ -31,6 +31,8 @@ def create_adapter_server(
         adapter_version=getattr(sidecar, "adapter_version", None) if sidecar is not None else None,
         display_name=getattr(sidecar, "display_name", None) if sidecar is not None else None,
         wait_ready_timeout_secs=_resolve_wait_ready(sidecar),
+        server_bin=getattr(sidecar, "server_bin", None) if sidecar is not None else None,
+        extra_args=_resolve_extra_args(sidecar),
     )
 
 
@@ -58,3 +60,12 @@ def _resolve_wait_ready(sidecar: Any) -> float:
     if value is None:
         return 15.0
     return float(value)
+
+
+def _resolve_extra_args(sidecar: Any) -> tuple:
+    if sidecar is None:
+        return ()
+    value = getattr(sidecar, "extra_args", None)
+    if not value:
+        return ()
+    return tuple(str(arg) for arg in value)

--- a/python/dcc_mcp_core/_runtime/server_factory.py
+++ b/python/dcc_mcp_core/_runtime/server_factory.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 from typing import Any
-from typing import Optional
 
 from dcc_mcp_core._runtime.core_availability import is_core_extension_available
 from dcc_mcp_core._runtime.sidecar_skill_server import SidecarBackedSkillServer
@@ -13,7 +12,7 @@ from dcc_mcp_core._runtime.sidecar_skill_server import SidecarBackedSkillServer
 def create_adapter_server(
     dcc_name: str,
     config: Any,
-    options: Optional[Any] = None,
+    options: Any | None = None,
 ) -> Any:
     """Create the inner server object used by :class:`DccServerBase`."""
     if is_core_extension_available():
@@ -44,7 +43,7 @@ def _resolve_host_rpc(sidecar: Any) -> str:
     return str(os.environ.get("DCC_MCP_HOST_RPC", "")).strip()
 
 
-def _resolve_watch_pid(options: Optional[Any]) -> Optional[int]:
+def _resolve_watch_pid(options: Any | None) -> int | None:
     if options is None:
         return None
     diagnostics = getattr(options, "diagnostics", None)

--- a/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
+++ b/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
@@ -56,6 +56,8 @@ class SidecarBackedSkillServer:
         adapter_version: Optional[str] = None,
         display_name: Optional[str] = None,
         wait_ready_timeout_secs: float = 15.0,
+        server_bin: Optional[str] = None,
+        extra_args: Optional[tuple] = None,
     ) -> None:
         self._dcc_name = str(dcc_name or "dcc")
         self._config = config
@@ -64,6 +66,8 @@ class SidecarBackedSkillServer:
         self._adapter_version = adapter_version
         self._display_name = display_name or self._dcc_name
         self._wait_ready_timeout_secs = float(wait_ready_timeout_secs)
+        self._server_bin = str(server_bin).strip() if server_bin else None
+        self._extra_args = tuple(str(arg) for arg in (extra_args or ()))
         self._registry = PurePythonToolRegistry()
         self._pending_skill_paths: List[str] = []
         self._handle: Optional[SidecarServerHandle] = None
@@ -121,6 +125,8 @@ class SidecarBackedSkillServer:
             gateway_port=gateway_port if gateway_port > 0 else None,
             wait_ready_timeout_secs=self._wait_ready_timeout_secs,
             require_dispatch_capable=True,
+            server_bin=self._server_bin,
+            extra_args=self._extra_args or None,
         )
         self._launch_result = dict(launch)
         if not launch.get("success"):

--- a/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
+++ b/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
@@ -1,0 +1,205 @@
+"""Sidecar-backed skill server facade for py37-lite ``DccServerBase``."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from dcc_mcp_core._install_lifecycle_sidecar import build_sidecar_command
+from dcc_mcp_core._install_lifecycle_sidecar import launch_sidecar
+from dcc_mcp_core._runtime.tool_registry_py import PurePythonToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class SidecarServerHandle:
+    """Handle returned by :meth:`SidecarBackedSkillServer.start`."""
+
+    def __init__(self, *, port: int, mcp_url: str, shutdown: Callable[[], None]) -> None:
+        self._port = int(port)
+        self._mcp_url = str(mcp_url)
+        self._shutdown = shutdown
+        self.is_gateway = False
+
+    @property
+    def port(self) -> int:
+        return self._port
+
+    def mcp_url(self) -> str:
+        return self._mcp_url
+
+    def shutdown(self) -> None:
+        self._shutdown()
+
+    def update_gateway_metadata(self, **metadata: Any) -> bool:
+        logger.debug("sidecar handle ignores update_gateway_metadata: %s", metadata)
+        return False
+
+
+class SidecarBackedSkillServer:
+    """Launch ``dcc-mcp-server sidecar`` instead of embedding ``McpHttpServer``."""
+
+    backend = "sidecar"
+
+    def __init__(
+        self,
+        dcc_name: str,
+        config: Any,
+        *,
+        host_rpc: str,
+        watch_pid: Optional[int] = None,
+        adapter_version: Optional[str] = None,
+        display_name: Optional[str] = None,
+        wait_ready_timeout_secs: float = 15.0,
+    ) -> None:
+        self._dcc_name = str(dcc_name or "dcc")
+        self._config = config
+        self._host_rpc = str(host_rpc or "").strip()
+        self._watch_pid = watch_pid
+        self._adapter_version = adapter_version
+        self._display_name = display_name or self._dcc_name
+        self._wait_ready_timeout_secs = float(wait_ready_timeout_secs)
+        self._registry = PurePythonToolRegistry()
+        self._pending_skill_paths: List[str] = []
+        self._handle: Optional[SidecarServerHandle] = None
+        self._launch_result: Dict[str, Any] = {}
+
+    @property
+    def registry(self) -> PurePythonToolRegistry:
+        return self._registry
+
+    def discover(self, extra_paths: Optional[List[str]] = None) -> int:
+        paths = [str(path) for path in (extra_paths or []) if str(path).strip()]
+        self._pending_skill_paths = paths
+        if paths:
+            existing = os.environ.get("DCC_MCP_SKILL_PATHS", "")
+            merged = os.pathsep.join([existing] + paths) if existing else os.pathsep.join(paths)
+            os.environ["DCC_MCP_SKILL_PATHS"] = merged
+        logger.info(
+            "[%s] sidecar discover recorded %d path(s); HTTP/MCP is owned by dcc-mcp-server sidecar",
+            self._dcc_name,
+            len(paths),
+        )
+        return len(paths)
+
+    def start(self) -> SidecarServerHandle:
+        if self._handle is not None:
+            return self._handle
+        if not self._host_rpc:
+            raise RuntimeError(
+                "host_rpc is required for py37-lite sidecar mode; "
+                "set DccServerOptions.sidecar.host_rpc or DCC_MCP_HOST_RPC"
+            )
+
+        gateway_port = int(getattr(self._config, "gateway_port", 0) or 0)
+        registry_dir = getattr(self._config, "registry_dir", None)
+        command = build_sidecar_command(
+            dcc_type=self._dcc_name,
+            host_rpc=self._host_rpc,
+            watch_pid=self._watch_pid,
+            registry_dir=registry_dir,
+            display_name=self._display_name,
+            adapter_version=self._adapter_version,
+            gateway_port=gateway_port if gateway_port > 0 else None,
+            require_dispatch_capable=True,
+        )
+        if not command.get("success"):
+            raise RuntimeError(command.get("message") or "failed to build sidecar launch command")
+
+        launch = launch_sidecar(
+            dcc_type=self._dcc_name,
+            host_rpc=self._host_rpc,
+            watch_pid=self._watch_pid,
+            registry_dir=registry_dir,
+            display_name=self._display_name,
+            adapter_version=self._adapter_version,
+            gateway_port=gateway_port if gateway_port > 0 else None,
+            wait_ready_timeout_secs=self._wait_ready_timeout_secs,
+            require_dispatch_capable=True,
+        )
+        self._launch_result = dict(launch)
+        if not launch.get("success"):
+            raise RuntimeError(launch.get("message") or "sidecar launch failed")
+
+        mcp_url = _resolve_mcp_url(launch)
+        port = _port_from_url(mcp_url)
+        proc = launch.get("process")
+
+        def _shutdown() -> None:
+            if proc is not None:
+                try:
+                    proc.terminate()
+                except Exception as exc:
+                    logger.debug("[%s] sidecar terminate failed: %s", self._dcc_name, exc)
+
+        self._handle = SidecarServerHandle(port=port, mcp_url=mcp_url, shutdown=_shutdown)
+        return self._handle
+
+    # SkillQueryClient compatibility stubs ---------------------------------
+
+    def list_skills(self) -> List[Any]:
+        return []
+
+    def search_skills(self, **kwargs: Any) -> List[Any]:
+        return []
+
+    def load_skill(self, name: str) -> None:
+        logger.debug("[%s] load_skill(%r) delegated to sidecar", self._dcc_name, name)
+
+    def get_skill(self, name: str) -> Any:
+        return None
+
+    def load_skill_object(self, skill: Any) -> None:
+        logger.debug("[%s] load_skill_object delegated to sidecar", self._dcc_name)
+
+    def unload_skill(self, name: str) -> None:
+        logger.debug("[%s] unload_skill(%r) delegated to sidecar", self._dcc_name, name)
+
+    def is_loaded(self, name: str) -> bool:
+        return False
+
+    def get_skill_info(self, name: str) -> Any:
+        return None
+
+    def set_in_process_executor(self, executor: Any) -> None:
+        logger.debug("[%s] set_in_process_executor stored for host-rpc dispatch", self._dcc_name)
+
+    def attach_dispatcher(self, dispatcher: Any) -> None:
+        logger.debug("[%s] attach_dispatcher ignored in sidecar mode", self._dcc_name)
+
+    def resources(self) -> Any:
+        return None
+
+    def set_readiness_probe(self, probe: Any) -> bool:
+        return False
+
+
+def _resolve_mcp_url(launch: Dict[str, Any]) -> str:
+    readiness = launch.get("readiness") or {}
+    for key in ("mcp_url", "discovery_mcp_url", "endpoint"):
+        value = readiness.get(key) or launch.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    metadata = readiness.get("metadata") or launch.get("metadata") or {}
+    if isinstance(metadata, dict):
+        value = metadata.get("mcp_url")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "http://127.0.0.1:0/mcp"
+
+
+def _port_from_url(url: str) -> int:
+    try:
+        from urllib.parse import urlsplit
+
+        split = urlsplit(url)
+        if split.port is not None:
+            return int(split.port)
+    except Exception:
+        pass
+    return 0

--- a/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
+++ b/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
@@ -6,9 +6,6 @@ import logging
 import os
 from typing import Any
 from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
 
 from dcc_mcp_core._install_lifecycle_sidecar import build_sidecar_command
 from dcc_mcp_core._install_lifecycle_sidecar import launch_sidecar
@@ -52,12 +49,12 @@ class SidecarBackedSkillServer:
         config: Any,
         *,
         host_rpc: str,
-        watch_pid: Optional[int] = None,
-        adapter_version: Optional[str] = None,
-        display_name: Optional[str] = None,
+        watch_pid: int | None = None,
+        adapter_version: str | None = None,
+        display_name: str | None = None,
         wait_ready_timeout_secs: float = 15.0,
-        server_bin: Optional[str] = None,
-        extra_args: Optional[tuple] = None,
+        server_bin: str | None = None,
+        extra_args: tuple | None = None,
     ) -> None:
         self._dcc_name = str(dcc_name or "dcc")
         self._config = config
@@ -69,20 +66,20 @@ class SidecarBackedSkillServer:
         self._server_bin = str(server_bin).strip() if server_bin else None
         self._extra_args = tuple(str(arg) for arg in (extra_args or ()))
         self._registry = PurePythonToolRegistry()
-        self._pending_skill_paths: List[str] = []
-        self._handle: Optional[SidecarServerHandle] = None
-        self._launch_result: Dict[str, Any] = {}
+        self._pending_skill_paths: list[str] = []
+        self._handle: SidecarServerHandle | None = None
+        self._launch_result: dict[str, Any] = {}
 
     @property
     def registry(self) -> PurePythonToolRegistry:
         return self._registry
 
-    def discover(self, extra_paths: Optional[List[str]] = None) -> int:
+    def discover(self, extra_paths: list[str] | None = None) -> int:
         paths = [str(path) for path in (extra_paths or []) if str(path).strip()]
         self._pending_skill_paths = paths
         if paths:
             existing = os.environ.get("DCC_MCP_SKILL_PATHS", "")
-            merged = os.pathsep.join([existing] + paths) if existing else os.pathsep.join(paths)
+            merged = os.pathsep.join([existing, *paths]) if existing else os.pathsep.join(paths)
             os.environ["DCC_MCP_SKILL_PATHS"] = merged
         logger.info(
             "[%s] sidecar discover recorded %d path(s); HTTP/MCP is owned by dcc-mcp-server sidecar",
@@ -148,10 +145,10 @@ class SidecarBackedSkillServer:
 
     # SkillQueryClient compatibility stubs ---------------------------------
 
-    def list_skills(self) -> List[Any]:
+    def list_skills(self) -> list[Any]:
         return []
 
-    def search_skills(self, **kwargs: Any) -> List[Any]:
+    def search_skills(self, **kwargs: Any) -> list[Any]:
         return []
 
     def load_skill(self, name: str) -> None:
@@ -185,7 +182,7 @@ class SidecarBackedSkillServer:
         return False
 
 
-def _resolve_mcp_url(launch: Dict[str, Any]) -> str:
+def _resolve_mcp_url(launch: dict[str, Any]) -> str:
     readiness = launch.get("readiness") or {}
     for key in ("mcp_url", "discovery_mcp_url", "endpoint"):
         value = readiness.get(key) or launch.get(key)

--- a/python/dcc_mcp_core/_runtime/skill_paths.py
+++ b/python/dcc_mcp_core/_runtime/skill_paths.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import List
-from typing import Optional
 
 from dcc_mcp_core._runtime.core_availability import is_core_extension_available
 
 
-def get_skill_paths_from_env() -> List[str]:
+def get_skill_paths_from_env() -> list[str]:
     if is_core_extension_available():
         from dcc_mcp_core._core import get_skill_paths_from_env as _impl
 
@@ -21,12 +19,12 @@ def get_skill_paths_from_env() -> List[str]:
     return [part.strip() for part in raw.split(os.pathsep) if part.strip()]
 
 
-def get_app_skill_paths_from_env(dcc_name: str) -> List[str]:
+def get_app_skill_paths_from_env(dcc_name: str) -> list[str]:
     if is_core_extension_available():
         from dcc_mcp_core._core import get_app_skill_paths_from_env as _impl
 
         return list(_impl(dcc_name))
-    env_name = "DCC_MCP_{0}_SKILL_PATHS".format(str(dcc_name or "").upper())
+    env_name = "DCC_MCP_{}_SKILL_PATHS".format(str(dcc_name or "").upper())
     raw = os.environ.get(env_name, "")
     if not raw.strip():
         return []
@@ -42,7 +40,7 @@ def get_local_skills_dir(dcc_name: str) -> str:
     return str(Path.home() / ".dcc-mcp" / slug / "skills")
 
 
-def get_skills_dir() -> Optional[str]:
+def get_skills_dir() -> str | None:
     if is_core_extension_available():
         from dcc_mcp_core._core import get_skills_dir as _impl
 

--- a/python/dcc_mcp_core/_runtime/skill_paths.py
+++ b/python/dcc_mcp_core/_runtime/skill_paths.py
@@ -1,0 +1,51 @@
+"""Import-light skill path helpers used when ``_core`` is unavailable."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+from typing import Optional
+
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+
+
+def get_skill_paths_from_env() -> List[str]:
+    if is_core_extension_available():
+        from dcc_mcp_core._core import get_skill_paths_from_env as _impl
+
+        return list(_impl())
+    raw = os.environ.get("DCC_MCP_SKILL_PATHS", "")
+    if not raw.strip():
+        return []
+    return [part.strip() for part in raw.split(os.pathsep) if part.strip()]
+
+
+def get_app_skill_paths_from_env(dcc_name: str) -> List[str]:
+    if is_core_extension_available():
+        from dcc_mcp_core._core import get_app_skill_paths_from_env as _impl
+
+        return list(_impl(dcc_name))
+    env_name = "DCC_MCP_{0}_SKILL_PATHS".format(str(dcc_name or "").upper())
+    raw = os.environ.get(env_name, "")
+    if not raw.strip():
+        return []
+    return [part.strip() for part in raw.split(os.pathsep) if part.strip()]
+
+
+def get_local_skills_dir(dcc_name: str) -> str:
+    if is_core_extension_available():
+        from dcc_mcp_core._core import get_local_skills_dir as _impl
+
+        return str(_impl(dcc_name))
+    slug = str(dcc_name or "dcc").strip().lower() or "dcc"
+    return str(Path.home() / ".dcc-mcp" / slug / "skills")
+
+
+def get_skills_dir() -> Optional[str]:
+    if is_core_extension_available():
+        from dcc_mcp_core._core import get_skills_dir as _impl
+
+        return _impl()
+    default = Path.home() / ".dcc-mcp" / "skills"
+    return str(default)

--- a/python/dcc_mcp_core/_runtime/tool_registry_py.py
+++ b/python/dcc_mcp_core/_runtime/tool_registry_py.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Dict
 from typing import Iterable
-from typing import List
-from typing import Optional
 
 
 class PurePythonToolRegistry:
     """Duck-typed registry placeholder while HTTP/MCP runs in the sidecar."""
 
     def __init__(self) -> None:
-        self._actions: Dict[str, Dict[str, Any]] = {}
+        self._actions: dict[str, dict[str, Any]] = {}
 
     def register(
         self,
@@ -21,7 +18,7 @@ class PurePythonToolRegistry:
         *,
         description: str = "",
         category: str = "",
-        tags: Optional[Iterable[str]] = None,
+        tags: Iterable[str] | None = None,
         dcc: str = "",
         **metadata: Any,
     ) -> None:
@@ -34,7 +31,7 @@ class PurePythonToolRegistry:
             **metadata,
         }
 
-    def list_actions(self, dcc_name: Optional[str] = None) -> List[Any]:
+    def list_actions(self, dcc_name: str | None = None) -> list[Any]:
         if dcc_name is None:
             return list(self._actions.values())
         return [action for action in self._actions.values() if action.get("dcc") in ("", dcc_name)]

--- a/python/dcc_mcp_core/_runtime/tool_registry_py.py
+++ b/python/dcc_mcp_core/_runtime/tool_registry_py.py
@@ -1,0 +1,40 @@
+"""Minimal pure-Python tool registry for py37-lite sidecar mode."""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+
+
+class PurePythonToolRegistry:
+    """Duck-typed registry placeholder while HTTP/MCP runs in the sidecar."""
+
+    def __init__(self) -> None:
+        self._actions: Dict[str, Dict[str, Any]] = {}
+
+    def register(
+        self,
+        name: str,
+        *,
+        description: str = "",
+        category: str = "",
+        tags: Optional[Iterable[str]] = None,
+        dcc: str = "",
+        **metadata: Any,
+    ) -> None:
+        self._actions[str(name)] = {
+            "name": str(name),
+            "description": description,
+            "category": category,
+            "tags": list(tags or []),
+            "dcc": dcc,
+            **metadata,
+        }
+
+    def list_actions(self, dcc_name: Optional[str] = None) -> List[Any]:
+        if dcc_name is None:
+            return list(self._actions.values())
+        return [action for action in self._actions.values() if action.get("dcc") in ("", dcc_name)]

--- a/python/dcc_mcp_core/_server/callable_dispatcher.py
+++ b/python/dcc_mcp_core/_server/callable_dispatcher.py
@@ -45,12 +45,11 @@ if TYPE_CHECKING:
     pass
 
 # `typing.Protocol`, `typing.runtime_checkable` and `typing.Literal` are
-# 3.8+. For Python 3.7 (Maya 2022), expose `BaseDccCallableDispatcherFull`
-# / `BaseDccPump` as duck-typed classes with the same attribute contracts;
-# concrete dispatchers do not need to inherit from them either way.
-from typing import Literal
-from typing import Protocol
-from typing import runtime_checkable  # type: ignore[assignment,misc]
+# 3.8+. For Python 3.7 (Maya 2022), expose duck-typed fallbacks with the
+# same attribute contracts; concrete dispatchers do not need to inherit.
+from dcc_mcp_core._typing_compat import Literal
+from dcc_mcp_core._typing_compat import Protocol
+from dcc_mcp_core._typing_compat import runtime_checkable
 
 logger = logging.getLogger(__name__)
 

--- a/python/dcc_mcp_core/_server/config.py
+++ b/python/dcc_mcp_core/_server/config.py
@@ -140,7 +140,7 @@ def build_mcp_http_config(
     *,
     package_version: str,
     version_provider: Callable[[], str],
-) -> McpHttpConfig:
+) -> Any:
     """Build the ``McpHttpConfig`` for ``DccServerBase`` from resolved options."""
     McpHttpConfig = resolve_mcp_http_config_class()
     config = McpHttpConfig(

--- a/python/dcc_mcp_core/_server/config.py
+++ b/python/dcc_mcp_core/_server/config.py
@@ -13,7 +13,7 @@ import os
 from typing import TYPE_CHECKING
 from typing import Any
 
-from dcc_mcp_core._core import McpHttpConfig
+from dcc_mcp_core._runtime.config_bridge import resolve_mcp_http_config_class
 from dcc_mcp_core._server.options import DccServerOptions
 from dcc_mcp_core._server.options import DiagnosticsOptions
 from dcc_mcp_core._server.options import ExecutionMode
@@ -142,6 +142,7 @@ def build_mcp_http_config(
     version_provider: Callable[[], str],
 ) -> McpHttpConfig:
     """Build the ``McpHttpConfig`` for ``DccServerBase`` from resolved options."""
+    McpHttpConfig = resolve_mcp_http_config_class()
     config = McpHttpConfig(
         port=options.port,
         server_name=options.server_name or f"{options.dcc_name}-mcp",

--- a/python/dcc_mcp_core/_server/execution_bridge.py
+++ b/python/dcc_mcp_core/_server/execution_bridge.py
@@ -12,12 +12,20 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from dcc_mcp_core._core import SandboxContext
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
 from dcc_mcp_core._server.inprocess_executor import BaseDccCallableDispatcher
 from dcc_mcp_core._server.inprocess_executor import HostExecutionBridge
 from dcc_mcp_core.script_execution import allow_script_materialization_root
 
 logger = logging.getLogger(__name__)
+
+
+def _sandbox_context(policy: Any) -> Any:
+    if not is_core_extension_available():
+        return None
+    from dcc_mcp_core._core import SandboxContext
+
+    return SandboxContext(policy)
 
 
 class ExecutionBridgeBinder:
@@ -44,7 +52,7 @@ class ExecutionBridgeBinder:
                     owner._dcc_name,
                     exc,
                 )
-            bridge.sandbox_context = SandboxContext(policy)
+            bridge.sandbox_context = _sandbox_context(policy)
 
     # -- HTTP dispatcher -------------------------------------------------------
 

--- a/python/dcc_mcp_core/_server/host_pump.py
+++ b/python/dcc_mcp_core/_server/host_pump.py
@@ -14,11 +14,11 @@ import time
 from typing import Any
 from typing import Callable
 from typing import Optional
-from typing import Protocol
-from typing import runtime_checkable
 
 from dcc_mcp_core._server.callable_dispatcher import AdaptivePumpPolicy
 from dcc_mcp_core._server.callable_dispatcher import DrainStats
+from dcc_mcp_core._typing_compat import Protocol
+from dcc_mcp_core._typing_compat import runtime_checkable
 
 __all__ = [
     "HostPumpController",

--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -45,11 +45,9 @@ if TYPE_CHECKING:
     pass
 
 # `typing.Protocol` / `typing.runtime_checkable` are 3.8+. For Python 3.7
-# (Maya 2022), expose `BaseDccCallableDispatcher` as a duck-typed class
-# with the same `dispatch_callable` attribute contract; concrete
-# dispatchers do not need to inherit from it either way.
-from typing import Protocol
-from typing import runtime_checkable
+# (Maya 2022), expose duck-typed fallbacks with the same attribute contracts.
+from dcc_mcp_core._typing_compat import Protocol
+from dcc_mcp_core._typing_compat import runtime_checkable
 
 logger = logging.getLogger(__name__)
 

--- a/python/dcc_mcp_core/_server/options.py
+++ b/python/dcc_mcp_core/_server/options.py
@@ -220,6 +220,8 @@ class SidecarOptions:
     adapter_version: str | None = None
     display_name: str | None = None
     wait_ready_timeout_secs: float = 15.0
+    server_bin: str | None = None
+    extra_args: tuple[str, ...] = ()
 
     @classmethod
     def from_env(
@@ -229,15 +231,22 @@ class SidecarOptions:
         adapter_version: str | None = None,
         display_name: str | None = None,
         wait_ready_timeout_secs: float = 15.0,
+        server_bin: str | None = None,
+        extra_args: tuple[str, ...] = (),
     ) -> SidecarOptions:
         resolved_host_rpc = host_rpc
         if resolved_host_rpc is None:
             resolved_host_rpc = os.environ.get("DCC_MCP_HOST_RPC", "") or None
+        resolved_server_bin = server_bin
+        if resolved_server_bin is None:
+            resolved_server_bin = os.environ.get("DCC_MCP_SERVER_BIN", "") or None
         return cls(
             host_rpc=resolved_host_rpc,
             adapter_version=adapter_version,
             display_name=display_name,
             wait_ready_timeout_secs=wait_ready_timeout_secs,
+            server_bin=resolved_server_bin,
+            extra_args=extra_args,
         )
 
 

--- a/python/dcc_mcp_core/_server/options.py
+++ b/python/dcc_mcp_core/_server/options.py
@@ -208,6 +208,40 @@ def BridgeExecution(bridge: HostExecutionBridge) -> _BridgeExecution:
 
 
 @dataclass(frozen=True)
+class SidecarOptions:
+    """Sidecar launch contract for py37-lite / no-_core adapters.
+
+    When the compiled ``_core`` extension is unavailable, ``DccServerBase``
+    delegates HTTP/MCP serving to ``dcc-mcp-server sidecar`` and routes tool
+    dispatch through ``host_rpc``.
+    """
+
+    host_rpc: str | None = None
+    adapter_version: str | None = None
+    display_name: str | None = None
+    wait_ready_timeout_secs: float = 15.0
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        host_rpc: str | None = None,
+        adapter_version: str | None = None,
+        display_name: str | None = None,
+        wait_ready_timeout_secs: float = 15.0,
+    ) -> SidecarOptions:
+        resolved_host_rpc = host_rpc
+        if resolved_host_rpc is None:
+            resolved_host_rpc = os.environ.get("DCC_MCP_HOST_RPC", "") or None
+        return cls(
+            host_rpc=resolved_host_rpc,
+            adapter_version=adapter_version,
+            display_name=display_name,
+            wait_ready_timeout_secs=wait_ready_timeout_secs,
+        )
+
+
+@dataclass(frozen=True)
 class ExecutionOptions:
     """Execution mode selection.
 
@@ -257,6 +291,7 @@ class DccServerOptions:
     observability: ObservabilityOptions = field(default_factory=ObservabilityOptions)
     diagnostics: DiagnosticsOptions = field(default_factory=DiagnosticsOptions)
     execution: ExecutionOptions = field(default_factory=ExecutionOptions)
+    sidecar: SidecarOptions = field(default_factory=SidecarOptions)
 
     @classmethod
     def from_env(
@@ -287,6 +322,11 @@ class DccServerOptions:
         dispatcher: BaseDccCallableDispatcher | None = None,
         execution_bridge: HostExecutionBridge | None = None,
         standalone_main_thread: bool = False,
+        # sidecar kwargs (py37-lite)
+        host_rpc: str | None = None,
+        adapter_version: str | None = None,
+        sidecar_display_name: str | None = None,
+        wait_ready_timeout_secs: float = 15.0,
     ) -> DccServerOptions:
         """Build a :class:`DccServerOptions` from keyword arguments + env vars.
 
@@ -333,6 +373,12 @@ class DccServerOptions:
             exec_mode = InlineExecution
 
         execution = ExecutionOptions(mode=exec_mode)
+        sidecar = SidecarOptions.from_env(
+            host_rpc=host_rpc,
+            adapter_version=adapter_version,
+            display_name=sidecar_display_name or server_name,
+            wait_ready_timeout_secs=wait_ready_timeout_secs,
+        )
 
         return cls(
             dcc_name=dcc_name,
@@ -344,4 +390,5 @@ class DccServerOptions:
             observability=observability,
             diagnostics=diagnostics,
             execution=execution,
+            sidecar=sidecar,
         )

--- a/python/dcc_mcp_core/_server/skill_discovery.py
+++ b/python/dcc_mcp_core/_server/skill_discovery.py
@@ -14,10 +14,10 @@ import os
 from pathlib import Path
 from typing import Any
 
-from dcc_mcp_core._core import get_app_skill_paths_from_env
-from dcc_mcp_core._core import get_local_skills_dir
-from dcc_mcp_core._core import get_skill_paths_from_env
-from dcc_mcp_core._core import get_skills_dir
+from dcc_mcp_core._runtime.skill_paths import get_app_skill_paths_from_env
+from dcc_mcp_core._runtime.skill_paths import get_local_skills_dir
+from dcc_mcp_core._runtime.skill_paths import get_skill_paths_from_env
+from dcc_mcp_core._runtime.skill_paths import get_skills_dir
 from dcc_mcp_core._server.minimal_mode import MinimalModeConfig
 from dcc_mcp_core._server.minimal_mode import apply_minimal_mode
 from dcc_mcp_core.hotreload import DccSkillHotReloader

--- a/python/dcc_mcp_core/_typing_compat.py
+++ b/python/dcc_mcp_core/_typing_compat.py
@@ -14,9 +14,12 @@ except ImportError:  # pragma: no cover - Python 3.7 only
     class Protocol:  # type: ignore[no-redef]
         """Duck-typed Protocol stand-in for Python 3.7."""
 
-    def Literal(*_args):  # type: ignore[misc]
+    class _LiteralMeta(type):
+        def __getitem__(cls, item):
+            return cls
+
+    class Literal(metaclass=_LiteralMeta):  # type: ignore[no-redef]
         """Literal stand-in for Python 3.7 static analysis only."""
-        return str
 
 
 __all__ = ["Literal", "Protocol", "runtime_checkable"]

--- a/python/dcc_mcp_core/_typing_compat.py
+++ b/python/dcc_mcp_core/_typing_compat.py
@@ -1,0 +1,22 @@
+"""Typing backports for Python 3.7 (Maya 2022 / Blender 2.83)."""
+
+from __future__ import annotations
+
+try:
+    from typing import Literal
+    from typing import Protocol
+    from typing import runtime_checkable
+except ImportError:  # pragma: no cover - Python 3.7 only
+
+    def runtime_checkable(cls):  # type: ignore[misc]
+        return cls
+
+    class Protocol:  # type: ignore[no-redef]
+        """Duck-typed Protocol stand-in for Python 3.7."""
+
+    def Literal(*_args):  # type: ignore[misc]
+        """Literal stand-in for Python 3.7 static analysis only."""
+        return str
+
+
+__all__ = ["Literal", "Protocol", "runtime_checkable"]

--- a/python/dcc_mcp_core/cancellation.py
+++ b/python/dcc_mcp_core/cancellation.py
@@ -51,8 +51,8 @@ if TYPE_CHECKING:
 # `cancelled` attribute contract; concrete impls don't need to inherit
 # from it either way (the `current_job` ContextVar is annotated, so the
 # type is only used for static analysis and runtime `isinstance` on 3.8+).
-from typing import Protocol
-from typing import runtime_checkable
+from dcc_mcp_core._typing_compat import Protocol
+from dcc_mcp_core._typing_compat import runtime_checkable
 
 __all__ = [
     "CancelToken",

--- a/python/dcc_mcp_core/host/_protocols.py
+++ b/python/dcc_mcp_core/host/_protocols.py
@@ -6,17 +6,8 @@ from __future__ import annotations
 # `typing.Protocol` and `typing.runtime_checkable` are 3.8+. For Python 3.7
 # (Maya 2022, Blender 2.83), expose duck-typed fallbacks with the same
 # attribute contracts; concrete dispatchers do not need to inherit either way.
-try:
-    from typing import Protocol
-    from typing import runtime_checkable
-except ImportError:  # pragma: no cover - Python 3.7 only
-
-    def runtime_checkable(cls):  # type: ignore[misc]
-        return cls
-
-    class Protocol:  # type: ignore[no-redef]
-        """Duck-typed Protocol stand-in for Python 3.7."""
-
+from dcc_mcp_core._typing_compat import Protocol
+from dcc_mcp_core._typing_compat import runtime_checkable
 
 # Import local modules
 try:

--- a/python/dcc_mcp_core/host/_protocols.py
+++ b/python/dcc_mcp_core/host/_protocols.py
@@ -4,9 +4,19 @@
 from __future__ import annotations
 
 # `typing.Protocol` and `typing.runtime_checkable` are 3.8+. For Python 3.7
-# (Maya 2022, Blender 2.83), expose a duck-typed base class there.
-from typing import Protocol
-from typing import runtime_checkable
+# (Maya 2022, Blender 2.83), expose duck-typed fallbacks with the same
+# attribute contracts; concrete dispatchers do not need to inherit either way.
+try:
+    from typing import Protocol
+    from typing import runtime_checkable
+except ImportError:  # pragma: no cover - Python 3.7 only
+
+    def runtime_checkable(cls):  # type: ignore[misc]
+        return cls
+
+    class Protocol:  # type: ignore[no-redef]
+        """Duck-typed Protocol stand-in for Python 3.7."""
+
 
 # Import local modules
 try:

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -59,6 +59,7 @@ def _package_version() -> str:
     except Exception:
         return _PKG_VERSION
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -20,9 +20,9 @@ import sys
 from typing import Any
 from typing import Callable
 
-from dcc_mcp_core import _core
-from dcc_mcp_core._core import create_skill_server
 from dcc_mcp_core._lifecycle_events import LifecycleEventDispatcher
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+from dcc_mcp_core._runtime.server_factory import create_adapter_server
 from dcc_mcp_core._server import ExecutionBridgeBinder
 from dcc_mcp_core._server import LifecycleController
 from dcc_mcp_core._server import ObservabilityFacade
@@ -39,7 +39,25 @@ from dcc_mcp_core._server.inprocess_executor import HostExecutionBridge
 from dcc_mcp_core._server.minimal_mode import MinimalModeConfig
 from dcc_mcp_core._server.options import DccServerOptions
 
-_PKG_VERSION: str = getattr(_core, "__version__", "0.0.0-dev")
+_PKG_VERSION: str = "0.0.0-dev"
+
+
+def _package_version() -> str:
+    if is_core_extension_available():
+        from dcc_mcp_core import _core
+
+        return str(getattr(_core, "__version__", "0.0.0-dev"))
+    try:
+        from importlib import metadata as importlib_metadata
+    except ImportError:
+        try:
+            import importlib_metadata  # type: ignore[import-not-found]
+        except ImportError:
+            return _PKG_VERSION
+    try:
+        return importlib_metadata.version("dcc-mcp-core")
+    except Exception:
+        return _PKG_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +129,7 @@ class DccServerBase:
         logger.info(
             "[%s] dcc-mcp-core %s (pid=%d, python=%s, platform=%s)",
             options.dcc_name,
-            _PKG_VERSION,
+            _package_version(),
             self._dcc_pid,
             "{}.{}.{}".format(*sys.version_info[:3]),
             sys.platform,
@@ -119,15 +137,15 @@ class DccServerBase:
 
         self._config = build_mcp_http_config(
             options,
-            package_version=_PKG_VERSION,
+            package_version=_package_version(),
             version_provider=self._version_string,
         )
 
         # --- Job persistence -----------------------------------------------------
         self._init_job_persistence(options.dcc_name)
 
-        # Create the inner skill manager
-        self._server: Any = create_skill_server(options.dcc_name, self._config)
+        # Create the inner skill manager (embedded _core or sidecar binary).
+        self._server: Any = create_adapter_server(options.dcc_name, self._config, options)
         self._register_builtin_skills(options)
 
         # Wire execution bridge / dispatcher

--- a/scripts/build_py37_pure_wheel.py
+++ b/scripts/build_py37_pure_wheel.py
@@ -1,0 +1,50 @@
+"""Build the py37-lite ``py3-none-any`` wheel without a ``_core`` extension.
+
+Maturin packages a platform wheel whenever ``Cargo.toml`` lists ``cdylib`` in
+``crate-type``, even when the PyO3 module is absent. For Maya 2022 / Python 3.7
+we need a pure-Python wheel, so this helper temporarily restricts the root
+crate to ``rlib`` only for the duration of ``maturin build``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+CARGO_TOML = ROOT / "Cargo.toml"
+CARGO_BACKUP = ROOT / "Cargo.toml.py37.bak"
+CRATE_TYPE_FROM = 'crate-type = ["cdylib", "rlib"]'
+CRATE_TYPE_TO = 'crate-type = ["rlib"]'
+
+
+def main() -> int:
+    """Patch ``Cargo.toml``, invoke maturin, and restore the manifest."""
+    text = CARGO_TOML.read_text(encoding="utf-8")
+    if CRATE_TYPE_FROM not in text:
+        sys.stderr.write(f"build_py37_pure_wheel: expected {CRATE_TYPE_FROM!r} in Cargo.toml\n")
+        return 1
+
+    shutil.copy2(CARGO_TOML, CARGO_BACKUP)
+    try:
+        CARGO_TOML.write_text(text.replace(CRATE_TYPE_FROM, CRATE_TYPE_TO), encoding="utf-8")
+        cmd = [
+            "maturin",
+            "build",
+            "--release",
+            "--out",
+            "dist",
+            "--no-default-features",
+            "-F",
+            "py37-lite",
+        ]
+        subprocess.check_call(cmd, cwd=str(ROOT))
+    finally:
+        shutil.move(str(CARGO_BACKUP), str(CARGO_TOML))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_py37_pure_wheel.py
+++ b/scripts/build_py37_pure_wheel.py
@@ -1,48 +1,69 @@
-"""Build the py37-lite ``py3-none-any`` wheel without a ``_core`` extension.
-
-Maturin packages a platform wheel whenever ``Cargo.toml`` lists ``cdylib`` in
-``crate-type``, even when the PyO3 module is absent. For Maya 2022 / Python 3.7
-we need a pure-Python wheel, so this helper temporarily restricts the root
-crate to ``rlib`` only for the duration of ``maturin build``.
-"""
+"""Build the py37-lite ``py3-none-any`` wheel without maturin or ``_core``."""
 
 from __future__ import annotations
 
+from email.message import EmailMessage
 from pathlib import Path
-import shutil
+import re
 import subprocess
 import sys
 
 ROOT = Path(__file__).resolve().parents[1]
-CARGO_TOML = ROOT / "Cargo.toml"
-CARGO_BACKUP = ROOT / "Cargo.toml.py37.bak"
-CRATE_TYPE_FROM = 'crate-type = ["cdylib", "rlib"]'
-CRATE_TYPE_TO = 'crate-type = ["rlib"]'
+PYTHON_ROOT = ROOT / "python"
+PACKAGE_DIR = PYTHON_ROOT / "dcc_mcp_core"
+DIST = ROOT / "dist"
+
+
+def _ensure_wheel() -> None:
+    try:
+        import wheel.wheelfile  # noqa: F401
+    except ImportError:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "wheel"])
+
+
+def _read_version() -> str:
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version = "([^"]+)"', text, re.MULTILINE)
+    if not match:
+        raise RuntimeError("could not read project version from pyproject.toml")
+    return match.group(1)
 
 
 def main() -> int:
-    """Patch ``Cargo.toml``, invoke maturin, and restore the manifest."""
-    text = CARGO_TOML.read_text(encoding="utf-8")
-    if CRATE_TYPE_FROM not in text:
-        sys.stderr.write(f"build_py37_pure_wheel: expected {CRATE_TYPE_FROM!r} in Cargo.toml\n")
-        return 1
+    """Assemble a pure-Python wheel from ``python/dcc_mcp_core``."""
+    _ensure_wheel()
+    from wheel.wheelfile import WheelFile
 
-    shutil.copy2(CARGO_TOML, CARGO_BACKUP)
-    try:
-        CARGO_TOML.write_text(text.replace(CRATE_TYPE_FROM, CRATE_TYPE_TO), encoding="utf-8")
-        cmd = [
-            "maturin",
-            "build",
-            "--release",
-            "--out",
-            "dist",
-            "--no-default-features",
-            "-F",
-            "py37-lite",
-        ]
-        subprocess.check_call(cmd, cwd=str(ROOT))
-    finally:
-        shutil.move(str(CARGO_BACKUP), str(CARGO_TOML))
+    version = _read_version()
+    dist_name = "dcc_mcp_core"
+    dist_info = f"{dist_name}-{version}.dist-info"
+    wheel_name = f"{dist_name}-{version}-py3-none-any.whl"
+    DIST.mkdir(parents=True, exist_ok=True)
+    wheel_path = DIST / wheel_name
+
+    metadata = EmailMessage()
+    metadata["Metadata-Version"] = "2.1"
+    metadata["Name"] = "dcc-mcp-core"
+    metadata["Version"] = version
+    metadata["Requires-Python"] = ">=3.7"
+    metadata["License"] = "MIT"
+    metadata["Summary"] = "Foundational library for the DCC Model Context Protocol (MCP) ecosystem"
+
+    wheel_meta = "Wheel-Version: 1.0\nGenerator: build_py37_pure_wheel\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+
+    with WheelFile(str(wheel_path), "w") as wf:
+        for file_path in sorted(PACKAGE_DIR.rglob("*")):
+            if not file_path.is_file():
+                continue
+            if "__pycache__" in file_path.parts:
+                continue
+            arcname = file_path.relative_to(PYTHON_ROOT).as_posix()
+            wf.write(str(file_path), arcname)
+
+        wf.writestr(f"{dist_info}/METADATA", metadata.as_string())
+        wf.writestr(f"{dist_info}/WHEEL", wheel_meta)
+
+    print(f"Built wheel: {wheel_path}")
     return 0
 
 

--- a/tests/test_dcc_adapter_base.py
+++ b/tests/test_dcc_adapter_base.py
@@ -537,7 +537,7 @@ class TestDccServerBase:
             calls.append((args, kwargs))
 
         monkeypatch.setattr("dcc_mcp_core._server.skill_discovery.register_all_builtin_skills", mock_register)
-        monkeypatch.setattr("dcc_mcp_core.server_base.create_skill_server", MagicMock())
+        monkeypatch.setattr("dcc_mcp_core.server_base.create_adapter_server", MagicMock())
 
         opts = DccServerOptions.from_env("maya", tmp_path, port=0, gateway_port=0)
         _ = DccServerBase(opts)
@@ -1033,7 +1033,7 @@ class TestDccServerBase:
                 return "20.5.1"
 
         opts = DccServerOptions.from_env("houdini", skills_dir, port=0, gateway_port=0)
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=_FakeDccServer()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=_FakeDccServer()):
             server = HoudiniMcpServer(opts)
 
         assert server._config.dcc_version == "20.5.1"
@@ -1056,7 +1056,7 @@ class TestDccServerBase:
             gateway_port=0,
             dcc_version="19.5.0",
         )
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=_FakeDccServer()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=_FakeDccServer()):
             server = HoudiniMcpServer(opts)
 
         assert server._config.dcc_version == "19.5.0"

--- a/tests/test_dcc_server_options.py
+++ b/tests/test_dcc_server_options.py
@@ -416,22 +416,17 @@ class TestDccServerBaseOptionsPath:
     """Verify DccServerBase(options) does not emit DeprecationWarning."""
 
     def _make_server_via_options(self, tmp_path):
-        import builtins
+        from unittest.mock import patch
 
         from dcc_mcp_core.server_base import DccServerBase
 
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir(exist_ok=True)
-        fake_cfg = _FakeConfig()
-        real_import = __import__
-
-        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-            if name == "dcc_mcp_core" and fromlist:
-                return _make_fake_dcc_mcp(fake_cfg)
-            return real_import(name, globals, locals, fromlist, level)
-
         opts = DccServerOptions.from_env("houdini", skills_dir)
-        with patch.object(builtins, "__import__", side_effect=fake_import):
+        with patch(
+            "dcc_mcp_core.server_base.create_adapter_server",
+            return_value=_FakeDccServer(),
+        ):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 server = DccServerBase(opts)

--- a/tests/test_inprocess_executor.py
+++ b/tests/test_inprocess_executor.py
@@ -593,7 +593,7 @@ def test_dcc_server_base_constructor_registers_dispatcher_before_discovery(
     fake_server = _Server()
     import dcc_mcp_core.server_base as server_base
 
-    monkeypatch.setattr(server_base, "create_skill_server", lambda *_args, **_kwargs: fake_server)
+    monkeypatch.setattr(server_base, "create_adapter_server", lambda *_args, **_kwargs: fake_server)
 
     class _Dispatcher:
         def dispatch_callable(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
@@ -636,7 +636,7 @@ def test_dcc_server_base_constructor_registers_execution_bridge_before_discovery
     fake_server = _Server()
     import dcc_mcp_core.server_base as server_base
 
-    monkeypatch.setattr(server_base, "create_skill_server", lambda *_args, **_kwargs: fake_server)
+    monkeypatch.setattr(server_base, "create_adapter_server", lambda *_args, **_kwargs: fake_server)
 
     bridge = HostExecutionBridge()
     opts = DccServerOptions.from_env(
@@ -675,7 +675,7 @@ def test_dcc_server_base_standalone_main_thread_registers_inline_executor_before
     fake_server = _Server()
     import dcc_mcp_core.server_base as server_base
 
-    monkeypatch.setattr(server_base, "create_skill_server", lambda *_args, **_kwargs: fake_server)
+    monkeypatch.setattr(server_base, "create_adapter_server", lambda *_args, **_kwargs: fake_server)
 
     opts = DccServerOptions.from_env(
         "test_standalone_ctor",
@@ -719,7 +719,7 @@ def test_dcc_server_base_execution_bridge_attaches_queue_dispatcher_before_disco
     fake_server = _Server()
     import dcc_mcp_core.server_base as server_base
 
-    monkeypatch.setattr(server_base, "create_skill_server", lambda *_args, **_kwargs: fake_server)
+    monkeypatch.setattr(server_base, "create_adapter_server", lambda *_args, **_kwargs: fake_server)
 
     dispatcher = QueueDispatcher()
     bridge = HostExecutionBridge(dispatcher=dispatcher)

--- a/tests/test_inprocess_sandbox.py
+++ b/tests/test_inprocess_sandbox.py
@@ -108,7 +108,7 @@ def _make_base_with_captured_executor(tmp_path: Path) -> tuple[DccServerBase, li
         enable_job_persistence=False,
         enable_telemetry=False,
     )
-    with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+    with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
         base = DccServerBase(opts)
 
     captured: list[Any] = []

--- a/tests/test_observability_defaults.py
+++ b/tests/test_observability_defaults.py
@@ -194,7 +194,9 @@ class TestTelemetryDefaults:
                 srv = _Stub(_options("maya", skills, port=0))
                 assert srv._enable_telemetry is False
 
-    def test_init_telemetry_skips_when_already_initialized(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_init_telemetry_skips_when_already_initialized(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """_init_telemetry must not call TelemetryConfig.init() twice."""
         with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging", return_value=""):

--- a/tests/test_observability_defaults.py
+++ b/tests/test_observability_defaults.py
@@ -42,7 +42,7 @@ def _options(dcc_name: str, skills: Path, **kwargs: object):
 class TestFileLoggingDefaults:
     def test_file_logging_enabled_by_default(self, tmp_path: Path) -> None:
         """init_file_logging must be called on construction when not disabled."""
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging") as mock_log:
                 mock_log.return_value = str(tmp_path)
                 _Stub, skills = _make_stub_class(tmp_path)
@@ -51,7 +51,7 @@ class TestFileLoggingDefaults:
 
     def test_file_logging_disabled_via_flag(self, tmp_path: Path) -> None:
         """enable_file_logging=False must be stored correctly."""
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging") as mock_log:
                 mock_log.return_value = ""
                 _Stub, skills = _make_stub_class(tmp_path)
@@ -68,7 +68,7 @@ class TestFileLoggingDefaults:
     def test_file_logging_disabled_via_env_var(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """DCC_MCP_DISABLE_FILE_LOGGING=1 must override enable_file_logging=True."""
         monkeypatch.setenv("DCC_MCP_DISABLE_FILE_LOGGING", "1")
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             _Stub, skills = _make_stub_class(tmp_path)
             srv = _Stub(_options("maya", skills, port=0))
             assert srv._enable_file_logging is False
@@ -76,13 +76,13 @@ class TestFileLoggingDefaults:
     def test_log_dir_property_reflects_resolved_dir(self, tmp_path: Path) -> None:
         """server.log_dir must return the path passed back by init_file_logging."""
         log_dir = str(tmp_path / "logs")
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging", return_value=log_dir):
                 _Stub, skills = _make_stub_class(tmp_path)
                 srv = _Stub(_options("maya", skills, port=0))
                 assert srv.log_dir == log_dir
 
-    def test_init_file_logging_helper_uses_dcc_prefix(self, tmp_path: Path) -> None:
+    def test_init_file_logging_helper_uses_dcc_prefix(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """_init_file_logging must set file_name_prefix=dcc-mcp-<dcc_name>."""
         captured: list = []
 
@@ -90,21 +90,20 @@ class TestFileLoggingDefaults:
             captured.append(cfg)
             return str(tmp_path)
 
-        with patch("dcc_mcp_core.init_file_logging", side_effect=_fake_init):
-            with patch("dcc_mcp_core.get_log_dir", return_value=str(tmp_path)):
-                from importlib import reload
+        import dcc_mcp_core
+        from types import SimpleNamespace
 
-                import dcc_mcp_core.server_base as sb
+        monkeypatch.setitem(dcc_mcp_core.__dict__, "init_file_logging", _fake_init)
+        monkeypatch.setitem(dcc_mcp_core.__dict__, "get_log_dir", lambda: str(tmp_path))
+        monkeypatch.setitem(
+            dcc_mcp_core.__dict__,
+            "FileLoggingConfig",
+            lambda **kwargs: SimpleNamespace(**kwargs),
+        )
 
-                reload(sb)
-
-                class _Stub(sb.DccServerBase):
-                    pass
-
-                skills = tmp_path / "skills"
-                skills.mkdir(exist_ok=True)
-                with patch.object(sb, "create_skill_server", return_value=MagicMock()):
-                    _Stub(_options("houdini", skills, port=0))
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
+            _Stub, skills = _make_stub_class(tmp_path)
+            _Stub(_options("houdini", skills, port=0))
 
         if captured:
             # Prefix includes PID suffix for multi-instance isolation (issue #402).
@@ -117,7 +116,7 @@ class TestFileLoggingDefaults:
 class TestJobPersistenceDefaults:
     def test_job_storage_path_set_by_default(self, tmp_path: Path) -> None:
         """job_storage_path on McpHttpConfig must be set when persistence is enabled."""
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging", return_value=str(tmp_path)):
                 _Stub, skills = _make_stub_class(tmp_path)
                 srv = _Stub(_options("maya", skills, port=0))
@@ -127,7 +126,7 @@ class TestJobPersistenceDefaults:
 
     def test_job_persistence_disabled_via_flag(self, tmp_path: Path) -> None:
         """enable_job_persistence=False must be stored correctly."""
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging", return_value=""):
                 _Stub, skills = _make_stub_class(tmp_path)
                 srv = _Stub(
@@ -143,7 +142,7 @@ class TestJobPersistenceDefaults:
     def test_job_persistence_disabled_via_env_var(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """DCC_MCP_DISABLE_JOB_PERSISTENCE=1 must override the default."""
         monkeypatch.setenv("DCC_MCP_DISABLE_JOB_PERSISTENCE", "1")
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging", return_value=""):
                 _Stub, skills = _make_stub_class(tmp_path)
                 srv = _Stub(_options("maya", skills, port=0))
@@ -161,7 +160,7 @@ class TestTelemetryDefaults:
         mock_server = MagicMock()
         mock_server.start.return_value = mock_handle
 
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=mock_server):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=mock_server):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging", return_value=""):
                 with patch("dcc_mcp_core.server_base.DccServerBase._init_telemetry") as mock_tel:
                     _Stub, skills = _make_stub_class(tmp_path)
@@ -172,7 +171,7 @@ class TestTelemetryDefaults:
 
     def test_telemetry_disabled_via_flag(self, tmp_path: Path) -> None:
         """enable_telemetry=False must be stored correctly."""
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging", return_value=""):
                 _Stub, skills = _make_stub_class(tmp_path)
                 srv = _Stub(
@@ -188,23 +187,26 @@ class TestTelemetryDefaults:
     def test_telemetry_disabled_via_env_var(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """DCC_MCP_DISABLE_TELEMETRY=1 must override enable_telemetry=True."""
         monkeypatch.setenv("DCC_MCP_DISABLE_TELEMETRY", "1")
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging", return_value=""):
                 _Stub, skills = _make_stub_class(tmp_path)
                 srv = _Stub(_options("maya", skills, port=0))
                 assert srv._enable_telemetry is False
 
-    def test_init_telemetry_skips_when_already_initialized(self, tmp_path: Path) -> None:
+    def test_init_telemetry_skips_when_already_initialized(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """_init_telemetry must not call TelemetryConfig.init() twice."""
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging", return_value=""):
                 _Stub, skills = _make_stub_class(tmp_path)
                 srv = _Stub(_options("maya", skills, port=0))
 
-        with patch("dcc_mcp_core.is_telemetry_initialized", return_value=True):
-            with patch("dcc_mcp_core.TelemetryConfig") as mock_tc:
-                srv._init_telemetry()
-                mock_tc.assert_not_called()
+        import dcc_mcp_core
+
+        mock_tc = MagicMock()
+        monkeypatch.setitem(dcc_mcp_core.__dict__, "is_telemetry_initialized", lambda: True)
+        monkeypatch.setitem(dcc_mcp_core.__dict__, "TelemetryConfig", mock_tc)
+        srv._init_telemetry()
+        mock_tc.assert_not_called()
 
 
 # ── observability_summary property ───────────────────────────────────────────
@@ -213,7 +215,7 @@ class TestTelemetryDefaults:
 class TestObservabilitySummary:
     def test_summary_keys_present(self, tmp_path: Path) -> None:
         """observability_summary must expose all three feature flags."""
-        with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        with patch("dcc_mcp_core.server_base.create_adapter_server", return_value=MagicMock()):
             with patch("dcc_mcp_core.server_base.DccServerBase._init_file_logging", return_value=""):
                 _Stub, skills = _make_stub_class(tmp_path)
                 srv = _Stub(_options("maya", skills, port=0))

--- a/tests/test_observability_defaults.py
+++ b/tests/test_observability_defaults.py
@@ -90,8 +90,9 @@ class TestFileLoggingDefaults:
             captured.append(cfg)
             return str(tmp_path)
 
-        import dcc_mcp_core
         from types import SimpleNamespace
+
+        import dcc_mcp_core
 
         monkeypatch.setitem(dcc_mcp_core.__dict__, "init_file_logging", _fake_init)
         monkeypatch.setitem(dcc_mcp_core.__dict__, "get_log_dir", lambda: str(tmp_path))

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -18,4 +18,5 @@ def _project_dependencies() -> list[str]:
 
 
 def test_core_requires_packaged_server_binary_runtime() -> None:
-    assert SERVER_BINARY_DEP in _project_dependencies()
+    deps = _project_dependencies()
+    assert any(dep.startswith(SERVER_BINARY_DEP) for dep in deps)

--- a/tests/test_py37_sidecar_server_factory.py
+++ b/tests/test_py37_sidecar_server_factory.py
@@ -22,6 +22,8 @@ class _SidecarStub:
     adapter_version: str | None = None
     display_name: str | None = None
     wait_ready_timeout_secs: float = 15.0
+    server_bin: str | None = None
+    extra_args: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -62,12 +64,18 @@ class TestServerFactoryRouting:
         )
         options = _OptionsStub(
             dcc_name="maya",
-            sidecar=_SidecarStub(host_rpc="commandport://127.0.0.1:6000"),
+            sidecar=_SidecarStub(
+                host_rpc="commandport://127.0.0.1:6000",
+                server_bin="dcc-mcp-server-test",
+                extra_args=("--ppid-poll-ms", "50"),
+            ),
         )
         config = PureMcpHttpConfig(port=8765, server_name="maya-mcp")
         server = create_adapter_server("maya", config, options)
         assert isinstance(server, SidecarBackedSkillServer)
         assert server.backend == "sidecar"
+        assert server._server_bin == "dcc-mcp-server-test"
+        assert server._extra_args == ("--ppid-poll-ms", "50")
 
     def test_uses_create_skill_server_when_core_available(self, monkeypatch: pytest.MonkeyPatch):
         import sys
@@ -127,6 +135,43 @@ class TestSidecarBackedSkillServer:
         server = SidecarBackedSkillServer("maya", PureMcpHttpConfig(), host_rpc="")
         with pytest.raises(RuntimeError, match="host_rpc"):
             server.start()
+
+    def test_start_forwards_server_bin_and_extra_args(self, monkeypatch: pytest.MonkeyPatch):
+        captured: dict = {}
+
+        def _fake_launch(**kwargs):
+            captured.update(kwargs)
+            return {
+                "success": True,
+                "readiness": {"mcp_url": "http://127.0.0.1:9876/mcp"},
+                "process": MagicMock(),
+            }
+
+        monkeypatch.setattr(
+            "dcc_mcp_core._runtime.sidecar_skill_server.launch_sidecar",
+            _fake_launch,
+        )
+        server = SidecarBackedSkillServer(
+            "maya",
+            PureMcpHttpConfig(port=8765),
+            host_rpc="commandport://127.0.0.1:6000",
+            server_bin="dcc-mcp-server-test",
+            extra_args=("--ppid-poll-ms", "50"),
+        )
+        server.start()
+        assert captured.get("server_bin") == "dcc-mcp-server-test"
+        assert captured.get("extra_args") == ("--ppid-poll-ms", "50")
+
+
+class TestExecutionBridgeLazyCore:
+    def test_sandbox_context_skips_core_when_unavailable(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            "dcc_mcp_core._server.execution_bridge.is_core_extension_available",
+            lambda: False,
+        )
+        from dcc_mcp_core._server.execution_bridge import _sandbox_context
+
+        assert _sandbox_context(MagicMock()) is None
 
 
 class TestServerBaseImportLight:

--- a/tests/test_py37_sidecar_server_factory.py
+++ b/tests/test_py37_sidecar_server_factory.py
@@ -1,0 +1,146 @@
+"""Tests for py37-lite sidecar server factory and pure-Python McpHttpConfig."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from dcc_mcp_core._runtime.config_bridge import resolve_mcp_http_config_class
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+from dcc_mcp_core._runtime.mcp_http_config import McpHttpConfig as PureMcpHttpConfig
+from dcc_mcp_core._runtime.server_factory import create_adapter_server
+from dcc_mcp_core._runtime.sidecar_skill_server import SidecarBackedSkillServer
+
+
+@dataclass(frozen=True)
+class _SidecarStub:
+    host_rpc: str
+    adapter_version: str | None = None
+    display_name: str | None = None
+    wait_ready_timeout_secs: float = 15.0
+
+
+@dataclass(frozen=True)
+class _DiagnosticsStub:
+    dcc_pid: int | None = None
+
+
+@dataclass(frozen=True)
+class _OptionsStub:
+    dcc_name: str
+    sidecar: _SidecarStub
+    diagnostics: _DiagnosticsStub = _DiagnosticsStub()
+
+
+class TestPureMcpHttpConfig:
+    def test_defaults_match_rust_surface(self):
+        cfg = PureMcpHttpConfig()
+        assert cfg.port == 8765
+        assert cfg.server_name == "dcc-mcp"
+        assert isinstance(cfg.server_version, str)
+        assert len(cfg.server_version) > 0
+        assert cfg.gateway_port == 9765
+        assert cfg.session_ttl_secs == 3600
+
+    def test_repr_contains_name_and_port(self):
+        cfg = PureMcpHttpConfig(port=1234, server_name="maya-mcp")
+        text = repr(cfg)
+        assert "McpHttpConfig" in text
+        assert "1234" in text
+        assert "maya-mcp" in text
+
+
+class TestServerFactoryRouting:
+    def test_uses_sidecar_backend_when_core_unavailable(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            "dcc_mcp_core._runtime.server_factory.is_core_extension_available",
+            lambda: False,
+        )
+        options = _OptionsStub(
+            dcc_name="maya",
+            sidecar=_SidecarStub(host_rpc="commandport://127.0.0.1:6000"),
+        )
+        config = PureMcpHttpConfig(port=8765, server_name="maya-mcp")
+        server = create_adapter_server("maya", config, options)
+        assert isinstance(server, SidecarBackedSkillServer)
+        assert server.backend == "sidecar"
+
+    def test_uses_create_skill_server_when_core_available(self, monkeypatch: pytest.MonkeyPatch):
+        import sys
+        import types
+
+        fake_server = MagicMock(name="embedded-server")
+        fake_core = types.ModuleType("dcc_mcp_core._core")
+
+        def _fake_create_skill_server(app_name, config):
+            assert app_name == "maya"
+            assert config is not None
+            return fake_server
+
+        fake_core.create_skill_server = _fake_create_skill_server
+        monkeypatch.setitem(sys.modules, "dcc_mcp_core._core", fake_core)
+        monkeypatch.setattr(
+            "dcc_mcp_core._runtime.server_factory.is_core_extension_available",
+            lambda: True,
+        )
+        options = SimpleNamespace(sidecar=_SidecarStub(host_rpc="commandport://127.0.0.1:6000"))
+        config = PureMcpHttpConfig()
+        server = create_adapter_server("maya", config, options)
+        assert server is fake_server
+
+
+class TestSidecarBackedSkillServer:
+    def test_discover_records_paths_without_core(self):
+        server = SidecarBackedSkillServer(
+            "maya",
+            PureMcpHttpConfig(),
+            host_rpc="commandport://127.0.0.1:6000",
+        )
+        count = server.discover(extra_paths=["/tmp/skills"])
+        assert count == 1
+
+    def test_start_launches_sidecar_and_returns_handle(self, monkeypatch: pytest.MonkeyPatch):
+        server = SidecarBackedSkillServer(
+            "maya",
+            PureMcpHttpConfig(port=8765),
+            host_rpc="commandport://127.0.0.1:6000",
+        )
+
+        monkeypatch.setattr(
+            "dcc_mcp_core._runtime.sidecar_skill_server.launch_sidecar",
+            lambda **kwargs: {
+                "success": True,
+                "readiness": {"mcp_url": "http://127.0.0.1:9876/mcp"},
+                "process": MagicMock(),
+            },
+        )
+
+        handle = server.start()
+        assert handle.port == 9876
+        assert handle.mcp_url() == "http://127.0.0.1:9876/mcp"
+
+    def test_start_requires_host_rpc(self):
+        server = SidecarBackedSkillServer("maya", PureMcpHttpConfig(), host_rpc="")
+        with pytest.raises(RuntimeError, match="host_rpc"):
+            server.start()
+
+
+class TestServerBaseImportLight:
+    def test_server_base_does_not_import_core_at_module_level(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setitem(__import__("sys").modules, "dcc_mcp_core._core", MagicMock(__version__="test"))
+        import importlib
+
+        module = importlib.import_module("dcc_mcp_core.server_base")
+
+        assert "create_skill_server" not in module.__dict__
+        assert "create_adapter_server" in module.__dict__
+
+
+@pytest.mark.skipif(is_core_extension_available(), reason="only meaningful on py37-lite profile")
+def test_resolve_mcp_http_config_class_uses_pure_python():
+    cls = resolve_mcp_http_config_class()
+    assert cls is PureMcpHttpConfig


### PR DESCRIPTION
## Summary

- Add a pure-Python `McpHttpConfig` and config bridge so py37-lite wheels can build HTTP config without importing `_core`.
- Route `DccServerBase` through `create_adapter_server()`: embedded `create_skill_server` when `_core` is available, otherwise `SidecarBackedSkillServer` that launches `dcc-mcp-server sidecar` via existing import-light lifecycle helpers.
- Remove module-level `_core` imports from `server_base.py` and skill path discovery; add `SidecarOptions` on `DccServerOptions` for `host_rpc`.

## Test plan

- [x] `PYTHONPATH=python pytest tests/test_py37_sidecar_server_factory.py -q` (9 passed locally)
- [ ] CI `py37 syntax check`
- [ ] CI `test-py37` wheel smoke
- [ ] Sidecar binary e2e matrix (follow-up)

## Notes

This is phase 1 of the py37-lite sidecar decoupling work. Remaining follow-ups: sidecar binary integration test matrix, broader `_core` import convergence in execution/observability modules, and Maya adapter wiring for `SidecarOptions.host_rpc`.
