### PR TITLE
fix: reuse registry sentinel during live republish

### DIFF
--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -561,9 +561,18 @@ impl FileRegistry {
                 port = entry.port,
                 "registering service"
             );
-            let (sentinel_path, sentinel_file) = self.create_sentinel(&key)?;
-            entry.sentinel_path = Some(sentinel_path);
-            self.sentinel_handles.insert(key.clone(), sentinel_file);
+            if self.sentinel_handles.contains_key(&key) {
+                // Re-registering a row owned by this process must reuse the
+                // existing sentinel handle. On Windows, opening the same file
+                // again and taking an exclusive lock is not re-entrant and
+                // would deadlock while this transaction still owns the global
+                // registry lock.
+                entry.sentinel_path = Some(self.sentinel_path_for(&key));
+            } else {
+                let (sentinel_path, sentinel_file) = self.create_sentinel(&key)?;
+                entry.sentinel_path = Some(sentinel_path);
+                self.sentinel_handles.insert(key.clone(), sentinel_file);
+            }
             self.services.insert(key, entry);
             Ok(((), true))
         })

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -663,6 +663,27 @@ fn test_missing_registry_file_during_transaction_clears_snapshot() {
 }
 
 #[test]
+fn test_register_same_owned_key_reuses_sentinel_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    let mut entry = ServiceEntry::new("blender", "127.0.0.1", 61142);
+    let key = entry.key();
+    registry.register(entry.clone()).unwrap();
+
+    std::fs::remove_file(registry.registry_file_path()).unwrap();
+    entry.version = Some("5.0.1".to_string());
+    registry.register(entry).unwrap();
+
+    let recovered = FileRegistry::new(dir.path())
+        .unwrap()
+        .get(&key)
+        .expect("same process should republish its missing row");
+    assert_eq!(recovered.version.as_deref(), Some("5.0.1"));
+    assert_eq!(registry.sentinel_handles.len(), 1);
+}
+
+#[test]
 fn test_empty_registry_file_during_transaction_clears_snapshot() {
     let dir = tempfile::tempdir().unwrap();
     let registry = FileRegistry::new(dir.path()).unwrap();


### PR DESCRIPTION
## Summary
- reuse an already-owned sentinel when a live instance republishes the same registry key
- prevent Windows lock re-entry from blocking the global registry writer
- add regression coverage for registry loss followed by same-UUID republish

## Validation
- cargo test -p dcc-mcp-transport --lib --quiet
- cargo test -p dcc-mcp-gateway --lib --quiet
- cargo fmt --all --check