### PR TITLE
fix: enforce marketplace install availability

### DIFF
--- a/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
@@ -327,7 +327,7 @@ fn marketplace_install_list_and_uninstall_path_package() {
 }
 
 #[test]
-fn marketplace_install_rejects_incompatible_core_version() {
+fn marketplace_install_rejects_incompatible_or_unavailable_entries() {
     let tmp = TempDir::new().unwrap();
     let skill_dir = write_skill(
         tmp.path(),
@@ -381,6 +381,37 @@ fn marketplace_install_rejects_incompatible_core_version() {
         &envs,
     );
     assert!(stderr.contains("requires dcc-mcp-core >= 999.0.0"));
+    assert!(!std::path::Path::new(&install_root).exists());
+
+    std::fs::write(
+        &catalog_path,
+        serde_json::to_string_pretty(&json!({
+            "version": "1",
+            "entries": [{
+                "name": "incompatible-skill",
+                "description": "Unavailable skill",
+                "dcc": ["maya"],
+                "tags": ["test"],
+                "policy": {"installation": "not_available"},
+                "install": {"type": "path", "url": skill_dir.to_string_lossy()}
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let stderr = run_failure_with_env(
+        &[
+            "marketplace",
+            "install",
+            "incompatible-skill",
+            "--dcc",
+            "maya",
+            "--source",
+            &source,
+        ],
+        &envs,
+    );
+    assert!(stderr.contains("is not available for installation"));
     assert!(!std::path::Path::new(&install_root).exists());
 }
 

--- a/crates/dcc-mcp-marketplace/src/error.rs
+++ b/crates/dcc-mcp-marketplace/src/error.rs
@@ -31,6 +31,9 @@ pub enum MarketplaceError {
     #[error("marketplace entry '{0}' does not declare install metadata")]
     MissingInstall(String),
 
+    #[error("marketplace entry '{0}' is not available for installation")]
+    NotAvailable(String),
+
     #[error("marketplace entry '{name}' has an invalid minCoreVersion '{required}'")]
     InvalidMinCoreVersion { name: String, required: String },
 

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -233,7 +233,7 @@ impl MarketplaceService {
         let hit = self
             .resolve_install_hit(&name, dcc.as_deref(), explicit_sources, skip_validation)
             .await?;
-        ensure_core_version_compatible(&hit.entry)?;
+        ensure_entry_installable(&hit.entry)?;
         let dcc = resolve_install_dcc(&hit.entry, dcc.as_deref())?;
         let install = hit
             .entry
@@ -731,7 +731,7 @@ impl MarketplaceService {
             )
             .await?;
         if let Some(entry) = latest_entry.as_ref() {
-            ensure_core_version_compatible(entry)?;
+            ensure_entry_installable(entry)?;
         }
 
         let git_dir = dest.join(".git");

--- a/crates/dcc-mcp-marketplace/src/service_internals.rs
+++ b/crates/dcc-mcp-marketplace/src/service_internals.rs
@@ -181,7 +181,14 @@ pub fn resolve_install_dcc(
     }
 }
 
-pub fn ensure_core_version_compatible(entry: &CatalogEntry) -> Result<(), MarketplaceError> {
+pub fn ensure_entry_installable(entry: &CatalogEntry) -> Result<(), MarketplaceError> {
+    if entry
+        .policy
+        .as_ref()
+        .is_some_and(|policy| policy.installation == "not_available")
+    {
+        return Err(MarketplaceError::NotAvailable(entry.name.clone()));
+    }
     let Some(required) = entry.min_core_version.as_deref() else {
         return Ok(());
     };

--- a/crates/dcc-mcp-marketplace/src/service_tests.rs
+++ b/crates/dcc-mcp-marketplace/src/service_tests.rs
@@ -97,16 +97,41 @@ fn core_version_gate_rejects_too_new_or_invalid_requirements() {
     };
 
     assert!(matches!(
-        ensure_core_version_compatible(&entry),
+        ensure_entry_installable(&entry),
         Err(MarketplaceError::IncompatibleCoreVersion { .. })
     ));
     entry.min_core_version = Some("not-semver".into());
     assert!(matches!(
-        ensure_core_version_compatible(&entry),
+        ensure_entry_installable(&entry),
         Err(MarketplaceError::InvalidMinCoreVersion { .. })
     ));
     entry.min_core_version = Some("0.19.0".into());
-    assert!(ensure_core_version_compatible(&entry).is_ok());
+    assert!(ensure_entry_installable(&entry).is_ok());
     entry.min_core_version = None;
-    assert!(ensure_core_version_compatible(&entry).is_ok());
+    assert!(ensure_entry_installable(&entry).is_ok());
+}
+
+#[test]
+fn install_policy_rejects_unavailable_entries() {
+    let entry = CatalogEntry {
+        name: "retired-skill".into(),
+        description: "desc".into(),
+        dcc: vec!["maya".into()],
+        url: None,
+        tags: vec![],
+        version: None,
+        min_core_version: None,
+        install: None,
+        maintainer: None,
+        category: None,
+        policy: Some(dcc_mcp_catalog::CatalogPolicy {
+            installation: "not_available".into(),
+        }),
+        requires: None,
+        icon: None,
+    };
+    assert!(matches!(
+        ensure_entry_installable(&entry),
+        Err(MarketplaceError::NotAvailable(name)) if name == "retired-skill"
+    ));
 }


### PR DESCRIPTION
## Summary
- reject marketplace entries marked policy.installation: not_available
- apply the shared guard to installs and in-place Git updates
- preserve legacy entries and installed_by_default behavior

## Validation
- cargo test -p dcc-mcp-marketplace --lib
- cargo test -p dcc-mcp-cli --test cli_marketplace_e2e
- cargo clippy -p dcc-mcp-marketplace -p dcc-mcp-cli --all-targets -- -D warnings