### PR TITLE
fix: add marketplace/service.rs to file-size-exemptions (PIP-2701)

### DIFF
--- a/.github/file-size-exemptions.txt
+++ b/.github/file-size-exemptions.txt
@@ -17,3 +17,5 @@ crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
 crates/dcc-mcp-skill-rest/src/service.rs
 # PIP-1799 — capability_service.rs 1507L, exceeds 1500 limit by 7 lines
 crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+# PIP-2701 — service.rs 1523L, exceeds 1500 limit by 23 lines
+crates/dcc-mcp-marketplace/src/service.rs


### PR DESCRIPTION
Fix the file-size-gate CI failure on #1857.

**Problem**: `crates/dcc-mcp-marketplace/src/service.rs` is 1523 lines (+23 over the 1500-line limit) and was not in `.github/file-size-exemptions.txt`.

**Fix**: Added the exemption entry with tracking reference to PIP-2701 for the eventual refactor.

Tracking issue: PIP-2701