### PR TITLE
fix(ci): unblock PyPI publish by fixing py37-lite wheel job

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -109,12 +109,9 @@ jobs:
 
   # ── py37-lite: pure-Python wheel (py3-none-any) for Python 3.7 ──
   # Maya 2022 / Blender 2.83 embed Python 3.7 and cannot load cp38-abi3
-  # wheels. This job produces a pure-Python wheel with zero compiled Rust
-  # extensions so users can `pip install dcc-mcp-core` without a Rust toolchain.
-  #
-  # maturin with --no-default-features -F py37-lite compiles the Rust source
-  # tree as an rlib only (no cdylib → no _core extension), and maturin falls
-  # back to packaging only the pure-Python sources under python/.
+  # wheels. scripts/build_py37_pure_wheel.py assembles a py3-none-any wheel
+  # from python/dcc_mcp_core without maturin, Rust, or just (just>=1.0 is
+  # unavailable on Python 3.7 and previously blocked release PyPI publish).
   py37-lite:
     runs-on: ubuntu-22.04
     permissions:
@@ -126,25 +123,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.7"
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.95.0"
-      - uses: loonghao/vx@v0.9.11
-        with:
-          version: "0.9.11"
-          cache-key-prefix: "vx-tools-v0.9.7"
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: rust-py37
-          shared-key: rust-ubuntu
-      - name: Install maturin & just
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install "maturin>=1.5,<2.0" "just>=1.0"
-        shell: bash
       - name: Build py37-lite pure-Python wheel
-        run: just build-py37
+        run: |
+          python -m pip install --upgrade pip wheel
+          python scripts/build_py37_pure_wheel.py
         shell: bash
       - name: Verify wheel tag is py3-none-any
         shell: bash
@@ -166,6 +148,12 @@ jobs:
             exit 1
           fi
           echo "OK: no _core extension in py37-lite wheel"
+      - name: Upload py37-lite wheel artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-py37-lite
+          path: dist/
+          retention-days: 30
       - name: Upload wheel to GitHub Release
         if: inputs.release-tag-name != ''
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,23 +367,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.7"
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.95.0"
-      - uses: loonghao/vx@v0.9.11
-        with:
-          version: "0.9.11"
-          cache-key-prefix: "vx-tools-v0.9.7"
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: rust-py37
-          shared-key: rust-ubuntu
-      - name: Install maturin
-        run: python -m pip install "maturin>=1.5,<2.0"
-        shell: bash
       - name: Build py37-lite wheel
-        run: vx just build-py37
+        run: |
+          python -m pip install --upgrade pip wheel
+          python scripts/build_py37_pure_wheel.py
         shell: bash
       - name: Verify wheel tag is py3-none-any
         shell: bash


### PR DESCRIPTION
## Summary

- Build the py37-lite `py3-none-any` wheel via `python scripts/build_py37_pure_wheel.py` instead of `just build-py37`, avoiding `just>=1.0` which is unavailable on Python 3.7.
- Drop unnecessary Rust/maturin/vx setup from the py37-lite release and CI jobs.
- Upload `wheels-py37-lite` artifact so `publish-core-pypi` includes the Maya 2022 wheel on PyPI.

Fixes #1810

## Test plan

- [x] `python scripts/build_py37_pure_wheel.py` locally
- [x] `pytest tests/test_release_workflow.py`
- [ ] CI green on this PR
- [ ] After merge: re-run v0.19.8 PyPI publish or cut patch release
