### PR TITLE
feat(py37-lite): scan_and_load_strict pure-Python fallback

### DIFF
--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -228,7 +228,7 @@ _LAZY: dict[str, str] = {
     "resolve_dependencies": "dcc_mcp_core._core",
     "scan_and_load": "dcc_mcp_core._core",
     "scan_and_load_lenient": "dcc_mcp_core._core",
-    "scan_and_load_strict": "dcc_mcp_core._core",
+    "scan_and_load_strict": "dcc_mcp_core._py37_fallback",
     "scan_and_load_team": "dcc_mcp_core._core",
     "scan_and_load_team_lenient": "dcc_mcp_core._core",
     "scan_and_load_user": "dcc_mcp_core._core",

--- a/python/dcc_mcp_core/_py37_fallback.py
+++ b/python/dcc_mcp_core/_py37_fallback.py
@@ -3,8 +3,8 @@
 When ``dcc_mcp_core._core`` is available (full Rust build), this module
 re-exports the compiled versions.  When ``_core`` is absent (py37-lite
 wheel), it provides pure-Python implementations of ``parse_skill_md``,
-``DccCapabilities``, and ``PyPumpedDispatcher`` so that downstream
-adapters such as ``dcc_mcp_maya`` can import successfully.
+``DccCapabilities``, ``PyPumpedDispatcher``, and ``scan_and_load_strict``
+so that downstream adapters such as ``dcc_mcp_maya`` can import successfully.
 
 Convention: every symbol exported here is an ``_core``-only symbol that
 the Maya adapter imports at package load time and that has no pure-Python
@@ -15,6 +15,10 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import Set
 
 # ── Probe whether _core is available ─────────────────────────────────
 
@@ -47,9 +51,15 @@ if _probe_core():
     DccCapabilities = _core.DccCapabilities
     PyPumpedDispatcher = _core.PyPumpedDispatcher
     parse_skill_md = _core.parse_skill_md
+    scan_and_load_strict = _core.scan_and_load_strict
 
     def __dir__() -> list[str]:
-        return ["DccCapabilities", "PyPumpedDispatcher", "parse_skill_md"]
+        return [
+            "DccCapabilities",
+            "PyPumpedDispatcher",
+            "parse_skill_md",
+            "scan_and_load_strict",
+        ]
 
 else:
     # ── Pure-Python fallbacks (only when _core is absent) ────────────
@@ -282,3 +292,109 @@ else:
 
         def __repr__(self) -> str:
             return f"PyPumpedDispatcher(pending=0, budget_ms={self.budget_ms})"
+
+    def _discover_skill_directories(extra_paths: Optional[Sequence[str]]) -> List[str]:
+        discovered: List[str] = []
+        seen: Set[str] = set()
+        for raw in extra_paths or ():
+            root = Path(raw)
+            if not root.is_dir():
+                continue
+            if (root / "SKILL.md").is_file():
+                candidates = [root]
+            else:
+                candidates = [child for child in root.iterdir() if child.is_dir()]
+            for candidate in sorted(candidates, key=lambda path: path.name):
+                if not (candidate / "SKILL.md").is_file():
+                    continue
+                key = str(candidate.resolve())
+                if key in seen:
+                    continue
+                seen.add(key)
+                discovered.append(str(candidate))
+        return discovered
+
+    def _missing_explicit_child_skill_md(extra_paths: Optional[Sequence[str]]) -> List[str]:
+        missing: List[str] = []
+        for raw in extra_paths or ():
+            root = Path(raw)
+            if not root.is_dir() or (root / "SKILL.md").is_file():
+                continue
+            for child in root.iterdir():
+                if child.is_dir() and not (child / "SKILL.md").is_file():
+                    missing.append(str(child))
+        return missing
+
+    def _resolve_dependencies_ordered(skills: List[Any]) -> List[Any]:
+        if not skills:
+            return []
+        by_name = {skill.name: skill for skill in skills}
+        for skill in skills:
+            for dep in skill.depends:
+                if dep not in by_name:
+                    raise ValueError(
+                        "Skill '{0}' depends on '{1}', but it was not found. "
+                        "Ensure '{1}' is available in one of the skill search paths.".format(
+                            skill.name,
+                            dep,
+                        )
+                    )
+        in_degree = {skill.name: 0 for skill in skills}
+        dependents = {skill.name: [] for skill in skills}
+        for skill in skills:
+            for dep in skill.depends:
+                if dep in by_name:
+                    in_degree[skill.name] += 1
+                    dependents[dep].append(skill.name)
+        queue = sorted(name for name, degree in in_degree.items() if degree == 0)
+        ordered_names: List[str] = []
+        while queue:
+            name = queue.pop(0)
+            ordered_names.append(name)
+            for child in dependents[name]:
+                in_degree[child] -= 1
+                if in_degree[child] == 0:
+                    queue.append(child)
+            queue.sort()
+        if len(ordered_names) != len(skills):
+            raise ValueError("Circular dependency detected")
+        return [by_name[name] for name in ordered_names]
+
+    def scan_and_load_strict(
+        extra_paths: Optional[Sequence[str]] = None,
+        dcc_name: Optional[str] = None,
+    ) -> tuple[List[Any], List[str]]:
+        dirs = _discover_skill_directories(extra_paths)
+        skills: List[Any] = []
+        skipped: List[str] = []
+        for dir_str in dirs:
+            lines = (Path(dir_str) / "SKILL.md").read_text(encoding="utf-8").splitlines()
+            if not lines or lines[0].strip() != "---":
+                skipped.append(dir_str)
+                continue
+            try:
+                meta = parse_skill_md(dir_str)
+            except Exception:
+                skipped.append(dir_str)
+                continue
+            if meta is None:
+                skipped.append(dir_str)
+                continue
+            if dcc_name and meta.dcc and meta.dcc != dcc_name:
+                continue
+            skills.append(meta)
+
+        ordered = _resolve_dependencies_ordered(skills)
+        for dir_str in _missing_explicit_child_skill_md(extra_paths):
+            if dir_str not in skipped:
+                skipped.append(dir_str)
+        if skipped:
+            raise ValueError(
+                "Strict scan rejected {0} directory/directories that failed to load: {1}. "
+                "Inspect the SKILL.md files for missing/invalid YAML frontmatter or "
+                "re-run with scan_and_load_lenient to tolerate them.".format(
+                    len(skipped),
+                    ", ".join(skipped),
+                )
+            )
+        return ordered, []

--- a/python/dcc_mcp_core/_py37_fallback.py
+++ b/python/dcc_mcp_core/_py37_fallback.py
@@ -15,10 +15,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from typing import List
-from typing import Optional
 from typing import Sequence
-from typing import Set
 
 # ── Probe whether _core is available ─────────────────────────────────
 
@@ -293,9 +290,9 @@ else:
         def __repr__(self) -> str:
             return f"PyPumpedDispatcher(pending=0, budget_ms={self.budget_ms})"
 
-    def _discover_skill_directories(extra_paths: Optional[Sequence[str]]) -> List[str]:
-        discovered: List[str] = []
-        seen: Set[str] = set()
+    def _discover_skill_directories(extra_paths: Sequence[str] | None) -> list[str]:
+        discovered: list[str] = []
+        seen: set[str] = set()
         for raw in extra_paths or ():
             root = Path(raw)
             if not root.is_dir():
@@ -314,8 +311,8 @@ else:
                 discovered.append(str(candidate))
         return discovered
 
-    def _missing_explicit_child_skill_md(extra_paths: Optional[Sequence[str]]) -> List[str]:
-        missing: List[str] = []
+    def _missing_explicit_child_skill_md(extra_paths: Sequence[str] | None) -> list[str]:
+        missing: list[str] = []
         for raw in extra_paths or ():
             root = Path(raw)
             if not root.is_dir() or (root / "SKILL.md").is_file():
@@ -325,7 +322,7 @@ else:
                     missing.append(str(child))
         return missing
 
-    def _resolve_dependencies_ordered(skills: List[Any]) -> List[Any]:
+    def _resolve_dependencies_ordered(skills: list[Any]) -> list[Any]:
         if not skills:
             return []
         by_name = {skill.name: skill for skill in skills}
@@ -333,11 +330,8 @@ else:
             for dep in skill.depends:
                 if dep not in by_name:
                     raise ValueError(
-                        "Skill '{0}' depends on '{1}', but it was not found. "
-                        "Ensure '{1}' is available in one of the skill search paths.".format(
-                            skill.name,
-                            dep,
-                        )
+                        f"Skill '{skill.name}' depends on '{dep}', but it was not found. "
+                        f"Ensure '{dep}' is available in one of the skill search paths."
                     )
         in_degree = {skill.name: 0 for skill in skills}
         dependents = {skill.name: [] for skill in skills}
@@ -347,7 +341,7 @@ else:
                     in_degree[skill.name] += 1
                     dependents[dep].append(skill.name)
         queue = sorted(name for name, degree in in_degree.items() if degree == 0)
-        ordered_names: List[str] = []
+        ordered_names: list[str] = []
         while queue:
             name = queue.pop(0)
             ordered_names.append(name)
@@ -361,12 +355,12 @@ else:
         return [by_name[name] for name in ordered_names]
 
     def scan_and_load_strict(
-        extra_paths: Optional[Sequence[str]] = None,
-        dcc_name: Optional[str] = None,
-    ) -> tuple[List[Any], List[str]]:
+        extra_paths: Sequence[str] | None = None,
+        dcc_name: str | None = None,
+    ) -> tuple[list[Any], list[str]]:
         dirs = _discover_skill_directories(extra_paths)
-        skills: List[Any] = []
-        skipped: List[str] = []
+        skills: list[Any] = []
+        skipped: list[str] = []
         for dir_str in dirs:
             lines = (Path(dir_str) / "SKILL.md").read_text(encoding="utf-8").splitlines()
             if not lines or lines[0].strip() != "---":
@@ -390,7 +384,7 @@ else:
                 skipped.append(dir_str)
         if skipped:
             raise ValueError(
-                "Strict scan rejected {0} directory/directories that failed to load: {1}. "
+                "Strict scan rejected {} directory/directories that failed to load: {}. "
                 "Inspect the SKILL.md files for missing/invalid YAML frontmatter or "
                 "re-run with scan_and_load_lenient to tolerate them.".format(
                     len(skipped),

--- a/tests/test_py37_lite_fallbacks.py
+++ b/tests/test_py37_lite_fallbacks.py
@@ -235,3 +235,42 @@ def test_fallback_imports_from_top_level(monkeypatch) -> None:
     # PyPumpedDispatcher should come from _py37_fallback
     disp = dcc_mcp_core.PyPumpedDispatcher()
     assert disp.budget_ms == 8
+
+    # scan_and_load_strict should come from _py37_fallback
+    strict = dcc_mcp_core.scan_and_load_strict
+    assert callable(strict)
+
+
+def test_scan_and_load_strict_fallback(monkeypatch, tmp_path) -> None:
+    """scan_and_load_strict works without _core (py37-lite)."""
+    modules = _import_without_core(
+        monkeypatch,
+        "dcc_mcp_core._py37_fallback",
+    )
+    fallback = modules["dcc_mcp_core._py37_fallback"]
+
+    good = tmp_path / "good-skill"
+    good.mkdir()
+    (good / "SKILL.md").write_text(
+        "---\nname: good-skill\ndescription: ok\ndcc: maya\n---\n# Good\n",
+        encoding="utf-8",
+    )
+
+    bad = tmp_path / "bad-skill"
+    bad.mkdir()
+    (bad / "SKILL.md").write_text("# missing frontmatter\n", encoding="utf-8")
+
+    skills, skipped = fallback.scan_and_load_strict(extra_paths=[str(good)])
+    assert len(skills) == 1
+    assert skills[0].name == "good-skill"
+    assert skipped == []
+
+    try:
+        fallback.scan_and_load_strict(extra_paths=[str(tmp_path)])
+    except ValueError as exc:
+        message = str(exc)
+        assert "Strict scan rejected 1 directory" in message
+        assert "bad-skill" in message
+        assert "scan_and_load_lenient" in message
+    else:
+        raise AssertionError("Expected ValueError for bad-skill directory")


### PR DESCRIPTION
## Summary
- Route `scan_and_load_strict` through `_py37_fallback` when `_core` is absent
- Completes GH-1812 for the Maya adapter import chain: `server.py` imports `scan_and_load_strict` at module load time
- Adds py37-lite unit coverage in `test_py37_lite_fallbacks.py`

## Problem
`dcc-mcp-core==0.19.10` py3-none-any wheel fixes `parse_skill_md` / `DccCapabilities` / `PyPumpedDispatcher` but `scan_and_load_strict` still lazy-resolves to `_core`. On mayapy 3.7 this blocks `import dcc_mcp_maya` and fails PR #425 required check `Test (mayapy / Maya 2022 / Python 3.7)`.

## Test plan
- [x] `pytest tests/test_py37_lite_fallbacks.py` (7/7)
- [ ] CI `Build wheel (py37-lite)` + `Test (py37-lite)`
- [ ] After release, re-run dcc-mcp-maya PR #425 mayapy py37 job

Closes #1812