### PR TITLE
docs: propagate Python 3.7 support policy to agent guidance layer for 0.20.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -589,7 +589,7 @@ docs/            # human-readable guides + API reference
 - Don't extend the JSON-RPC `match` arm in `dispatch.rs` → **register a `MethodHandler` on `MethodRouter`** (#492)
 - Don't hand-roll JSON-RPC envelopes → **`NotificationBuilder` / `JsonRpcRequestBuilder`** (#484)
 - Don't add per-crate `*Error` enums → **return `DccMcpError` via `From` impls** (#488)
-- Don't add Python runtime deps → **zero-dep by design**
+- Don't break Python 3.7 support → **supported until 2026-12-31; py37-lite is NOT valid evidence for release gates; PyO3 upgrades frozen until deadline is lifted**
 - Don't manually bump versions → **Release Please handles this**
 - Don't hardcode scope strings → **use `SkillScope` when introspecting from Python and `SkillMetadata` methods for policy checks**
 - Don't add a generic `utils` / `common` / `helpers` crate → **route helpers to their owner: domain crate, `dcc-mcp-paths`, `dcc-mcp-logging`, or `dcc-mcp-pybridge`** ([rationale](docs/guide/agents-reference.md#workspace-boundary-rationale))

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -373,6 +373,20 @@ tools:
       on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]
 ```
 
+## 🔴 Red Lines — Python 3.7 Support Policy
+
+**dcc-mcp supports Python 3.7 until `2026-12-31`** unless hallong explicitly lifts the deadline.
+
+This is a hard requirement — Maya 2022, Blender 2.83, and many DCC hosts embed Python 3.7. Every change you make must keep this constraint in mind:
+
+1. **`py37-lite` / fallback mode is NOT valid evidence** of Python 3.7 support for release gates. Native py37 compatibility is required.
+2. **PyO3 upgrades stay frozen** until the py37 deadline is lifted. Any Cargo.toml change touching PyO3 or maturin requires explicit py37 CI validation.
+3. **`requires-python = ">=3.7"`** in `pyproject.toml` is the canonical classifier. Do not bump it without explicit policy override.
+4. **CI must include a Python 3.7 job** for every PR that touches Rust/PyO3/maturin wiring, Python API surface, or packaging. A py37-lite or py38-only CI pass is insufficient.
+5. **Release/review agents**: verify py37 wheels exist and py37 CI is green before approving any release or merge. The `compatibility` field in SKILL.md frontmatter should include `Python 3.7+`.
+
+If you are uncertain whether a change affects py37 compatibility, ask. Never assume "it probably works on 3.7 too."
+
 ## 🚫 Top Traps — Memorize These
 
 1. **`scan_and_load` returns a 2-tuple** → `skills, skipped = scan_and_load(...)`

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -1775,3 +1775,53 @@ A single error enum with `From<HttpError>`, `From<ProcessError>`, … impls.
 Crates keep their domain-specific enums (`HttpError`, `ProcessError`, …) and
 convert to `DccMcpError` at the public boundary. New top-level helpers should
 return `Result<T, DccMcpError>` rather than introducing yet another error type.
+
+---
+
+## Python 3.7 Support Policy
+
+**dcc-mcp supports Python 3.7 until `2026-12-31`** unless hallong explicitly
+lifts the deadline. This constraint exists because Maya 2022, Blender 2.83,
+3ds Max 2022, and many other DCC hosts embed Python 3.7.
+
+### Why This Matters for Review/Release Agents
+
+| Role | What to check |
+|------|---------------|
+| **Merge/review gate** | Verify py37 CI is green before approving. Reject if py37 CI was skipped or replaced by `py37-lite`. |
+| **Release** | Confirm py37 wheels are built (not just py38+ wheels). Check that `requires-python = ">=3.7"` in `pyproject.toml` has not been bumped. |
+| **PR author** | Run `vx just test` on Python 3.7 before opening PR if touching Rust/PyO3/maturin wiring, Python API surface, or packaging. |
+| **Skill creator** | Set `compatibility: "dcc-mcp-core <version>, Python 3.7+"` in SKILL.md frontmatter. |
+
+### What is NOT valid
+
+- `py37-lite` / fallback wheels — native py37 builds are required for release
+  gates. A lite wheel that drops Rust extensions to support py37 without
+  compiling native code does **not** count as py37 compliance.
+- py38-only CI passing — all changes that affect the Python surface must
+  have a passing py37 CI job.
+- "Nobody uses py37 anymore" — the deadline is fixed. If you think it should
+  be lifted, raise it with hallong.
+
+### PyO3 / Maturin Constraints
+
+- **PyO3 upgrades are frozen** until the py37 deadline is lifted.
+- Any `Cargo.toml` change touching `pyo3` or `maturin` version pins requires
+  explicit py37 CI validation in the same PR.
+- When adding a new Rust extension to an existing adapter, verify that
+  `maturin build` succeeds on Python 3.7 with the current PyO3 pin.
+
+### CI Configuration
+
+The CI workflow (`.github/workflows/`) must include a Python 3.7 job for PRs
+that touch:
+
+1. `Cargo.toml` / `Cargo.lock` — workspace-level or per-crate dependency changes
+2. `pyproject.toml` — build system, dependencies, classifiers
+3. `python/` — any Python source or stub file
+4. `.github/workflows/` — CI workflow changes that could affect test matrix
+5. `crates/` — Rust source that affects the PyO3 bridge
+
+The py37 job must run the full test suite (`vx just test`), not a subset.
+If a test genuinely cannot run on 3.7 (e.g. depends on Python 3.8+ only
+features), it should be marked with `@pytest.mark.skipif(sys.version_info < (3, 8), ...)` and the skip must be documented in the PR.

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -55,6 +55,7 @@ skill taxonomy), load `dcc-mcp-skills-creator` instead.
    - [HOST_PATTERN_MATRIX.md](references/HOST_PATTERN_MATRIX.md) for host-specific wiring.
    - [CORE_ESCALATION_CHECKLIST.md](references/CORE_ESCALATION_CHECKLIST.md) before adding adapter-local glue.
     - [TESTING_AND_RELEASE.md](references/TESTING_AND_RELEASE.md) before validating or publishing.
+    - **Python 3.7 policy**: native py37 support is required until `2026-12-31`. Verify py37 CI is green and `requires-python = ">=3.7"` is unchanged before any release. `py37-lite` fallback does NOT satisfy release gates.
     - [docs/guide/gateway.md](../../docs/guide/gateway.md) for gateway daemon lifecycle details.
     - [docs/guide/adapter-install-lifecycle.md](../../docs/guide/adapter-install-lifecycle.md) for sidecar launch/readiness details.
     - [docs/guide/adapter-release-checklist.md](../../docs/guide/adapter-release-checklist.md) for release train compliance.

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -187,6 +187,14 @@ canonical tags. For example, Autodesk Product Help should use `docs`,
 production-tracking search unless the user explicitly asks for help or reference
 material.
 
+### Python 3.7 Policy
+
+All authored skills must declare `compatibility: "Python 3.7+"` in their
+frontmatter until the policy deadline (`2026-12-31`). This applies to every
+skill that is installed into a DCC host embedding Python 3.7 (Maya 2022,
+Blender 2.83, 3ds Max 2022, etc.). `py37-lite` fallback builds do NOT
+satisfy release gates — only native py37 compatibility counts.
+
 **Skill SKILL.md example** (frontmatter excerpt):
 
 ```yaml

--- a/skills/marketplace-publish-extension/SKILL.md
+++ b/skills/marketplace-publish-extension/SKILL.md
@@ -55,6 +55,13 @@ push the change.
 - Write access to the target marketplace catalog path
 - Git (if using commit+push mode)
 
+## Release Gate — Python 3.7
+
+- **Verify py37 wheels exist** and py37 CI is green before publishing.
+- `py37-lite` fallback wheels do NOT satisfy the release gate. Native py37
+  builds are required until `2026-12-31`.
+- Confirm `requires-python = ">=3.7"` in `pyproject.toml` is unchanged.
+
 ## Workflow
 
 1. Point the tool at a local extension directory containing `SKILL.md`.


### PR DESCRIPTION
## Summary

Propagate the Python 3.7 support policy (native support through
2026-12-31, py37-lite disqualification, PyO3 freeze) to every
layer of the agent-facing documentation in preparation for the
0.20.0 release.

## Files changed

- **AI_AGENT_GUIDE.md** — new "Red Lines — Python 3.7 Support Policy"
  section as canonical shared guidance for all agents
- **AGENTS.md** — compact trap entry for navigation-map readers
- **docs/guide/agents-reference.md** — detailed role-specific policy
  table, what-is-NOT-valid section, PyO3/maturin constraints, CI
  configuration rules for review/release agents
- **skills/marketplace-publish-extension/SKILL.md** — release gate
  checklist confirming py37 wheels and CI are green before publishing
- **skills/dcc-mcp-creator/SKILL.md** — inline policy reminder in
  the fast-workflow reference links
- **skills/dcc-mcp-skills-creator/SKILL.md** — policy section for
  skill authors requiring `compatibility: "Python 3.7+"` frontmatter

## Validation

- All changed files are documentation/skill guidance — no code changes
- Each file was read to verify insertion point correctness
- Rust formatting check passed on push (cargo fmt --check)

## Agent/Squad coverage

| Layer | File | Audience |
|-------|------|----------|
| Shared guidance | AI_AGENT_GUIDE.md | All agents |
| Navigation map | AGENTS.md | All agents |
| Detailed reference | docs/guide/agents-reference.md | Review/release agents |
| Release gate | marketplace-publish-extension | Publish agents |
| Adapter creators | dcc-mcp-creator | Backend/core agents |
| Skill authors | dcc-mcp-skills-creator | Skill authoring agents |