### PR TITLE
feat(semantic): add Python 3.7 cp37 wheels for dcc-mcp-core-semantic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,9 +374,13 @@ jobs:
   #
   # Native Rust semantic embeddings (fastembed-rs + ONNX Runtime) shipped as
   # an opt-in PyPI package. Users only pay this wheel's cost when they
-  # explicitly `pip install 'dcc-mcp-core[semantic]'`. Python 3.7 wheels were
-  # dropped when the workspace upgraded to pyo3 0.29 (which dropped 3.7
-  # support).
+  # explicitly `pip install 'dcc-mcp-core[semantic]'`.
+  #
+  # Two wheel tiers per platform:
+  #   - abi3 (cp38-abi3): single wheel for Python 3.8-3.13 via pyo3 abi3.
+  #   - py37 (cp37-cp37m): native non-abi3 wheel for DCC embedded Python 3.7
+  #     hosts (Maya 2022, Blender 2.83). Builds without abi3-py38 feature;
+  #     pyo3 0.28 (workspace) supports this path.
   #
   # IMPORTANT: ort 2.x (pulled in transitively by fastembed-rs) requires
   # glibc >= 2.27, so Linux wheels target manylinux_2_28 — NOT manylinux2014
@@ -399,6 +403,12 @@ jobs:
           - os: macos-latest
             artifact_name: semantic-wheel-macos-abi3
             target: macos-abi3
+          - os: ubuntu-latest
+            artifact_name: semantic-wheel-linux-py37
+            target: linux-py37
+          - os: windows-latest
+            artifact_name: semantic-wheel-windows-py37
+            target: windows-py37
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -408,10 +418,10 @@ jobs:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
       # Rust toolchain is only needed for non-Linux builds; the Linux
-      # builds run inside the pyo3/maturin docker image which bundles its
-      # own pinned toolchain.
+      # builds (abi3 and py37) run inside the pyo3/maturin docker image
+      # which bundles its own pinned toolchain.
       - name: Setup Rust
-        if: matrix.target != 'linux-abi3'
+        if: "!startsWith(matrix.target, 'linux-')"
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: '1.95.0'
@@ -423,8 +433,12 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Setup Windows Python 3.7 (py37 build)
+        if: matrix.target == 'windows-py37'
+        uses: ./.github/actions/setup-windows-python37
+
       - name: Install maturin
-        if: matrix.target != 'linux-abi3'
+        if: "!startsWith(matrix.target, 'linux-')"
         shell: bash
         run: |
           python -m pip install --upgrade pip
@@ -462,6 +476,23 @@ jobs:
         run: |
           maturin build --release \
             --features python-bindings,ext-module,abi3-py38 \
+            --out wheels
+
+      # ── Linux (py37) — cp37-cp37m, non-abi3 for Python 3.7 DCC hosts ──
+      - name: Build wheel (Linux py37)
+        if: matrix.target == 'linux-py37'
+        shell: bash
+        run: scripts/release/build_manylinux_semantic_wheel.sh py37
+
+      # ── Windows (py37) — cp37-cp37m, non-abi3 for Python 3.7 DCC hosts ──
+      - name: Build wheel (Windows py37)
+        if: matrix.target == 'windows-py37'
+        shell: bash
+        working-directory: pkg/dcc-mcp-core-semantic
+        run: |
+          maturin build --release \
+            --features python-bindings,ext-module \
+            -i python3.7 \
             --out wheels
 
       - name: Upload semantic wheel artefact

--- a/pkg/dcc-mcp-core-semantic/pyproject.toml
+++ b/pkg/dcc-mcp-core-semantic/pyproject.toml
@@ -22,9 +22,10 @@ version = "0.19.18"  # x-release-please-version
 description = "Native Rust semantic embeddings (fastembed-rs) for dcc-mcp-core"
 readme = "README.md"
 license = { text = "MIT" }
-# Matches the main `dcc-mcp-core` baseline. Python 3.7 support was
-# dropped when the workspace upgraded to pyo3 0.29.
-requires-python = ">=3.8"
+# Matches the main `dcc-mcp-core` baseline. The workspace is on pyo3 0.28
+# which supports Python 3.7 (non-abi3). cp37 wheels are built via the
+# `py37` mode in scripts/release/build_manylinux_semantic_wheel.sh.
+requires-python = ">=3.7"
 keywords = ["dcc", "mcp", "embeddings", "fastembed", "semantic", "vector"]
 authors = [
     { name = "Hal Long", email = "hal.long@outlook.com" },
@@ -35,6 +36,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -61,13 +63,16 @@ Issues = "https://github.com/dcc-mcp/dcc-mcp-core/issues"
 # duplicated under pkg/.
 manifest-path = "../../crates/dcc-mcp-semantic/Cargo.toml"
 
-# Build the PyO3 extension module (abi3 for Python 3.8+).
+# Build the PyO3 extension module.
 #
 #   - `python-bindings` pulls in fastembed + `dep:pyo3`
 #   - `ext-module` enables `pyo3/extension-module`
 #   - `abi3-py38` enables `pyo3/abi3-py38` (single abi3 wheel for 3.8-3.13)
 #
-# Python 3.7 (non-abi3) was dropped when the workspace upgraded to pyo3 0.29.
+# The abi3 wheel is the default. Python 3.7 (non-abi3, cp37-cp37m) wheels
+# are built by overriding features via maturin CLI args (without abi3-py38),
+# matching the py37 path in scripts/release/build_manylinux_semantic_wheel.sh.
+# The workspace is on pyo3 0.28 which supports Python 3.7 targeting.
 features = ["python-bindings", "ext-module", "abi3-py38"]
 
 bindings = "pyo3"


### PR DESCRIPTION
## Problem

`dcc_mcp_core_semantic` v0.19.18 ships only `cp38-abi3` wheels (Linux manylinux_2_28, Windows, macOS aarch64). Python 3.7 DCC hosts — Maya 2022, Blender 2.83 — cannot install these. `dcc_mcp_core` correctly ships `cp37-cp37m` wheels, but the semantic companion does not.

## Root cause

The `build-semantic-wheels` job in release.yml only built with `abi3-py38` features. The `build_manylinux_semantic_wheel.sh` script has had a `py37` mode since it was written — it was just never wired into CI. The workspace is on **pyo3 0.28** (not 0.29), which supports Python 3.7 non-abi3 builds. Comments in several files were stale.

## Changes

- **pyproject.toml**: `requires-python = ">=3.7"` (was ">=3.8"); add 3.7 classifier; correct stale comments
- **release.yml** `build-semantic-wheels`: add `linux-py37` and `windows-py37` matrix entries; wire the existing `build_manylinux_semantic_wheel.sh py37` path; Windows py37 builds with `--features python-bindings,ext-module -i python3.7`

## Evidence

| Package | py37 Linux | py37 Windows | py37 macOS |
|---|---|---|---|
| dcc_mcp_core v0.19.18 | ✅ cp37-cp37m | ✅ cp37-cp37m | ✅ py3-none-any |
| dcc_mcp_core_semantic v0.19.18 | ❌ | ❌ | ❌ |

- pyo3 workspace version: **0.28.3** (Cargo.lock) — supports Python 3.7
- `dcc-mcp-semantic` crate features: `python-bindings + ext-module` = cp37 non-abi3 path (documented in crate Cargo.toml:57-59)
- `build_manylinux_semantic_wheel.sh` already implements `py37` mode (lines 29-31)

## Red line

Python 3.7 support is preserved: non-abi3 `cp37-cp37m` wheels compile the native extension for 3.7. No downgrade, no removal.