### PR TITLE
fix: reregister live instances after registry loss

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handle.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handle.rs
@@ -62,6 +62,9 @@ pub struct GatewayHandle {
     /// sentinel key for winners); `Drop` drains the vector so a second
     /// call is a no-op. See issue #718.
     pub(crate) pending_deregister: Vec<ServiceKey>,
+    /// Prevents a concurrent heartbeat from republishing the instance after
+    /// clean shutdown has started.
+    pub(crate) registration_active: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl GatewayHandle {
@@ -116,6 +119,11 @@ impl GatewayHandle {
     /// succeeds. On the rare contention case we log and leave the row —
     /// the existing `stale_timeout_secs` cleanup path still purges it.
     pub fn deregister_all(&mut self) {
+        self.registration_active
+            .store(false, std::sync::atomic::Ordering::Release);
+        if let Some(heartbeat) = self.heartbeat_abort.take() {
+            heartbeat.abort();
+        }
         if self.pending_deregister.is_empty() {
             return;
         }

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -13,6 +13,100 @@ fn panic_message(info: &dyn std::any::Any) -> String {
     }
 }
 
+fn apply_live_snapshot(entry: &mut ServiceEntry, snapshot: &LiveSnapshot) {
+    if let Some(scene) = &snapshot.scene {
+        entry.scene = (!scene.is_empty()).then(|| scene.clone());
+    }
+    if let Some(version) = &snapshot.version {
+        entry.version = (!version.is_empty()).then(|| version.clone());
+    }
+    if !snapshot.documents.is_empty() {
+        entry.documents = snapshot
+            .documents
+            .iter()
+            .filter(|document| !document.is_empty())
+            .cloned()
+            .collect();
+        if let Some(display_name) = &snapshot.display_name {
+            entry.display_name = (!display_name.is_empty()).then(|| display_name.clone());
+        }
+    }
+    for (name, value) in &snapshot.metadata {
+        if value.is_empty() {
+            entry.metadata.remove(name);
+        } else {
+            entry.metadata.insert(name.clone(), value.clone());
+        }
+    }
+    entry.touch();
+}
+
+fn refresh_or_republish_registration(
+    registry: &FileRegistry,
+    key: &ServiceKey,
+    template: &ServiceEntry,
+    provider: Option<&MetadataProvider>,
+    registration_active: &std::sync::atomic::AtomicBool,
+) {
+    let (refresh_result, snapshot) = if let Some(provider) = provider {
+        let snapshot = provider();
+        let primary_result = if snapshot.documents.is_empty() {
+            registry.update_metadata(key, snapshot.scene.as_deref(), snapshot.version.as_deref())
+        } else {
+            registry.update_documents(
+                key,
+                snapshot.scene.as_deref(),
+                &snapshot.documents,
+                snapshot.display_name.as_deref(),
+            )
+        };
+        let refresh_result = match primary_result {
+            Ok(true) if !snapshot.metadata.is_empty() => {
+                registry.update_instance_metadata(key, &snapshot.metadata)
+            }
+            other => other,
+        };
+        (refresh_result, Some(snapshot))
+    } else {
+        (registry.heartbeat(key), None)
+    };
+
+    match refresh_result {
+        Ok(true) => {}
+        Ok(false) if registration_active.load(std::sync::atomic::Ordering::Acquire) => {
+            let mut recovered = template.clone();
+            if let Some(snapshot) = &snapshot {
+                apply_live_snapshot(&mut recovered, snapshot);
+            } else {
+                recovered.touch();
+            }
+            if !registration_active.load(std::sync::atomic::Ordering::Acquire) {
+                return;
+            }
+            match registry.register(recovered) {
+                Ok(()) => tracing::warn!(
+                    dcc_type = %key.dcc_type,
+                    instance_id = %key.instance_id,
+                    "FileRegistry row disappeared; heartbeat re-registered the live instance"
+                ),
+                Err(error) => tracing::warn!(
+                    error = %error,
+                    dcc_type = %key.dcc_type,
+                    instance_id = %key.instance_id,
+                    "heartbeat failed to re-register the missing FileRegistry row"
+                ),
+            }
+        }
+        Ok(false) => {}
+        Err(error) => tracing::warn!(
+            error = %error,
+            dcc_type = %key.dcc_type,
+            instance_id = %key.instance_id,
+            "FileRegistry heartbeat refresh failed"
+        ),
+    }
+}
+
 /// Orchestrates FileRegistry registration, heartbeat, stale cleanup, and the
 /// optional gateway HTTP server.
 pub struct GatewayRunner {
@@ -86,6 +180,8 @@ impl GatewayRunner {
         metadata_provider: Option<MetadataProvider>,
     ) -> Result<GatewayHandle, Box<dyn std::error::Error + Send + Sync>> {
         let service_key = entry.key();
+        let registration_template = entry.clone();
+        let registration_active = Arc::new(std::sync::atomic::AtomicBool::new(true));
 
         // ── Register in FileRegistry ─────────────────────────────────────
         {
@@ -108,42 +204,30 @@ impl GatewayRunner {
             let key = service_key.clone();
             let secs = self.config.heartbeat_secs;
             let provider = metadata_provider;
+            let template = registration_template;
+            let active = registration_active.clone();
             let h = tokio::spawn(async move {
                 loop {
                     let reg = reg.clone();
                     let key_inner = key.clone();
                     let provider = provider.clone();
+                    let template = template.clone();
+                    let active = active.clone();
                     let result = std::panic::AssertUnwindSafe(async move {
                         let mut tick = tokio::time::interval(Duration::from_secs(secs));
                         loop {
                             tick.tick().await;
-                            let r = reg.read().await;
-                            if let Some(ref prov) = provider {
-                                let snap = prov();
-                                if !snap.documents.is_empty() {
-                                    // Multi-document DCC (Photoshop, After Effects…):
-                                    // update active document + full open-document list + label.
-                                    let _ = r.update_documents(
-                                        &key_inner,
-                                        snap.scene.as_deref(),
-                                        &snap.documents,
-                                        snap.display_name.as_deref(),
-                                    );
-                                } else {
-                                    // Single-document DCC (Maya, Blender, Houdini…):
-                                    // update scene path and version only.
-                                    let _ = r.update_metadata(
-                                        &key_inner,
-                                        snap.scene.as_deref(),
-                                        snap.version.as_deref(),
-                                    );
-                                }
-                                if !snap.metadata.is_empty() {
-                                    let _ = r.update_instance_metadata(&key_inner, &snap.metadata);
-                                }
-                            } else {
-                                let _ = r.heartbeat(&key_inner);
+                            if !active.load(std::sync::atomic::Ordering::Acquire) {
+                                break;
                             }
+                            let r = reg.read().await;
+                            refresh_or_republish_registration(
+                                &r,
+                                &key_inner,
+                                &template,
+                                provider.as_ref(),
+                                &active,
+                            );
                         }
                     })
                     .catch_unwind()
@@ -211,6 +295,7 @@ impl GatewayRunner {
             challenger_abort,
             registry: self.registry.clone(),
             pending_deregister,
+            registration_active,
         })
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tests.rs
@@ -641,6 +641,111 @@ async fn test_gateway_heartbeat_merges_live_instance_metadata() {
 }
 
 #[tokio::test]
+async fn test_gateway_heartbeat_reregisters_missing_instance_row() {
+    let dir = tempfile::tempdir().unwrap();
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = occupied.local_addr().unwrap().port();
+
+    let cfg = GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        gateway_port: port,
+        heartbeat_secs: 1,
+        registry_dir: Some(dir.path().to_path_buf()),
+        ..GatewayConfig::default()
+    };
+    let runner = GatewayRunner::new(cfg).unwrap();
+
+    let entry = ServiceEntry::new("blender", "127.0.0.1", 18888);
+    let key = entry.key();
+    let provider: MetadataProvider = std::sync::Arc::new(|| LiveSnapshot {
+        scene: Some("recovered.blend".to_string()),
+        version: Some("5.0.1".to_string()),
+        metadata: std::collections::HashMap::from([(
+            "gateway_guardian_enabled".to_string(),
+            "true".to_string(),
+        )]),
+        ..LiveSnapshot::default()
+    });
+    let handle = runner.start(entry, Some(provider)).await.unwrap();
+
+    {
+        let reg = runner.registry.read().await;
+        assert!(reg.deregister(&key).unwrap().is_some());
+        assert!(reg.get(&key).is_none());
+    }
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        {
+            let reg = runner.registry.read().await;
+            if let Some(row) = reg.get(&key) {
+                assert_eq!(row.scene.as_deref(), Some("recovered.blend"));
+                assert_eq!(row.version.as_deref(), Some("5.0.1"));
+                assert_eq!(
+                    row.metadata
+                        .get("gateway_guardian_enabled")
+                        .map(String::as_str),
+                    Some("true")
+                );
+                break;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "live instance heartbeat did not republish a missing FileRegistry row"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    drop(handle);
+    drop(occupied);
+}
+
+#[tokio::test]
+async fn test_gateway_heartbeat_recovery_stops_after_explicit_deregister() {
+    let dir = tempfile::tempdir().unwrap();
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = occupied.local_addr().unwrap().port();
+    let cfg = GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        gateway_port: port,
+        heartbeat_secs: 1,
+        registry_dir: Some(dir.path().to_path_buf()),
+        ..GatewayConfig::default()
+    };
+    let runner = GatewayRunner::new(cfg).unwrap();
+    let entry = ServiceEntry::new("houdini", "127.0.0.1", 18889);
+    let key = entry.key();
+    let mut handle = runner.start(entry, None).await.unwrap();
+
+    {
+        let reg = runner.registry.read().await;
+        assert!(reg.deregister(&key).unwrap().is_some());
+    }
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        if runner.registry.read().await.get(&key).is_some() {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "heartbeat without a metadata provider did not republish the row"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    handle.deregister_all();
+    tokio::time::sleep(Duration::from_millis(1_200)).await;
+    assert!(
+        runner.registry.read().await.get(&key).is_none(),
+        "shutdown heartbeat must not republish an explicitly deregistered row"
+    );
+
+    drop(handle);
+    drop(occupied);
+}
+
+#[tokio::test]
 async fn test_explicit_deregister_all_is_idempotent() {
     // `McpServerHandle::shutdown` calls `deregister_all` explicitly
     // before dropping the gateway. Verify both the explicit path and


### PR DESCRIPTION
## Summary
- republish a live DCC instance when its FileRegistry row disappears during gateway recovery
- preserve the original instance UUID while merging the latest scene, version, documents, and runtime metadata
- stop heartbeat recovery before explicit deregistration so clean shutdown cannot resurrect a row

## Root cause
The heartbeat loop treated a missing registry key as a successful no-op. A gateway handoff could therefore leave healthy DCC processes permanently undiscoverable.

## Validation
- regression reproduced before the fix
- `cargo test -p dcc-mcp-gateway --lib --quiet` (505 passed)
- `cargo fmt --all -- --check`