### PR TITLE
fix(gateway-ensure): remove dead non-Windows hide_command_window no-op

### DIFF
--- a/crates/dcc-mcp-gateway-ensure/src/lib.rs
+++ b/crates/dcc-mcp-gateway-ensure/src/lib.rs
@@ -31,9 +31,6 @@ fn hide_command_window(cmd: &mut Command) {
     cmd.creation_flags(CREATE_NO_WINDOW);
 }
 
-#[cfg(not(windows))]
-fn hide_command_window(_cmd: &mut Command) {}
-
 // ── Constants ──────────────────────────────────────────────────────────────
 
 /// How long to wait for a single `/health` probe before timing out.


### PR DESCRIPTION
## Summary

The `#[cfg(not(windows))]` no-op version of `hide_command_window` was never called on Linux/macOS because all call sites in `is_process_alive()` and `stop_process()` are inside `#[cfg(windows)]` blocks. This triggers clippy `dead_code` on Linux (treated as error via `-D warnings`), causing the Rust (ubuntu-latest) CI check to fail on [PR #1843](https://github.com/dcc-mcp/dcc-mcp-core/pull/1843).

## Fix

Remove the unused `#[cfg(not(windows))]` no-op function. Only the `#[cfg(windows)]` version is needed.

## Validation

- `cargo check -p dcc-mcp-gateway-ensure` — passes
- `cargo clippy -p dcc-mcp-gateway-ensure -- -D warnings` — passes (no dead_code or any other warnings)

Fixes PIP-2647.