### PR TITLE
chore(python): remove dead unreachable code and stale comment noise

### DIFF
--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -14,7 +14,6 @@ adapter install root. This keeps installer/uninstaller scripts free to inspect
 and remove bundled native artifacts before opting into Rust-backed APIs.
 """
 
-# Import future modules
 from __future__ import annotations
 
 from dcc_mcp_core._exports import _LAZY

--- a/python/dcc_mcp_core/asset_import.py
+++ b/python/dcc_mcp_core/asset_import.py
@@ -44,7 +44,6 @@ Example:
 
 """
 
-# Import future modules
 from __future__ import annotations
 
 # Import built-in modules

--- a/python/dcc_mcp_core/factory.py
+++ b/python/dcc_mcp_core/factory.py
@@ -48,7 +48,6 @@ Usage::
                 _holder[0] = None
 """
 
-# Import future modules
 from __future__ import annotations
 
 # Import built-in modules

--- a/python/dcc_mcp_core/gateway_election.py
+++ b/python/dcc_mcp_core/gateway_election.py
@@ -31,7 +31,6 @@ Usage example::
             self._handle.shutdown()
 """
 
-# Import future modules
 from __future__ import annotations
 
 import contextlib

--- a/python/dcc_mcp_core/host/__init__.py
+++ b/python/dcc_mcp_core/host/__init__.py
@@ -20,7 +20,6 @@ from the host's native idle primitive (``bpy.app.timers.register``,
 ``maya.utils.executeDeferred``, ``hou.ui.addEventLoopCallback``, etc.).
 """
 
-# Import future modules
 from __future__ import annotations
 
 # Import local modules — Rust-backed primitives live in _core when available.

--- a/python/dcc_mcp_core/host/_adapter.py
+++ b/python/dcc_mcp_core/host/_adapter.py
@@ -55,7 +55,6 @@ See ``docs/guide/host-adapter.md`` for the full authoring guide and
 ``examples/host_adapter_template.py`` for a ready-to-copy starter.
 """
 
-# Import future modules
 from __future__ import annotations
 
 # Import built-in modules

--- a/python/dcc_mcp_core/host/_protocols.py
+++ b/python/dcc_mcp_core/host/_protocols.py
@@ -1,6 +1,5 @@
 """Shared structural protocols for host dispatcher adapters."""
 
-# Import future modules
 from __future__ import annotations
 
 # `typing.Protocol` and `typing.runtime_checkable` are 3.8+. For Python 3.7

--- a/python/dcc_mcp_core/host/_standalone.py
+++ b/python/dcc_mcp_core/host/_standalone.py
@@ -13,7 +13,6 @@ friction-free because every adapter satisfies the same dispatcher contract
 (LSP/OCP).
 """
 
-# Import future modules
 from __future__ import annotations
 
 # Import built-in modules

--- a/python/dcc_mcp_core/host/_wire.py
+++ b/python/dcc_mcp_core/host/_wire.py
@@ -14,13 +14,9 @@ except ImportError:
 
 def normalize_tool_arguments(arguments: Any = None) -> dict[str, Any]:
     """Normalize raw tool ``arguments`` to a JSON-object-shaped dict."""
-    if _normalize_tool_arguments is None:
-        raise ImportError("normalize_tool_arguments requires the _core extension (not available in py37-lite)")
     return _normalize_tool_arguments(arguments)
 
 
 def normalize_tool_meta(meta: Any = None) -> dict[str, Any] | None:
     """Normalize raw tool ``_meta`` to a dict or ``None``."""
-    if _normalize_tool_meta is None:
-        raise ImportError("normalize_tool_meta requires the _core extension (not available in py37-lite)")
     return _normalize_tool_meta(meta)

--- a/python/dcc_mcp_core/hotreload.py
+++ b/python/dcc_mcp_core/hotreload.py
@@ -29,7 +29,6 @@ Usage example::
             self._hot_reloader.disable()
 """
 
-# Import future modules
 from __future__ import annotations
 
 # Import built-in modules

--- a/python/dcc_mcp_core/verifier.py
+++ b/python/dcc_mcp_core/verifier.py
@@ -41,7 +41,6 @@ Example:
 
 """
 
-# Import future modules
 from __future__ import annotations
 
 # Import built-in modules


### PR DESCRIPTION
## Summary

Remove two categories of dead code from the Python codebase:

### 1. Unreachable `is None` guards in `host/_wire.py`

The `try/except ImportError` block always resolves `_normalize_tool_arguments` and `_normalize_tool_meta` to a non-None callable — either from `_core` (Rust build) or `_fallback` (pure-Python, always importable). The `if ... is None: raise ImportError(...)` paths are never reached.

### 2. Stale `# Import future modules` comments (10 files)

These comments precede `from __future__ import annotations` in 10 files but are inconsistent with the 60+ other files that use the same import without the comment. Removed for consistency.

## Test plan

- [x] All cleaned modules import successfully
- [x] `tests/test_imports.py` passes
- [x] `tests/test_import_surface.py` passes
- [x] All py37-related tests pass

No functional change — pure dead-code removal.
