### PR TITLE
fix(test): replace flaky sleep with wait loop in gateway resources blob test

### DIFF
--- a/tests/test_gateway_resources_forwarding.py
+++ b/tests/test_gateway_resources_forwarding.py
@@ -306,16 +306,20 @@ class TestResourcesReadBlobRoundTrip:
         registry_dir = tmp_path_factory.mktemp("blob-e2e-registry")
         gw_port = allocate_gateway_port()
         _server_a, handle_a = _make_backend("maya", registry_dir, gw_port)
+        register_shutdown_handle(handle_a)
         time.sleep(0.3)
         _server_b, handle_b = _make_backend("blender", registry_dir, gw_port)
-        time.sleep(2.2)
+        register_shutdown_handle(handle_b)
 
         if not handle_a.is_gateway:
-            handle_b.shutdown()
-            handle_a.shutdown()
             pytest.skip("gateway port contention — blob round-trip test")
 
         gw_url = f"http://127.0.0.1:{gw_port}/mcp"
+
+        # Wait for the gateway watcher to merge backend resources —
+        # a fixed sleep was flaky on slower macOS runners.
+        _wait_for_forwarded_backend_resources(gw_url)
+
         try:
             list_resp = _post_mcp(gw_url, "resources/list")
             prefixed_audit = next(


### PR DESCRIPTION
## Root cause

`test_blob_base64_survives_gateway_proxy` used a fixed 2.2s sleep to wait for the gateway to aggregate backend resources. On slower macOS runners the gateway watcher hadn't discovered live backends yet, producing an empty merged list with only gateway-native resources — no prefixed `audit://` URI from the backends.

## Fix

- Replace the fixed sleep with `_wait_for_forwarded_backend_resources()` which polls the gateway until backend resources are visible
- Register shutdown handles for both backends so cleanup is consistent with the module-scoped fixture

## Test plan

- `test_blob_base64_survives_gateway_proxy` passes locally (Windows)
- All 8 tests in `test_gateway_resources_forwarding.py` pass
- CI on macOS py3.14 should pass (was the only failing platform)