### PR TITLE
fix(host): re-export _fallback dispatchers on ImportError

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,12 +525,14 @@ jobs:
           from dcc_mcp_core.host import StandaloneHost
           from dcc_mcp_core.host._fallback import BlockingDispatcher as FallbackBlockingDispatcher
           from dcc_mcp_core.host._fallback import QueueDispatcher as FallbackQueueDispatcher
-          assert BlockingDispatcher is None
-          assert QueueDispatcher is None
-          dispatcher = FallbackQueueDispatcher()
+          assert BlockingDispatcher is FallbackBlockingDispatcher, \
+              f"BlockingDispatcher should re-export _fallback, got {BlockingDispatcher}"
+          assert QueueDispatcher is FallbackQueueDispatcher, \
+              f"QueueDispatcher should re-export _fallback, got {QueueDispatcher}"
+          dispatcher = BlockingDispatcher()
           with StandaloneHost(dispatcher):
               assert dispatcher.post(lambda: 42).wait(timeout=2.0) == 42
-          blocking = FallbackBlockingDispatcher()
+          blocking = QueueDispatcher()
           with StandaloneHost(blocking):
               assert blocking.post(lambda: 'ok').wait(timeout=2.0) == 'ok'
           from dcc_mcp_core.host._adapter import HostAdapter, TickableDispatcher

--- a/docs/guide/py37-lite-architecture.md
+++ b/docs/guide/py37-lite-architecture.md
@@ -121,14 +121,18 @@ There are two acceptable variants, depending on whether the module wants to surf
 try:
     from dcc_mcp_core._core import BlockingDispatcher
     from dcc_mcp_core._core import DispatchError
+    from dcc_mcp_core._core import PostHandle
     from dcc_mcp_core._core import QueueDispatcher
+    from dcc_mcp_core._core import TickOutcome
 except ImportError:
-    BlockingDispatcher = None
-    DispatchError = None
-    QueueDispatcher = None
+    from dcc_mcp_core.host._fallback import BlockingDispatcher
+    from dcc_mcp_core.host._fallback import DispatchError
+    from dcc_mcp_core.host._fallback import PostHandle
+    from dcc_mcp_core.host._fallback import QueueDispatcher
+    from dcc_mcp_core.host._fallback import TickOutcome
 ```
 
-Callers check `is None` to detect absence.
+Callers import from the public surface and get working classes on py37-lite.
 
 **B. Internal fallback (for implementation modules)**:
 
@@ -174,7 +178,7 @@ except ImportError:
 
 | File | Imports from `_core` | Fallback source |
 |------|---------------------|-----------------|
-| `host/__init__.py` | `BlockingDispatcher`, `DispatchError`, `PostHandle`, `QueueDispatcher`, `TickOutcome` | Sets to `None` |
+| `host/__init__.py` | `BlockingDispatcher`, `DispatchError`, `PostHandle`, `QueueDispatcher`, `TickOutcome` | `host/_fallback` |
 | `host/_standalone.py` | `BlockingDispatcher`, `QueueDispatcher` | `host/_fallback` |
 | `host/_protocols.py` | `TickOutcome` | `host/_fallback` |
 | `host/_wire.py` | `normalize_tool_arguments`, `normalize_tool_meta` | Inline pure-Python functions |
@@ -392,7 +396,7 @@ Python 3.7 is not available in the `actions/setup-python` tool cache on `ubuntu-
 - [scripts/check_py37_syntax.py](https://github.com/dcc-mcp/dcc-mcp-core/blob/main/scripts/check_py37_syntax.py) — Syntax gate.
 - [scripts/run_with_py37.py](https://github.com/dcc-mcp/dcc-mcp-core/blob/main/scripts/run_with_py37.py) — Local 3.7 runner helper.
 - [host/_fallback.py](https://github.com/dcc-mcp/dcc-mcp-core/blob/main/python/dcc_mcp_core/host/_fallback.py) — Pure-Python dispatcher fallback.
-- [host/__init__.py](https://github.com/dcc-mcp/dcc-mcp-core/blob/main/python/dcc_mcp_core/host/__init__.py) — Re-export with fallback to `None`.
+- [host/__init__.py](https://github.com/dcc-mcp/dcc-mcp-core/blob/main/python/dcc_mcp_core/host/__init__.py) — Re-export with `_fallback` on `ImportError`.
 - [host/_standalone.py](https://github.com/dcc-mcp/dcc-mcp-core/blob/main/python/dcc_mcp_core/host/_standalone.py) — Import fallback at use site.
 - [host/_protocols.py](https://github.com/dcc-mcp/dcc-mcp-core/blob/main/python/dcc_mcp_core/host/_protocols.py) — `TickOutcome` fallback.
 - [_typing_compat.py](https://github.com/dcc-mcp/dcc-mcp-core/blob/main/python/dcc_mcp_core/_typing_compat.py) — Protocol/Literal backport.

--- a/python/dcc_mcp_core/host/__init__.py
+++ b/python/dcc_mcp_core/host/__init__.py
@@ -31,11 +31,11 @@ try:
     from dcc_mcp_core._core import QueueDispatcher
     from dcc_mcp_core._core import TickOutcome
 except ImportError:
-    BlockingDispatcher = None
-    DispatchError = None
-    PostHandle = None
-    QueueDispatcher = None
-    TickOutcome = None
+    from dcc_mcp_core.host._fallback import BlockingDispatcher
+    from dcc_mcp_core.host._fallback import DispatchError
+    from dcc_mcp_core.host._fallback import PostHandle
+    from dcc_mcp_core.host._fallback import QueueDispatcher
+    from dcc_mcp_core.host._fallback import TickOutcome
 from dcc_mcp_core.host._adapter import HostAdapter
 from dcc_mcp_core.host._adapter import TickableDispatcher
 from dcc_mcp_core.host._standalone import StandaloneHost

--- a/tests/test_py37_lite_fallbacks.py
+++ b/tests/test_py37_lite_fallbacks.py
@@ -29,19 +29,19 @@ def test_host_namespace_falls_back_without_core(monkeypatch) -> None:
     host = modules["dcc_mcp_core.host"]
     fallback = modules["dcc_mcp_core.host._fallback"]
 
-    assert host.BlockingDispatcher is None
-    assert host.QueueDispatcher is None
-    assert host.PostHandle is None
-    assert host.TickOutcome is None
-    assert host.DispatchError is None
+    assert host.BlockingDispatcher is fallback.BlockingDispatcher
+    assert host.QueueDispatcher is fallback.QueueDispatcher
+    assert host.PostHandle is fallback.PostHandle
+    assert host.TickOutcome is fallback.TickOutcome
+    assert host.DispatchError is fallback.DispatchError
 
-    dispatcher = fallback.QueueDispatcher()
+    dispatcher = host.QueueDispatcher()
     assert dispatcher.tick().jobs_executed == 0
 
     with host.StandaloneHost(dispatcher):
         assert dispatcher.post(lambda: 42).wait(timeout=2.0) == 42
 
-    blocking = fallback.BlockingDispatcher()
+    blocking = host.BlockingDispatcher()
     with host.StandaloneHost(blocking):
         assert blocking.post(lambda: "ok").wait(timeout=2.0) == "ok"
 


### PR DESCRIPTION
## Summary
- Re-export pure-Python dispatcher classes from `host/_fallback` when `dcc_mcp_core._core` is absent (py37-lite wheels).
- Update py37-lite architecture docs (Pattern A + section 4.2 table) to reflect the public host surface behavior.
- Extend the py37-lite host namespace test to assert instantiable classes from `dcc_mcp_core.host`.

## Test plan
- [x] `pytest tests/test_py37_lite_fallbacks.py::test_host_namespace_falls_back_without_core`
- [x] `pytest tests/test_py37_lite_fallbacks.py tests/test_host_dispatcher.py`
- [ ] CI required checks (including py37-lite wheel validation)