### PR TITLE
fix(py37-lite): add ReadinessProbe pure-Python fallback

### DIFF
--- a/docs/guide/py37-lite-architecture.md
+++ b/docs/guide/py37-lite-architecture.md
@@ -191,10 +191,13 @@ except ImportError:
 | `_runtime/config_bridge.py` | Various | (check per import) |
 | `dcc_server.py` | `SandboxContext`, `SandboxPolicy`, `ToolRecorder`, `TransportAddress` | Graceful `ImportError` — feature degrades |
 | `skill.py` | Various | (check per import) |
+| `_exports.py` | `ReadinessProbe` | `_py37_fallback` |
+| `readiness.py` | `ReadinessProbe` (via `_new_probe`) | `_py37_fallback` |
 
 **Fallback implementations**:
 
 - `host/_fallback.py` — `QueueDispatcher`, `BlockingDispatcher`, `PostHandle`, `TickOutcome`, `DispatchError`, utility functions. A fully functional pure-Python replacement used when `_core` is absent.
+- `_py37_fallback.py` — `ReadinessProbe`, `DccCapabilities`, `PyPumpedDispatcher`, `parse_skill_md`, `scan_and_load_strict`, GUI executable helpers. Re-exports from `_core` when the compiled extension is present.
 - `_typing_compat.py` — `Protocol`, `runtime_checkable`, `Literal` backports for Python 3.7 (where `typing.Protocol` is unavailable).
 - Inline `@dataclass` definitions — simple value types like `McpHttpConfig` are redefined as pure-Python `@dataclass` in the fallback path.
 

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -96,7 +96,7 @@ _LAZY: dict[str, str] = {
     "PySharedSceneBuffer": "dcc_mcp_core._core",
     "PyStandaloneDispatcher": "dcc_mcp_core._core",
     "RateLimitMiddleware": "dcc_mcp_core._core",
-    "ReadinessProbe": "dcc_mcp_core._core",
+    "ReadinessProbe": "dcc_mcp_core._py37_fallback",
     "AdapterReadinessBinder": "dcc_mcp_core.readiness",
     "RecordingGuard": "dcc_mcp_core._core",
     "RenderOutput": "dcc_mcp_core._core",

--- a/python/dcc_mcp_core/_py37_fallback.py
+++ b/python/dcc_mcp_core/_py37_fallback.py
@@ -7,6 +7,9 @@ wheel), it provides pure-Python implementations of ``parse_skill_md``,
 ``GuiExecutableHint``, ``is_gui_executable``, and ``correct_python_executable``
 so that downstream adapters such as ``dcc_mcp_maya`` can import successfully.
 
+Also provides ``ReadinessProbe`` so adapter readiness binders can start
+without importing the compiled extension.
+
 Convention: every symbol exported here is an ``_core``-only symbol that
 the Maya adapter imports at package load time and that has no pure-Python
 equivalent elsewhere in the tree.
@@ -53,12 +56,14 @@ if _probe_core():
     scan_and_load_strict = _core.scan_and_load_strict
     correct_python_executable = _core.correct_python_executable
     is_gui_executable = _core.is_gui_executable
+    ReadinessProbe = _core.ReadinessProbe
 
     def __dir__() -> list[str]:
         return [
             "DccCapabilities",
             "GuiExecutableHint",
             "PyPumpedDispatcher",
+            "ReadinessProbe",
             "correct_python_executable",
             "is_gui_executable",
             "parse_skill_md",
@@ -488,3 +493,79 @@ else:
         if hint is not None and hint.recommended_replacement is not None:
             return hint.recommended_replacement
         return probe
+
+    class ReadinessProbe:
+        """Pure-Python fallback for the Rust ``ReadinessProbe``.
+
+        Matches ``StaticReadiness`` defaults and ``is_ready()`` semantics from
+        ``dcc_mcp_skill_rest::readiness``.
+        """
+
+        def __init__(
+            self,
+            *,
+            process: bool = True,
+            dcc: bool = False,
+            skill_catalog: bool = True,
+            dispatcher: bool = False,
+            host_execution_bridge: bool = False,
+            main_thread_executor: bool = False,
+        ) -> None:
+            self._process = process
+            self._dcc = dcc
+            self._skill_catalog = skill_catalog
+            self._dispatcher = dispatcher
+            self._host_execution_bridge = host_execution_bridge
+            self._main_thread_executor = main_thread_executor
+
+        @staticmethod
+        def fully_ready() -> ReadinessProbe:
+            return ReadinessProbe(
+                process=True,
+                dcc=True,
+                skill_catalog=True,
+                dispatcher=True,
+                host_execution_bridge=True,
+                main_thread_executor=True,
+            )
+
+        def set_dispatcher_ready(self, ready: bool) -> None:
+            self._dispatcher = bool(ready)
+
+        def set_dcc_ready(self, ready: bool) -> None:
+            self._dcc = bool(ready)
+
+        def set_skill_catalog_ready(self, ready: bool) -> None:
+            self._skill_catalog = bool(ready)
+
+        def set_host_execution_bridge_ready(self, ready: bool) -> None:
+            self._host_execution_bridge = bool(ready)
+
+        def set_main_thread_executor_ready(self, ready: bool) -> None:
+            self._main_thread_executor = bool(ready)
+
+        def is_ready(self) -> bool:
+            return (
+                self._process
+                and self._dcc
+                and self._skill_catalog
+                and self._dispatcher
+            )
+
+        def report(self) -> dict[str, bool]:
+            return {
+                "process": self._process,
+                "dcc": self._dcc,
+                "skill_catalog": self._skill_catalog,
+                "dispatcher": self._dispatcher,
+                "host_execution_bridge": self._host_execution_bridge,
+                "main_thread_executor": self._main_thread_executor,
+            }
+
+        def __repr__(self) -> str:
+            report = self.report()
+            return (
+                "ReadinessProbe(process={process}, dcc={dcc}, skill_catalog={skill_catalog}, "
+                "dispatcher={dispatcher}, host_execution_bridge={host_execution_bridge}, "
+                "main_thread_executor={main_thread_executor})"
+            ).format(**report)

--- a/python/dcc_mcp_core/_py37_fallback.py
+++ b/python/dcc_mcp_core/_py37_fallback.py
@@ -29,16 +29,19 @@ _HAS_CORE: bool | None = None  # tri-state: None=unchecked, True/False
 def _probe_core() -> bool:
     """Return ``True`` when the compiled ``_core`` extension is importable."""
     global _HAS_CORE
-    if _HAS_CORE is None:
-        import importlib
+    if _HAS_CORE is True:
+        return True
 
-        try:
-            importlib.import_module("dcc_mcp_core._core")
-        except ImportError:
-            _HAS_CORE = False
-        else:
-            _HAS_CORE = True
-    return _HAS_CORE
+    import importlib
+
+    try:
+        importlib.import_module("dcc_mcp_core._core")
+    except ImportError:
+        _HAS_CORE = False
+        return False
+
+    _HAS_CORE = True
+    return True
 
 
 # ── Re-export from _core when available ──────────────────────────────

--- a/python/dcc_mcp_core/_py37_fallback.py
+++ b/python/dcc_mcp_core/_py37_fallback.py
@@ -545,12 +545,7 @@ else:
             self._main_thread_executor = bool(ready)
 
         def is_ready(self) -> bool:
-            return (
-                self._process
-                and self._dcc
-                and self._skill_catalog
-                and self._dispatcher
-            )
+            return self._process and self._dcc and self._skill_catalog and self._dispatcher
 
         def report(self) -> dict[str, bool]:
             return {

--- a/python/dcc_mcp_core/readiness.py
+++ b/python/dcc_mcp_core/readiness.py
@@ -24,7 +24,10 @@ DEFAULT_FIRST_PUMP_TIMEOUT_SECS = 2.0
 
 
 def _new_probe() -> Any:
-    from dcc_mcp_core._py37_fallback import ReadinessProbe
+    try:
+        from dcc_mcp_core._core import ReadinessProbe
+    except ImportError:
+        from dcc_mcp_core._py37_fallback import ReadinessProbe
 
     return ReadinessProbe()
 

--- a/python/dcc_mcp_core/readiness.py
+++ b/python/dcc_mcp_core/readiness.py
@@ -24,7 +24,7 @@ DEFAULT_FIRST_PUMP_TIMEOUT_SECS = 2.0
 
 
 def _new_probe() -> Any:
-    from dcc_mcp_core import ReadinessProbe
+    from dcc_mcp_core._py37_fallback import ReadinessProbe
 
     return ReadinessProbe()
 

--- a/tests/test_py37_lite_fallbacks.py
+++ b/tests/test_py37_lite_fallbacks.py
@@ -244,6 +244,57 @@ def test_fallback_imports_from_top_level(monkeypatch) -> None:
     assert callable(dcc_mcp_core.is_gui_executable)
     assert callable(dcc_mcp_core.correct_python_executable)
 
+    # ReadinessProbe should come from _py37_fallback
+    probe = dcc_mcp_core.ReadinessProbe()
+    assert probe.report()["process"] is True
+    assert probe.is_ready() is False
+
+
+def test_readiness_probe_fallback_without_core(monkeypatch) -> None:
+    """ReadinessProbe and AdapterReadinessBinder work without _core (py37-lite)."""
+    modules = _import_without_core(
+        monkeypatch,
+        "dcc_mcp_core._py37_fallback",
+        "dcc_mcp_core.readiness",
+    )
+    fallback = modules["dcc_mcp_core._py37_fallback"]
+    readiness = modules["dcc_mcp_core.readiness"]
+
+    probe = fallback.ReadinessProbe()
+    report = probe.report()
+    assert report["process"] is True
+    assert report["dcc"] is False
+    assert report["skill_catalog"] is True
+    assert report["dispatcher"] is False
+    assert report["host_execution_bridge"] is False
+    assert report["main_thread_executor"] is False
+    assert probe.is_ready() is False
+
+    probe.set_dispatcher_ready(True)
+    probe.set_dcc_ready(True)
+    assert probe.is_ready() is True
+
+    probe.set_host_execution_bridge_ready(True)
+    probe.set_main_thread_executor_ready(True)
+    report = probe.report()
+    assert report["host_execution_bridge"] is True
+    assert report["main_thread_executor"] is True
+
+    full = fallback.ReadinessProbe.fully_ready()
+    assert all(full.report().values())
+
+    class _FakeServer:
+        def __init__(self) -> None:
+            self.probe = None
+
+        def set_readiness_probe(self, probe_obj: object) -> None:
+            self.probe = probe_obj
+
+    server = _FakeServer()
+    binder = readiness.AdapterReadinessBinder.bind_inline(server)
+    assert binder.probe.is_ready() is True
+    assert server.probe is binder.probe
+
 
 def test_gui_executable_fallback(monkeypatch, tmp_path) -> None:
     """is_gui_executable / correct_python_executable work without _core."""

--- a/tests/test_py37_lite_fallbacks.py
+++ b/tests/test_py37_lite_fallbacks.py
@@ -5,6 +5,15 @@ import os
 from pathlib import Path
 import sys
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_py37_fallback_module_after_stub_core():
+    """Drop cached ``_py37_fallback`` so xdist workers do not keep py37 bindings."""
+    yield
+    sys.modules.pop("dcc_mcp_core._py37_fallback", None)
+
 
 def _import_without_core(monkeypatch, *module_names: str):
     monkeypatch.setitem(sys.modules, "dcc_mcp_core._core", None)


### PR DESCRIPTION
## Summary
- Add a pure-Python `ReadinessProbe` to `_py37_fallback.py` matching Rust `StaticReadiness` defaults and `is_ready()` semantics
- Route the lazy export through `_py37_fallback` and break the `readiness.py` circular import
- Extend py37-lite regression tests and document the fallback in `py37-lite-architecture.md`

## Test plan
- [x] `pytest tests/test_readiness_probe.py tests/test_py37_lite_fallbacks.py`
- [ ] CI `Test (py37-lite)` green
- [ ] Maya 2022 smoke: `from dcc_mcp_core import ReadinessProbe; ReadinessProbe().report()` on py37-lite wheel