### PR TITLE
Make CLI tool-call timeout configurable

### DIFF
--- a/crates/dcc-mcp-cli/src/application/control_plane.rs
+++ b/crates/dcc-mcp-cli/src/application/control_plane.rs
@@ -5,6 +5,7 @@
 //! instance's advertised MCP endpoint; remote profiles use gateway REST.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use serde_json::{Value, json};
 
@@ -18,6 +19,7 @@ use crate::domain::rest::{
     CallRequest, DescribeRequest, DirectCallRequest, Endpoint, LoadSkillRequest,
     ReloadSkillsRequest, SearchRequest, StopInstanceRequest, WaitReadyRequest,
 };
+use crate::infra::http::HttpGateway;
 
 const RELOAD_SKILLS_TOOL: &str = "dcc_admin__reload_skills";
 
@@ -89,6 +91,7 @@ impl DccControlPlane {
         instance_id: Option<String>,
         arguments: Value,
         meta: Option<Value>,
+        timeout: Duration,
     ) -> anyhow::Result<Value> {
         if self.target.is_local() {
             return local_control::call_local(
@@ -98,11 +101,13 @@ impl DccControlPlane {
                 instance_id,
                 arguments,
                 meta,
+                timeout,
             )
             .await;
         }
 
-        let client = self.gateway_client();
+        let client =
+            DccMcpClient::with_gateway(self.endpoint.clone(), HttpGateway::with_timeout(timeout));
         match (dcc_type, instance_id) {
             (Some(dcc_type), Some(instance_id)) => client
                 .direct_call(DirectCallRequest {

--- a/crates/dcc-mcp-cli/src/application/local_control.rs
+++ b/crates/dcc-mcp-cli/src/application/local_control.rs
@@ -190,6 +190,7 @@ pub async fn call_local(
     instance_id: Option<String>,
     arguments: Value,
     meta: Option<Value>,
+    timeout: Duration,
 ) -> anyhow::Result<Value> {
     let route = resolve_tool_route(
         &registry_dir,
@@ -197,7 +198,7 @@ pub async fn call_local(
         dcc_type.as_deref(),
         instance_id.as_deref(),
     )?;
-    let gateway = HttpGateway::default();
+    let gateway = HttpGateway::with_timeout(timeout);
     let result = mcp_call_tool(
         &gateway,
         &local_instance::mcp_url(&route.entry),

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -138,6 +138,9 @@ enum Command {
         arguments_json: String,
         #[arg(long)]
         meta_json: Option<String>,
+        /// Per-request timeout for the tool call. Increase for renders and other long-running sync tools.
+        #[arg(long, env = "DCC_MCP_CLI_CALL_TIMEOUT_SECS", default_value = "30")]
+        timeout_secs: u64,
     },
     /// Wait until a local or gateway-managed instance reports readiness bits.
     WaitReady {
@@ -562,6 +565,7 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
             instance_id,
             arguments_json,
             meta_json,
+            timeout_secs,
         } => {
             let arguments = parse_json_object(&arguments_json, "--json")?;
             let meta = meta_json
@@ -569,7 +573,14 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                 .map(|raw| parse_json_object(raw, "--meta-json"))
                 .transpose()?;
             control
-                .call(tool_slug, dcc_type, instance_id, arguments, meta)
+                .call(
+                    tool_slug,
+                    dcc_type,
+                    instance_id,
+                    arguments,
+                    meta,
+                    Duration::from_secs(timeout_secs.max(1)),
+                )
                 .await?
         }
         Command::WaitReady {
@@ -1216,266 +1227,5 @@ fn gateway_summary(value: &Value, fallback_role: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
-        let local = GatewayTarget::Local;
-        let remote = GatewayTarget::Remote {
-            name: "pcA".to_string(),
-            endpoint: Endpoint::new(DEFAULT_BASE_URL),
-        };
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::Smoke {
-                    url: None,
-                    query: "sphere".to_string(),
-                    limit: 5,
-                    timeout_secs: 5,
-                },
-                &local,
-            )
-            .is_some()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::Smoke {
-                    url: Some("http://127.0.0.1:8765/mcp".to_string()),
-                    query: "sphere".to_string(),
-                    limit: 5,
-                    timeout_secs: 5,
-                },
-                &local,
-            )
-            .is_none()
-        );
-        assert!(gateway_endpoint_for_command(DEFAULT_BASE_URL, &Command::Health, &local).is_some());
-        assert!(gateway_endpoint_for_command(DEFAULT_BASE_URL, &Command::List, &local).is_some());
-        assert!(gateway_endpoint_for_command(DEFAULT_BASE_URL, &Command::List, &remote).is_some());
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::Search {
-                    query: Some("sphere".to_string()),
-                    dcc_type: None,
-                    instance_id: None,
-                    limit: None,
-                },
-                &local,
-            )
-            .is_some()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::Describe {
-                    tool_slug: "maya.abc12345.create_sphere".to_string(),
-                },
-                &local,
-            )
-            .is_some()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::LoadSkill {
-                    skill_name: Some("maya-modeling".to_string()),
-                    dcc_type: Some("maya".to_string()),
-                    dcc: None,
-                    instance_id: Some("abc12345".to_string()),
-                    activate_groups: None,
-                    request_json: None,
-                },
-                &local,
-            )
-            .is_some()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::Call {
-                    tool_slug: "maya.abc12345.create_sphere".to_string(),
-                    dcc_type: None,
-                    instance_id: None,
-                    arguments_json: "{}".to_string(),
-                    meta_json: None,
-                },
-                &local,
-            )
-            .is_some()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::WaitReady {
-                    dcc_type: Some("maya".to_string()),
-                    instance_id: Some("abc12345".to_string()),
-                    require: vec!["process".to_string(), "dispatcher".to_string()],
-                    timeout_secs: 30,
-                    interval_secs: 1,
-                },
-                &local,
-            )
-            .is_some()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::ReloadSkills {
-                    dcc_type: Some("maya".to_string()),
-                    instance_id: Some("abc12345".to_string()),
-                },
-                &local,
-            )
-            .is_some()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::StopInstance {
-                    dcc_type: "maya".to_string(),
-                    instance_id: "abc12345".to_string(),
-                    expected_owner: Some("release-smoke-test".to_string()),
-                    expected_session: Some("test".to_string()),
-                },
-                &local,
-            )
-            .is_some()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::Search {
-                    query: Some("sphere".to_string()),
-                    dcc_type: None,
-                    instance_id: None,
-                    limit: None,
-                },
-                &remote,
-            )
-            .is_some()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::ReloadSkills {
-                    dcc_type: Some("maya".to_string()),
-                    instance_id: Some("abc12345".to_string()),
-                },
-                &remote,
-            )
-            .is_some()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::Update {
-                    action: UpdateAction::Check {
-                        binary: Some("dcc-mcp-server".to_string()),
-                        current_version: Some("0.0.0".to_string()),
-                    },
-                },
-                &local,
-            )
-            .is_some()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::Doctor {
-                    registry_dir: None,
-                    gateway_host: "127.0.0.1".to_string(),
-                    gateway_port: 9765,
-                },
-                &local,
-            )
-            .is_none()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::Marketplace {
-                    action: MarketplaceAction::List,
-                },
-                &local,
-            )
-            .is_none()
-        );
-        assert!(
-            gateway_endpoint_for_command(
-                DEFAULT_BASE_URL,
-                &Command::Gateway {
-                    action: Some(GatewayAction::Status(GatewayStatusArgs {
-                        host: "127.0.0.1".to_string(),
-                        port: 9765,
-                        registry_dir: None,
-                    })),
-                    daemon: default_gateway_daemon_args(),
-                },
-                &local,
-            )
-            .is_none()
-        );
-    }
-
-    #[test]
-    fn gateway_daemon_start_defaults_to_persistent_daemon() {
-        let args = Args::parse_from(["dcc-mcp-cli", "gateway", "daemon", "start"]);
-
-        let Command::Gateway {
-            action:
-                Some(GatewayAction::Daemon {
-                    action: GatewayDaemonAction::Start(start),
-                }),
-            ..
-        } = args.command
-        else {
-            panic!("expected gateway daemon start");
-        };
-
-        assert_eq!(start.gateway_idle_timeout_secs, 0);
-    }
-
-    #[test]
-    fn gateway_daemon_restart_defaults_to_persistent_daemon() {
-        let args = Args::parse_from(["dcc-mcp-cli", "gateway", "daemon", "restart"]);
-
-        let Command::Gateway {
-            action:
-                Some(GatewayAction::Daemon {
-                    action: GatewayDaemonAction::Restart(restart),
-                }),
-            ..
-        } = args.command
-        else {
-            panic!("expected gateway daemon restart");
-        };
-
-        assert_eq!(restart.start.gateway_idle_timeout_secs, 0);
-        assert_eq!(restart.stop_timeout_secs, 10);
-    }
-
-    fn default_gateway_daemon_args() -> dcc_mcp_sidecar::gateway_daemon::GatewayArgs {
-        dcc_mcp_sidecar::gateway_daemon::GatewayArgs {
-            host: "127.0.0.1".to_string(),
-            port: 9765,
-            name: None,
-            remote_host: "0.0.0.0".to_string(),
-            remote_port: 59765,
-            registry_dir: None,
-            no_admin: false,
-            admin_path: "/admin".to_string(),
-            stale_timeout_secs: 30,
-            relay_sources: Vec::new(),
-            gateway_persist: false,
-            gateway_idle_timeout_secs: 30,
-            semantic_search_enabled: false,
-            daemon: false,
-            pidfile: None,
-            restart: false,
-        }
-    }
-}
+#[path = "cli/tests.rs"]
+mod tests;

--- a/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
@@ -1,0 +1,278 @@
+use super::*;
+
+#[test]
+fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
+    let local = GatewayTarget::Local;
+    let remote = GatewayTarget::Remote {
+        name: "pcA".to_string(),
+        endpoint: Endpoint::new(DEFAULT_BASE_URL),
+    };
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::Smoke {
+                url: None,
+                query: "sphere".to_string(),
+                limit: 5,
+                timeout_secs: 5,
+            },
+            &local,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::Smoke {
+                url: Some("http://127.0.0.1:8765/mcp".to_string()),
+                query: "sphere".to_string(),
+                limit: 5,
+                timeout_secs: 5,
+            },
+            &local,
+        )
+        .is_none()
+    );
+    assert!(gateway_endpoint_for_command(DEFAULT_BASE_URL, &Command::Health, &local).is_some());
+    assert!(gateway_endpoint_for_command(DEFAULT_BASE_URL, &Command::List, &local).is_some());
+    assert!(gateway_endpoint_for_command(DEFAULT_BASE_URL, &Command::List, &remote).is_some());
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::Search {
+                query: Some("sphere".to_string()),
+                dcc_type: None,
+                instance_id: None,
+                limit: None,
+            },
+            &local,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::Describe {
+                tool_slug: "maya.abc12345.create_sphere".to_string(),
+            },
+            &local,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::LoadSkill {
+                skill_name: Some("maya-modeling".to_string()),
+                dcc_type: Some("maya".to_string()),
+                dcc: None,
+                instance_id: Some("abc12345".to_string()),
+                activate_groups: None,
+                request_json: None,
+            },
+            &local,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::Call {
+                tool_slug: "maya.abc12345.create_sphere".to_string(),
+                dcc_type: None,
+                instance_id: None,
+                arguments_json: "{}".to_string(),
+                meta_json: None,
+                timeout_secs: 30,
+            },
+            &local,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::WaitReady {
+                dcc_type: Some("maya".to_string()),
+                instance_id: Some("abc12345".to_string()),
+                require: vec!["process".to_string(), "dispatcher".to_string()],
+                timeout_secs: 30,
+                interval_secs: 1,
+            },
+            &local,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::ReloadSkills {
+                dcc_type: Some("maya".to_string()),
+                instance_id: Some("abc12345".to_string()),
+            },
+            &local,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::StopInstance {
+                dcc_type: "maya".to_string(),
+                instance_id: "abc12345".to_string(),
+                expected_owner: Some("release-smoke-test".to_string()),
+                expected_session: Some("test".to_string()),
+            },
+            &local,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::Search {
+                query: Some("sphere".to_string()),
+                dcc_type: None,
+                instance_id: None,
+                limit: None,
+            },
+            &remote,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::ReloadSkills {
+                dcc_type: Some("maya".to_string()),
+                instance_id: Some("abc12345".to_string()),
+            },
+            &remote,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::Update {
+                action: UpdateAction::Check {
+                    binary: Some("dcc-mcp-server".to_string()),
+                    current_version: Some("0.0.0".to_string()),
+                },
+            },
+            &local,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::Doctor {
+                registry_dir: None,
+                gateway_host: "127.0.0.1".to_string(),
+                gateway_port: 9765,
+            },
+            &local,
+        )
+        .is_none()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::Marketplace {
+                action: MarketplaceAction::List,
+            },
+            &local,
+        )
+        .is_none()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::Gateway {
+                action: Some(GatewayAction::Status(GatewayStatusArgs {
+                    host: "127.0.0.1".to_string(),
+                    port: 9765,
+                    registry_dir: None,
+                })),
+                daemon: default_gateway_daemon_args(),
+            },
+            &local,
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn call_parses_configurable_request_timeout() {
+    let args = Args::parse_from([
+        "dcc-mcp-cli",
+        "call",
+        "blender.abc12345.render",
+        "--timeout-secs",
+        "120",
+    ]);
+
+    let Command::Call { timeout_secs, .. } = args.command else {
+        panic!("expected call command");
+    };
+    assert_eq!(timeout_secs, 120);
+}
+
+#[test]
+fn gateway_daemon_start_defaults_to_persistent_daemon() {
+    let args = Args::parse_from(["dcc-mcp-cli", "gateway", "daemon", "start"]);
+
+    let Command::Gateway {
+        action:
+            Some(GatewayAction::Daemon {
+                action: GatewayDaemonAction::Start(start),
+            }),
+        ..
+    } = args.command
+    else {
+        panic!("expected gateway daemon start");
+    };
+
+    assert_eq!(start.gateway_idle_timeout_secs, 0);
+}
+
+#[test]
+fn gateway_daemon_restart_defaults_to_persistent_daemon() {
+    let args = Args::parse_from(["dcc-mcp-cli", "gateway", "daemon", "restart"]);
+
+    let Command::Gateway {
+        action:
+            Some(GatewayAction::Daemon {
+                action: GatewayDaemonAction::Restart(restart),
+            }),
+        ..
+    } = args.command
+    else {
+        panic!("expected gateway daemon restart");
+    };
+
+    assert_eq!(restart.start.gateway_idle_timeout_secs, 0);
+    assert_eq!(restart.stop_timeout_secs, 10);
+}
+
+fn default_gateway_daemon_args() -> dcc_mcp_sidecar::gateway_daemon::GatewayArgs {
+    dcc_mcp_sidecar::gateway_daemon::GatewayArgs {
+        host: "127.0.0.1".to_string(),
+        port: 9765,
+        name: None,
+        remote_host: "0.0.0.0".to_string(),
+        remote_port: 59765,
+        registry_dir: None,
+        no_admin: false,
+        admin_path: "/admin".to_string(),
+        stale_timeout_secs: 30,
+        relay_sources: Vec::new(),
+        gateway_persist: false,
+        gateway_idle_timeout_secs: 30,
+        semantic_search_enabled: false,
+        daemon: false,
+        pidfile: None,
+        restart: false,
+    }
+}


### PR DESCRIPTION
Adds a per-call timeout option and DCC_MCP_CLI_CALL_TIMEOUT_SECS environment override while preserving the 30-second default. Applies consistently to local and remote routing.

Validation: full dcc-mcp-cli test suite, formatting, and a live 35-second Blender tool call.