### PR TITLE
feat: harden marketplace catalog contracts

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -45,7 +45,11 @@ pub struct CatalogEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
     /// Minimum dcc-mcp-core version required by this package.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "minCoreVersion"
+    )]
     pub min_core_version: Option<String>,
     /// Installation metadata for CLI-driven marketplace installs.
     ///
@@ -57,9 +61,36 @@ pub struct CatalogEntry {
     /// Maintainer or publishing organization.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub maintainer: Option<String>,
+    /// Marketplace category used for curation and browse UI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    /// Installation availability policy declared by the marketplace publisher.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy: Option<CatalogPolicy>,
+    /// External runtime prerequisites declared by the package publisher.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires: Option<CatalogRequirements>,
     /// Icon path or URL (e.g. `"icon.png"` for repo-relative, or an absolute URL).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icon: Option<String>,
+}
+
+/// Installation policy attached to a marketplace package.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CatalogPolicy {
+    /// Whether a package may be installed by the current marketplace.
+    pub installation: String,
+}
+
+/// External prerequisites needed to use a marketplace package.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct CatalogRequirements {
+    /// Required environment variable names. Values are never stored in the catalog.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<String>,
+    /// Required executable names that must be available on PATH.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bins: Vec<String>,
 }
 
 /// Installation metadata for a marketplace catalog entry.
@@ -286,6 +317,23 @@ const MARKETPLACE_V1_SCHEMA_JSON: &str = r##"{
         "version":          { "type": "string" },
         "min_core_version": { "type": "string" },
         "maintainer":       { "type": "string" },
+        "category":         { "type": "string" },
+        "policy": {
+          "type": "object",
+          "required": ["installation"],
+          "properties": {
+            "installation": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "requires": {
+          "type": "object",
+          "properties": {
+            "env": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+            "bins": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+          },
+          "additionalProperties": false
+        },
         "icon":        { "type": "string" },
         "install": {
           "type": "object",
@@ -499,6 +547,9 @@ entries:
             min_core_version: None,
             install: None,
             maintainer: None,
+            category: None,
+            policy: None,
+            requires: None,
             icon: None,
         }];
         let hits = search_hits(&entries, "maya");
@@ -558,6 +609,60 @@ entries:
         assert_eq!(install.ref_.as_deref(), Some("v0.1.0"));
     }
 
+    #[test]
+    fn marketplace_v1_aliases_preserve_curation_and_runtime_metadata() {
+        let json = r#"
+{
+  "name": "dcc-mcp-official",
+  "version": "1.0.0",
+  "skills": [{
+    "name": "maya-rig-tools",
+    "description": "Rigging tools for Maya",
+    "dcc": ["maya"],
+    "tags": ["rigging", "domain"],
+    "version": "1.2.3",
+    "minCoreVersion": "0.19.0",
+    "category": "Skills",
+    "maintainer": "dcc-mcp",
+    "source": {
+      "type": "git",
+      "url": "https://github.com/dcc-mcp/maya-rig-tools",
+      "ref": "0123456789012345678901234567890123456789"
+    },
+    "policy": { "installation": "available" },
+    "requires": { "env": ["RIG_TOKEN"], "bins": ["rigctl"] }
+  }]
+}
+"#;
+
+        let entries = load_from_str(json).unwrap();
+        let entry = entries.first().unwrap();
+        assert_eq!(entry.min_core_version.as_deref(), Some("0.19.0"));
+        assert_eq!(entry.category.as_deref(), Some("Skills"));
+        assert_eq!(
+            entry
+                .policy
+                .as_ref()
+                .map(|policy| policy.installation.as_str()),
+            Some("available")
+        );
+        assert_eq!(
+            entry
+                .requires
+                .as_ref()
+                .map(|requires| requires.env.as_slice()),
+            Some(["RIG_TOKEN".to_string()].as_slice())
+        );
+        assert_eq!(
+            entry
+                .install
+                .as_ref()
+                .and_then(|install| install.ref_.as_deref()),
+            Some("0123456789012345678901234567890123456789")
+        );
+        assert!(validate_entry(entry).is_ok());
+    }
+
     // -- schema validation tests ------------------------------------------------
 
     fn make_entry(name: &str, description: &str) -> CatalogEntry {
@@ -571,6 +676,9 @@ entries:
             min_core_version: None,
             install: None,
             maintainer: None,
+            category: None,
+            policy: None,
+            requires: None,
             icon: None,
         }
     }
@@ -612,6 +720,9 @@ entries:
             version: Some("0.1.0".into()),
             min_core_version: Some("0.17.0".into()),
             maintainer: Some("dcc-mcp".into()),
+            category: None,
+            policy: None,
+            requires: None,
             install: Some(CatalogInstall {
                 install_type: "zip".into(),
                 url: Some("https://example.com/skill.zip".into()),
@@ -639,6 +750,9 @@ entries:
             version: Some("0.3.0".into()),
             min_core_version: Some("0.18.0".into()),
             maintainer: Some("dcc-mcp".into()),
+            category: None,
+            policy: None,
+            requires: None,
             install: Some(CatalogInstall {
                 install_type: "pip".into(),
                 url: None,
@@ -714,6 +828,9 @@ entries:
             version: None,
             min_core_version: None,
             maintainer: None,
+            category: None,
+            policy: None,
+            requires: None,
             install: Some(CatalogInstall {
                 install_type: "pip".into(),
                 url: None,
@@ -742,6 +859,9 @@ entries:
             min_core_version: None,
             install: None,
             maintainer: None,
+            category: None,
+            policy: None,
+            requires: None,
             icon: Some("icon.png".into()),
         };
         assert!(validate_entry(&entry).is_ok());

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -792,6 +792,9 @@ mod tests {
                 min_core_version: None,
                 install: None,
                 maintainer: None,
+                category: None,
+                policy: None,
+                requires: None,
                 icon: None,
             },
             steps: vec![

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -538,6 +538,9 @@ mod tests {
             min_core_version: None,
             install,
             maintainer: None,
+            category: None,
+            policy: None,
+            requires: None,
             icon: None,
         }
     }

--- a/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
@@ -97,6 +97,58 @@ fn marketplace_add_list_search_and_inspect_local_source() {
 }
 
 #[test]
+fn marketplace_v1_catalog_preserves_curation_and_runtime_metadata() {
+    let tmp = TempDir::new().unwrap();
+    let catalog_path = tmp.path().join("marketplace.json");
+    std::fs::write(
+        &catalog_path,
+        r#"
+{
+  "name": "dcc-mcp-official",
+  "schemaVersion": "1",
+  "version": "1.0.0",
+  "skills": [{
+    "name": "maya-rig-tools",
+    "description": "Rigging helpers for Maya",
+    "dcc": ["maya"],
+    "tags": ["rigging", "domain"],
+    "version": "1.2.3",
+    "minCoreVersion": "0.19.0",
+    "category": "Skills",
+    "maintainer": "dcc-mcp",
+    "source": {
+      "type": "git",
+      "url": "https://github.com/dcc-mcp/maya-rig-tools",
+      "ref": "0123456789012345678901234567890123456789"
+    },
+    "policy": { "installation": "available" },
+    "requires": { "env": ["RIG_TOKEN"], "bins": ["rigctl"] }
+  }]
+}
+"#,
+    )
+    .unwrap();
+
+    let source = catalog_path.to_string_lossy().to_string();
+    let inspect = run_json(&[
+        "marketplace",
+        "inspect",
+        "maya-rig-tools",
+        "--source",
+        &source,
+    ]);
+    let entry = &inspect["matches"][0]["entry"];
+    assert_eq!(entry["min_core_version"], "0.19.0");
+    assert_eq!(entry["category"], "Skills");
+    assert_eq!(entry["policy"]["installation"], "available");
+    assert_eq!(entry["requires"]["env"], json!(["RIG_TOKEN"]));
+    assert_eq!(
+        entry["install"]["ref"],
+        "0123456789012345678901234567890123456789"
+    );
+}
+
+#[test]
 fn marketplace_pack_and_publish_updates_catalog() {
     let tmp = TempDir::new().unwrap();
     let skill_dir = write_skill(
@@ -129,6 +181,8 @@ fn marketplace_pack_and_publish_updates_catalog() {
         &sha256,
         "--maintainer",
         "dcc-mcp",
+        "--min-core-version",
+        "0.19.0",
         "--tag",
         "extra",
     ]);
@@ -138,6 +192,11 @@ fn marketplace_pack_and_publish_updates_catalog() {
     assert_eq!(published["entry"]["version"], "0.2.0");
     assert_eq!(published["entry"]["install"]["type"], "zip");
     assert_eq!(published["entry"]["install"]["sha256"], sha256);
+    let catalog =
+        serde_json::from_str::<Value>(&std::fs::read_to_string(&catalog_path).unwrap()).unwrap();
+    assert_eq!(catalog["schemaVersion"], "1");
+    assert_eq!(catalog["skills"][0]["minCoreVersion"], "0.19.0");
+    assert_eq!(catalog["skills"][0]["source"]["type"], "zip");
 
     let updated = run_json(&[
         "marketplace",
@@ -147,6 +206,8 @@ fn marketplace_pack_and_publish_updates_catalog() {
         &catalog_s,
         "--install-url",
         "https://github.com/dcc-mcp/release-skill/releases/download/v0.3.0/release-skill.zip",
+        "--sha256",
+        &sha256,
         "--version",
         "0.3.0",
     ]);

--- a/crates/dcc-mcp-gateway/src/gateway/admin/marketplace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/marketplace.rs
@@ -527,6 +527,9 @@ mod tests {
             min_core_version: None,
             install: None,
             maintainer: None,
+            category: None,
+            policy: None,
+            requires: None,
             icon: None,
         };
         assert!(dcc_mcp_marketplace::entry_targets_dcc(&entry, "Maya"));

--- a/crates/dcc-mcp-marketplace/src/package.rs
+++ b/crates/dcc-mcp-marketplace/src/package.rs
@@ -2,9 +2,9 @@ use std::fs;
 use std::io::{Cursor, Write};
 use std::path::{Path, PathBuf};
 
-use dcc_mcp_catalog::{CatalogEntry, CatalogInstall};
+use dcc_mcp_catalog::{CatalogEntry, CatalogInstall, CatalogPolicy};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use zip::write::SimpleFileOptions;
 
@@ -145,18 +145,21 @@ pub fn publish_marketplace_package(
             string_at(&skill_meta, &["metadata", "dcc-mcp", "maintainer"])
                 .or_else(|| string_at(&skill_meta, &["maintainer"]))
         }),
+        category: Some("Skills".into()),
+        policy: Some(CatalogPolicy {
+            installation: "available".into(),
+        }),
+        requires: None,
         icon: options.icon,
     };
     dcc_mcp_catalog::validate_entry(&entry)?;
 
-    let mut catalog = load_catalog_doc(&options.catalog_path)?;
-    let action = upsert_entry(&mut catalog.entries, entry.clone());
-    save_catalog_doc(&options.catalog_path, &catalog)?;
+    let (action, count) = upsert_catalog_entry(&options.catalog_path, entry.clone())?;
     Ok(MarketplacePublishResult {
         catalog_path: options.catalog_path.display().to_string(),
         entry,
         action,
-        count: catalog.entries.len(),
+        count,
     })
 }
 
@@ -247,17 +250,223 @@ fn should_skip_path(path: &Path, name: &str, out_path: &Path) -> bool {
         )
 }
 
-fn load_catalog_doc(path: &Path) -> Result<CatalogDoc, MarketplaceError> {
+fn upsert_catalog_entry(
+    path: &Path,
+    entry: CatalogEntry,
+) -> Result<(String, usize), MarketplaceError> {
+    let mut raw = load_catalog_value(path)?;
+    if raw.get("skills").is_some() || !path.exists() {
+        let skills = raw
+            .get_mut("skills")
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| {
+                MarketplaceError::ConfigParse(
+                    path.display().to_string(),
+                    serde_json::Error::io(std::io::Error::other(
+                        "marketplace v1 catalog must contain a skills array",
+                    )),
+                )
+            })?;
+        let entry_value = marketplace_v1_entry_value(&entry)?;
+        let action = upsert_entry_value(skills, entry_value, &entry.name)?;
+        let count = skills.len();
+        save_catalog_value(path, &raw)?;
+        return Ok((action, count));
+    }
+
+    let mut catalog: CatalogDoc = serde_json::from_value(raw)
+        .map_err(|err| MarketplaceError::ConfigParse(path.display().to_string(), err))?;
+    let action = upsert_entry(&mut catalog.entries, entry);
+    let count = catalog.entries.len();
+    save_catalog_doc(path, &catalog)?;
+    Ok((action, count))
+}
+
+fn load_catalog_value(path: &Path) -> Result<Value, MarketplaceError> {
     if !path.exists() {
-        return Ok(CatalogDoc {
-            version: default_catalog_version(),
-            entries: Vec::new(),
-        });
+        return Ok(json!({
+            "name": "dcc-mcp-local",
+            "schemaVersion": "1",
+            "version": "1.0.0",
+            "skills": []
+        }));
     }
     let text = fs::read_to_string(path)
         .map_err(|err| MarketplaceError::ConfigIo(path.display().to_string(), err))?;
     serde_json::from_str(&text)
         .map_err(|err| MarketplaceError::ConfigParse(path.display().to_string(), err))
+}
+
+fn save_catalog_value(path: &Path, catalog: &Value) -> Result<(), MarketplaceError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| MarketplaceError::ConfigIo(parent.display().to_string(), err))?;
+    }
+    let text = serde_json::to_string_pretty(catalog)
+        .expect("marketplace catalog serialization should not fail");
+    fs::write(path, format!("{text}\n"))
+        .map_err(|err| MarketplaceError::ConfigIo(path.display().to_string(), err))
+}
+
+fn marketplace_v1_entry_value(entry: &CatalogEntry) -> Result<Value, MarketplaceError> {
+    let version = required_entry_value(entry, "version", entry.version.as_deref())?;
+    if entry.dcc.is_empty() {
+        return Err(MarketplaceError::CommandFailed(format!(
+            "marketplace v1 entry '{}' requires at least one DCC target",
+            entry.name
+        )));
+    }
+    if entry.tags.is_empty() {
+        return Err(MarketplaceError::CommandFailed(format!(
+            "marketplace v1 entry '{}' requires at least one tag",
+            entry.name
+        )));
+    }
+    let install = entry
+        .install
+        .as_ref()
+        .ok_or_else(|| MarketplaceError::MissingInstall(entry.name.clone()))?;
+    if install.url.as_deref().is_none_or(str::is_empty) {
+        return Err(MarketplaceError::MissingInstall("source.url".into()));
+    }
+    if install.install_type == "git" && install.ref_.as_deref().is_none_or(str::is_empty) {
+        return Err(MarketplaceError::MissingInstall("source.ref".into()));
+    }
+    if install.install_type == "zip" && install.sha256.as_deref().is_none_or(str::is_empty) {
+        return Err(MarketplaceError::MissingInstall("source.sha256".into()));
+    }
+
+    let mut value = json!({
+        "name": entry.name,
+        "description": entry.description,
+        "version": version,
+        "dcc": entry.dcc,
+        "tags": entry.tags,
+        "category": entry.category.as_deref().unwrap_or("Skills"),
+        "source": install,
+        "policy": entry.policy.as_ref().unwrap_or(&CatalogPolicy {
+            installation: "available".into()
+        })
+    });
+    let object = value
+        .as_object_mut()
+        .expect("json object literal should remain an object");
+    if let Some(requires) = entry.requires.as_ref() {
+        object.insert("requires".into(), serde_json::to_value(requires).unwrap());
+    }
+    if let Some(min_core_version) = entry.min_core_version.as_ref() {
+        object.insert(
+            "minCoreVersion".into(),
+            Value::String(min_core_version.clone()),
+        );
+    }
+    if let Some(maintainer) = entry.maintainer.as_ref() {
+        object.insert("maintainer".into(), Value::String(maintainer.clone()));
+    }
+    if let Some(docs) = entry.url.as_ref() {
+        object.insert("docs".into(), Value::String(docs.clone()));
+    }
+    if let Some(icon) = entry.icon.as_ref() {
+        object.insert("icon".into(), Value::String(icon.clone()));
+    }
+    Ok(value)
+}
+
+fn required_entry_value<'a>(
+    entry: &CatalogEntry,
+    field: &str,
+    value: Option<&'a str>,
+) -> Result<&'a str, MarketplaceError> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            MarketplaceError::CommandFailed(format!(
+                "marketplace v1 entry '{}' requires {field}",
+                entry.name
+            ))
+        })
+}
+
+fn upsert_entry_value(
+    entries: &mut Vec<Value>,
+    mut entry: Value,
+    name: &str,
+) -> Result<String, MarketplaceError> {
+    for existing in entries.iter_mut() {
+        if existing.get("name").and_then(Value::as_str) == Some(name) {
+            preserve_marketplace_v1_metadata(&mut entry, existing);
+            validate_marketplace_v1_entry(&entry)?;
+            *existing = entry;
+            return Ok("updated".to_string());
+        }
+    }
+    validate_marketplace_v1_entry(&entry)?;
+    entries.push(entry);
+    Ok("created".to_string())
+}
+
+fn preserve_marketplace_v1_metadata(entry: &mut Value, existing: &Value) {
+    let Some(entry_object) = entry.as_object_mut() else {
+        return;
+    };
+    let Some(existing_object) = existing.as_object() else {
+        return;
+    };
+    for key in [
+        "minCoreVersion",
+        "maintainer",
+        "category",
+        "policy",
+        "requires",
+        "docs",
+        "icon",
+        "license",
+        "lifecycle",
+        "replacedBy",
+    ] {
+        if !entry_object.contains_key(key)
+            && let Some(value) = existing_object.get(key)
+        {
+            entry_object.insert(key.to_string(), value.clone());
+        }
+    }
+}
+
+fn validate_marketplace_v1_entry(entry: &Value) -> Result<(), MarketplaceError> {
+    for key in [
+        "name",
+        "description",
+        "version",
+        "maintainer",
+        "minCoreVersion",
+        "source",
+        "policy",
+    ] {
+        if entry.get(key).is_none() {
+            return Err(MarketplaceError::CommandFailed(format!(
+                "marketplace v1 entry is missing required field '{key}'"
+            )));
+        }
+    }
+    if entry
+        .get("dcc")
+        .and_then(Value::as_array)
+        .is_none_or(Vec::is_empty)
+    {
+        return Err(MarketplaceError::CommandFailed(
+            "marketplace v1 entry requires at least one DCC target".into(),
+        ));
+    }
+    if entry
+        .get("tags")
+        .and_then(Value::as_array)
+        .is_none_or(Vec::is_empty)
+    {
+        return Err(MarketplaceError::CommandFailed(
+            "marketplace v1 entry requires at least one tag".into(),
+        ));
+    }
+    Ok(())
 }
 
 fn save_catalog_doc(path: &Path, catalog: &CatalogDoc) -> Result<(), MarketplaceError> {
@@ -422,14 +631,14 @@ mod tests {
             install_url: "https://example.com/my-skill.zip".into(),
             install_type: "zip".into(),
             install_ref: None,
-            sha256: Some("sha256:abc".into()),
+            sha256: Some(format!("sha256:{}", "a".repeat(64))),
             name: None,
             description: None,
             dcc: Vec::new(),
             version: None,
             maintainer: Some("dcc-mcp".into()),
             tags: vec!["extra".into()],
-            min_core_version: None,
+            min_core_version: Some("0.19.0".into()),
             homepage_url: None,
             icon: None,
         })
@@ -440,6 +649,9 @@ mod tests {
         assert_eq!(result.entry.dcc, vec!["maya", "blender"]);
         assert_eq!(result.entry.version.as_deref(), Some("0.1.0"));
         let text = fs::read_to_string(catalog_path).unwrap();
-        assert!(text.contains("\"sha256\": \"sha256:abc\""));
+        assert!(text.contains("\"schemaVersion\": \"1\""));
+        assert!(text.contains("\"skills\": ["));
+        assert!(text.contains("\"minCoreVersion\": \"0.19.0\""));
+        assert!(text.contains("\"source\": {"));
     }
 }

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -286,6 +286,7 @@ impl MarketplaceService {
                     return Err(err);
                 }
             };
+        let resolved_commit = resolved_git_commit(&install, &final_path);
 
         let package = InstalledMarketplacePackage {
             name: package_name.clone(),
@@ -297,6 +298,7 @@ impl MarketplaceService {
             install_type: install.install_type.clone(),
             install_url: install.url.clone(),
             install_ref: install.ref_.clone(),
+            resolved_commit: resolved_commit.clone(),
             installed_at_ms: now_ms(),
         };
         self.upsert_installed(package)?;
@@ -311,6 +313,7 @@ impl MarketplaceService {
             source: hit.source,
             entry: hit.entry,
             install_type: install.install_type.clone(),
+            resolved_commit,
             reload_required: true,
         })
     }
@@ -384,13 +387,7 @@ impl MarketplaceService {
         let mut outdated = Vec::new();
         for pkg in filtered {
             let entry = self.find_latest_entry_for_package(&sources, &pkg).await?;
-            let is_outdated = match (&entry, &pkg.version) {
-                (Some(entry), Some(installed)) => {
-                    entry.version.as_deref() != Some(installed.as_str())
-                }
-                (Some(_), None) => true,
-                (None, _) => false,
-            };
+            let (is_outdated, latest_commit) = is_entry_outdated(entry.as_ref(), &pkg);
             if is_outdated && let Some(entry) = entry {
                 let latest_install = entry.install.as_ref();
                 outdated.push(OutdatedMarketplacePackage {
@@ -409,6 +406,8 @@ impl MarketplaceService {
                     install_ref: latest_install
                         .and_then(|i| i.ref_.clone())
                         .or(pkg.install_ref),
+                    installed_commit: pkg.resolved_commit,
+                    latest_commit,
                     path: pkg.path,
                 });
             }
@@ -443,6 +442,7 @@ impl MarketplaceService {
         for pkg in outdated.packages {
             let dest = PathBuf::from(&pkg.path);
             let previous_version = pkg.installed_version.clone();
+            let previous_commit = pkg.installed_commit.clone();
 
             let update_result = match pkg.install_type.as_str() {
                 "git" => self.update_git_package(&pkg, &dest).await,
@@ -461,6 +461,8 @@ impl MarketplaceService {
                         dcc: pkg.dcc.clone(),
                         previous_version,
                         new_version: result.version,
+                        previous_commit,
+                        new_commit: result.resolved_commit,
                         path: result.path,
                         install_type: result.install_type,
                         source_name: pkg.source_name.clone(),
@@ -480,6 +482,7 @@ impl MarketplaceService {
                     install_type: update_result.install_type.clone(),
                     install_url: pkg.install_url.clone(),
                     install_ref: pkg.install_ref.clone(),
+                    resolved_commit: update_result.new_commit.clone(),
                     installed_at_ms: now_ms(),
                 })?;
             }
@@ -730,6 +733,8 @@ impl MarketplaceService {
                 dcc: pkg.dcc.clone(),
                 previous_version: pkg.installed_version.clone(),
                 new_version: result.version,
+                previous_commit: pkg.installed_commit.clone(),
+                new_commit: result.resolved_commit,
                 path: result.path,
                 install_type: result.install_type,
                 source_name: pkg.source_name.clone(),
@@ -752,6 +757,7 @@ impl MarketplaceService {
                     install_type: pkg.install_type.clone(),
                     install_url: pkg.install_url.clone(),
                     install_ref: pkg.install_ref.clone(),
+                    resolved_commit: pkg.installed_commit.clone(),
                     installed_at_ms: 0,
                 },
             )
@@ -764,6 +770,8 @@ impl MarketplaceService {
             dcc: pkg.dcc.clone(),
             previous_version: pkg.installed_version.clone(),
             new_version,
+            previous_commit: pkg.installed_commit.clone(),
+            new_commit: pkg.latest_commit.clone().or_else(|| git_head_commit(dest)),
             path: dest.display().to_string(),
             install_type: pkg.install_type.clone(),
             source_name: pkg.source_name.clone(),
@@ -1011,6 +1019,56 @@ fn install_from_git_command(install: &CatalogInstall, dest: &Path) -> Result<(),
         output.status,
         String::from_utf8_lossy(&output.stderr)
     )))
+}
+
+fn immutable_git_commit(install: &CatalogInstall) -> Option<String> {
+    if install.install_type != "git" {
+        return None;
+    }
+    let ref_ = install.ref_.as_deref()?.trim();
+    is_full_git_oid(ref_).then(|| ref_.to_ascii_lowercase())
+}
+
+fn resolved_git_commit(install: &CatalogInstall, dest: &Path) -> Option<String> {
+    immutable_git_commit(install).or_else(|| git_head_commit(dest))
+}
+
+fn is_entry_outdated(
+    entry: Option<&CatalogEntry>,
+    installed: &InstalledMarketplacePackage,
+) -> (bool, Option<String>) {
+    let Some(entry) = entry else {
+        return (false, None);
+    };
+    let version_changed = match (&entry.version, &installed.version) {
+        (Some(latest), Some(current)) => latest != current,
+        (Some(_), None) => true,
+        (None, _) => false,
+    };
+    let latest_commit = entry.install.as_ref().and_then(immutable_git_commit);
+    let commit_changed = latest_commit
+        .as_deref()
+        .is_some_and(|latest| installed.resolved_commit.as_deref() != Some(latest));
+    (version_changed || commit_changed, latest_commit)
+}
+
+fn is_full_git_oid(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn git_head_commit(repo_path: &Path) -> Option<String> {
+    let output = git_command()
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let revision = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .to_ascii_lowercase();
+    is_full_git_oid(&revision).then_some(revision)
 }
 
 fn github_archive_url(install: &CatalogInstall) -> Option<String> {
@@ -1356,12 +1414,89 @@ mod tests {
             install_type: "git".into(),
             install_url: None,
             install_ref: None,
+            resolved_commit: None,
             installed_at_ms: 1000,
         };
         svc.upsert_installed(pkg.clone()).unwrap();
         let list = svc.list_installed(None).unwrap();
         assert_eq!(list.count, 1);
         assert_eq!(list.packages[0].name, "test-skill");
+    }
+
+    #[test]
+    fn pinned_git_revision_marks_unchanged_version_as_outdated() {
+        let entry = CatalogEntry {
+            name: "test-skill".into(),
+            description: "desc".into(),
+            dcc: vec!["maya".into()],
+            url: None,
+            tags: vec![],
+            version: Some("1.0.0".into()),
+            min_core_version: None,
+            install: Some(CatalogInstall {
+                install_type: "git".into(),
+                url: Some("https://example.invalid/skill".into()),
+                ref_: Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".into()),
+                sha256: None,
+                pip_package: None,
+                pip_extras: None,
+                python_path: None,
+                entry_point: None,
+                instructions_url: None,
+            }),
+            maintainer: None,
+            category: None,
+            policy: None,
+            requires: None,
+            icon: None,
+        };
+        let installed = InstalledMarketplacePackage {
+            name: "test-skill".into(),
+            dcc: "maya".into(),
+            version: Some("1.0.0".into()),
+            path: "/tmp/test".into(),
+            source_name: "official".into(),
+            source_url: "https://example.invalid/catalog.json".into(),
+            install_type: "git".into(),
+            install_url: entry
+                .install
+                .as_ref()
+                .and_then(|install| install.url.clone()),
+            install_ref: entry
+                .install
+                .as_ref()
+                .and_then(|install| install.ref_.clone()),
+            resolved_commit: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into()),
+            installed_at_ms: 1,
+        };
+
+        let (outdated, latest_commit) = is_entry_outdated(Some(&entry), &installed);
+        assert!(outdated);
+        assert_eq!(
+            latest_commit.as_deref(),
+            Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+        );
+    }
+
+    #[test]
+    fn immutable_git_commit_only_accepts_full_object_ids() {
+        let mut install = CatalogInstall {
+            install_type: "git".into(),
+            url: Some("https://example.invalid/skill".into()),
+            ref_: Some("main".into()),
+            sha256: None,
+            pip_package: None,
+            pip_extras: None,
+            python_path: None,
+            entry_point: None,
+            instructions_url: None,
+        };
+        assert_eq!(immutable_git_commit(&install), None);
+        install.ref_ = Some("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into());
+        assert_eq!(
+            immutable_git_commit(&install).as_deref(),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -1370,6 +1370,10 @@ fn now_ms() -> u128 {
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
+#[path = "service_tests.rs"]
+mod service_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -1421,82 +1425,6 @@ mod tests {
         let list = svc.list_installed(None).unwrap();
         assert_eq!(list.count, 1);
         assert_eq!(list.packages[0].name, "test-skill");
-    }
-
-    #[test]
-    fn pinned_git_revision_marks_unchanged_version_as_outdated() {
-        let entry = CatalogEntry {
-            name: "test-skill".into(),
-            description: "desc".into(),
-            dcc: vec!["maya".into()],
-            url: None,
-            tags: vec![],
-            version: Some("1.0.0".into()),
-            min_core_version: None,
-            install: Some(CatalogInstall {
-                install_type: "git".into(),
-                url: Some("https://example.invalid/skill".into()),
-                ref_: Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".into()),
-                sha256: None,
-                pip_package: None,
-                pip_extras: None,
-                python_path: None,
-                entry_point: None,
-                instructions_url: None,
-            }),
-            maintainer: None,
-            category: None,
-            policy: None,
-            requires: None,
-            icon: None,
-        };
-        let installed = InstalledMarketplacePackage {
-            name: "test-skill".into(),
-            dcc: "maya".into(),
-            version: Some("1.0.0".into()),
-            path: "/tmp/test".into(),
-            source_name: "official".into(),
-            source_url: "https://example.invalid/catalog.json".into(),
-            install_type: "git".into(),
-            install_url: entry
-                .install
-                .as_ref()
-                .and_then(|install| install.url.clone()),
-            install_ref: entry
-                .install
-                .as_ref()
-                .and_then(|install| install.ref_.clone()),
-            resolved_commit: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into()),
-            installed_at_ms: 1,
-        };
-
-        let (outdated, latest_commit) = is_entry_outdated(Some(&entry), &installed);
-        assert!(outdated);
-        assert_eq!(
-            latest_commit.as_deref(),
-            Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
-        );
-    }
-
-    #[test]
-    fn immutable_git_commit_only_accepts_full_object_ids() {
-        let mut install = CatalogInstall {
-            install_type: "git".into(),
-            url: Some("https://example.invalid/skill".into()),
-            ref_: Some("main".into()),
-            sha256: None,
-            pip_package: None,
-            pip_extras: None,
-            python_path: None,
-            entry_point: None,
-            instructions_url: None,
-        };
-        assert_eq!(immutable_git_commit(&install), None);
-        install.ref_ = Some("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into());
-        assert_eq!(
-            immutable_git_commit(&install).as_deref(),
-            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-        );
     }
 
     #[test]

--- a/crates/dcc-mcp-marketplace/src/service_tests.rs
+++ b/crates/dcc-mcp-marketplace/src/service_tests.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+#[test]
+fn pinned_git_revision_marks_unchanged_version_as_outdated() {
+    let entry = CatalogEntry {
+        name: "test-skill".into(),
+        description: "desc".into(),
+        dcc: vec!["maya".into()],
+        url: None,
+        tags: vec![],
+        version: Some("1.0.0".into()),
+        min_core_version: None,
+        install: Some(CatalogInstall {
+            install_type: "git".into(),
+            url: Some("https://example.invalid/skill".into()),
+            ref_: Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".into()),
+            sha256: None,
+            pip_package: None,
+            pip_extras: None,
+            python_path: None,
+            entry_point: None,
+            instructions_url: None,
+        }),
+        maintainer: None,
+        category: None,
+        policy: None,
+        requires: None,
+        icon: None,
+    };
+    let installed = InstalledMarketplacePackage {
+        name: "test-skill".into(),
+        dcc: "maya".into(),
+        version: Some("1.0.0".into()),
+        path: "/tmp/test".into(),
+        source_name: "official".into(),
+        source_url: "https://example.invalid/catalog.json".into(),
+        install_type: "git".into(),
+        install_url: entry
+            .install
+            .as_ref()
+            .and_then(|install| install.url.clone()),
+        install_ref: entry
+            .install
+            .as_ref()
+            .and_then(|install| install.ref_.clone()),
+        resolved_commit: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into()),
+        installed_at_ms: 1,
+    };
+
+    let (outdated, latest_commit) = is_entry_outdated(Some(&entry), &installed);
+    assert!(outdated);
+    assert_eq!(
+        latest_commit.as_deref(),
+        Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    );
+}
+
+#[test]
+fn immutable_git_commit_only_accepts_full_object_ids() {
+    let mut install = CatalogInstall {
+        install_type: "git".into(),
+        url: Some("https://example.invalid/skill".into()),
+        ref_: Some("main".into()),
+        sha256: None,
+        pip_package: None,
+        pip_extras: None,
+        python_path: None,
+        entry_point: None,
+        instructions_url: None,
+    };
+    assert_eq!(immutable_git_commit(&install), None);
+    install.ref_ = Some("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into());
+    assert_eq!(
+        immutable_git_commit(&install).as_deref(),
+        Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    );
+}

--- a/crates/dcc-mcp-marketplace/src/types.rs
+++ b/crates/dcc-mcp-marketplace/src/types.rs
@@ -76,6 +76,9 @@ pub struct MarketplaceInstallResult {
     pub source: MarketplaceSource,
     pub entry: CatalogEntry,
     pub install_type: String,
+    /// Immutable git revision that was actually installed, when the source supplies one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_commit: Option<String>,
     pub reload_required: bool,
 }
 
@@ -103,6 +106,11 @@ pub struct InstalledMarketplacePackage {
     pub install_type: String,
     pub install_url: Option<String>,
     pub install_ref: Option<String>,
+    /// Immutable git revision resolved during installation.
+    ///
+    /// Older state files omit this field and remain readable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_commit: Option<String>,
     pub installed_at_ms: u128,
 }
 
@@ -132,6 +140,10 @@ pub struct OutdatedMarketplacePackage {
     pub install_type: String,
     pub install_url: Option<String>,
     pub install_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installed_commit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_commit: Option<String>,
     pub path: String,
 }
 
@@ -149,6 +161,10 @@ pub struct MarketplaceUpdateResult {
     pub dcc: String,
     pub previous_version: Option<String>,
     pub new_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_commit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub new_commit: Option<String>,
     pub path: String,
     pub install_type: String,
     pub source_name: String,
@@ -216,6 +232,9 @@ mod tests {
             min_core_version: None,
             install: None,
             maintainer: None,
+            category: None,
+            policy: None,
+            requires: None,
             icon: None,
         };
         assert!(entry_targets_dcc(&entry, "Maya"));

--- a/skills/marketplace-publish-extension/SKILL.md
+++ b/skills/marketplace-publish-extension/SKILL.md
@@ -38,7 +38,8 @@ dcc-mcp-cli marketplace pack ./my-extension --out dist/
 dcc-mcp-cli marketplace publish ./my-extension \
   --catalog ./marketplace.json \
   --install-url https://github.com/<owner>/<repo>/releases/download/v0.1.0/my-extension.zip \
-  --sha256 sha256:<digest>
+  --sha256 sha256:<digest> \
+  --min-core-version 0.19.0
 ```
 
 ## Tools
@@ -69,5 +70,18 @@ push the change.
 3. Additional CLI-supplied fields (install url, ref, tags, maintainer, icon,
    etc.) are merged in.
 4. A `CatalogEntry` is built and upserted into the target `marketplace.json`.
+   New catalogs use the v1 `skills` layout and preserve v1-only fields when an
+   existing entry is updated.
 5. If the catalog source is a git repo and `--commit` is passed, the updated
    `marketplace.json` is committed and pushed.
+
+## Official catalog requirements
+
+- Pass `--min-core-version`; v1 entries require an explicit compatibility floor.
+- Git sources in the official catalog must use a complete 40-character commit
+  SHA in `--install-ref`, never a mutable branch name.
+- Zip sources require a 64-character SHA-256 digest. When the archive URL
+  changes, provide the new digest rather than reusing old metadata.
+- The publisher preserves v1 curation fields such as `requires` and `policy`
+  when updating an existing entry, but new official entries must provide the
+  complete marketplace metadata required by the catalog schema.

--- a/skills/marketplace-publish-extension/tools.yaml
+++ b/skills/marketplace-publish-extension/tools.yaml
@@ -29,7 +29,8 @@ tools:
           type: string
           description: >-
             Install source URL (Git repo URL, zip download URL, or local path).
-            Written into the CatalogEntry `install.url` field.
+            Written into the CatalogEntry install metadata and serialized as
+            `source.url` for v1 marketplace catalogs.
         install_type:
           type: string
           enum:
@@ -41,8 +42,9 @@ tools:
         install_ref:
           type: string
           description: >-
-            Git ref, branch name, or tag for git-type installs. Written into
-            the CatalogEntry `install.ref` field.
+            Git revision for git-type installs. Official catalogs require a
+            complete immutable 40-character commit SHA; custom catalogs may
+            use a studio-managed release tag.
         version:
           type: string
           description: >-
@@ -70,7 +72,8 @@ tools:
           type: string
           description: >-
             Minimum dcc-mcp-core version required by this extension. Written
-            into the CatalogEntry `min_core_version` field.
+            into the CatalogEntry `min_core_version` field and serialized as
+            `minCoreVersion` for v1 marketplace catalogs.
         extension_url:
           type: string
           description: >-


### PR DESCRIPTION
## Summary
- preserve v1 marketplace metadata through CLI and gateway contracts
- record immutable installed Git revisions and detect revision-only updates
- emit v1 catalog entries from the publish workflow

## Validation
- cargo clippy -p dcc-mcp-catalog -p dcc-mcp-marketplace -p dcc-mcp-cli --all-targets -- -D warnings
- cargo test -p dcc-mcp-catalog
- cargo test -p dcc-mcp-marketplace
- cargo test -p dcc-mcp-cli --test cli_marketplace_e2e