### PR TITLE
fix: satisfy ruff on py37-lite helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,35 +518,38 @@ jobs:
           "
       - name: Verify import dcc_mcp_core works
         shell: bash
-        run: python -c "import dcc_mcp_core; print('OK: import dcc_mcp_core')"
+        run: |
+          python -c "import dcc_mcp_core; print('OK: import dcc_mcp_core')"
       - name: Verify skill module works
         shell: bash
-        run: python -c "
-          from dcc_mcp_core.skill import skill_entry, skill_success, skill_error;
-          result = skill_success('test');
-          assert result['success'] is True;
+        run: |
+          python -c "
+          from dcc_mcp_core.skill import skill_entry, skill_success, skill_error
+          result = skill_success('test')
+          assert result['success'] is True
           print('OK: dcc_mcp_core.skill works')
-        "
+          "
       - name: Verify host module imports (without _core)
         shell: bash
-        run: python -c "
-          import dcc_mcp_core.host;
-          assert dcc_mcp_core.host.BlockingDispatcher is None;
-          assert dcc_mcp_core.host.QueueDispatcher is None;
-          # Pure-Python sub-modules work fine
-          from dcc_mcp_core.host._adapter import HostAdapter, TickableDispatcher;
-          from dcc_mcp_core.host._standalone import StandaloneHost;
+        run: |
+          python -c "
+          import dcc_mcp_core.host
+          assert dcc_mcp_core.host.BlockingDispatcher is None
+          assert dcc_mcp_core.host.QueueDispatcher is None
+          from dcc_mcp_core.host._adapter import HostAdapter, TickableDispatcher
+          from dcc_mcp_core.host._standalone import StandaloneHost
           print('OK: dcc_mcp_core.host imports without _core')
-        "
+          "
       - name: Verify lazy _core fallback (skill._serialize_result)
         shell: bash
-        run: python -c "
-          from dcc_mcp_core.skill import skill_success;
-          from dcc_mcp_core.skill import _serialize_result as sr;
-          result = sr(skill_success('test'));
-          assert 'success' in result;
+        run: |
+          python -c "
+          from dcc_mcp_core.skill import skill_success
+          from dcc_mcp_core.skill import _serialize_result as sr
+          result = sr(skill_success('test'))
+          assert 'success' in result
           print('OK: skill._serialize_result falls back to pure Python')
-        "
+          "
       - name: Run py37 sidecar factory tests (source tree)
         shell: bash
         run: PYTHONPATH=python pytest tests/test_py37_sidecar_server_factory.py -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,9 @@ jobs:
           assert 'success' in result;
           print('OK: skill._serialize_result falls back to pure Python')
         "
+      - name: Run py37 sidecar factory tests (source tree)
+        shell: bash
+        run: PYTHONPATH=python pytest tests/test_py37_sidecar_server_factory.py -q
 
   # ── Lint Python source ──
   lint:

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -79,7 +79,7 @@ _LAZY: dict[str, str] = {
     "IntWrapper": "dcc_mcp_core._core",
     "IpcChannelAdapter": "dcc_mcp_core._core",
     "LoggingMiddleware": "dcc_mcp_core._core",
-    "McpHttpConfig": "dcc_mcp_core._core",
+    "McpHttpConfig": "dcc_mcp_core._runtime.config_bridge",
     "McpHttpServer": "dcc_mcp_core._core",
     "McpServerHandle": "dcc_mcp_core._core",
     "ObjectTransform": "dcc_mcp_core._core",

--- a/python/dcc_mcp_core/_runtime/__init__.py
+++ b/python/dcc_mcp_core/_runtime/__init__.py
@@ -8,5 +8,5 @@ __all__ = [
     "resolve_mcp_http_config_class",
 ]
 
-from dcc_mcp_core._runtime.core_availability import is_core_extension_available
 from dcc_mcp_core._runtime.config_bridge import resolve_mcp_http_config_class
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available

--- a/python/dcc_mcp_core/_runtime/__init__.py
+++ b/python/dcc_mcp_core/_runtime/__init__.py
@@ -1,0 +1,12 @@
+"""Runtime helpers for py37-lite and sidecar-backed HTTP/MCP serving."""
+
+from __future__ import annotations
+
+__all__ = [
+    "create_adapter_server",
+    "is_core_extension_available",
+    "resolve_mcp_http_config_class",
+]
+
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+from dcc_mcp_core._runtime.config_bridge import resolve_mcp_http_config_class

--- a/python/dcc_mcp_core/_runtime/config_bridge.py
+++ b/python/dcc_mcp_core/_runtime/config_bridge.py
@@ -1,0 +1,22 @@
+"""Resolve the active ``McpHttpConfig`` implementation for the current wheel."""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Type
+
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+
+
+def resolve_mcp_http_config_class() -> Type[Any]:
+    """Return PyO3 ``McpHttpConfig`` when available, else the pure-Python dataclass."""
+    if is_core_extension_available():
+        from dcc_mcp_core._core import McpHttpConfig as CoreMcpHttpConfig
+
+        return CoreMcpHttpConfig
+    from dcc_mcp_core._runtime.mcp_http_config import McpHttpConfig as PureMcpHttpConfig
+
+    return PureMcpHttpConfig
+
+
+McpHttpConfig = resolve_mcp_http_config_class()

--- a/python/dcc_mcp_core/_runtime/config_bridge.py
+++ b/python/dcc_mcp_core/_runtime/config_bridge.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Type
 
 from dcc_mcp_core._runtime.core_availability import is_core_extension_available
 
 
-def resolve_mcp_http_config_class() -> Type[Any]:
+def resolve_mcp_http_config_class() -> type[Any]:
     """Return PyO3 ``McpHttpConfig`` when available, else the pure-Python dataclass."""
     if is_core_extension_available():
         from dcc_mcp_core._core import McpHttpConfig as CoreMcpHttpConfig

--- a/python/dcc_mcp_core/_runtime/core_availability.py
+++ b/python/dcc_mcp_core/_runtime/core_availability.py
@@ -1,0 +1,27 @@
+"""Detect whether the compiled ``dcc_mcp_core._core`` extension is loadable."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+_CORE_AVAILABLE: bool | None = None
+
+
+def is_core_extension_available() -> bool:
+    """Return ``True`` when the PyO3 ``_core`` extension can be imported."""
+    global _CORE_AVAILABLE
+    if _CORE_AVAILABLE is not None:
+        return _CORE_AVAILABLE
+
+    if sys.version_info < (3, 8):
+        _CORE_AVAILABLE = False
+        return _CORE_AVAILABLE
+
+    try:
+        importlib.import_module("dcc_mcp_core._core")
+    except ImportError:
+        _CORE_AVAILABLE = False
+    else:
+        _CORE_AVAILABLE = True
+    return _CORE_AVAILABLE

--- a/python/dcc_mcp_core/_runtime/core_availability.py
+++ b/python/dcc_mcp_core/_runtime/core_availability.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib
-import sys
 
 _CORE_AVAILABLE: bool | None = None
 
@@ -12,10 +11,6 @@ def is_core_extension_available() -> bool:
     """Return ``True`` when the PyO3 ``_core`` extension can be imported."""
     global _CORE_AVAILABLE
     if _CORE_AVAILABLE is not None:
-        return _CORE_AVAILABLE
-
-    if sys.version_info < (3, 8):
-        _CORE_AVAILABLE = False
         return _CORE_AVAILABLE
 
     try:

--- a/python/dcc_mcp_core/_runtime/mcp_http_config.py
+++ b/python/dcc_mcp_core/_runtime/mcp_http_config.py
@@ -1,0 +1,90 @@
+"""Pure-Python ``McpHttpConfig`` for py37-lite and sidecar-backed adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+
+def _default_server_version() -> str:
+    try:
+        from importlib import metadata as importlib_metadata
+    except ImportError:
+        try:
+            import importlib_metadata  # type: ignore[import-not-found]
+        except ImportError:
+            return "0.0.0-dev"
+    try:
+        return importlib_metadata.version("dcc-mcp-core")
+    except Exception:
+        return "0.0.0-dev"
+
+
+@dataclass
+class McpHttpConfig:
+    """Python-visible MCP HTTP server configuration without PyO3."""
+
+    port: int = 8765
+    server_name: str = "dcc-mcp"
+    server_version: str = field(default_factory=_default_server_version)
+    host: str = "127.0.0.1"
+    endpoint_path: str = "/mcp"
+    enable_cors: bool = False
+    request_timeout_ms: int = 30000
+    session_ttl_secs: int = 3600
+    enable_tool_cache: bool = False
+    enable_prometheus: bool = False
+    gateway_port: int = 9765
+    registry_dir: Optional[str] = None
+    dcc_version: str = ""
+    scene: str = ""
+    dcc_type: str = ""
+    instance_metadata: Dict[str, str] = field(default_factory=dict)
+    standalone_main_thread_execution: bool = False
+    exclude_skill_stubs_from_tools_list: bool = False
+    exclude_group_stubs_from_tools_list: bool = False
+    job_storage_path: Optional[str] = None
+    sandbox_policy: Any = None
+
+    def __init__(
+        self,
+        port: int = 8765,
+        server_name: Optional[str] = None,
+        server_version: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.port = int(port)
+        self.server_name = server_name if server_name is not None else "dcc-mcp"
+        self.server_version = server_version if server_version is not None else _default_server_version()
+        self.host = str(kwargs.pop("host", "127.0.0.1"))
+        self.endpoint_path = str(kwargs.pop("endpoint_path", "/mcp"))
+        self.enable_cors = bool(kwargs.pop("enable_cors", False))
+        self.request_timeout_ms = int(kwargs.pop("request_timeout_ms", 30000))
+        self.session_ttl_secs = int(kwargs.pop("session_ttl_secs", 3600))
+        self.enable_tool_cache = bool(kwargs.pop("enable_tool_cache", False))
+        self.enable_prometheus = bool(kwargs.pop("enable_prometheus", False))
+        self.gateway_port = int(kwargs.pop("gateway_port", 9765))
+        self.registry_dir = kwargs.pop("registry_dir", None)
+        self.dcc_version = str(kwargs.pop("dcc_version", ""))
+        self.scene = str(kwargs.pop("scene", ""))
+        self.dcc_type = str(kwargs.pop("dcc_type", ""))
+        metadata = kwargs.pop("instance_metadata", None)
+        self.instance_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        self.standalone_main_thread_execution = bool(kwargs.pop("standalone_main_thread_execution", False))
+        self.exclude_skill_stubs_from_tools_list = bool(kwargs.pop("exclude_skill_stubs_from_tools_list", False))
+        self.exclude_group_stubs_from_tools_list = bool(kwargs.pop("exclude_group_stubs_from_tools_list", False))
+        self.job_storage_path = kwargs.pop("job_storage_path", None)
+        self.sandbox_policy = kwargs.pop("sandbox_policy", None)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def __repr__(self) -> str:
+        return (
+            "McpHttpConfig("
+            f"port={self.port}, "
+            f"server_name={self.server_name!r}, "
+            f"server_version={self.server_version!r})"
+        )

--- a/python/dcc_mcp_core/_runtime/mcp_http_config.py
+++ b/python/dcc_mcp_core/_runtime/mcp_http_config.py
@@ -81,8 +81,5 @@ class McpHttpConfig:
 
     def __repr__(self) -> str:
         return (
-            "McpHttpConfig("
-            f"port={self.port}, "
-            f"server_name={self.server_name!r}, "
-            f"server_version={self.server_version!r})"
+            f"McpHttpConfig(port={self.port}, server_name={self.server_name!r}, server_version={self.server_version!r})"
         )

--- a/python/dcc_mcp_core/_runtime/mcp_http_config.py
+++ b/python/dcc_mcp_core/_runtime/mcp_http_config.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
-from typing import Dict
-from typing import Optional
 
 
 def _default_server_version() -> str:
@@ -38,22 +36,22 @@ class McpHttpConfig:
     enable_tool_cache: bool = False
     enable_prometheus: bool = False
     gateway_port: int = 9765
-    registry_dir: Optional[str] = None
+    registry_dir: str | None = None
     dcc_version: str = ""
     scene: str = ""
     dcc_type: str = ""
-    instance_metadata: Dict[str, str] = field(default_factory=dict)
+    instance_metadata: dict[str, str] = field(default_factory=dict)
     standalone_main_thread_execution: bool = False
     exclude_skill_stubs_from_tools_list: bool = False
     exclude_group_stubs_from_tools_list: bool = False
-    job_storage_path: Optional[str] = None
+    job_storage_path: str | None = None
     sandbox_policy: Any = None
 
     def __init__(
         self,
         port: int = 8765,
-        server_name: Optional[str] = None,
-        server_version: Optional[str] = None,
+        server_name: str | None = None,
+        server_version: str | None = None,
         **kwargs: Any,
     ) -> None:
         self.port = int(port)

--- a/python/dcc_mcp_core/_runtime/server_factory.py
+++ b/python/dcc_mcp_core/_runtime/server_factory.py
@@ -1,0 +1,60 @@
+"""Factory for adapter-local MCP servers (embedded _core or sidecar binary)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from typing import Optional
+
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+from dcc_mcp_core._runtime.sidecar_skill_server import SidecarBackedSkillServer
+
+
+def create_adapter_server(
+    dcc_name: str,
+    config: Any,
+    options: Optional[Any] = None,
+) -> Any:
+    """Create the inner server object used by :class:`DccServerBase`."""
+    if is_core_extension_available():
+        from dcc_mcp_core._core import create_skill_server
+
+        return create_skill_server(dcc_name, config)
+
+    sidecar = getattr(options, "sidecar", None) if options is not None else None
+    host_rpc = _resolve_host_rpc(sidecar)
+    return SidecarBackedSkillServer(
+        dcc_name,
+        config,
+        host_rpc=host_rpc,
+        watch_pid=_resolve_watch_pid(options),
+        adapter_version=getattr(sidecar, "adapter_version", None) if sidecar is not None else None,
+        display_name=getattr(sidecar, "display_name", None) if sidecar is not None else None,
+        wait_ready_timeout_secs=_resolve_wait_ready(sidecar),
+    )
+
+
+def _resolve_host_rpc(sidecar: Any) -> str:
+    if sidecar is not None:
+        value = getattr(sidecar, "host_rpc", None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return str(os.environ.get("DCC_MCP_HOST_RPC", "")).strip()
+
+
+def _resolve_watch_pid(options: Optional[Any]) -> Optional[int]:
+    if options is None:
+        return None
+    diagnostics = getattr(options, "diagnostics", None)
+    if diagnostics is not None and getattr(diagnostics, "dcc_pid", None) is not None:
+        return int(diagnostics.dcc_pid)
+    return None
+
+
+def _resolve_wait_ready(sidecar: Any) -> float:
+    if sidecar is None:
+        return 15.0
+    value = getattr(sidecar, "wait_ready_timeout_secs", None)
+    if value is None:
+        return 15.0
+    return float(value)

--- a/python/dcc_mcp_core/_runtime/server_factory.py
+++ b/python/dcc_mcp_core/_runtime/server_factory.py
@@ -31,6 +31,8 @@ def create_adapter_server(
         adapter_version=getattr(sidecar, "adapter_version", None) if sidecar is not None else None,
         display_name=getattr(sidecar, "display_name", None) if sidecar is not None else None,
         wait_ready_timeout_secs=_resolve_wait_ready(sidecar),
+        server_bin=getattr(sidecar, "server_bin", None) if sidecar is not None else None,
+        extra_args=_resolve_extra_args(sidecar),
     )
 
 
@@ -58,3 +60,12 @@ def _resolve_wait_ready(sidecar: Any) -> float:
     if value is None:
         return 15.0
     return float(value)
+
+
+def _resolve_extra_args(sidecar: Any) -> tuple:
+    if sidecar is None:
+        return ()
+    value = getattr(sidecar, "extra_args", None)
+    if not value:
+        return ()
+    return tuple(str(arg) for arg in value)

--- a/python/dcc_mcp_core/_runtime/server_factory.py
+++ b/python/dcc_mcp_core/_runtime/server_factory.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 from typing import Any
-from typing import Optional
 
 from dcc_mcp_core._runtime.core_availability import is_core_extension_available
 from dcc_mcp_core._runtime.sidecar_skill_server import SidecarBackedSkillServer
@@ -13,7 +12,7 @@ from dcc_mcp_core._runtime.sidecar_skill_server import SidecarBackedSkillServer
 def create_adapter_server(
     dcc_name: str,
     config: Any,
-    options: Optional[Any] = None,
+    options: Any | None = None,
 ) -> Any:
     """Create the inner server object used by :class:`DccServerBase`."""
     if is_core_extension_available():
@@ -44,7 +43,7 @@ def _resolve_host_rpc(sidecar: Any) -> str:
     return str(os.environ.get("DCC_MCP_HOST_RPC", "")).strip()
 
 
-def _resolve_watch_pid(options: Optional[Any]) -> Optional[int]:
+def _resolve_watch_pid(options: Any | None) -> int | None:
     if options is None:
         return None
     diagnostics = getattr(options, "diagnostics", None)

--- a/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
+++ b/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
@@ -56,6 +56,8 @@ class SidecarBackedSkillServer:
         adapter_version: Optional[str] = None,
         display_name: Optional[str] = None,
         wait_ready_timeout_secs: float = 15.0,
+        server_bin: Optional[str] = None,
+        extra_args: Optional[tuple] = None,
     ) -> None:
         self._dcc_name = str(dcc_name or "dcc")
         self._config = config
@@ -64,6 +66,8 @@ class SidecarBackedSkillServer:
         self._adapter_version = adapter_version
         self._display_name = display_name or self._dcc_name
         self._wait_ready_timeout_secs = float(wait_ready_timeout_secs)
+        self._server_bin = str(server_bin).strip() if server_bin else None
+        self._extra_args = tuple(str(arg) for arg in (extra_args or ()))
         self._registry = PurePythonToolRegistry()
         self._pending_skill_paths: List[str] = []
         self._handle: Optional[SidecarServerHandle] = None
@@ -121,6 +125,8 @@ class SidecarBackedSkillServer:
             gateway_port=gateway_port if gateway_port > 0 else None,
             wait_ready_timeout_secs=self._wait_ready_timeout_secs,
             require_dispatch_capable=True,
+            server_bin=self._server_bin,
+            extra_args=self._extra_args or None,
         )
         self._launch_result = dict(launch)
         if not launch.get("success"):

--- a/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
+++ b/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
@@ -1,0 +1,205 @@
+"""Sidecar-backed skill server facade for py37-lite ``DccServerBase``."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from dcc_mcp_core._install_lifecycle_sidecar import build_sidecar_command
+from dcc_mcp_core._install_lifecycle_sidecar import launch_sidecar
+from dcc_mcp_core._runtime.tool_registry_py import PurePythonToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class SidecarServerHandle:
+    """Handle returned by :meth:`SidecarBackedSkillServer.start`."""
+
+    def __init__(self, *, port: int, mcp_url: str, shutdown: Callable[[], None]) -> None:
+        self._port = int(port)
+        self._mcp_url = str(mcp_url)
+        self._shutdown = shutdown
+        self.is_gateway = False
+
+    @property
+    def port(self) -> int:
+        return self._port
+
+    def mcp_url(self) -> str:
+        return self._mcp_url
+
+    def shutdown(self) -> None:
+        self._shutdown()
+
+    def update_gateway_metadata(self, **metadata: Any) -> bool:
+        logger.debug("sidecar handle ignores update_gateway_metadata: %s", metadata)
+        return False
+
+
+class SidecarBackedSkillServer:
+    """Launch ``dcc-mcp-server sidecar`` instead of embedding ``McpHttpServer``."""
+
+    backend = "sidecar"
+
+    def __init__(
+        self,
+        dcc_name: str,
+        config: Any,
+        *,
+        host_rpc: str,
+        watch_pid: Optional[int] = None,
+        adapter_version: Optional[str] = None,
+        display_name: Optional[str] = None,
+        wait_ready_timeout_secs: float = 15.0,
+    ) -> None:
+        self._dcc_name = str(dcc_name or "dcc")
+        self._config = config
+        self._host_rpc = str(host_rpc or "").strip()
+        self._watch_pid = watch_pid
+        self._adapter_version = adapter_version
+        self._display_name = display_name or self._dcc_name
+        self._wait_ready_timeout_secs = float(wait_ready_timeout_secs)
+        self._registry = PurePythonToolRegistry()
+        self._pending_skill_paths: List[str] = []
+        self._handle: Optional[SidecarServerHandle] = None
+        self._launch_result: Dict[str, Any] = {}
+
+    @property
+    def registry(self) -> PurePythonToolRegistry:
+        return self._registry
+
+    def discover(self, extra_paths: Optional[List[str]] = None) -> int:
+        paths = [str(path) for path in (extra_paths or []) if str(path).strip()]
+        self._pending_skill_paths = paths
+        if paths:
+            existing = os.environ.get("DCC_MCP_SKILL_PATHS", "")
+            merged = os.pathsep.join([existing] + paths) if existing else os.pathsep.join(paths)
+            os.environ["DCC_MCP_SKILL_PATHS"] = merged
+        logger.info(
+            "[%s] sidecar discover recorded %d path(s); HTTP/MCP is owned by dcc-mcp-server sidecar",
+            self._dcc_name,
+            len(paths),
+        )
+        return len(paths)
+
+    def start(self) -> SidecarServerHandle:
+        if self._handle is not None:
+            return self._handle
+        if not self._host_rpc:
+            raise RuntimeError(
+                "host_rpc is required for py37-lite sidecar mode; "
+                "set DccServerOptions.sidecar.host_rpc or DCC_MCP_HOST_RPC"
+            )
+
+        gateway_port = int(getattr(self._config, "gateway_port", 0) or 0)
+        registry_dir = getattr(self._config, "registry_dir", None)
+        command = build_sidecar_command(
+            dcc_type=self._dcc_name,
+            host_rpc=self._host_rpc,
+            watch_pid=self._watch_pid,
+            registry_dir=registry_dir,
+            display_name=self._display_name,
+            adapter_version=self._adapter_version,
+            gateway_port=gateway_port if gateway_port > 0 else None,
+            require_dispatch_capable=True,
+        )
+        if not command.get("success"):
+            raise RuntimeError(command.get("message") or "failed to build sidecar launch command")
+
+        launch = launch_sidecar(
+            dcc_type=self._dcc_name,
+            host_rpc=self._host_rpc,
+            watch_pid=self._watch_pid,
+            registry_dir=registry_dir,
+            display_name=self._display_name,
+            adapter_version=self._adapter_version,
+            gateway_port=gateway_port if gateway_port > 0 else None,
+            wait_ready_timeout_secs=self._wait_ready_timeout_secs,
+            require_dispatch_capable=True,
+        )
+        self._launch_result = dict(launch)
+        if not launch.get("success"):
+            raise RuntimeError(launch.get("message") or "sidecar launch failed")
+
+        mcp_url = _resolve_mcp_url(launch)
+        port = _port_from_url(mcp_url)
+        proc = launch.get("process")
+
+        def _shutdown() -> None:
+            if proc is not None:
+                try:
+                    proc.terminate()
+                except Exception as exc:
+                    logger.debug("[%s] sidecar terminate failed: %s", self._dcc_name, exc)
+
+        self._handle = SidecarServerHandle(port=port, mcp_url=mcp_url, shutdown=_shutdown)
+        return self._handle
+
+    # SkillQueryClient compatibility stubs ---------------------------------
+
+    def list_skills(self) -> List[Any]:
+        return []
+
+    def search_skills(self, **kwargs: Any) -> List[Any]:
+        return []
+
+    def load_skill(self, name: str) -> None:
+        logger.debug("[%s] load_skill(%r) delegated to sidecar", self._dcc_name, name)
+
+    def get_skill(self, name: str) -> Any:
+        return None
+
+    def load_skill_object(self, skill: Any) -> None:
+        logger.debug("[%s] load_skill_object delegated to sidecar", self._dcc_name)
+
+    def unload_skill(self, name: str) -> None:
+        logger.debug("[%s] unload_skill(%r) delegated to sidecar", self._dcc_name, name)
+
+    def is_loaded(self, name: str) -> bool:
+        return False
+
+    def get_skill_info(self, name: str) -> Any:
+        return None
+
+    def set_in_process_executor(self, executor: Any) -> None:
+        logger.debug("[%s] set_in_process_executor stored for host-rpc dispatch", self._dcc_name)
+
+    def attach_dispatcher(self, dispatcher: Any) -> None:
+        logger.debug("[%s] attach_dispatcher ignored in sidecar mode", self._dcc_name)
+
+    def resources(self) -> Any:
+        return None
+
+    def set_readiness_probe(self, probe: Any) -> bool:
+        return False
+
+
+def _resolve_mcp_url(launch: Dict[str, Any]) -> str:
+    readiness = launch.get("readiness") or {}
+    for key in ("mcp_url", "discovery_mcp_url", "endpoint"):
+        value = readiness.get(key) or launch.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    metadata = readiness.get("metadata") or launch.get("metadata") or {}
+    if isinstance(metadata, dict):
+        value = metadata.get("mcp_url")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "http://127.0.0.1:0/mcp"
+
+
+def _port_from_url(url: str) -> int:
+    try:
+        from urllib.parse import urlsplit
+
+        split = urlsplit(url)
+        if split.port is not None:
+            return int(split.port)
+    except Exception:
+        pass
+    return 0

--- a/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
+++ b/python/dcc_mcp_core/_runtime/sidecar_skill_server.py
@@ -6,9 +6,6 @@ import logging
 import os
 from typing import Any
 from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
 
 from dcc_mcp_core._install_lifecycle_sidecar import build_sidecar_command
 from dcc_mcp_core._install_lifecycle_sidecar import launch_sidecar
@@ -52,12 +49,12 @@ class SidecarBackedSkillServer:
         config: Any,
         *,
         host_rpc: str,
-        watch_pid: Optional[int] = None,
-        adapter_version: Optional[str] = None,
-        display_name: Optional[str] = None,
+        watch_pid: int | None = None,
+        adapter_version: str | None = None,
+        display_name: str | None = None,
         wait_ready_timeout_secs: float = 15.0,
-        server_bin: Optional[str] = None,
-        extra_args: Optional[tuple] = None,
+        server_bin: str | None = None,
+        extra_args: tuple | None = None,
     ) -> None:
         self._dcc_name = str(dcc_name or "dcc")
         self._config = config
@@ -69,20 +66,20 @@ class SidecarBackedSkillServer:
         self._server_bin = str(server_bin).strip() if server_bin else None
         self._extra_args = tuple(str(arg) for arg in (extra_args or ()))
         self._registry = PurePythonToolRegistry()
-        self._pending_skill_paths: List[str] = []
-        self._handle: Optional[SidecarServerHandle] = None
-        self._launch_result: Dict[str, Any] = {}
+        self._pending_skill_paths: list[str] = []
+        self._handle: SidecarServerHandle | None = None
+        self._launch_result: dict[str, Any] = {}
 
     @property
     def registry(self) -> PurePythonToolRegistry:
         return self._registry
 
-    def discover(self, extra_paths: Optional[List[str]] = None) -> int:
+    def discover(self, extra_paths: list[str] | None = None) -> int:
         paths = [str(path) for path in (extra_paths or []) if str(path).strip()]
         self._pending_skill_paths = paths
         if paths:
             existing = os.environ.get("DCC_MCP_SKILL_PATHS", "")
-            merged = os.pathsep.join([existing] + paths) if existing else os.pathsep.join(paths)
+            merged = os.pathsep.join([existing, *paths]) if existing else os.pathsep.join(paths)
             os.environ["DCC_MCP_SKILL_PATHS"] = merged
         logger.info(
             "[%s] sidecar discover recorded %d path(s); HTTP/MCP is owned by dcc-mcp-server sidecar",
@@ -148,10 +145,10 @@ class SidecarBackedSkillServer:
 
     # SkillQueryClient compatibility stubs ---------------------------------
 
-    def list_skills(self) -> List[Any]:
+    def list_skills(self) -> list[Any]:
         return []
 
-    def search_skills(self, **kwargs: Any) -> List[Any]:
+    def search_skills(self, **kwargs: Any) -> list[Any]:
         return []
 
     def load_skill(self, name: str) -> None:
@@ -185,7 +182,7 @@ class SidecarBackedSkillServer:
         return False
 
 
-def _resolve_mcp_url(launch: Dict[str, Any]) -> str:
+def _resolve_mcp_url(launch: dict[str, Any]) -> str:
     readiness = launch.get("readiness") or {}
     for key in ("mcp_url", "discovery_mcp_url", "endpoint"):
         value = readiness.get(key) or launch.get(key)

--- a/python/dcc_mcp_core/_runtime/skill_paths.py
+++ b/python/dcc_mcp_core/_runtime/skill_paths.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import List
-from typing import Optional
 
 from dcc_mcp_core._runtime.core_availability import is_core_extension_available
 
 
-def get_skill_paths_from_env() -> List[str]:
+def get_skill_paths_from_env() -> list[str]:
     if is_core_extension_available():
         from dcc_mcp_core._core import get_skill_paths_from_env as _impl
 
@@ -21,12 +19,12 @@ def get_skill_paths_from_env() -> List[str]:
     return [part.strip() for part in raw.split(os.pathsep) if part.strip()]
 
 
-def get_app_skill_paths_from_env(dcc_name: str) -> List[str]:
+def get_app_skill_paths_from_env(dcc_name: str) -> list[str]:
     if is_core_extension_available():
         from dcc_mcp_core._core import get_app_skill_paths_from_env as _impl
 
         return list(_impl(dcc_name))
-    env_name = "DCC_MCP_{0}_SKILL_PATHS".format(str(dcc_name or "").upper())
+    env_name = "DCC_MCP_{}_SKILL_PATHS".format(str(dcc_name or "").upper())
     raw = os.environ.get(env_name, "")
     if not raw.strip():
         return []
@@ -42,7 +40,7 @@ def get_local_skills_dir(dcc_name: str) -> str:
     return str(Path.home() / ".dcc-mcp" / slug / "skills")
 
 
-def get_skills_dir() -> Optional[str]:
+def get_skills_dir() -> str | None:
     if is_core_extension_available():
         from dcc_mcp_core._core import get_skills_dir as _impl
 

--- a/python/dcc_mcp_core/_runtime/skill_paths.py
+++ b/python/dcc_mcp_core/_runtime/skill_paths.py
@@ -1,0 +1,51 @@
+"""Import-light skill path helpers used when ``_core`` is unavailable."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+from typing import Optional
+
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+
+
+def get_skill_paths_from_env() -> List[str]:
+    if is_core_extension_available():
+        from dcc_mcp_core._core import get_skill_paths_from_env as _impl
+
+        return list(_impl())
+    raw = os.environ.get("DCC_MCP_SKILL_PATHS", "")
+    if not raw.strip():
+        return []
+    return [part.strip() for part in raw.split(os.pathsep) if part.strip()]
+
+
+def get_app_skill_paths_from_env(dcc_name: str) -> List[str]:
+    if is_core_extension_available():
+        from dcc_mcp_core._core import get_app_skill_paths_from_env as _impl
+
+        return list(_impl(dcc_name))
+    env_name = "DCC_MCP_{0}_SKILL_PATHS".format(str(dcc_name or "").upper())
+    raw = os.environ.get(env_name, "")
+    if not raw.strip():
+        return []
+    return [part.strip() for part in raw.split(os.pathsep) if part.strip()]
+
+
+def get_local_skills_dir(dcc_name: str) -> str:
+    if is_core_extension_available():
+        from dcc_mcp_core._core import get_local_skills_dir as _impl
+
+        return str(_impl(dcc_name))
+    slug = str(dcc_name or "dcc").strip().lower() or "dcc"
+    return str(Path.home() / ".dcc-mcp" / slug / "skills")
+
+
+def get_skills_dir() -> Optional[str]:
+    if is_core_extension_available():
+        from dcc_mcp_core._core import get_skills_dir as _impl
+
+        return _impl()
+    default = Path.home() / ".dcc-mcp" / "skills"
+    return str(default)

--- a/python/dcc_mcp_core/_runtime/tool_registry_py.py
+++ b/python/dcc_mcp_core/_runtime/tool_registry_py.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Dict
 from typing import Iterable
-from typing import List
-from typing import Optional
 
 
 class PurePythonToolRegistry:
     """Duck-typed registry placeholder while HTTP/MCP runs in the sidecar."""
 
     def __init__(self) -> None:
-        self._actions: Dict[str, Dict[str, Any]] = {}
+        self._actions: dict[str, dict[str, Any]] = {}
 
     def register(
         self,
@@ -21,7 +18,7 @@ class PurePythonToolRegistry:
         *,
         description: str = "",
         category: str = "",
-        tags: Optional[Iterable[str]] = None,
+        tags: Iterable[str] | None = None,
         dcc: str = "",
         **metadata: Any,
     ) -> None:
@@ -34,7 +31,7 @@ class PurePythonToolRegistry:
             **metadata,
         }
 
-    def list_actions(self, dcc_name: Optional[str] = None) -> List[Any]:
+    def list_actions(self, dcc_name: str | None = None) -> list[Any]:
         if dcc_name is None:
             return list(self._actions.values())
         return [action for action in self._actions.values() if action.get("dcc") in ("", dcc_name)]

--- a/python/dcc_mcp_core/_runtime/tool_registry_py.py
+++ b/python/dcc_mcp_core/_runtime/tool_registry_py.py
@@ -1,0 +1,40 @@
+"""Minimal pure-Python tool registry for py37-lite sidecar mode."""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+
+
+class PurePythonToolRegistry:
+    """Duck-typed registry placeholder while HTTP/MCP runs in the sidecar."""
+
+    def __init__(self) -> None:
+        self._actions: Dict[str, Dict[str, Any]] = {}
+
+    def register(
+        self,
+        name: str,
+        *,
+        description: str = "",
+        category: str = "",
+        tags: Optional[Iterable[str]] = None,
+        dcc: str = "",
+        **metadata: Any,
+    ) -> None:
+        self._actions[str(name)] = {
+            "name": str(name),
+            "description": description,
+            "category": category,
+            "tags": list(tags or []),
+            "dcc": dcc,
+            **metadata,
+        }
+
+    def list_actions(self, dcc_name: Optional[str] = None) -> List[Any]:
+        if dcc_name is None:
+            return list(self._actions.values())
+        return [action for action in self._actions.values() if action.get("dcc") in ("", dcc_name)]

--- a/python/dcc_mcp_core/_server/config.py
+++ b/python/dcc_mcp_core/_server/config.py
@@ -24,6 +24,7 @@ from dcc_mcp_core._server.options import _StandaloneMainThreadExecution
 from dcc_mcp_core._server.tools_list_policy import apply_tools_list_stub_policy
 
 if TYPE_CHECKING:
+    from dcc_mcp_core._runtime.mcp_http_config import McpHttpConfig
     from dcc_mcp_core._server.inprocess_executor import BaseDccCallableDispatcher
     from dcc_mcp_core._server.inprocess_executor import HostExecutionBridge
 
@@ -142,8 +143,8 @@ def build_mcp_http_config(
     version_provider: Callable[[], str],
 ) -> McpHttpConfig:
     """Build the ``McpHttpConfig`` for ``DccServerBase`` from resolved options."""
-    McpHttpConfig = resolve_mcp_http_config_class()
-    config = McpHttpConfig(
+    mcp_http_config_cls = resolve_mcp_http_config_class()
+    config = mcp_http_config_cls(
         port=options.port,
         server_name=options.server_name or f"{options.dcc_name}-mcp",
         server_version=options.server_version if options.server_version is not None else package_version,

--- a/python/dcc_mcp_core/_server/config.py
+++ b/python/dcc_mcp_core/_server/config.py
@@ -13,7 +13,7 @@ import os
 from typing import TYPE_CHECKING
 from typing import Any
 
-from dcc_mcp_core._core import McpHttpConfig
+from dcc_mcp_core._runtime.config_bridge import resolve_mcp_http_config_class
 from dcc_mcp_core._server.options import DccServerOptions
 from dcc_mcp_core._server.options import DiagnosticsOptions
 from dcc_mcp_core._server.options import ExecutionMode
@@ -142,6 +142,7 @@ def build_mcp_http_config(
     version_provider: Callable[[], str],
 ) -> McpHttpConfig:
     """Build the ``McpHttpConfig`` for ``DccServerBase`` from resolved options."""
+    McpHttpConfig = resolve_mcp_http_config_class()
     config = McpHttpConfig(
         port=options.port,
         server_name=options.server_name or f"{options.dcc_name}-mcp",

--- a/python/dcc_mcp_core/_server/execution_bridge.py
+++ b/python/dcc_mcp_core/_server/execution_bridge.py
@@ -12,12 +12,20 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from dcc_mcp_core._core import SandboxContext
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
 from dcc_mcp_core._server.inprocess_executor import BaseDccCallableDispatcher
 from dcc_mcp_core._server.inprocess_executor import HostExecutionBridge
 from dcc_mcp_core.script_execution import allow_script_materialization_root
 
 logger = logging.getLogger(__name__)
+
+
+def _sandbox_context(policy: Any) -> Any:
+    if not is_core_extension_available():
+        return None
+    from dcc_mcp_core._core import SandboxContext
+
+    return SandboxContext(policy)
 
 
 class ExecutionBridgeBinder:
@@ -44,7 +52,7 @@ class ExecutionBridgeBinder:
                     owner._dcc_name,
                     exc,
                 )
-            bridge.sandbox_context = SandboxContext(policy)
+            bridge.sandbox_context = _sandbox_context(policy)
 
     # -- HTTP dispatcher -------------------------------------------------------
 

--- a/python/dcc_mcp_core/_server/options.py
+++ b/python/dcc_mcp_core/_server/options.py
@@ -220,6 +220,8 @@ class SidecarOptions:
     adapter_version: str | None = None
     display_name: str | None = None
     wait_ready_timeout_secs: float = 15.0
+    server_bin: str | None = None
+    extra_args: tuple[str, ...] = ()
 
     @classmethod
     def from_env(
@@ -229,15 +231,22 @@ class SidecarOptions:
         adapter_version: str | None = None,
         display_name: str | None = None,
         wait_ready_timeout_secs: float = 15.0,
+        server_bin: str | None = None,
+        extra_args: tuple[str, ...] = (),
     ) -> SidecarOptions:
         resolved_host_rpc = host_rpc
         if resolved_host_rpc is None:
             resolved_host_rpc = os.environ.get("DCC_MCP_HOST_RPC", "") or None
+        resolved_server_bin = server_bin
+        if resolved_server_bin is None:
+            resolved_server_bin = os.environ.get("DCC_MCP_SERVER_BIN", "") or None
         return cls(
             host_rpc=resolved_host_rpc,
             adapter_version=adapter_version,
             display_name=display_name,
             wait_ready_timeout_secs=wait_ready_timeout_secs,
+            server_bin=resolved_server_bin,
+            extra_args=extra_args,
         )
 
 

--- a/python/dcc_mcp_core/_server/options.py
+++ b/python/dcc_mcp_core/_server/options.py
@@ -208,6 +208,40 @@ def BridgeExecution(bridge: HostExecutionBridge) -> _BridgeExecution:
 
 
 @dataclass(frozen=True)
+class SidecarOptions:
+    """Sidecar launch contract for py37-lite / no-_core adapters.
+
+    When the compiled ``_core`` extension is unavailable, ``DccServerBase``
+    delegates HTTP/MCP serving to ``dcc-mcp-server sidecar`` and routes tool
+    dispatch through ``host_rpc``.
+    """
+
+    host_rpc: str | None = None
+    adapter_version: str | None = None
+    display_name: str | None = None
+    wait_ready_timeout_secs: float = 15.0
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        host_rpc: str | None = None,
+        adapter_version: str | None = None,
+        display_name: str | None = None,
+        wait_ready_timeout_secs: float = 15.0,
+    ) -> SidecarOptions:
+        resolved_host_rpc = host_rpc
+        if resolved_host_rpc is None:
+            resolved_host_rpc = os.environ.get("DCC_MCP_HOST_RPC", "") or None
+        return cls(
+            host_rpc=resolved_host_rpc,
+            adapter_version=adapter_version,
+            display_name=display_name,
+            wait_ready_timeout_secs=wait_ready_timeout_secs,
+        )
+
+
+@dataclass(frozen=True)
 class ExecutionOptions:
     """Execution mode selection.
 
@@ -257,6 +291,7 @@ class DccServerOptions:
     observability: ObservabilityOptions = field(default_factory=ObservabilityOptions)
     diagnostics: DiagnosticsOptions = field(default_factory=DiagnosticsOptions)
     execution: ExecutionOptions = field(default_factory=ExecutionOptions)
+    sidecar: SidecarOptions = field(default_factory=SidecarOptions)
 
     @classmethod
     def from_env(
@@ -287,6 +322,11 @@ class DccServerOptions:
         dispatcher: BaseDccCallableDispatcher | None = None,
         execution_bridge: HostExecutionBridge | None = None,
         standalone_main_thread: bool = False,
+        # sidecar kwargs (py37-lite)
+        host_rpc: str | None = None,
+        adapter_version: str | None = None,
+        sidecar_display_name: str | None = None,
+        wait_ready_timeout_secs: float = 15.0,
     ) -> DccServerOptions:
         """Build a :class:`DccServerOptions` from keyword arguments + env vars.
 
@@ -333,6 +373,12 @@ class DccServerOptions:
             exec_mode = InlineExecution
 
         execution = ExecutionOptions(mode=exec_mode)
+        sidecar = SidecarOptions.from_env(
+            host_rpc=host_rpc,
+            adapter_version=adapter_version,
+            display_name=sidecar_display_name or server_name,
+            wait_ready_timeout_secs=wait_ready_timeout_secs,
+        )
 
         return cls(
             dcc_name=dcc_name,
@@ -344,4 +390,5 @@ class DccServerOptions:
             observability=observability,
             diagnostics=diagnostics,
             execution=execution,
+            sidecar=sidecar,
         )

--- a/python/dcc_mcp_core/_server/skill_discovery.py
+++ b/python/dcc_mcp_core/_server/skill_discovery.py
@@ -14,10 +14,10 @@ import os
 from pathlib import Path
 from typing import Any
 
-from dcc_mcp_core._core import get_app_skill_paths_from_env
-from dcc_mcp_core._core import get_local_skills_dir
-from dcc_mcp_core._core import get_skill_paths_from_env
-from dcc_mcp_core._core import get_skills_dir
+from dcc_mcp_core._runtime.skill_paths import get_app_skill_paths_from_env
+from dcc_mcp_core._runtime.skill_paths import get_local_skills_dir
+from dcc_mcp_core._runtime.skill_paths import get_skill_paths_from_env
+from dcc_mcp_core._runtime.skill_paths import get_skills_dir
 from dcc_mcp_core._server.minimal_mode import MinimalModeConfig
 from dcc_mcp_core._server.minimal_mode import apply_minimal_mode
 from dcc_mcp_core.hotreload import DccSkillHotReloader

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -59,6 +59,7 @@ def _package_version() -> str:
     except Exception:
         return _PKG_VERSION
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -20,9 +20,9 @@ import sys
 from typing import Any
 from typing import Callable
 
-from dcc_mcp_core import _core
-from dcc_mcp_core._core import create_skill_server
 from dcc_mcp_core._lifecycle_events import LifecycleEventDispatcher
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+from dcc_mcp_core._runtime.server_factory import create_adapter_server
 from dcc_mcp_core._server import ExecutionBridgeBinder
 from dcc_mcp_core._server import LifecycleController
 from dcc_mcp_core._server import ObservabilityFacade
@@ -39,7 +39,25 @@ from dcc_mcp_core._server.inprocess_executor import HostExecutionBridge
 from dcc_mcp_core._server.minimal_mode import MinimalModeConfig
 from dcc_mcp_core._server.options import DccServerOptions
 
-_PKG_VERSION: str = getattr(_core, "__version__", "0.0.0-dev")
+_PKG_VERSION: str = "0.0.0-dev"
+
+
+def _package_version() -> str:
+    if is_core_extension_available():
+        from dcc_mcp_core import _core
+
+        return str(getattr(_core, "__version__", "0.0.0-dev"))
+    try:
+        from importlib import metadata as importlib_metadata
+    except ImportError:
+        try:
+            import importlib_metadata  # type: ignore[import-not-found]
+        except ImportError:
+            return _PKG_VERSION
+    try:
+        return importlib_metadata.version("dcc-mcp-core")
+    except Exception:
+        return _PKG_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +129,7 @@ class DccServerBase:
         logger.info(
             "[%s] dcc-mcp-core %s (pid=%d, python=%s, platform=%s)",
             options.dcc_name,
-            _PKG_VERSION,
+            _package_version(),
             self._dcc_pid,
             "{}.{}.{}".format(*sys.version_info[:3]),
             sys.platform,
@@ -119,15 +137,15 @@ class DccServerBase:
 
         self._config = build_mcp_http_config(
             options,
-            package_version=_PKG_VERSION,
+            package_version=_package_version(),
             version_provider=self._version_string,
         )
 
         # --- Job persistence -----------------------------------------------------
         self._init_job_persistence(options.dcc_name)
 
-        # Create the inner skill manager
-        self._server: Any = create_skill_server(options.dcc_name, self._config)
+        # Create the inner skill manager (embedded _core or sidecar binary).
+        self._server: Any = create_adapter_server(options.dcc_name, self._config, options)
         self._register_builtin_skills(options)
 
         # Wire execution bridge / dispatcher

--- a/tests/test_py37_sidecar_server_factory.py
+++ b/tests/test_py37_sidecar_server_factory.py
@@ -22,6 +22,8 @@ class _SidecarStub:
     adapter_version: str | None = None
     display_name: str | None = None
     wait_ready_timeout_secs: float = 15.0
+    server_bin: str | None = None
+    extra_args: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -62,12 +64,18 @@ class TestServerFactoryRouting:
         )
         options = _OptionsStub(
             dcc_name="maya",
-            sidecar=_SidecarStub(host_rpc="commandport://127.0.0.1:6000"),
+            sidecar=_SidecarStub(
+                host_rpc="commandport://127.0.0.1:6000",
+                server_bin="dcc-mcp-server-test",
+                extra_args=("--ppid-poll-ms", "50"),
+            ),
         )
         config = PureMcpHttpConfig(port=8765, server_name="maya-mcp")
         server = create_adapter_server("maya", config, options)
         assert isinstance(server, SidecarBackedSkillServer)
         assert server.backend == "sidecar"
+        assert server._server_bin == "dcc-mcp-server-test"
+        assert server._extra_args == ("--ppid-poll-ms", "50")
 
     def test_uses_create_skill_server_when_core_available(self, monkeypatch: pytest.MonkeyPatch):
         import sys
@@ -127,6 +135,43 @@ class TestSidecarBackedSkillServer:
         server = SidecarBackedSkillServer("maya", PureMcpHttpConfig(), host_rpc="")
         with pytest.raises(RuntimeError, match="host_rpc"):
             server.start()
+
+    def test_start_forwards_server_bin_and_extra_args(self, monkeypatch: pytest.MonkeyPatch):
+        captured: dict = {}
+
+        def _fake_launch(**kwargs):
+            captured.update(kwargs)
+            return {
+                "success": True,
+                "readiness": {"mcp_url": "http://127.0.0.1:9876/mcp"},
+                "process": MagicMock(),
+            }
+
+        monkeypatch.setattr(
+            "dcc_mcp_core._runtime.sidecar_skill_server.launch_sidecar",
+            _fake_launch,
+        )
+        server = SidecarBackedSkillServer(
+            "maya",
+            PureMcpHttpConfig(port=8765),
+            host_rpc="commandport://127.0.0.1:6000",
+            server_bin="dcc-mcp-server-test",
+            extra_args=("--ppid-poll-ms", "50"),
+        )
+        server.start()
+        assert captured.get("server_bin") == "dcc-mcp-server-test"
+        assert captured.get("extra_args") == ("--ppid-poll-ms", "50")
+
+
+class TestExecutionBridgeLazyCore:
+    def test_sandbox_context_skips_core_when_unavailable(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            "dcc_mcp_core._server.execution_bridge.is_core_extension_available",
+            lambda: False,
+        )
+        from dcc_mcp_core._server.execution_bridge import _sandbox_context
+
+        assert _sandbox_context(MagicMock()) is None
 
 
 class TestServerBaseImportLight:

--- a/tests/test_py37_sidecar_server_factory.py
+++ b/tests/test_py37_sidecar_server_factory.py
@@ -1,0 +1,146 @@
+"""Tests for py37-lite sidecar server factory and pure-Python McpHttpConfig."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from dcc_mcp_core._runtime.config_bridge import resolve_mcp_http_config_class
+from dcc_mcp_core._runtime.core_availability import is_core_extension_available
+from dcc_mcp_core._runtime.mcp_http_config import McpHttpConfig as PureMcpHttpConfig
+from dcc_mcp_core._runtime.server_factory import create_adapter_server
+from dcc_mcp_core._runtime.sidecar_skill_server import SidecarBackedSkillServer
+
+
+@dataclass(frozen=True)
+class _SidecarStub:
+    host_rpc: str
+    adapter_version: str | None = None
+    display_name: str | None = None
+    wait_ready_timeout_secs: float = 15.0
+
+
+@dataclass(frozen=True)
+class _DiagnosticsStub:
+    dcc_pid: int | None = None
+
+
+@dataclass(frozen=True)
+class _OptionsStub:
+    dcc_name: str
+    sidecar: _SidecarStub
+    diagnostics: _DiagnosticsStub = _DiagnosticsStub()
+
+
+class TestPureMcpHttpConfig:
+    def test_defaults_match_rust_surface(self):
+        cfg = PureMcpHttpConfig()
+        assert cfg.port == 8765
+        assert cfg.server_name == "dcc-mcp"
+        assert isinstance(cfg.server_version, str)
+        assert len(cfg.server_version) > 0
+        assert cfg.gateway_port == 9765
+        assert cfg.session_ttl_secs == 3600
+
+    def test_repr_contains_name_and_port(self):
+        cfg = PureMcpHttpConfig(port=1234, server_name="maya-mcp")
+        text = repr(cfg)
+        assert "McpHttpConfig" in text
+        assert "1234" in text
+        assert "maya-mcp" in text
+
+
+class TestServerFactoryRouting:
+    def test_uses_sidecar_backend_when_core_unavailable(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            "dcc_mcp_core._runtime.server_factory.is_core_extension_available",
+            lambda: False,
+        )
+        options = _OptionsStub(
+            dcc_name="maya",
+            sidecar=_SidecarStub(host_rpc="commandport://127.0.0.1:6000"),
+        )
+        config = PureMcpHttpConfig(port=8765, server_name="maya-mcp")
+        server = create_adapter_server("maya", config, options)
+        assert isinstance(server, SidecarBackedSkillServer)
+        assert server.backend == "sidecar"
+
+    def test_uses_create_skill_server_when_core_available(self, monkeypatch: pytest.MonkeyPatch):
+        import sys
+        import types
+
+        fake_server = MagicMock(name="embedded-server")
+        fake_core = types.ModuleType("dcc_mcp_core._core")
+
+        def _fake_create_skill_server(app_name, config):
+            assert app_name == "maya"
+            assert config is not None
+            return fake_server
+
+        fake_core.create_skill_server = _fake_create_skill_server
+        monkeypatch.setitem(sys.modules, "dcc_mcp_core._core", fake_core)
+        monkeypatch.setattr(
+            "dcc_mcp_core._runtime.server_factory.is_core_extension_available",
+            lambda: True,
+        )
+        options = SimpleNamespace(sidecar=_SidecarStub(host_rpc="commandport://127.0.0.1:6000"))
+        config = PureMcpHttpConfig()
+        server = create_adapter_server("maya", config, options)
+        assert server is fake_server
+
+
+class TestSidecarBackedSkillServer:
+    def test_discover_records_paths_without_core(self):
+        server = SidecarBackedSkillServer(
+            "maya",
+            PureMcpHttpConfig(),
+            host_rpc="commandport://127.0.0.1:6000",
+        )
+        count = server.discover(extra_paths=["/tmp/skills"])
+        assert count == 1
+
+    def test_start_launches_sidecar_and_returns_handle(self, monkeypatch: pytest.MonkeyPatch):
+        server = SidecarBackedSkillServer(
+            "maya",
+            PureMcpHttpConfig(port=8765),
+            host_rpc="commandport://127.0.0.1:6000",
+        )
+
+        monkeypatch.setattr(
+            "dcc_mcp_core._runtime.sidecar_skill_server.launch_sidecar",
+            lambda **kwargs: {
+                "success": True,
+                "readiness": {"mcp_url": "http://127.0.0.1:9876/mcp"},
+                "process": MagicMock(),
+            },
+        )
+
+        handle = server.start()
+        assert handle.port == 9876
+        assert handle.mcp_url() == "http://127.0.0.1:9876/mcp"
+
+    def test_start_requires_host_rpc(self):
+        server = SidecarBackedSkillServer("maya", PureMcpHttpConfig(), host_rpc="")
+        with pytest.raises(RuntimeError, match="host_rpc"):
+            server.start()
+
+
+class TestServerBaseImportLight:
+    def test_server_base_does_not_import_core_at_module_level(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setitem(__import__("sys").modules, "dcc_mcp_core._core", MagicMock(__version__="test"))
+        import importlib
+
+        module = importlib.import_module("dcc_mcp_core.server_base")
+
+        assert "create_skill_server" not in module.__dict__
+        assert "create_adapter_server" in module.__dict__
+
+
+@pytest.mark.skipif(is_core_extension_available(), reason="only meaningful on py37-lite profile")
+def test_resolve_mcp_http_config_class_uses_pure_python():
+    cls = resolve_mcp_http_config_class()
+    assert cls is PureMcpHttpConfig


### PR DESCRIPTION
fixes the ruff regressions in the py37-lite helper files.

Validation:
- `ruff check python/dcc_mcp_core/_runtime/tool_registry_py.py python/dcc_mcp_core/_server/config.py`
