### PR TITLE
Hide Windows taskkill helper windows

### DIFF
--- a/crates/dcc-mcp-gateway-ensure/src/lib.rs
+++ b/crates/dcc-mcp-gateway-ensure/src/lib.rs
@@ -31,9 +31,6 @@ fn hide_command_window(cmd: &mut Command) {
     cmd.creation_flags(CREATE_NO_WINDOW);
 }
 
-#[cfg(not(windows))]
-fn hide_command_window(_cmd: &mut Command) {}
-
 // ── Constants ──────────────────────────────────────────────────────────────
 
 /// How long to wait for a single `/health` probe before timing out.

--- a/crates/dcc-mcp-gateway-ensure/src/lib.rs
+++ b/crates/dcc-mcp-gateway-ensure/src/lib.rs
@@ -23,6 +23,17 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use anyhow::Context;
 use serde::Serialize;
 
+#[cfg(windows)]
+fn hide_command_window(cmd: &mut Command) {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(windows))]
+fn hide_command_window(_cmd: &mut Command) {}
+
 // ── Constants ──────────────────────────────────────────────────────────────
 
 /// How long to wait for a single `/health` probe before timing out.
@@ -537,7 +548,9 @@ pub fn is_process_alive(pid: u32) -> bool {
         // `tasklist /FI "PID eq <pid>" /NH` returns output containing the
         // PID if the process exists, or "INFO: No tasks..." on stderr if not.
         // Exit code is always 0, so we check stdout for the PID string.
-        let output = Command::new("tasklist")
+        let mut cmd = Command::new("tasklist");
+        hide_command_window(&mut cmd);
+        let output = cmd
             .args([
                 "/FI",
                 &format!("PID eq {pid}"),
@@ -571,7 +584,9 @@ pub fn is_process_alive(pid: u32) -> bool {
 pub fn stop_process(pid: u32) -> anyhow::Result<()> {
     #[cfg(windows)]
     {
-        let status = Command::new("taskkill")
+        let mut cmd = Command::new("taskkill");
+        hide_command_window(&mut cmd);
+        let status = cmd
             .args(["/PID", &pid.to_string(), "/F"])
             .stdout(Stdio::null())
             .stderr(Stdio::null())


### PR DESCRIPTION
## Summary
- hide Windows console windows for `tasklist` process checks in gateway ensure
- hide Windows console windows for `taskkill /PID <pid> /F` gateway termination
- keep existing detached gateway launch flags unchanged

## Root cause
The 3ds Max v0.1.32 + core 0.19.18 smoke exercised stale gateway replacement. The adapter delegates sidecar creation to `dcc_mcp_core.install_lifecycle.launch_sidecar(... detached=True ...)`, which already uses `DETACHED_PROCESS`, `CREATE_NEW_PROCESS_GROUP`, and `CREATE_NO_WINDOW` for the sidecar. The literal `taskkill` invocation is owned by core in `crates/dcc-mcp-gateway-ensure/src/lib.rs::stop_process`; that helper was spawning `tasklist`/`taskkill` without `CREATE_NO_WINDOW`, so Windows could show a black console during gateway process cleanup/restart.

## Evidence
- 3ds Max artifact: `artifacts/3dsmax-smoke-0.19.18/registry/gateway-autolaunch-9765.json` shows adapter `0.1.32`, crate `0.19.18`, and `core-0.19.18-tools/dcc-mcp-server.exe`.
- Sidecar log: `artifacts/3dsmax-smoke-0.19.18/registry/logs/sidecar-3dsmax-80780.stdout.log` shows stale gateway replacement: `requesting direct yield`, then `spawned standalone gateway process`.
- Adapter path checked: `dcc_mcp_3dsmax/max_bootstrap.py` uses `terminate()`/`kill()` on the sidecar handle and contains no `taskkill`.

## Validation
- `cargo test -p dcc-mcp-gateway-ensure`
