### PR TITLE
feat: restore native Python 3.7 wheel build support

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: '1.95.0'
   maturin-extra-args:
-    description: 'Extra maturin args (e.g. --sdist). Features
+    description: 'Extra maturin args (e.g. --sdist, -i python3.7). Features
       and --release/--out are set by this action from the justfile.'
     required: false
     default: '--find-interpreter'
@@ -44,9 +44,14 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Python
+      if: runner.os != 'Windows' || inputs.python-version != '3.7'
       uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
+
+    - name: Setup Windows Python 3.7
+      if: runner.os == 'Windows' && inputs.python-version == '3.7'
+      uses: ./.github/actions/setup-windows-python37
 
     - name: Remove pre-installed cargo-clippy (conflict workaround)
       # GitHub-hosted runners (macOS aarch64 AND ubuntu-latest) pre-install Rust
@@ -85,7 +90,12 @@ runs:
       shell: bash
       run: |
         # Single source of truth: the feature list lives in justfile.
-        features=$(vx just print-wheel-features)
+        # Python 3.7 cannot use abi3-py38 (PyO3 requires interpreter >= 3.8).
+        if [[ "${{ inputs.python-version }}" == "3.7" ]]; then
+          features=$(vx just print-wheel-features-py37)
+        else
+          features=$(vx just print-wheel-features)
+        fi
         args="--release --out dist --features ${features} ${{ inputs.maturin-extra-args }}"
         echo "Resolved maturin args: ${args}"
         echo "value=${args}" >> "$GITHUB_OUTPUT"
@@ -150,7 +160,7 @@ runs:
         test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
 
     - name: Generate type stubs
-      if: inputs.generate-stubs == 'true'
+      if: inputs.generate-stubs == 'true' && inputs.python-version != '3.7'
       shell: bash
       env:
         DCC_MCP_ADMIN_UI_PREBUILT: "1"
@@ -182,6 +192,7 @@ runs:
       if: inputs.test-wheel == 'true'
       shell: bash
       run: |
+        # Use python -m venv for Python 3.7 (uv does not support 3.7)
         python -m venv test-env
         if [ "${{ runner.os }}" = "Windows" ]; then
           source test-env/Scripts/activate

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -161,6 +161,77 @@ jobs:
           tag_name: ${{ inputs.release-tag-name }}
           files: dist/*.whl
 
+  # ── Native Python 3.7 builds (non-abi3, compiled _core extension) ──
+  # These produce cp37-cp37m wheels with a compiled _core extension
+  # for Maya 2022 / Blender 2.83 embedded Python 3.7 hosts.
+  # Uses WHEEL_FEATURES_PY37 (no abi3-py38) via build-wheel action py37 branch.
+
+  linux-py37:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+      - uses: ./.github/actions/build-wheel
+        with:
+          target: x86_64
+          python-version: '3.7'
+          maturin-extra-args: '-i python3.7'
+          artifact-name: wheels-linux-x86_64-py37
+      - name: Verify wheel tag is cp37 (not abi3)
+        shell: bash
+        run: |
+          wheel=$(ls dist/*.whl | head -1)
+          echo "Built wheel: $wheel"
+          if [[ "$wheel" != *cp37* ]]; then
+            echo "::error::Expected cp37 wheel tag, got: $wheel"
+            exit 1
+          fi
+          if [[ "$wheel" == *cp38-abi3* ]]; then
+            echo "::error::cp37 wheel must NOT be abi3, got: $wheel"
+            exit 1
+          fi
+          echo "OK: native cp37 wheel tag confirmed"
+      - name: Upload wheel to GitHub Release
+        if: inputs.release-tag-name != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.release-tag-name }}
+          files: dist/*.whl
+
+  windows-py37:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+      - uses: ./.github/actions/build-wheel
+        with:
+          target: x64
+          python-version: '3.7'
+          maturin-extra-args: '-i python3.7'
+          artifact-name: wheels-windows-x64-py37
+      - name: Verify wheel tag is cp37 (not abi3)
+        shell: bash
+        run: |
+          wheel=$(ls dist/*.whl | head -1)
+          echo "Built wheel: $wheel"
+          if [[ "$wheel" != *cp37* ]]; then
+            echo "::error::Expected cp37 wheel tag, got: $wheel"
+            exit 1
+          fi
+          echo "OK: native cp37 wheel tag confirmed"
+      - name: Upload wheel to GitHub Release
+        if: inputs.release-tag-name != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.release-tag-name }}
+          files: dist/*.whl
+
   macos:
     runs-on: macos-latest
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4021,9 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.29.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
+checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
 dependencies = [
  "libc",
  "ndarray",
@@ -4894,9 +4894,9 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "pyo3"
-version = "0.29.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "inventory",
  "libc",
@@ -4909,18 +4909,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.29.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.29.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -4928,9 +4928,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.29.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -4940,12 +4940,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.29.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ dcc-mcp-gateway-search = { path = "crates/dcc-mcp-gateway-search" }
 dcc-mcp-semantic = { path = "crates/dcc-mcp-semantic" }
 
 # Shared dependencies (single version across workspace)
-pyo3 = { version = "0.29", features = ["multiple-pymethods"] }
+pyo3 = { version = "0.28", features = ["multiple-pymethods"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml_ng = "0.10"

--- a/justfile
+++ b/justfile
@@ -19,6 +19,9 @@ DEV_FEATURES := "python-bindings,ext-module," + OPT_FEATURES
 # Feature set for abi3 release wheels (Python 3.8+)
 WHEEL_FEATURES := "python-bindings,ext-module,abi3-py38," + OPT_FEATURES
 
+# Feature set for Python 3.7 native wheels (non-abi3 — PyO3 requires >=3.8 for abi3)
+WHEEL_FEATURES_PY37 := "python-bindings,ext-module," + OPT_FEATURES
+
 default:
     @just --list
 
@@ -45,6 +48,9 @@ print-dev-features:
 
 print-wheel-features:
     @echo "{{WHEEL_FEATURES}}"
+
+print-wheel-features-py37:
+    @echo "{{WHEEL_FEATURES_PY37}}"
 
 # ── Admin UI ──────────────────────────────────────────────────────────────────
 #
@@ -200,8 +206,14 @@ build *EXTRA:
 # Uses no PyO3 features so maturin produces a wheel with only pure-Python
 # sources — no compiled _core extension. The wheel is tagged py3-none-any
 # and installable on Python 3.7 (Maya 2022 / Blender 2.83).
-build-py37:
+build-py37-lite:
     python scripts/build_py37_pure_wheel.py
+
+# Build Python 3.7 native wheel (non-abi3, compiled _core extension).
+# EXTRA is forwarded to maturin (e.g. `-i python3.7`, `--target x86_64`).
+build-py37 *EXTRA:
+    just stubgen
+    maturin build --release --out dist --features {{WHEEL_FEATURES_PY37}} {{EXTRA}}
 
 # Install dev/test dependencies
 install-dev-deps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     # Maya 2022 / Blender 2.83 embed Python 3.7; the py37-lite wheel ships
     # pure-Python code only and users install dcc-mcp-server separately when
     # their platform provides a compatible binary wheel.
-    "dcc-mcp-server>=0.18.17,<1.0.0; python_version >= '3.8'",
+    "dcc-mcp-server>=0.18.17,<1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -99,14 +99,14 @@ features = ["python-bindings", "ext-module", "abi3-py38", "workflow", "scheduler
 bindings = "pyo3"
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.7"
 strict = true
 ignore_missing_imports = true
 disable_error_code = ["type-arg", "misc", "no-any-return"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py38"
+target-version = "py37"
 src = ["python/dcc_mcp_core", "tests", "examples"]
 # `_core.pyi` is regenerated from the Rust extension by `pyo3-stub-gen`
 # on every build; running ruff against it produces ~1k spurious diffs

--- a/python/dcc_mcp_core/agent_memory.py
+++ b/python/dcc_mcp_core/agent_memory.py
@@ -36,6 +36,7 @@ from typing import Any
 from typing import Callable
 from typing import Iterable
 from typing import Mapping
+
 from dcc_mcp_core._typing_compat import Protocol
 
 __all__ = [

--- a/python/dcc_mcp_core/agent_memory.py
+++ b/python/dcc_mcp_core/agent_memory.py
@@ -36,7 +36,7 @@ from typing import Any
 from typing import Callable
 from typing import Iterable
 from typing import Mapping
-from typing import Protocol
+from dcc_mcp_core._typing_compat import Protocol
 
 __all__ = [
     "InMemoryMemoryStore",

--- a/python/dcc_mcp_core/semantic_skill_index.py
+++ b/python/dcc_mcp_core/semantic_skill_index.py
@@ -34,7 +34,7 @@ from math import log
 import re
 from threading import RLock
 from typing import Iterable
-from typing import Protocol
+from dcc_mcp_core._typing_compat import Protocol
 
 __all__ = [
     "LexicalSkillIndex",

--- a/python/dcc_mcp_core/semantic_skill_index.py
+++ b/python/dcc_mcp_core/semantic_skill_index.py
@@ -34,6 +34,7 @@ from math import log
 import re
 from threading import RLock
 from typing import Iterable
+
 from dcc_mcp_core._typing_compat import Protocol
 
 __all__ = [

--- a/python/dcc_mcp_core/vector_embedder.py
+++ b/python/dcc_mcp_core/vector_embedder.py
@@ -44,6 +44,7 @@ import os
 import re
 from typing import Iterable
 from typing import Mapping
+
 from dcc_mcp_core._typing_compat import Protocol
 from dcc_mcp_core._typing_compat import runtime_checkable
 

--- a/python/dcc_mcp_core/vector_embedder.py
+++ b/python/dcc_mcp_core/vector_embedder.py
@@ -44,8 +44,8 @@ import os
 import re
 from typing import Iterable
 from typing import Mapping
-from typing import Protocol
-from typing import runtime_checkable
+from dcc_mcp_core._typing_compat import Protocol
+from dcc_mcp_core._typing_compat import runtime_checkable
 
 __all__ = [
     "DEFAULT_DIM",

--- a/python/dcc_mcp_core/vector_skill_index.py
+++ b/python/dcc_mcp_core/vector_skill_index.py
@@ -55,8 +55,8 @@ from array import array
 from dataclasses import dataclass
 from threading import RLock
 from typing import Iterable
-from typing import Protocol
-from typing import runtime_checkable
+from dcc_mcp_core._typing_compat import Protocol
+from dcc_mcp_core._typing_compat import runtime_checkable
 
 from dcc_mcp_core.semantic_skill_index import SkillDocument
 from dcc_mcp_core.semantic_skill_index import SkillSearchHit

--- a/python/dcc_mcp_core/vector_skill_index.py
+++ b/python/dcc_mcp_core/vector_skill_index.py
@@ -55,9 +55,9 @@ from array import array
 from dataclasses import dataclass
 from threading import RLock
 from typing import Iterable
+
 from dcc_mcp_core._typing_compat import Protocol
 from dcc_mcp_core._typing_compat import runtime_checkable
-
 from dcc_mcp_core.semantic_skill_index import SkillDocument
 from dcc_mcp_core.semantic_skill_index import SkillSearchHit
 from dcc_mcp_core.vector_embedder import Embedder


### PR DESCRIPTION
## Summary

Restores native Python 3.7 (cp37-cp37m) wheel build support by pinning pyo3
to 0.28 and updating Python tooling configuration for py37 compatibility.
The CI infrastructure for native py37 builds (linux-py37, windows-py37 jobs,
build-wheel py37 branch, setup-windows-python37 action) is already on main —
this commit completes the restore.

## Changes

- `Cargo.toml`: Pin pyo3 from 0.29 → 0.28 (frozen until py37 deadline 2026-12-31 lifted by hallong)
- `pyproject.toml`:
  - `python_version`: 3.8 → 3.7
  - `target-version`: py38 → py37
  - `dcc-mcp-server` dependency: made unconditional

## Constraints

- PyO3 **frozen** at 0.28 — no upgrade until py37 deadline lifted by hallong
- `requires-python = ">=3.7"` — preserved
- `py37-lite` pure-Python wheel remains as safety net

## CI

Build Wheels must pass native linux-py37 and windows-py37 jobs.