### PR TITLE
fix(admin-ui): resolve missing instance info and layout misalignment

### DIFF
--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dcc-mcp-core-admin-ui",
-  "version": "0.19.0",
+  "version": "0.19.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dcc-mcp-core-admin-ui",
-      "version": "0.19.0",
+      "version": "0.19.18",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",

--- a/admin-ui/src/admin-ui-core.tsx
+++ b/admin-ui/src/admin-ui-core.tsx
@@ -550,7 +550,15 @@ export function compactInstanceId(value: string | null | undefined): string {
   if (typeof value !== 'string' || value.length === 0) {
     return 'unrouted';
   }
-  return value.length > 8 ? value.slice(0, 8) : value;
+  if (value.length > 8) {
+    const hyphenIdx = value.indexOf('-');
+    if (hyphenIdx !== -1 && hyphenIdx >= 7) {
+      const suffix = value.slice(hyphenIdx + 1);
+      return value.slice(0, hyphenIdx + 1) + suffix.slice(0, 4);
+    }
+    return value.slice(0, 8);
+  }
+  return value;
 }
 
 export function toolInstanceLabel(tool: ToolRow): string {

--- a/admin-ui/src/features/instances/InstancesPanel.tsx
+++ b/admin-ui/src/features/instances/InstancesPanel.tsx
@@ -103,8 +103,8 @@ export function InstancesPanel({
                                 </div>
                                 <div className="instance-subline">
                                   <span>{t('instances.field.appType')} {instance.dcc_type}</span>
-                                  <span>PID {instance.pid ?? '-'}</span>
-                                  <span>{formatUptime(instance.uptime_secs)}</span>
+                                  {instance.pid != null ? <span>PID {instance.pid}</span> : null}
+                                  {instance.uptime_secs != null ? <span>{formatUptime(instance.uptime_secs)}</span> : null}
                                 </div>
                               </div>
                             </div>
@@ -152,7 +152,7 @@ export function InstancesPanel({
                             {instance.host_rpc_uri || instance.host_rpc_scheme ? (
                               <span className="instance-detail-item wide">
                                 <small>{t('instances.field.hostRpc')}</small>
-                                <strong title={instance.host_rpc_uri ?? undefined}>{instance.host_rpc_scheme ?? instance.host_rpc_uri}</strong>
+                                <strong title={instance.host_rpc_uri ?? undefined}>{instance.host_rpc_uri ?? instance.host_rpc_scheme}</strong>
                               </span>
                             ) : null}
                             <span className="instance-detail-item wide">

--- a/admin-ui/src/styles.css
+++ b/admin-ui/src/styles.css
@@ -2211,7 +2211,7 @@ tbody tr:hover td {
   grid-template-columns: minmax(18rem, 0.92fr) minmax(24rem, 1.28fr) minmax(17rem, 0.82fr);
   line-height: 1.45;
   min-width: 0;
-  padding: 0.85rem 0.95rem;
+  padding: 0.75rem 0.95rem;
   transition: border-color 0.16s ease, box-shadow 0.16s ease, background-color 0.16s ease;
 }
 
@@ -2339,13 +2339,13 @@ tbody tr:hover td {
   border-radius: 8px;
   display: grid;
   gap: 0.16rem;
-  min-height: 3.1rem;
+  min-height: 3.0rem;
   min-width: 0;
   padding: 0.45rem 0.55rem;
 }
 
 .instance-detail-item.wide {
-  grid-column: auto;
+  grid-column: span 3;
 }
 
 .instance-detail-item strong {


### PR DESCRIPTION
## Summary
- **Enhance Instance Suffix Compacting**: Preserves up to 4 characters of the unique suffix hash when DCC-type prefix is long (e.g. `houdini-abcdef12` is compacted to `houdini-abcd` instead of `houdini-`).
- **Complete Visual Field Details**: Visually display the full Host RPC URI in the dashboard card instead of only showing the scheme (falls back to scheme if URI is missing). Hide empty PID and Uptime blocks if their values are null (such as when booting or in error states).
- **Responsive Layout and Padding**: Adjust `.instance-detail-item.wide` to span 3 columns for better alignment and readability of long URIs. Slightly reduce row padding and element min-height to ensure the card stays within the height limits of the test cases (under 260px).

## Test plan
- All 49 unit tests passed successfully.
- All 78 Playwright integration/E2E layout and functionality tests passed successfully.
- Verified in local browser environments and generated screenshots showing zero visual overflow or misalignment.
