### PR TITLE
Fix local descriptions and Python skill execution

### DIFF
--- a/crates/dcc-mcp-cli/src/application/local_control.rs
+++ b/crates/dcc-mcp-cli/src/application/local_control.rs
@@ -13,7 +13,7 @@ use serde_json::{Map, Value, json};
 
 use crate::application::local_instance;
 use crate::domain::rest::{
-    ReloadSkillsRequest, SearchRequest, StopInstanceRequest, WaitReadyRequest,
+    Endpoint, ReloadSkillsRequest, SearchRequest, StopInstanceRequest, WaitReadyRequest,
 };
 use crate::infra::http::HttpGateway;
 
@@ -92,18 +92,35 @@ pub async fn search_local(registry_dir: PathBuf, request: SearchRequest) -> anyh
 pub async fn describe_local(registry_dir: PathBuf, tool_slug: String) -> anyhow::Result<Value> {
     let route = resolve_tool_route(&registry_dir, &tool_slug, None, None)?;
     let gateway = HttpGateway::default();
-    let tools = list_mcp_tools(&gateway, &local_instance::mcp_url(&route.entry)).await?;
-    let Some(tool) = tools.into_iter().find(|tool| {
+    let mcp_url = local_instance::mcp_url(&route.entry);
+    let tools = list_mcp_tools(&gateway, &mcp_url).await?;
+    let tool = if let Some(tool) = tools.into_iter().find(|tool| {
         tool.get("name")
             .and_then(Value::as_str)
             .is_some_and(|name| name == route.backend_tool)
-    }) else {
-        anyhow::bail!(
-            "tool '{}' was not found on local {} instance {}",
-            route.backend_tool,
-            route.entry.dcc_type,
-            local_instance::instance_short(&route.entry)
-        );
+    }) {
+        tool
+    } else {
+        let endpoint = Endpoint::from_mcp_url(mcp_url);
+        let described = gateway
+            .post_json(
+                &endpoint.path("/v1/describe"),
+                &json!({"tool_slug": route.backend_tool, "include_schema": true}),
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "tool '{}' was not found in tools/list and the local describe fallback failed",
+                    route.backend_tool
+                )
+            })?;
+        json!({
+            "name": route.backend_tool,
+            "description": described.get("description").cloned().unwrap_or(Value::Null),
+            "inputSchema": described.get("input_schema").cloned().unwrap_or_else(|| json!({"type": "object"})),
+            "annotations": described.get("annotations").cloned().unwrap_or_else(|| json!({})),
+            "_meta": described.get("metadata").cloned().unwrap_or(Value::Null),
+        })
     };
 
     Ok(json!({

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -394,6 +394,38 @@ fn local_search_without_query_lists_tools_for_dcc_filter() {
 }
 
 #[test]
+fn local_describe_uses_rest_for_loaded_tool_missing_from_tools_list() {
+    let fixture = spawn_local_mcp_fixture();
+    let registry = TempDir::new().unwrap();
+    let file_registry = FileRegistry::new(registry.path()).unwrap();
+    let mut entry = ServiceEntry::new("maya", "127.0.0.1", 0);
+    let instance_short = entry.instance_id.to_string()[..8].to_string();
+    entry
+        .metadata
+        .insert("mcp_url".to_string(), fixture.mcp_url());
+    file_registry.register(entry).unwrap();
+
+    let registry_s = registry.path().to_string_lossy().to_string();
+    let profiles_s = registry
+        .path()
+        .join("gateway-profiles.json")
+        .to_string_lossy()
+        .to_string();
+    let envs = [
+        ("DCC_MCP_REGISTRY_DIR", registry_s.as_str()),
+        ("DCC_MCP_GATEWAY_PROFILES_FILE", profiles_s.as_str()),
+        ("DCC_MCP_GATEWAY_PROFILE", "local"),
+        ("DCC_MCP_BASE_URL", ""),
+        ("DCC_MCP_CLI_NO_AUTO_GATEWAY", "true"),
+    ];
+    let slug = format!("maya.{instance_short}.dynamic__run");
+    let describe = run_json_with_env(&["describe", &slug], &envs);
+    assert_eq!(describe["source"], "local_mcp");
+    assert_eq!(describe["tool"]["name"], "dynamic__run");
+    assert_eq!(describe["tool"]["inputSchema"]["required"][0], "name");
+}
+
+#[test]
 fn local_search_routes_ready_sidecar_and_skips_unavailable_rows() {
     let fixture = spawn_local_mcp_fixture();
     let registry = TempDir::new().unwrap();

--- a/crates/dcc-mcp-cli/tests/support/mod.rs
+++ b/crates/dcc-mcp-cli/tests/support/mod.rs
@@ -626,6 +626,22 @@ pub(crate) fn spawn_local_mcp_fixture() -> LocalMcpFixture {
             }),
         )
         .route(
+            "/v1/describe",
+            post(|Json(body): Json<Value>| async move {
+                Json(json!({
+                    "entry": {"slug": body["tool_slug"], "loaded": true},
+                    "description": "Dynamically loaded workflow tool",
+                    "input_schema": {
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {"name": {"type": "string"}}
+                    },
+                    "annotations": {"loaded": true},
+                    "metadata": {"dcc": {"affinity": "main"}}
+                }))
+            }),
+        )
+        .route(
             "/safe-stop",
             post(|Json(body): Json<Value>| async move {
                 Json(json!({

--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -585,7 +585,7 @@ class HostExecutionBridge:
 
 def _call_script_main(main: Callable[..., Any], params: Mapping[str, Any]) -> Any:
     """Invoke a skill ``main`` using the best supported calling convention."""
-    params_dict = dict(params)
+    params_dict = {key: value for key, value in params.items() if not key.startswith("_")}
     try:
         signature = inspect.signature(main)
     except (TypeError, ValueError):
@@ -649,6 +649,10 @@ def run_skill_script(script_path: str, params: Mapping[str, Any]) -> Any:
         raise ImportError(f"Cannot create import spec for {script_path}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[mod_name] = module
+    script_dir = str(path.parent)
+    added_script_dir = script_dir not in sys.path
+    if added_script_dir:
+        sys.path.insert(0, script_dir)
     try:
         try:
             spec.loader.exec_module(module)
@@ -665,6 +669,8 @@ def run_skill_script(script_path: str, params: Mapping[str, Any]) -> Any:
             return getattr(module, "__mcp_result__", None)
     finally:
         sys.modules.pop(mod_name, None)
+        if added_script_dir and script_dir in sys.path:
+            sys.path.remove(script_dir)
 
 
 def build_inprocess_executor(

--- a/tests/test_inprocess_executor.py
+++ b/tests/test_inprocess_executor.py
@@ -80,6 +80,21 @@ def test_run_skill_script_calls_main_with_params(tmp_path: Path) -> None:
     assert run_skill_script(str(p), {"a": 5}) == {"sum": 7}
 
 
+def test_run_skill_script_strips_reserved_metadata(tmp_path: Path) -> None:
+    p = _write_script(
+        tmp_path,
+        "def main(**kwargs):\n    return sorted(kwargs)\n",
+    )
+    assert run_skill_script(str(p), {"color": "red", "_meta": {"session": "test"}}) == ["color"]
+
+
+def test_run_skill_script_supports_sibling_imports(tmp_path: Path) -> None:
+    (tmp_path / "_helper.py").write_text("VALUE = 42\n", encoding="utf-8")
+    p = _write_script(tmp_path, "from _helper import VALUE\ndef main(): return VALUE\n")
+    assert run_skill_script(str(p), {}) == 42
+    assert str(tmp_path) not in __import__("sys").path
+
+
 def test_run_skill_script_supports_single_dict_main(tmp_path: Path) -> None:
     p = _write_script(
         tmp_path,


### PR DESCRIPTION
## Summary
- fall back to backend REST describe for dynamically loaded local tools
- strip reserved request metadata before Python skill entrypoints
- support sibling imports from skill script directories

## Tests
- 19 CLI E2E tests
- 35 in-process executor tests
- cargo fmt --check