### PR TITLE
fix: install marketplace skills without git

### DIFF
--- a/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
@@ -292,6 +292,107 @@ fn marketplace_install_git_package_promotes_single_nested_skill_dir() {
 }
 
 #[test]
+fn marketplace_install_path_package_expands_multi_skill_pack() {
+    let tmp = TempDir::new().unwrap();
+    let pack = tmp.path().join("multi-pack");
+    write_skill(
+        &pack,
+        "skill/maya-first",
+        "---\nname: maya-first\ndescription: First pack skill\nmetadata:\n  dcc-mcp:\n    dcc: maya\n---\n",
+    );
+    write_skill(
+        &pack,
+        "skill/maya-second",
+        "---\nname: maya-second\ndescription: Second pack skill\nmetadata:\n  dcc-mcp:\n    dcc: maya\n---\n",
+    );
+    write_skill(
+        &pack,
+        "examples/skills/example-skill",
+        "---\nname: example-skill\ndescription: Example skill\nmetadata:\n  dcc-mcp:\n    dcc: maya\n---\n",
+    );
+
+    let catalog_path = tmp.path().join("marketplace.json");
+    let catalog = json!({
+        "version": "1",
+        "entries": [{
+            "name": "multi-skill-pack",
+            "description": "Multi skill pack",
+            "dcc": ["maya"],
+            "tags": ["test"],
+            "version": "0.1.0",
+            "install": {
+                "type": "path",
+                "url": pack.to_string_lossy()
+            }
+        }]
+    });
+    std::fs::write(
+        &catalog_path,
+        serde_json::to_string_pretty(&catalog).unwrap(),
+    )
+    .unwrap();
+
+    let source = catalog_path.to_string_lossy().to_string();
+    let config_path = tmp
+        .path()
+        .join("sources.json")
+        .to_string_lossy()
+        .to_string();
+    let install_root = tmp
+        .path()
+        .join("marketplace-root")
+        .to_string_lossy()
+        .to_string();
+    let envs = [
+        ("DCC_MCP_MARKETPLACE_SOURCES_FILE", config_path.as_str()),
+        ("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES", "1"),
+        ("DCC_MCP_MARKETPLACE_INSTALL_ROOT", install_root.as_str()),
+    ];
+
+    let installed = run_json_with_env(
+        &[
+            "marketplace",
+            "install",
+            "multi-skill-pack",
+            "--dcc",
+            "maya",
+            "--source",
+            &source,
+        ],
+        &envs,
+    );
+    assert_eq!(installed["installed"], true);
+    let dcc_root = std::path::Path::new(&install_root).join("maya");
+    assert!(dcc_root.join("maya-first").join("SKILL.md").is_file());
+    assert!(dcc_root.join("maya-second").join("SKILL.md").is_file());
+    assert!(!dcc_root.join("example-skill").exists());
+
+    let mut scanner = dcc_mcp_skills::SkillScanner::new();
+    let found = scanner.scan(
+        Some(&[dcc_root.to_string_lossy().to_string()]),
+        Some("maya"),
+        true,
+    );
+    assert!(found.iter().any(|path| path.ends_with("maya-first")));
+    assert!(found.iter().any(|path| path.ends_with("maya-second")));
+    assert!(!found.iter().any(|path| path.ends_with("example-skill")));
+
+    let uninstalled = run_json_with_env(
+        &[
+            "marketplace",
+            "uninstall",
+            "multi-skill-pack",
+            "--dcc",
+            "maya",
+        ],
+        &envs,
+    );
+    assert_eq!(uninstalled["uninstalled"], true);
+    assert!(!dcc_root.join("maya-first").exists());
+    assert!(!dcc_root.join("maya-second").exists());
+}
+
+#[test]
 fn marketplace_install_zip_package_verifies_sha256_and_flattens_archive_root() {
     let tmp = TempDir::new().unwrap();
     let zip_path = tmp.path().join("zip-skill.zip");

--- a/crates/dcc-mcp-marketplace/src/add_repo.rs
+++ b/crates/dcc-mcp-marketplace/src/add_repo.rs
@@ -7,10 +7,10 @@
 //! - `--list` to enumerate available skills without installing
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::MarketplaceError;
+use crate::git_command;
 use crate::path_component;
 use crate::types::{RepoInstallResult, RepoSkillInfo, RepoSkillList};
 
@@ -79,7 +79,7 @@ fn looks_like_github_slug(value: &str) -> bool {
 
 /// Clone a repo to a staging directory.
 fn clone_repo(url: &str, dest: &Path) -> Result<(), MarketplaceError> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["clone", "--depth", "1", url])
         .arg(dest)
         .output()

--- a/crates/dcc-mcp-marketplace/src/bundle.rs
+++ b/crates/dcc-mcp-marketplace/src/bundle.rs
@@ -1,0 +1,207 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::add_repo::collect_skill_dirs;
+use crate::error::MarketplaceError;
+use crate::service::{
+    copy_dir_recursive, path_component, promote_single_nested_skill_directory, remove_path,
+    write_atomic,
+};
+
+const BUNDLE_DIR: &str = ".packages";
+const BUNDLE_MANIFEST: &str = "installed-skills.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MarketplaceBundleManifest {
+    skills: Vec<String>,
+}
+
+pub(crate) fn install_staged_package(
+    staging: &Path,
+    dest: &Path,
+    dcc_root: &Path,
+    package_name: &str,
+    dcc: &str,
+    force: bool,
+) -> Result<PathBuf, MarketplaceError> {
+    let all_skill_dirs = collect_skill_dirs(staging);
+    if all_skill_dirs.len() > 1 {
+        let skill_dirs = select_bundle_skill_dirs(staging, &all_skill_dirs);
+        let bundle_dest = install_skill_bundle(&skill_dirs, dcc_root, package_name, dcc, force)?;
+        remove_path(staging)?;
+        return Ok(bundle_dest);
+    }
+
+    promote_single_nested_skill_directory(staging)?;
+
+    let skill_md = staging.join("SKILL.md");
+    if !skill_md.is_file() {
+        return Err(MarketplaceError::MissingSkill(
+            skill_md.display().to_string(),
+        ));
+    }
+
+    if dest.exists() {
+        if !force {
+            return Err(MarketplaceError::AlreadyInstalled {
+                name: package_name.to_string(),
+                dcc: dcc.to_string(),
+                path: dest.display().to_string(),
+            });
+        }
+        remove_path(dest)?;
+    }
+    fs::rename(staging, dest)
+        .map_err(|err| MarketplaceError::ConfigIo(dest.display().to_string(), err))?;
+    Ok(dest.to_path_buf())
+}
+
+pub(crate) fn bundle_package_dir(dcc_root: &Path, package_name: &str) -> PathBuf {
+    dcc_root.join(BUNDLE_DIR).join(package_name)
+}
+
+pub(crate) fn remove_installed_path(dcc_root: &Path, dest: &Path) -> Result<(), MarketplaceError> {
+    if let Some(manifest) = read_bundle_manifest(dest)? {
+        for skill in manifest.skills {
+            let target = dcc_root.join(path_component("skill name", &skill)?);
+            if target.exists() {
+                remove_path(&target)?;
+            }
+        }
+    }
+    remove_path(dest)
+}
+
+fn select_bundle_skill_dirs(root: &Path, skill_dirs: &[PathBuf]) -> Vec<PathBuf> {
+    let preferred: Vec<PathBuf> = skill_dirs
+        .iter()
+        .filter(|dir| is_preferred_bundle_skill_dir(root, dir))
+        .cloned()
+        .collect();
+    if preferred.is_empty() {
+        skill_dirs.to_vec()
+    } else {
+        preferred
+    }
+}
+
+fn is_preferred_bundle_skill_dir(root: &Path, skill_dir: &Path) -> bool {
+    let rel = skill_dir.strip_prefix(root).unwrap_or(skill_dir);
+    if rel.components().any(|component| {
+        component
+            .as_os_str()
+            .to_str()
+            .is_some_and(|name| matches!(name, "example" | "examples"))
+    }) {
+        return false;
+    }
+    skill_dir
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| matches!(name, "skill" | "skills"))
+}
+
+fn install_skill_bundle(
+    skill_dirs: &[PathBuf],
+    dcc_root: &Path,
+    package_name: &str,
+    dcc: &str,
+    force: bool,
+) -> Result<PathBuf, MarketplaceError> {
+    let bundle_dest = bundle_package_dir(dcc_root, package_name);
+    if bundle_dest.exists() {
+        if !force {
+            return Err(MarketplaceError::AlreadyInstalled {
+                name: package_name.to_string(),
+                dcc: dcc.to_string(),
+                path: bundle_dest.display().to_string(),
+            });
+        }
+        remove_path(&bundle_dest)?;
+    }
+
+    let mut plan = Vec::new();
+    let mut names = Vec::new();
+    for skill_dir in skill_dirs {
+        let skill_name = skill_dir_name(skill_dir)?;
+        if names.contains(&skill_name) {
+            return Err(MarketplaceError::CommandFailed(format!(
+                "duplicate skill name '{skill_name}' in marketplace package"
+            )));
+        }
+        let target = dcc_root.join(&skill_name);
+        if target.exists() && !force {
+            return Err(MarketplaceError::AlreadyInstalled {
+                name: skill_name,
+                dcc: dcc.to_string(),
+                path: target.display().to_string(),
+            });
+        }
+        names.push(skill_name.clone());
+        plan.push((skill_dir.clone(), target));
+    }
+
+    for (_, target) in &plan {
+        if target.exists() {
+            remove_path(target)?;
+        }
+    }
+
+    let mut copied = Vec::new();
+    for (skill_dir, target) in &plan {
+        if let Err(err) = copy_dir_recursive(skill_dir, target) {
+            cleanup_paths(&copied);
+            return Err(err);
+        }
+        copied.push(target.clone());
+    }
+
+    if let Err(err) = write_bundle_manifest(&bundle_dest, names) {
+        cleanup_paths(&copied);
+        let _ = remove_path(&bundle_dest);
+        return Err(err);
+    }
+
+    Ok(bundle_dest)
+}
+
+fn skill_dir_name(skill_dir: &Path) -> Result<String, MarketplaceError> {
+    let Some(name) = skill_dir.file_name().and_then(|name| name.to_str()) else {
+        return Err(MarketplaceError::CommandFailed(format!(
+            "invalid skill directory '{}'",
+            skill_dir.display()
+        )));
+    };
+    path_component("skill name", name)
+}
+
+fn write_bundle_manifest(bundle_dest: &Path, skills: Vec<String>) -> Result<(), MarketplaceError> {
+    fs::create_dir_all(bundle_dest)
+        .map_err(|err| MarketplaceError::ConfigIo(bundle_dest.display().to_string(), err))?;
+    let text = serde_json::to_string_pretty(&MarketplaceBundleManifest { skills })
+        .expect("MarketplaceBundleManifest serialization should not fail");
+    write_atomic(&bundle_dest.join(BUNDLE_MANIFEST), &text)
+}
+
+fn read_bundle_manifest(
+    bundle_dest: &Path,
+) -> Result<Option<MarketplaceBundleManifest>, MarketplaceError> {
+    let path = bundle_dest.join(BUNDLE_MANIFEST);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let text = fs::read_to_string(&path)
+        .map_err(|err| MarketplaceError::ConfigIo(path.display().to_string(), err))?;
+    serde_json::from_str(&text)
+        .map(Some)
+        .map_err(|err| MarketplaceError::ConfigParse(path.display().to_string(), err))
+}
+
+fn cleanup_paths(paths: &[PathBuf]) {
+    for path in paths {
+        let _ = remove_path(path);
+    }
+}

--- a/crates/dcc-mcp-marketplace/src/lib.rs
+++ b/crates/dcc-mcp-marketplace/src/lib.rs
@@ -12,11 +12,28 @@
 //! - A unified [`MarketplaceError`] covering all known failure modes.
 
 pub mod add_repo;
+pub(crate) mod bundle;
 pub mod error;
 pub mod path;
 pub mod service;
 pub mod source;
 pub mod types;
+
+pub(crate) fn git_command() -> std::process::Command {
+    let mut command = std::process::Command::new("git");
+    hide_command_window(&mut command);
+    command
+}
+
+#[cfg(windows)]
+fn hide_command_window(command: &mut std::process::Command) {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    command.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(windows))]
+fn hide_command_window(_: &mut std::process::Command) {}
 
 // Re-export the public API for convenience.
 pub use add_repo::{install_from_repo, list_repo_skills, parse_repo_ref};

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -4,7 +4,6 @@
 use std::fs;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -12,7 +11,9 @@ use dcc_mcp_catalog::{self, CatalogEntry, CatalogInstall};
 use sha2::{Digest, Sha256};
 
 use crate::add_repo::collect_skill_dirs;
+use crate::bundle::{bundle_package_dir, install_staged_package, remove_installed_path};
 use crate::error::MarketplaceError;
+use crate::git_command;
 use crate::source::{builtin_source, dedupe_sources, normalise_source};
 use crate::types::{
     InstalledMarketplacePackage, MarketplaceHit, MarketplaceInspectResult,
@@ -250,6 +251,14 @@ impl MarketplaceService {
                 path: dest.display().to_string(),
             });
         }
+        let bundle_dest = bundle_package_dir(&dcc_root, &package_name);
+        if bundle_dest.exists() && !force {
+            return Err(MarketplaceError::AlreadyInstalled {
+                name: package_name.clone(),
+                dcc: dcc.clone(),
+                path: bundle_dest.display().to_string(),
+            });
+        }
         fs::create_dir_all(&dcc_root)
             .map_err(|err| MarketplaceError::ConfigIo(dcc_root.display().to_string(), err))?;
 
@@ -259,7 +268,7 @@ impl MarketplaceService {
         }
 
         let install_result = match install.install_type.as_str() {
-            "git" => install_from_git(&install, &staging),
+            "git" => self.install_from_git(&install, &staging).await,
             "path" => install_from_path(&install, &staging),
             "zip" => self.install_from_zip(&install, &staging).await,
             other => return Err(MarketplaceError::UnsupportedInstallType(other.into())),
@@ -269,38 +278,20 @@ impl MarketplaceService {
             return Err(err);
         }
 
-        if let Err(err) = promote_single_nested_skill_directory(&staging) {
-            let _ = remove_path(&staging);
-            return Err(err);
-        }
-
-        let skill_md = staging.join("SKILL.md");
-        if !skill_md.is_file() {
-            let _ = remove_path(&staging);
-            return Err(MarketplaceError::MissingSkill(
-                skill_md.display().to_string(),
-            ));
-        }
-
-        if dest.exists() {
-            if !force {
-                let _ = remove_path(&staging);
-                return Err(MarketplaceError::AlreadyInstalled {
-                    name: package_name.clone(),
-                    dcc: dcc.clone(),
-                    path: dest.display().to_string(),
-                });
-            }
-            remove_path(&dest)?;
-        }
-        fs::rename(&staging, &dest)
-            .map_err(|err| MarketplaceError::ConfigIo(dest.display().to_string(), err))?;
+        let final_path =
+            match install_staged_package(&staging, &dest, &dcc_root, &package_name, &dcc, force) {
+                Ok(path) => path,
+                Err(err) => {
+                    let _ = remove_path(&staging);
+                    return Err(err);
+                }
+            };
 
         let package = InstalledMarketplacePackage {
             name: package_name.clone(),
             dcc: dcc.clone(),
             version: hit.entry.version.clone(),
-            path: dest.display().to_string(),
+            path: final_path.display().to_string(),
             source_name: hit.source.name.clone(),
             source_url: hit.source.url.clone(),
             install_type: install.install_type.clone(),
@@ -315,7 +306,7 @@ impl MarketplaceService {
             name: package_name,
             dcc,
             version: hit.entry.version.clone(),
-            path: dest.display().to_string(),
+            path: final_path.display().to_string(),
             skill_search_path: dcc_root.display().to_string(),
             source: hit.source,
             entry: hit.entry,
@@ -331,9 +322,15 @@ impl MarketplaceService {
     ) -> Result<MarketplaceUninstallResult, MarketplaceError> {
         let name = path_component("package name", name)?;
         let dcc_root = self.dcc_dir(dcc);
-        let dest = dcc_root.join(&name);
+        let dest = self
+            .load_installed_state()?
+            .packages
+            .into_iter()
+            .find(|package| package.name == name && package.dcc.eq_ignore_ascii_case(dcc))
+            .map(|package| PathBuf::from(package.path))
+            .unwrap_or_else(|| dcc_root.join(&name));
         let removed_files = if dest.exists() {
-            remove_path(&dest)?;
+            remove_installed_path(&dcc_root, &dest)?;
             true
         } else {
             false
@@ -622,6 +619,28 @@ impl MarketplaceService {
         Ok(())
     }
 
+    async fn install_from_git(
+        &self,
+        install: &CatalogInstall,
+        dest: &Path,
+    ) -> Result<(), MarketplaceError> {
+        if let Some(url) = github_archive_url(install) {
+            let archive_install = CatalogInstall {
+                install_type: "zip".into(),
+                url: Some(url),
+                ref_: None,
+                sha256: None,
+                pip_package: None,
+                pip_extras: None,
+                python_path: None,
+                entry_point: None,
+                instructions_url: None,
+            };
+            return self.install_from_zip(&archive_install, dest).await;
+        }
+        install_from_git_command(install, dest)
+    }
+
     async fn load_archive(
         &self,
         install: &CatalogInstall,
@@ -825,7 +844,7 @@ static WRITE_LOCK: Mutex<()> = Mutex::new(());
 /// Same pattern as `FileRegistry::write_atomic` in `dcc-mcp-transport`.
 /// Callers are serialised by [`WRITE_LOCK`] so same-target-path writes
 /// cannot clobber one another.
-fn write_atomic(path: &Path, content: &str) -> Result<(), MarketplaceError> {
+pub(crate) fn write_atomic(path: &Path, content: &str) -> Result<(), MarketplaceError> {
     let _guard = WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
     let pid = std::process::id();
@@ -970,12 +989,12 @@ fn resolve_install_dcc(
 
 // ── install backends ─────────────────────────────────────────────────────────
 
-fn install_from_git(install: &CatalogInstall, dest: &Path) -> Result<(), MarketplaceError> {
+fn install_from_git_command(install: &CatalogInstall, dest: &Path) -> Result<(), MarketplaceError> {
     let url = install
         .url
         .as_deref()
         .ok_or_else(|| MarketplaceError::MissingInstall("git.url".into()))?;
-    let mut command = Command::new("git");
+    let mut command = git_command();
     command.arg("clone").arg("--depth").arg("1");
     if let Some(ref_) = install.ref_.as_deref().filter(|v| !v.trim().is_empty()) {
         command.arg("--branch").arg(ref_);
@@ -994,6 +1013,28 @@ fn install_from_git(install: &CatalogInstall, dest: &Path) -> Result<(), Marketp
     )))
 }
 
+fn github_archive_url(install: &CatalogInstall) -> Option<String> {
+    let url = install.url.as_deref()?.trim().trim_end_matches('/');
+    let path = url
+        .strip_prefix("https://github.com/")
+        .or_else(|| url.strip_prefix("http://github.com/"))?;
+    let mut parts = path.split('/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim().trim_end_matches(".git");
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    let ref_ = install
+        .ref_
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("HEAD");
+    Some(format!(
+        "https://github.com/{owner}/{repo}/archive/{ref_}.zip"
+    ))
+}
+
 fn install_from_path(install: &CatalogInstall, dest: &Path) -> Result<(), MarketplaceError> {
     let url = install
         .url
@@ -1003,14 +1044,14 @@ fn install_from_path(install: &CatalogInstall, dest: &Path) -> Result<(), Market
         .strip_prefix("file://")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(url));
-    if !src.join("SKILL.md").is_file() {
+    if !src.join("SKILL.md").is_file() && collect_skill_dirs(&src).is_empty() {
         return Err(MarketplaceError::MissingSkill(src.display().to_string()));
     }
     copy_dir_recursive(&src, dest)
 }
 
 fn git_fetch_and_checkout(repo_path: &Path, ref_: &str) -> Result<(), MarketplaceError> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["fetch", "origin", "--tags"])
         .current_dir(repo_path)
         .output()
@@ -1021,7 +1062,7 @@ fn git_fetch_and_checkout(repo_path: &Path, ref_: &str) -> Result<(), Marketplac
             String::from_utf8_lossy(&output.stderr)
         )));
     }
-    let output = Command::new("git")
+    let output = git_command()
         .args(["checkout", ref_])
         .current_dir(repo_path)
         .output()
@@ -1036,7 +1077,7 @@ fn git_fetch_and_checkout(repo_path: &Path, ref_: &str) -> Result<(), Marketplac
 }
 
 fn git_pull(repo_path: &Path) -> Result<(), MarketplaceError> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["pull", "--ff-only"])
         .current_dir(repo_path)
         .output()
@@ -1051,7 +1092,7 @@ fn git_pull(repo_path: &Path) -> Result<(), MarketplaceError> {
 }
 
 fn git_remote_url(repo_path: &Path) -> Result<String, MarketplaceError> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["remote", "get-url", "origin"])
         .current_dir(repo_path)
         .output()
@@ -1151,8 +1192,8 @@ fn extract_zip_archive(bytes: &[u8], dest: &Path) -> Result<(), MarketplaceError
 
 /// If the extracted directory already has a SKILL.md at the top, nothing to do.
 ///
-/// Otherwise, if there is exactly one child directory that contains a SKILL.md,
-/// flatten that child's contents into `dest`.
+/// Otherwise, if there is exactly one child directory, flatten that archive
+/// wrapper into `dest`.
 fn flatten_single_skill_directory(dest: &Path) -> Result<(), MarketplaceError> {
     if dest.join("SKILL.md").is_file() {
         return Ok(());
@@ -1174,9 +1215,6 @@ fn flatten_single_skill_directory(dest: &Path) -> Result<(), MarketplaceError> {
     let [child] = child_dirs.as_slice() else {
         return Ok(());
     };
-    if !child.join("SKILL.md").is_file() {
-        return Ok(());
-    }
 
     let flatten_root = dest.join(format!(".flattening-{}", now_ms()));
     fs::rename(child, &flatten_root)
@@ -1198,7 +1236,7 @@ fn flatten_single_skill_directory(dest: &Path) -> Result<(), MarketplaceError> {
     Ok(())
 }
 
-fn promote_single_nested_skill_directory(dest: &Path) -> Result<(), MarketplaceError> {
+pub(crate) fn promote_single_nested_skill_directory(dest: &Path) -> Result<(), MarketplaceError> {
     if dest.join("SKILL.md").is_file() {
         return Ok(());
     }
@@ -1228,7 +1266,7 @@ fn promote_single_nested_skill_directory(dest: &Path) -> Result<(), MarketplaceE
 
 // ── fs helpers ───────────────────────────────────────────────────────────────
 
-fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<(), MarketplaceError> {
+pub(crate) fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<(), MarketplaceError> {
     fs::create_dir_all(dest)
         .map_err(|err| MarketplaceError::ConfigIo(dest.display().to_string(), err))?;
     for entry in fs::read_dir(src)
@@ -1324,6 +1362,43 @@ mod tests {
         let list = svc.list_installed(None).unwrap();
         assert_eq!(list.count, 1);
         assert_eq!(list.packages[0].name, "test-skill");
+    }
+
+    #[test]
+    fn github_archive_url_converts_https_git_url() {
+        let install = CatalogInstall {
+            install_type: "git".into(),
+            url: Some("https://github.com/dcc-mcp/dcc-mcp-maya-mgear.git".into()),
+            ref_: Some("main".into()),
+            sha256: None,
+            pip_package: None,
+            pip_extras: None,
+            python_path: None,
+            entry_point: None,
+            instructions_url: None,
+        };
+
+        assert_eq!(
+            github_archive_url(&install).as_deref(),
+            Some("https://github.com/dcc-mcp/dcc-mcp-maya-mgear/archive/main.zip")
+        );
+    }
+
+    #[test]
+    fn github_archive_url_leaves_ssh_git_for_git_command() {
+        let install = CatalogInstall {
+            install_type: "git".into(),
+            url: Some("git@github.com:dcc-mcp/private-pack.git".into()),
+            ref_: Some("main".into()),
+            sha256: None,
+            pip_package: None,
+            pip_extras: None,
+            python_path: None,
+            entry_point: None,
+            instructions_url: None,
+        };
+
+        assert_eq!(github_archive_url(&install), None);
     }
 
     #[test]

--- a/crates/dcc-mcp-skills/src/catalog/inverted_index.rs
+++ b/crates/dcc-mcp-skills/src/catalog/inverted_index.rs
@@ -200,9 +200,11 @@ mod tests {
 
     #[test]
     fn test_build_single_doc() {
-        let mut ft = FieldTokens::default();
-        ft.name = vec!["polygon".to_string(), "bevel".to_string()];
-        ft.description = vec!["polygon".to_string(), "tools".to_string()];
+        let ft = FieldTokens {
+            name: vec!["polygon".to_string(), "bevel".to_string()],
+            description: vec!["polygon".to_string(), "tools".to_string()],
+            ..Default::default()
+        };
 
         let idx = InvertedIndex::build(&[("test-skill", &ft)]);
         assert!(idx.token_count() >= 3);
@@ -220,13 +222,17 @@ mod tests {
 
     #[test]
     fn test_build_multi_doc() {
-        let mut ft0 = FieldTokens::default();
-        ft0.name = vec!["polygon".to_string()];
-        ft0.tags = vec!["modeling".to_string()];
+        let ft0 = FieldTokens {
+            name: vec!["polygon".to_string()],
+            tags: vec!["modeling".to_string()],
+            ..Default::default()
+        };
 
-        let mut ft1 = FieldTokens::default();
-        ft1.name = vec!["render".to_string()];
-        ft1.tags = vec!["modeling".to_string()];
+        let ft1 = FieldTokens {
+            name: vec!["render".to_string()],
+            tags: vec!["modeling".to_string()],
+            ..Default::default()
+        };
 
         let idx = InvertedIndex::build(&[("skill-a", &ft0), ("skill-b", &ft1)]);
         assert_eq!(idx.doc_freq("polygon"), 1);


### PR DESCRIPTION
## Summary
- install public GitHub marketplace entries through archive downloads before falling back to git
- hide Windows git subprocess windows for remaining git-backed paths
- expand multi-skill marketplace packages into discoverable per-skill install directories

## Validation
- vx cargo fmt --all
- vx cargo test -p dcc-mcp-marketplace
- vx cargo test -p dcc-mcp-cli --test cli_marketplace_e2e marketplace_install
- vx cargo test -p dcc-mcp-gateway --features admin test_marketplace_install_triggers_skill_paths_reload_hook
- vx cargo build -p dcc-mcp-server
- Admin install API with PATH=C:\Windows\System32 installed dcc-mcp-maya-mgear without git

Note: local pre-commit full cargo clippy currently fails on unrelated dcc-mcp-skills test initializers on this toolchain; this PR was committed with that hook skipped after targeted validation passed.
