### PR TITLE
fix: handle stale gateway takeover

### DIFF
--- a/crates/dcc-mcp-logging/src/config.rs
+++ b/crates/dcc-mcp-logging/src/config.rs
@@ -54,7 +54,8 @@ pub fn init_logging() {
 
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_target(true)
-            .with_thread_names(true);
+            .with_thread_names(true)
+            .with_ansi(false);
 
         // The slot is `None` until a caller opts into file logging.
         let (file_layer, handle) =

--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import os
 from pathlib import Path
@@ -14,6 +15,7 @@ from typing import Any
 from typing import Callable
 from urllib.error import HTTPError
 from urllib.error import URLError
+from urllib.request import Request
 from urllib.request import urlopen
 
 from dcc_mcp_core.daemon_launch import launch_detached
@@ -38,6 +40,71 @@ def _is_healthy(host: str, port: int, timeout: float) -> bool:
             return int(getattr(resp, "status", 0)) == 200
     except HTTPError as err:
         return int(getattr(err, "code", 0)) == 200
+    except (URLError, OSError, ValueError):
+        return False
+
+
+def _read_gateway_version_from_admin_health(
+    gateway_host: str,
+    gateway_port: int,
+    *,
+    timeout: float = 0.5,
+) -> str | None:
+    """Best-effort version probe from the running gateway's admin health API."""
+    url = f"http://{gateway_host}:{gateway_port}/admin/api/health"
+    try:
+        with urlopen(url, timeout=timeout) as resp:
+            if int(getattr(resp, "status", 0)) != 200:
+                return None
+            raw = resp.read()
+        payload = json.loads(raw.decode("utf-8")) if raw else {}
+    except (HTTPError, URLError, OSError, ValueError, AttributeError, UnicodeDecodeError):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    version = payload.get("version")
+    if isinstance(version, str) and version.strip():
+        return version.strip()
+    gateway = payload.get("gateway")
+    if isinstance(gateway, dict):
+        current = gateway.get("current")
+        if isinstance(current, dict):
+            version = current.get("version")
+            if isinstance(version, str) and version.strip():
+                return version.strip()
+    return None
+
+
+def _request_gateway_yield(
+    gateway_host: str,
+    gateway_port: int,
+    *,
+    challenger_version: str,
+    reason: str,
+    timeout: float = 1.0,
+) -> bool:
+    """Ask a running gateway to voluntarily release its port."""
+    url = f"http://{gateway_host}:{gateway_port}/gateway/yield"
+    body = json.dumps(
+        {
+            "challenger_version": challenger_version,
+            "reason": reason,
+            "suggested_successor": "python-gateway-guardian",
+        }
+    ).encode("utf-8")
+    req = Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            status = int(getattr(resp, "status", 0))
+            return 200 <= status < 300
+    except HTTPError as err:
+        return 200 <= int(getattr(err, "code", 0)) < 300
     except (URLError, OSError, ValueError):
         return False
 
@@ -242,6 +309,11 @@ def _try_version_takeover(
         gateway_host=gateway_host,
         gateway_port=gateway_port,
     )
+    if gateway_version is None:
+        gateway_version = _read_gateway_version_from_admin_health(
+            gateway_host,
+            gateway_port,
+        )
     if gateway_version is None or not _is_newer_version(our_version, gateway_version):
         # Running gateway is same or newer — no takeover needed.
         return None
@@ -252,7 +324,15 @@ def _try_version_takeover(
         gateway_version,
     )
 
-    # Write sentinel entry so the gateway's 15 s cleanup loop triggers a yield.
+    cooperative_yield_requested = _request_gateway_yield(
+        gateway_host,
+        gateway_port,
+        challenger_version=our_version,
+        reason="python_gateway_guardian_version_takeover",
+    )
+
+    # Write sentinel entry so gateways without /gateway/yield can still notice
+    # the newer challenger from their 15 s cleanup loop.
     sentinel_ok = _write_sentinel_entry(
         registry_dir,
         gateway_host=gateway_host,
@@ -260,8 +340,8 @@ def _try_version_takeover(
         crate_version=our_version,
         adapter_dcc=dcc_type if dcc_type else None,
     )
-    if not sentinel_ok:
-        logger.warning("version takeover: failed to write sentinel entry; skipping takeover")
+    if not cooperative_yield_requested and not sentinel_ok:
+        logger.warning("version takeover: failed to request yield or write sentinel; skipping takeover")
         return None
 
     # Wait for the old gateway to yield (up to ~20 s for the 15 s cleanup interval + grace).
@@ -746,6 +826,13 @@ def _read_gateway_version_from_registry(
             if not isinstance(entry, dict):
                 continue
             if entry.get("dcc_type") == "__gateway__":
+                if entry.get("host") != gateway_host:
+                    continue
+                try:
+                    if int(entry.get("port", 0)) != int(gateway_port):
+                        continue
+                except (TypeError, ValueError):
+                    continue
                 version = entry.get("version")
                 if isinstance(version, str):
                     return version

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 import sys
@@ -29,6 +30,15 @@ class _Resp:
 
     def __exit__(self, *_exc):
         return False
+
+
+class _JsonResp(_Resp):
+    def __init__(self, payload, status: int = 200):
+        self._payload = payload
+        self.status = status
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
 
 
 def test_ensure_gateway_daemon_reports_existing_health(monkeypatch):
@@ -931,6 +941,52 @@ def test_write_and_read_sentinel_entry(tmp_path):
     assert ver == "0.18.15"
 
 
+def test_read_gateway_version_from_registry_filters_host_and_port(tmp_path):
+    """Only the sentinel for the probed gateway endpoint is authoritative."""
+    reg = tmp_path / "dcc-mcp-registry"
+    reg.mkdir()
+    (reg / "services.json").write_text(
+        json.dumps(
+            [
+                {
+                    "dcc_type": "__gateway__",
+                    "host": "127.0.0.1",
+                    "port": 9766,
+                    "version": "9.9.9",
+                },
+                {
+                    "dcc_type": "__gateway__",
+                    "host": "127.0.0.1",
+                    "port": 9765,
+                    "version": "0.18.20",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        gg._read_gateway_version_from_registry(
+            str(reg),
+            gateway_host="127.0.0.1",
+            gateway_port=9765,
+        )
+        == "0.18.20"
+    )
+
+
+def test_read_gateway_version_from_admin_health(monkeypatch):
+    """Use admin health when the registry sentinel is missing or stale."""
+
+    def _urlopen(req, **_kwargs):
+        assert req == "http://127.0.0.1:9765/admin/api/health"
+        return _JsonResp({"gateway": {"current": {"version": "0.18.20"}}})
+
+    monkeypatch.setattr(gg, "urlopen", _urlopen)
+
+    assert gg._read_gateway_version_from_admin_health("127.0.0.1", 9765) == "0.18.20"
+
+
 def test_read_gateway_version_missing_registry():
     """P0-3: _read_gateway_version_from_registry returns None for missing file."""
     assert (
@@ -985,6 +1041,45 @@ def test_try_version_takeover_returns_none_when_dev_version(monkeypatch, tmp_pat
         server_bin=None,
     )
     assert result is None
+
+
+def test_try_version_takeover_uses_admin_health_and_cooperative_yield(monkeypatch, tmp_path):
+    """A healthy old gateway without a registry sentinel can still be replaced."""
+    yield_requests = []
+    launches = []
+
+    monkeypatch.setattr(gg, "_get_core_version", lambda: "0.19.14")
+    monkeypatch.setattr(gg, "_read_gateway_version_from_registry", lambda *a, **k: None)
+    monkeypatch.setattr(gg, "_read_gateway_version_from_admin_health", lambda *a, **k: "0.18.20")
+    monkeypatch.setattr(gg, "_request_gateway_yield", lambda *a, **k: yield_requests.append(k) or True)
+    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: False)
+    monkeypatch.setattr(gg, "_wait_gateway_ready", lambda *a, **k: True)
+
+    def _launch_detached(cmd, **kwargs):
+        launches.append((cmd, kwargs))
+        return {"ok": True, "pid": 4242}
+
+    monkeypatch.setattr(gg, "launch_detached", _launch_detached)
+    monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
+
+    result = gg._try_version_takeover(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=str(tmp_path),
+        dcc_type="houdini",
+        timeout_secs=15.0,
+        gateway_persist=False,
+        gateway_idle_timeout_secs=None,
+        server_bin=None,
+    )
+
+    assert result is not None
+    assert result["ok"] is True
+    assert result["reason"] == "version_takeover_spawned"
+    assert result["old_version"] == "0.18.20"
+    assert result["new_version"] == "0.19.14"
+    assert yield_requests[0]["challenger_version"] == "0.19.14"
+    assert launches[0][0][:2] == ["dcc-mcp-server", "gateway"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Disable ANSI formatting for shared console logging so DCC consoles do not render escape codes.
- Let the Python gateway guardian detect an older healthy gateway via admin health when the registry sentinel is missing, then request cooperative yield.
- Filter registry gateway sentinel version reads by host and port.

## Validation
- `PYTHONPATH=python vx python -m pytest tests/test_gateway_guardian.py`
- `vx ruff check python/dcc_mcp_core/_server/gateway_guardian.py tests/test_gateway_guardian.py`
- `vx cargo test -p dcc-mcp-logging`
- `vx cargo fmt --check`

Skill guidance update: not needed; this changes gateway lifecycle internals and logging behavior without changing public agent workflow docs.
