### PR TITLE
ci: add pinned py37 native image gate

### DIFF
--- a/.github/docker/py37-ci/Dockerfile
+++ b/.github/docker/py37-ci/Dockerfile
@@ -1,0 +1,35 @@
+FROM quay.io/pypa/manylinux2014_x86_64@sha256:fc58a97ebc50df8acfa25204711c27aa5a89c818cba270ec780feae8c0f58268
+
+ARG RUST_VERSION=1.95.0
+
+ENV CARGO_HOME=/opt/rust/cargo \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PY37_HOME=/opt/python/cp37-cp37m \
+    RUSTUP_HOME=/opt/rust/rustup
+ENV PATH="${PY37_HOME}/bin:${CARGO_HOME}/bin:${PATH}"
+
+RUN ln -sf "${PY37_HOME}/bin/python" /usr/local/bin/python \
+    && ln -sf "${PY37_HOME}/bin/python" /usr/local/bin/python3 \
+    && ln -sf "${PY37_HOME}/bin/python" /usr/local/bin/python3.7 \
+    && ln -sf "${PY37_HOME}/bin/pip" /usr/local/bin/pip \
+    && python --version | grep "Python 3.7.17" \
+    && python -m pip install --upgrade \
+        "pip>=20.3,<24.1" \
+        "setuptools==68.0.0" \
+        "wheel==0.42.0" \
+        "build==1.1.1" \
+        "maturin>=1.0,<2.0"
+
+RUN curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --profile minimal --default-toolchain "${RUST_VERSION}" \
+    && rustup component add clippy rustfmt \
+    && chmod -R a+rX /opt/rust \
+    && python --version \
+    && pip --version \
+    && maturin --version \
+    && rustc --version \
+    && cargo --version
+
+LABEL org.opencontainers.image.title="dcc-mcp Python 3.7 CI image" \
+      org.opencontainers.image.description="Pinned Linux CI image for native cp37 dcc-mcp wheel builds." \
+      org.opencontainers.image.source="https://github.com/dcc-mcp/dcc-mcp-core"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -41,7 +41,7 @@ permissions:
   packages: read
 
 env:
-  PY37_CI_IMAGE: ghcr.io/dcc-mcp/dcc-mcp-py37@sha256:1dd8fba0da3f2a70ce44f55aee7cf08ee3d67768367deb3985a4f70779687ac5
+  PY37_CI_IMAGE: ghcr.io/dcc-mcp/dcc-mcp-py37@sha256:cb56feaca373ce2ade71ac4855dbf8eb14653bf3bfac33ce0ad79caa31fa6e35
   PY37_WHEEL_FEATURES: python-bindings,ext-module,workflow,scheduler,prometheus,job-persist-sqlite,admin
 
 jobs:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -38,9 +38,33 @@ concurrency:
 
 permissions:
   contents: write
+  packages: read
+
+env:
+  PY37_CI_IMAGE: ghcr.io/dcc-mcp/dcc-mcp-py37@sha256:1dd8fba0da3f2a70ce44f55aee7cf08ee3d67768367deb3985a4f70779687ac5
+  PY37_WHEEL_FEATURES: python-bindings,ext-module,workflow,scheduler,prometheus,job-persist-sqlite,admin
 
 jobs:
   # ── ABI3 builds (Python 3.8+) — one wheel works for all 3.8+ ──
+
+  admin-ui-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+      - uses: loonghao/vx@v0.9.11
+        with:
+          version: "0.9.11"
+          cache-key-prefix: "vx-tools-v0.9.7"
+      - name: Build admin UI bundle
+        shell: bash
+        run: scripts/release/prebuild_admin_ui.sh
+      - name: Upload admin UI bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-ui-bundle
+          path: crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
 
   linux:
     runs-on: ubuntu-latest
@@ -107,51 +131,50 @@ jobs:
           tag_name: ${{ inputs.release-tag-name }}
           files: dist/*.whl
 
-  # ── py37-lite: pure-Python wheel (py3-none-any) for Python 3.7 ──
-  # Maya 2022 / Blender 2.83 embed Python 3.7 and cannot load cp38-abi3
-  # wheels. scripts/build_py37_pure_wheel.py assembles a py3-none-any wheel
-  # from python/dcc_mcp_core without maturin, Rust, or just (just>=1.0 is
-  # unavailable on Python 3.7 and previously blocked release PyPI publish).
-  py37-lite:
-    runs-on: ubuntu-22.04
+  # ── Native Linux cp37 wheel for supported Python 3.7 DCC hosts ──
+  # Built in the canonical GHCR image pinned by digest. The py37-lite fallback
+  # remains tested below, but release uploads must come from this native lane.
+  linux-py37:
+    runs-on: ubuntu-latest
+    needs: [admin-ui-bundle]
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout-ref || github.ref }}
-      - uses: actions/setup-python@v6
+      - name: Download admin UI bundle
+        uses: actions/download-artifact@v8
         with:
-          python-version: "3.7"
-      - name: Build py37-lite pure-Python wheel
+          name: admin-ui-bundle
+          path: crates/dcc-mcp-gateway/src/gateway/admin/generated
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Build native py37 wheel
         run: |
-          python -m pip install --upgrade pip wheel
-          python scripts/build_py37_pure_wheel.py
+          docker run --rm \
+            -v "$PWD:/io" \
+            -w /io \
+            -e DCC_MCP_ADMIN_UI_PREBUILT=1 \
+            -e PY37_WHEEL_FEATURES \
+            "$PY37_CI_IMAGE" \
+            sh -lc 'maturin build --release --out dist --features "$PY37_WHEEL_FEATURES" -i python3.7'
         shell: bash
-      - name: Verify wheel tag is py3-none-any
+      - name: Verify wheel tag is native cp37
         shell: bash
         run: |
           wheel=$(ls dist/*.whl | head -1)
           echo "Built wheel: $wheel"
-          if [[ "$wheel" != *py3-none-any* ]]; then
-            echo "::error::Expected py3-none-any wheel tag, got: $wheel"
+          if [[ "$wheel" != *cp37-cp37m* ]]; then
+            echo "::error::Expected native cp37-cp37m wheel tag, got: $wheel"
             exit 1
           fi
-          echo "OK: py3-none-any wheel tag confirmed"
-      - name: Verify _core extension is NOT present in the wheel
-        shell: bash
-        run: |
-          wheel=$(ls dist/*.whl | head -1)
-          # Match compiled extensions only; _core.pyi stub is expected in py37-lite wheels.
-          if unzip -l "$wheel" | grep -E '_core\.(so|pyd|dll|dylib)'; then
-            echo "::error::py37-lite wheel should not contain compiled _core extension"
-            exit 1
-          fi
-          echo "OK: no compiled _core extension in py37-lite wheel"
-      - name: Upload py37-lite wheel artifact
+          unzip -l "$wheel" | grep -E '_core\..*\.so'
+          echo "OK: native cp37 wheel tag and _core extension confirmed"
+      - name: Upload native py37 wheel artifact
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-py37-lite
+          name: wheels-linux-x86_64-py37
           path: dist/
           retention-days: 30
       - name: Upload wheel to GitHub Release
@@ -160,6 +183,43 @@ jobs:
         with:
           tag_name: ${{ inputs.release-tag-name }}
           files: dist/*.whl
+
+  py37-lite-fallback:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.7"
+      - name: Build py37-lite fallback wheel
+        run: |
+          python -m pip install --upgrade pip wheel
+          python scripts/build_py37_pure_wheel.py
+        shell: bash
+      - name: Verify fallback wheel has no compiled _core
+        shell: bash
+        run: |
+          wheel=$(ls dist/*.whl | head -1)
+          echo "Built wheel: $wheel"
+          if [[ "$wheel" != *py3-none-any* ]]; then
+            echo "::error::Expected py3-none-any fallback wheel tag, got: $wheel"
+            exit 1
+          fi
+          if unzip -l "$wheel" | grep -E '_core\.(so|pyd|dll|dylib)'; then
+            echo "::error::py37-lite fallback wheel should not contain compiled _core extension"
+            exit 1
+          fi
+          echo "OK: py37-lite fallback wheel remains pure Python"
+      - name: Upload py37-lite fallback wheel artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-py37-lite-fallback
+          path: dist/
+          retention-days: 30
 
   macos:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PY37_CI_IMAGE: ghcr.io/dcc-mcp/dcc-mcp-py37@sha256:1dd8fba0da3f2a70ce44f55aee7cf08ee3d67768367deb3985a4f70779687ac5
+  PY37_CI_IMAGE: ghcr.io/dcc-mcp/dcc-mcp-py37@sha256:cb56feaca373ce2ade71ac4855dbf8eb14653bf3bfac33ce0ad79caa31fa6e35
   PY37_WHEEL_FEATURES: python-bindings,ext-module,workflow,scheduler,prometheus,job-persist-sqlite,admin
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,15 @@ on:
 
 permissions:
   contents: write
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+env:
+  PY37_CI_IMAGE: ghcr.io/dcc-mcp/dcc-mcp-py37@sha256:1dd8fba0da3f2a70ce44f55aee7cf08ee3d67768367deb3985a4f70779687ac5
+  PY37_WHEEL_FEATURES: python-bindings,ext-module,workflow,scheduler,prometheus,job-persist-sqlite,admin
 
 jobs:
   release-metadata:
@@ -355,19 +360,59 @@ jobs:
           # npm install/build in every wheel job.
           prebuild-admin-ui: "false"
 
-  # ── Build py37-lite pure-Python wheel (py3-none-any) ──
-  # Runs on ubuntu-22.04 (Python 3.7 available) to produce a platform-
-  # independent wheel with zero compiled Rust extensions. The wheel is
-  # reused by the test-py37 job below.
+  # ── Build native CPython 3.7 wheel (cp37-cp37m) ──
+  # Linux py37 uses the canonical GHCR image pinned by digest. The pure-Python
+  # fallback stays covered below but is no longer the default supported lane.
   build-py37-wheel:
-    name: Build wheel (py37-lite)
+    name: Build wheel (py37 native)
+    needs: [admin-ui-bundle]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download admin UI bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: admin-ui-bundle
+          path: crates/dcc-mcp-gateway/src/gateway/admin/generated
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Build native py37 wheel
+        run: |
+          docker run --rm \
+            -v "$PWD:/io" \
+            -w /io \
+            -e DCC_MCP_ADMIN_UI_PREBUILT=1 \
+            -e PY37_WHEEL_FEATURES \
+            "$PY37_CI_IMAGE" \
+            sh -lc 'maturin build --release --out dist --features "$PY37_WHEEL_FEATURES" -i python3.7'
+        shell: bash
+      - name: Verify wheel tag is cp37
+        shell: bash
+        run: |
+          wheel=$(ls dist/*.whl | head -1)
+          echo "Built wheel: $wheel"
+          if [[ "$wheel" != *cp37-cp37m* ]]; then
+            echo "::error::Expected native cp37-cp37m wheel tag, got: $wheel"
+            exit 1
+          fi
+          unzip -l "$wheel" | grep -E '_core\..*\.so'
+          echo "OK: native cp37 wheel tag and _core extension confirmed"
+      - name: Upload native py37 wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheel-py37-native
+          path: dist/
+          retention-days: 30
+
+  build-py37-lite-wheel:
+    name: Build wheel (py37-lite fallback)
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.7"
-      - name: Build py37-lite wheel
+      - name: Build py37-lite fallback wheel
         run: |
           python -m pip install --upgrade pip wheel
           python scripts/build_py37_pure_wheel.py
@@ -381,8 +426,8 @@ jobs:
             echo "::error::Expected py3-none-any wheel tag, got: $wheel"
             exit 1
           fi
-          echo "OK: py3-none-any wheel tag confirmed"
-      - name: Upload py37-lite wheel
+          echo "OK: py3-none-any fallback wheel tag confirmed"
+      - name: Upload py37-lite fallback wheel
         uses: actions/upload-artifact@v7
         with:
           name: wheel-py37-lite
@@ -467,21 +512,42 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  # ── py37-lite wheel test: pure-Python subset on Python 3.7 ──
-  # Installs the py3-none-any wheel from build-py37-wheel and runs
-  # the minimal import/skill/host smoke that exercises only pure-Python
-  # code paths. The _core extension is absent in this profile:
-  # `from dcc_mcp_core import _core` must raise ImportError.
+  # ── Native py37 wheel test: supported Maya/Blender cp37 lane ──
   test-py37:
-    name: Test (py37-lite)
+    name: Test (py37 native)
     needs: [build-py37-wheel]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download native py37 wheel
+        uses: actions/download-artifact@v8
+        with:
+          name: wheel-py37-native
+          path: dist/
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Install wheel + test deps
+        run: |
+          docker run --rm \
+            -v "$PWD:/io" \
+            -w /io \
+            "$PY37_CI_IMAGE" \
+            sh -lc 'pip install dist/*.whl pytest && python -c "import importlib, sys; assert sys.version_info[:3] == (3, 7, 17), sys.version; core = importlib.import_module(\"dcc_mcp_core._core\"); print(\"OK: native _core import\", core.__name__)" && pytest tests/test_py37_sidecar_server_factory.py -q'
+        shell: bash
+
+  # ── py37-lite fallback test: pure-Python subset on Python 3.7 ──
+  # The _core extension is absent in this profile:
+  # `from dcc_mcp_core import _core` must raise ImportError.
+  test-py37-lite-fallback:
+    name: Test (py37-lite fallback)
+    needs: [build-py37-lite-wheel]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.7"
-      - name: Download py37-lite wheel
+      - name: Download py37-lite fallback wheel
         uses: actions/download-artifact@v8
         with:
           name: wheel-py37-lite
@@ -591,14 +657,19 @@ jobs:
   # walrus operators, and other 3.8+ syntax.
   py37-syntax-check:
     name: py37 syntax check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.7"
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Run py37 syntax check
-        run: python scripts/check_py37_syntax.py
+        run: |
+          docker run --rm \
+            -v "$PWD:/io" \
+            -w /io \
+            "$PY37_CI_IMAGE" \
+            python scripts/check_py37_syntax.py
+        shell: bash
 
   # -- Sentry E2E: real ingest through dcc-mcp-server init_sentry() --
   # Requires DCC_MCP_SENTRY_DSN GitHub Actions secret. Skips cleanly when

--- a/.github/workflows/py37-ci-image.yml
+++ b/.github/workflows/py37-ci-image.yml
@@ -1,0 +1,51 @@
+name: Python 3.7 CI Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/docker/py37-ci/Dockerfile"
+      - ".github/workflows/py37-ci-image.yml"
+
+env:
+  IMAGE_NAME: ghcr.io/dcc-mcp/dcc-mcp-py37
+  IMAGE_TAG: 3.7.17-rust-1.95.0
+
+jobs:
+  publish:
+    name: Publish py37 CI image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build image
+        run: docker build -f .github/docker/py37-ci/Dockerfile -t "$IMAGE_NAME:$IMAGE_TAG" .
+
+      - name: Smoke image
+        run: |
+          docker run --rm "$IMAGE_NAME:$IMAGE_TAG" python - <<'PY'
+          import subprocess
+          import sys
+
+          assert sys.version_info[:3] == (3, 7, 17), sys.version
+          for command in ("pip --version", "maturin --version", "rustc --version", "cargo --version"):
+              print("+", command)
+              subprocess.check_call(command.split())
+          PY
+
+      - name: Push image
+        run: docker push "$IMAGE_NAME:$IMAGE_TAG"
+
+      - name: Report digest
+        run: |
+          digest="$(docker buildx imagetools inspect "$IMAGE_NAME:$IMAGE_TAG" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "Pinned image: \`$IMAGE_NAME@$digest\`" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/guide/py37-ci-image.md
+++ b/docs/guide/py37-ci-image.md
@@ -1,0 +1,42 @@
+# Python 3.7 CI image
+
+`dcc-mcp-core` uses a canonical Linux image for the supported native
+CPython 3.7 lane:
+
+```text
+ghcr.io/dcc-mcp/dcc-mcp-py37@sha256:1dd8fba0da3f2a70ce44f55aee7cf08ee3d67768367deb3985a4f70779687ac5
+```
+
+The image is built from `.github/docker/py37-ci/Dockerfile` and must be
+referenced by digest in workflows. Tags are only publishing conveniences; CI
+must not depend on mutable tags.
+
+## Contents
+
+- Python `3.7.17` from the pinned manylinux2014 base image.
+- `pip>=20.3,<24.1`, `setuptools`, `wheel`, `build`, and `maturin`.
+- Rust/Cargo with `clippy` and `rustfmt`.
+
+## CI contract
+
+- `.github/workflows/ci.yml` builds and tests the native Linux
+  `cp37-cp37m` wheel as the default Python 3.7 gate.
+- `.github/workflows/build-wheels.yml` uploads the release Python 3.7 Linux
+  wheel from the native lane.
+- The `py37-lite` pure-Python wheel remains a fallback-only job. It must keep
+  proving that `_core` is absent and import fallback paths still work, but it
+  must not be the default supported Maya Python 3.7 artifact.
+
+## Boundaries
+
+- The GHCR package must either be public or grant GitHub Actions access to
+  every repository that pulls it. For the current cross-repo gate that means at
+  least `dcc-mcp-core` and `dcc-mcp-maya`.
+- This image covers Linux CI only. Native macOS and Windows `cp37` wheels need
+  separate runner strategies because they must be built on their target OS.
+- DCC host smoke tests still need real host environments such as Maya, Blender,
+  or mayapy containers. The Linux Python 3.7 image proves wheel build and
+  resolver behavior, not host integration.
+- When the image is rebuilt, publish it to GHCR, read back the immutable
+  digest, update every workflow reference, and include a smoke proving:
+  `python == 3.7.17`, `pip`, `maturin`, `rustc`, and `cargo` are available.

--- a/docs/guide/py37-ci-image.md
+++ b/docs/guide/py37-ci-image.md
@@ -4,7 +4,7 @@
 CPython 3.7 lane:
 
 ```text
-ghcr.io/dcc-mcp/dcc-mcp-py37@sha256:1dd8fba0da3f2a70ce44f55aee7cf08ee3d67768367deb3985a4f70779687ac5
+ghcr.io/dcc-mcp/dcc-mcp-py37@sha256:cb56feaca373ce2ade71ac4855dbf8eb14653bf3bfac33ce0ad79caa31fa6e35
 ```
 
 The image is built from `.github/docker/py37-ci/Dockerfile` and must be

--- a/justfile
+++ b/justfile
@@ -19,6 +19,10 @@ DEV_FEATURES := "python-bindings,ext-module," + OPT_FEATURES
 # Feature set for abi3 release wheels (Python 3.8+)
 WHEEL_FEATURES := "python-bindings,ext-module,abi3-py38," + OPT_FEATURES
 
+# Feature set for native CPython 3.7 wheels. Python 3.7 cannot consume the
+# cp38-abi3 wheel, so this lane intentionally omits abi3-py38.
+PY37_WHEEL_FEATURES := "python-bindings,ext-module," + OPT_FEATURES
+
 default:
     @just --list
 
@@ -45,6 +49,9 @@ print-dev-features:
 
 print-wheel-features:
     @echo "{{WHEEL_FEATURES}}"
+
+print-py37-wheel-features:
+    @echo "{{PY37_WHEEL_FEATURES}}"
 
 # ── Admin UI ──────────────────────────────────────────────────────────────────
 #
@@ -196,11 +203,15 @@ build *EXTRA:
     just stubgen
     maturin build --release --out dist --features {{WHEEL_FEATURES}} {{EXTRA}}
 
-# Build the py37-lite pure-Python wheel (py3-none-any).
-# Uses no PyO3 features so maturin produces a wheel with only pure-Python
-# sources — no compiled _core extension. The wheel is tagged py3-none-any
-# and installable on Python 3.7 (Maya 2022 / Blender 2.83).
-build-py37:
+# Build native CPython 3.7 wheel (cp37-cp37m).
+# EXTRA is forwarded to maturin — used by CI to pass --find-interpreter,
+# --target, etc. without duplicating feature flags.
+build-py37 *EXTRA:
+    maturin build --release --out dist --features {{PY37_WHEEL_FEATURES}} {{EXTRA}}
+
+# Build the py37-lite pure-Python fallback wheel (py3-none-any).
+# Uses no PyO3 features so the wheel has no compiled _core extension.
+build-py37-lite:
     python scripts/build_py37_pure_wheel.py
 
 # Install dev/test dependencies


### PR DESCRIPTION
Adds the canonical GHCR Python 3.7.17 image definition, digest-pinned native Linux cp37 CI/release gates, and keeps py37-lite as an explicit fallback lane. Draft blockers: the manually published GHCR package is private/unlinked, so Actions digest pulls need package Actions access or public visibility; after image access is fixed, the native core build is expected to block on PyO3 0.29 because configured Python 3.7 is below PyO3's minimum supported version 3.8.