### PR TITLE
Fix stale cross-registry gateway takeover

### DIFF
--- a/crates/dcc-mcp-sidecar/src/gateway_daemon/launcher.rs
+++ b/crates/dcc-mcp-sidecar/src/gateway_daemon/launcher.rs
@@ -2,12 +2,15 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use anyhow::Context as _;
-use dcc_mcp_gateway::{ElectionInfo, has_newer_sentinel, is_newer_election};
+use dcc_mcp_gateway::{ElectionInfo, has_newer_sentinel, is_newer_election, is_newer_version};
 use dcc_mcp_gateway_ensure as ensure;
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};
+use serde_json::Value;
 
 const GATEWAY_SENTINEL_STALE_SECS: u64 = 30;
+const GATEWAY_TAKEOVER_WAIT_SECS: u64 = 20;
+const RESIDENT_GATEWAY_PROBE_TIMEOUT_MS: u64 = 800;
 pub const AUTO_ENSURE_GATEWAY_IDLE_TIMEOUT_SECS: u64 = 300;
 
 /// Helpers for auto-launching the standalone gateway from inside another
@@ -126,6 +129,7 @@ async fn try_version_takeover(opts: &EnsureGatewayOptions) -> anyhow::Result<()>
     });
 
     if !should_takeover {
+        try_direct_gateway_takeover(opts, crate_version).await?;
         return Ok(());
     }
 
@@ -147,17 +151,148 @@ async fn try_version_takeover(opts: &EnsureGatewayOptions) -> anyhow::Result<()>
 
     // Wait for the old gateway to yield (up to ~20 s for the 15 s cleanup
     // interval + grace).
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    if wait_for_gateway_down(
+        &opts.host,
+        opts.port,
+        Duration::from_secs(GATEWAY_TAKEOVER_WAIT_SECS),
+    )
+    .await
+    {
+        tracing::info!("old gateway yielded — spawning new gateway");
+        return spawn_gateway_with_lock(opts).await;
+    }
+
+    tracing::warn!(
+        timeout_secs = GATEWAY_TAKEOVER_WAIT_SECS,
+        "old gateway did not yield within timeout; continuing with existing gateway"
+    );
+    Ok(())
+}
+
+async fn try_direct_gateway_takeover(
+    opts: &EnsureGatewayOptions,
+    crate_version: &str,
+) -> anyhow::Result<()> {
+    let Some(resident_version) = probe_resident_gateway_version(&opts.host, opts.port).await else {
+        tracing::debug!(
+            host = %opts.host,
+            port = opts.port,
+            "gateway is healthy but resident version could not be probed; no takeover requested"
+        );
+        return Ok(());
+    };
+
+    if !is_newer_version(crate_version, &resident_version) {
+        tracing::debug!(
+            our_version = crate_version,
+            resident_version = %resident_version,
+            "resident gateway is not older; no direct takeover needed"
+        );
+        return Ok(());
+    }
+
+    tracing::info!(
+        crate_version = crate_version,
+        resident_version = %resident_version,
+        adapter_version = ?opts.adapter_version,
+        adapter_dcc = ?opts.adapter_dcc,
+        "sidecar is newer than resident gateway without a local sentinel; requesting direct yield"
+    );
+
+    if !request_gateway_yield(&opts.host, opts.port, crate_version).await {
+        tracing::warn!(
+            host = %opts.host,
+            port = opts.port,
+            "resident gateway did not accept direct yield request; continuing with existing gateway"
+        );
+        return Ok(());
+    }
+
+    if wait_for_gateway_down(
+        &opts.host,
+        opts.port,
+        Duration::from_secs(GATEWAY_TAKEOVER_WAIT_SECS),
+    )
+    .await
+    {
+        tracing::info!("resident gateway yielded — spawning new gateway");
+        return spawn_gateway_with_lock(opts).await;
+    }
+
+    tracing::warn!(
+        timeout_secs = GATEWAY_TAKEOVER_WAIT_SECS,
+        "resident gateway accepted yield but did not exit within timeout; continuing with existing gateway"
+    );
+    Ok(())
+}
+
+async fn probe_resident_gateway_version(host: &str, port: u16) -> Option<String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(RESIDENT_GATEWAY_PROBE_TIMEOUT_MS))
+        .build()
+        .ok()?;
+
+    let url = format!("http://{host}:{port}/admin/api/health");
+    let response = client.get(url).send().await.ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let body = response.json::<Value>().await.ok()?;
+    resident_gateway_version_from_admin_health(&body).map(str::to_string)
+}
+
+fn resident_gateway_version_from_admin_health(body: &Value) -> Option<&str> {
+    body.get("version")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            body.pointer("/gateway/current/version")
+                .and_then(Value::as_str)
+        })
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+async fn request_gateway_yield(host: &str, port: u16, crate_version: &str) -> bool {
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to build HTTP client for gateway yield");
+            return false;
+        }
+    };
+
+    let url = format!("http://{host}:{port}/gateway/yield");
+    let response = match client
+        .post(url)
+        .json(&serde_json::json!({
+            "challenger_version": crate_version,
+            "reason": "version_preempt_missing_registry_sentinel"
+        }))
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(err) => {
+            tracing::debug!(error = %err, "gateway yield request failed");
+            return false;
+        }
+    };
+
+    response.status().is_success()
+}
+
+async fn wait_for_gateway_down(host: &str, port: u16, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
     while tokio::time::Instant::now() < deadline {
-        if !ensure::gateway_health_ok(&opts.host, opts.port).await {
-            tracing::info!("old gateway yielded — spawning new gateway");
-            return spawn_gateway_with_lock(opts).await;
+        if !ensure::gateway_health_ok(host, port).await {
+            return true;
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
-
-    tracing::warn!("old gateway did not yield within 20 s; continuing with existing gateway");
-    Ok(())
+    false
 }
 
 /// Acquire the launch lock and spawn the gateway, then wait for it to be
@@ -255,6 +390,135 @@ pub use ensure::gateway_health_ok_with_timeout;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn admin_health_probe_reads_running_gateway_version_without_local_sentinel() {
+        let body = serde_json::json!({
+            "ok": true,
+            "version": "0.18.20",
+            "gateway": {
+                "current": {
+                    "version": "0.18.20",
+                    "adapter_version": null,
+                    "adapter_dcc": null,
+                    "metadata": {
+                        "gateway_process_exe": "F:\\dcc-mcp-core-maya-verify\\target\\release\\dcc-mcp-server.exe"
+                    }
+                }
+            }
+        });
+        let version = resident_gateway_version_from_admin_health(&body)
+            .expect("admin health should expose the resident gateway version");
+
+        assert_eq!(version, "0.18.20");
+    }
+
+    #[test]
+    fn admin_health_probe_uses_current_gateway_version_when_top_level_missing() {
+        let body = serde_json::json!({
+            "gateway": {
+                "current": {
+                    "version": "0.18.20",
+                    "adapter_version": "0.1.31",
+                    "adapter_dcc": "maya"
+                }
+            }
+        });
+        let version = resident_gateway_version_from_admin_health(&body)
+            .expect("gateway.current.version should be enough for resident probing");
+
+        assert_eq!(version, "0.18.20");
+    }
+
+    #[test]
+    fn resident_gateway_probe_detects_older_cross_registry_gateway() {
+        assert!(is_newer_version("0.19.17", "0.18.20"));
+    }
+
+    #[test]
+    fn resident_gateway_probe_does_not_preempt_same_gateway_version() {
+        assert!(!is_newer_version("0.19.17", "0.19.17"));
+    }
+
+    #[tokio::test]
+    async fn resident_gateway_probe_reads_admin_health_endpoint() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let app = axum::Router::new().route(
+            "/admin/api/health",
+            axum::routing::get(|| async {
+                axum::Json(serde_json::json!({
+                    "ok": true,
+                    "version": "0.18.20",
+                    "gateway": {
+                        "current": {
+                            "version": "0.18.20",
+                            "adapter_version": null,
+                            "adapter_dcc": null
+                        }
+                    }
+                }))
+            }),
+        );
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        let version = probe_resident_gateway_version("127.0.0.1", port)
+            .await
+            .expect("probe should read admin health");
+
+        assert_eq!(version, "0.18.20");
+        let _ = shutdown_tx.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn direct_yield_request_sends_challenger_version() {
+        use std::sync::{Arc, Mutex};
+
+        let seen = Arc::new(Mutex::new(None::<Value>));
+        let seen_for_handler = Arc::clone(&seen);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let app = axum::Router::new().route(
+            "/gateway/yield",
+            axum::routing::post(move |axum::Json(body): axum::Json<Value>| {
+                let seen_for_handler = Arc::clone(&seen_for_handler);
+                async move {
+                    *seen_for_handler.lock().unwrap() = Some(body);
+                    axum::Json(serde_json::json!({"ok": true, "handoff": true}))
+                }
+            }),
+        );
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        assert!(request_gateway_yield("127.0.0.1", port, "0.19.17").await);
+
+        let body = seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("yield request body should be captured");
+        assert_eq!(body["challenger_version"], "0.19.17");
+        assert_eq!(body["reason"], "version_preempt_missing_registry_sentinel");
+        let _ = shutdown_tx.send(());
+        let _ = server.await;
+    }
 
     #[test]
     fn auto_launch_gateway_args_do_not_include_registry_dir_flag() {


### PR DESCRIPTION
## Summary
- Probe `/admin/api/health` when the gateway port is healthy but the current registry has no older `__gateway__` sentinel to compare.
- If the resident gateway core version is older, request cooperative `/gateway/yield` directly and then spawn the replacement gateway after the port drops.
- Keep the existing same-registry sentinel election path unchanged.

## Validation
- `cargo test -p dcc-mcp-sidecar gateway_daemon::launcher -- --nocapture`
- `cargo test -p dcc-mcp-sidecar --lib`
- `cargo build -p dcc-mcp-server`
- Synthetic stale-gateway smoke: `artifacts/stale-gateway-takeover-smoke-20260709-044119/summary.json`
  - mock resident gateway version: `0.18.20`
  - direct yield body: `challenger_version=0.19.5`, `reason=version_preempt_missing_registry_sentinel`
  - observed replacement gateway version on the same port: `0.19.5`

## Notes
This matches the 3ds Max release-smoke failure mode where the 0.19.17 sidecar launched correctly but the healthy 0.18.20 gateway lived in another registry, so the local sentinel-based replacement path never saw it.
