### PR TITLE
fix: audit healthy gateway versions in guardian

### DIFF
--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -219,6 +219,39 @@ def _wait_gateway_ready(host: str, port: int, *, timeout_secs: float, probe_time
     return False
 
 
+def _wait_managed_gateway_ready(
+    host: str,
+    port: int,
+    *,
+    registry_dir: str | None,
+    minimum_version: str,
+    timeout_secs: float,
+    probe_timeout: float = 0.5,
+) -> bool:
+    """Wait for a healthy gateway with a formal ownership sentinel.
+
+    A healthy port alone is insufficient during takeover: an older guardian
+    can win the bind race and make the endpoint look ready. The Rust gateway
+    sentinel includes process ownership fields that the temporary Python
+    challenger row deliberately lacks.
+    """
+    deadline = time.time() + max(timeout_secs, 0.2)
+    while time.time() < deadline:
+        managed_version = _read_managed_gateway_version_from_registry(
+            registry_dir,
+            gateway_host=host,
+            gateway_port=port,
+        )
+        version_is_acceptable = managed_version is not None and not _is_newer_version(
+            minimum_version,
+            managed_version,
+        )
+        if version_is_acceptable and _is_healthy(host, port, timeout=probe_timeout):
+            return True
+        time.sleep(0.1)
+    return False
+
+
 def _resolve_gateway_persist(gateway_persist: bool | None) -> bool:
     if gateway_persist is not None:
         return bool(gateway_persist)
@@ -365,7 +398,13 @@ def _try_version_takeover(
 
     if not acquired:
         # Another process is spawning — wait for it.
-        if _wait_gateway_ready(gateway_host, gateway_port, timeout_secs=timeout_secs):
+        if _wait_managed_gateway_ready(
+            gateway_host,
+            gateway_port,
+            registry_dir=str(registry_path),
+            minimum_version=our_version,
+            timeout_secs=timeout_secs,
+        ):
             return {"ok": True, "reason": "takeover_spawned_by_peer"}
         return {"ok": False, "reason": "takeover_lock_in_progress_timeout"}
 
@@ -391,7 +430,13 @@ def _try_version_takeover(
         except Exception as exc:
             return {"ok": False, "reason": "takeover_spawn_failed", "error": str(exc), "command": cmd}
 
-        if _wait_gateway_ready(gateway_host, gateway_port, timeout_secs=timeout_secs):
+        if _wait_managed_gateway_ready(
+            gateway_host,
+            gateway_port,
+            registry_dir=str(registry_path),
+            minimum_version=our_version,
+            timeout_secs=timeout_secs,
+        ):
             return {
                 "ok": True,
                 "reason": "version_takeover_spawned",
@@ -402,7 +447,7 @@ def _try_version_takeover(
                 "new_version": our_version,
             }
 
-        return {"ok": False, "reason": "takeover_spawn_timeout", "command": cmd}
+        return {"ok": False, "reason": "takeover_managed_ready_timeout", "command": cmd}
     finally:
         launch_lock.release()
 
@@ -605,6 +650,19 @@ class GatewayDaemonGuardian:
 
         if _is_healthy(self.gateway_host, self.gateway_port, timeout=self.probe_timeout_secs):
             self._consecutive_failures = 0
+            takeover_result = _try_version_takeover(
+                gateway_host=self.gateway_host,
+                gateway_port=self.gateway_port,
+                registry_dir=self.registry_dir,
+                dcc_type=self.dcc_type,
+                timeout_secs=self.restart_timeout_secs,
+                gateway_persist=None,
+                gateway_idle_timeout_secs=None,
+                server_bin=None,
+            )
+            if takeover_result is not None:
+                self._restart_attempts += 1
+                return self._publish(takeover_result)
             return self._publish({"ok": True, "reason": "healthy", "consecutive_failures": 0})
 
         self._consecutive_failures += 1
@@ -836,6 +894,49 @@ def _read_gateway_version_from_registry(
                 version = entry.get("version")
                 if isinstance(version, str):
                     return version
+    return None
+
+
+def _read_managed_gateway_version_from_registry(
+    registry_dir: str | None,
+    *,
+    gateway_host: str,
+    gateway_port: int,
+) -> str | None:
+    """Return the version only for a process-owned Rust gateway sentinel."""
+    import json as _json
+
+    try:
+        services_file = _resolve_registry_dir(registry_dir) / "services.json"
+        raw = services_file.read_text(encoding="utf-8")
+        data = _json.loads(raw) if raw.strip() else []
+    except Exception:
+        return None
+
+    entries: list[object]
+    if isinstance(data, dict):
+        sentinel_key = f"__gateway__:{gateway_host}:{gateway_port}"
+        entries = [data.get(sentinel_key)]
+    elif isinstance(data, list):
+        entries = data
+    else:
+        return None
+
+    for entry in entries:
+        if not isinstance(entry, dict) or entry.get("dcc_type") != "__gateway__":
+            continue
+        if entry.get("host") != gateway_host:
+            continue
+        try:
+            if int(entry.get("port", 0)) != int(gateway_port):
+                continue
+            pid = int(entry.get("pid", 0))
+        except (TypeError, ValueError):
+            continue
+        instance_id = entry.get("instance_id")
+        version = entry.get("version")
+        if pid > 0 and isinstance(instance_id, str) and instance_id and isinstance(version, str):
+            return version
     return None
 
 

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -419,6 +419,7 @@ def test_gateway_daemon_guardian_jitter_skips_when_peer_recovers(monkeypatch):
 def test_gateway_daemon_guardian_resets_failures_on_health(monkeypatch):
     checks = iter([False, True])
     monkeypatch.setattr(gg, "_is_healthy", lambda *_a, **_k: next(checks))
+    monkeypatch.setattr(gg, "_try_version_takeover", lambda **_kwargs: None)
     guardian = gg.GatewayDaemonGuardian(
         gateway_host="127.0.0.1",
         gateway_port=9765,
@@ -433,6 +434,42 @@ def test_gateway_daemon_guardian_resets_failures_on_health(monkeypatch):
     assert first["reason"] == "probe_failed"
     assert second["reason"] == "healthy"
     assert second["consecutive_failures"] == 0
+
+
+def test_gateway_daemon_guardian_audits_version_when_endpoint_is_healthy(monkeypatch, tmp_path):
+    """A healthy stale gateway must still enter the version takeover path."""
+    monkeypatch.setattr(gg, "_is_healthy", lambda *_a, **_k: True)
+    calls = []
+
+    def _takeover(**kwargs):
+        calls.append(kwargs)
+        return {"ok": True, "reason": "version_takeover_spawned"}
+
+    monkeypatch.setattr(gg, "_try_version_takeover", _takeover)
+    guardian = gg.GatewayDaemonGuardian(
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        registry_dir=str(tmp_path),
+        dcc_type="houdini",
+        restart_timeout_secs=17.0,
+    )
+
+    result = guardian.probe_once()
+
+    assert result["reason"] == "version_takeover_spawned"
+    assert result["restart_attempts"] == 1
+    assert calls == [
+        {
+            "gateway_host": "127.0.0.1",
+            "gateway_port": 9765,
+            "registry_dir": str(tmp_path),
+            "dcc_type": "houdini",
+            "timeout_secs": 17.0,
+            "gateway_persist": None,
+            "gateway_idle_timeout_secs": None,
+            "server_bin": None,
+        }
+    ]
 
 
 def test_guardian_run_catches_crash_and_increments_crash_count(monkeypatch):
@@ -999,6 +1036,49 @@ def test_read_gateway_version_missing_registry():
     )
 
 
+def test_wait_managed_gateway_ready_rejects_health_only_challenger(monkeypatch, tmp_path):
+    """A temporary challenger sentinel cannot prove gateway ownership."""
+    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: True)
+    gg._write_sentinel_entry(
+        str(tmp_path),
+        gateway_host="127.0.0.1",
+        gateway_port=9765,
+        crate_version="0.19.23",
+    )
+
+    assert not gg._wait_managed_gateway_ready(
+        "127.0.0.1",
+        9765,
+        registry_dir=str(tmp_path),
+        minimum_version="0.19.23",
+        timeout_secs=0.01,
+    )
+
+
+def test_wait_managed_gateway_ready_accepts_owned_same_version(monkeypatch, tmp_path):
+    """A healthy process-owned sentinel satisfies the takeover contract."""
+    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: True)
+    services = [
+        {
+            "dcc_type": "__gateway__",
+            "instance_id": "gateway-instance",
+            "host": "127.0.0.1",
+            "port": 9765,
+            "version": "0.19.23",
+            "pid": 4242,
+        }
+    ]
+    (tmp_path / "services.json").write_text(json.dumps(services), encoding="utf-8")
+
+    assert gg._wait_managed_gateway_ready(
+        "127.0.0.1",
+        9765,
+        registry_dir=str(tmp_path),
+        minimum_version="0.19.23",
+        timeout_secs=0.2,
+    )
+
+
 def test_ensure_gateway_daemon_skips_takeover_when_gateway_newer(monkeypatch, tmp_path):
     """P0-3: No takeover when running gateway version is same or newer."""
     monkeypatch.setattr(gg, "urlopen", lambda *args, **kwargs: _Resp())
@@ -1053,7 +1133,7 @@ def test_try_version_takeover_uses_admin_health_and_cooperative_yield(monkeypatc
     monkeypatch.setattr(gg, "_read_gateway_version_from_admin_health", lambda *a, **k: "0.18.20")
     monkeypatch.setattr(gg, "_request_gateway_yield", lambda *a, **k: yield_requests.append(k) or True)
     monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: False)
-    monkeypatch.setattr(gg, "_wait_gateway_ready", lambda *a, **k: True)
+    monkeypatch.setattr(gg, "_wait_managed_gateway_ready", lambda *a, **k: True)
 
     def _launch_detached(cmd, **kwargs):
         launches.append((cmd, kwargs))


### PR DESCRIPTION
## Summary
- audit the running gateway version even when its health endpoint succeeds
- require a process-owned gateway sentinel before declaring a version takeover successful
- prevent a stale gateway from winning the restart race behind a healthy port

## Validation
- `ruff check python/dcc_mcp_core/_server/gateway_guardian.py tests/test_gateway_guardian.py`
- `pytest tests/test_gateway_guardian.py -q` (53 passed)
- live old-to-current gateway takeover with formal sentinel ownership