### PR TITLE
fix(ci): add Sync ClawHub Skills to release guard workflow_run triggers

### DIFF
--- a/.github/workflows/release-please-pr-guard.yml
+++ b/.github/workflows/release-please-pr-guard.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, synchronize, edited]
     branches: [main]
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI", "Sync ClawHub Skills"]
     types: [completed]
 
 permissions:


### PR DESCRIPTION
## Problem

[PR #1829](https://github.com/dcc-mcp/dcc-mcp-core/pull/1829) (release-please v0.19.14) merged at 00:03:00Z with `Package and sync skills to ClawHub` **failed**. The guard's `pull_request` event ran at 23:57:41 before ClawHub even started (00:03:55). The `workflow_run` re-trigger only watched `CI` completion — when CI finished at 00:17:03, the guard finally caught the failure but the PR had already been merged 14 minutes earlier.

## Root Cause

1. **Guard timing gap**: The `Release Please PR Guard` workflow only re-checked on `workflow_run: CI`. ClawHub is a separate workflow that runs in parallel; if ClawHub completes after the guard's initial `pull_request` run but before CI completes, the failure goes undetected until the `workflow_run: CI` re-trigger — which may be too late.

2. **No required status checks** (surfaced separately): The `main` branch ruleset (id: 4583130) only enforces `deletion` + `non_fast_forward`. Without `required_status_checks`, no check can truly block merge.

## Fix

Add `"Sync ClawHub Skills"` to the guard's `workflow_run.workflows` list. When ClawHub completes (typically ~30s), the guard immediately re-checks CI status for the PR head commit. If ClawHub failed, the `Validate release PR metadata` check turns red within ~40s of PR creation — well before any reviewer can merge.

## Validation

- [x] Single-line YAML change, no script logic changes needed
- [x] `check_release_please_pr.py` already handles `workflow_run` events correctly — it queries all check runs for the commit and fails on any `failure`/`timed_out`/`action_required` conclusion