### PR TITLE
fix: register adapter skill reload tool

### DIFF
--- a/python/dcc_mcp_core/_server/skill_discovery.py
+++ b/python/dcc_mcp_core/_server/skill_discovery.py
@@ -174,6 +174,7 @@ class SkillDiscoveryController:
                 dcc_window_handle=owner._dcc_window_handle,
                 dcc_window_title=owner._dcc_window_title,
                 gateway_failover_resolver=owner.get_gateway_election_status,
+                reload_skills=owner.reload_skill_paths,
             )
         except Exception as exc:
             logger.warning("[%s] built-in skill registration failed: %s", options.dcc_name, exc)

--- a/python/dcc_mcp_core/admin_tools.py
+++ b/python/dcc_mcp_core/admin_tools.py
@@ -1,0 +1,43 @@
+"""Administrative tools shared by every DCC adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def register_admin_tools(
+    server: Any,
+    *,
+    dcc_name: str,
+    reload_skills: Callable[[], int],
+) -> None:
+    """Register the adapter-side skill catalog refresh contract."""
+    name = "dcc_admin__reload_skills"
+    try:
+        server.registry.register(
+            name=name,
+            description="Re-scan configured skill paths without restarting the DCC.",
+            input_schema=json.dumps({"type": "object", "properties": {}, "additionalProperties": False}),
+            dcc=dcc_name,
+            category="admin",
+            version="1.0.0",
+            source_file="",
+        )
+        server.register_handler(
+            name,
+            lambda _params: {
+                "success": True,
+                "reloaded": True,
+                "skill_count": int(reload_skills()),
+            },
+        )
+    except Exception as exc:
+        logger.warning("register_admin_tools failed for %s: %s", name, exc)
+
+
+__all__ = ["register_admin_tools"]

--- a/python/dcc_mcp_core/skills/builtin.py
+++ b/python/dcc_mcp_core/skills/builtin.py
@@ -11,6 +11,7 @@ import logging
 from typing import Any
 from typing import Callable
 
+from dcc_mcp_core.admin_tools import register_admin_tools
 from dcc_mcp_core.dcc_server import register_diagnostic_mcp_tools
 from dcc_mcp_core.feedback import register_feedback_tool
 from dcc_mcp_core.introspect import register_introspect_tools
@@ -29,6 +30,7 @@ def register_all_builtin_skills(
     dcc_window_handle: int | None = None,
     dcc_window_title: str | None = None,
     gateway_failover_resolver: Callable[[], dict[str, Any]] | None = None,
+    reload_skills: Callable[[], int] | None = None,
     skills: list[Any] | None = None,
 ) -> None:
     """Register all standard built-in tools on *server*.
@@ -52,6 +54,9 @@ def register_all_builtin_skills(
     populated set (registration is idempotent).
     """
     logger.debug("[%s] Registering all built-in skills", dcc_name)
+
+    if reload_skills is not None:
+        register_admin_tools(server, dcc_name=dcc_name, reload_skills=reload_skills)
 
     # 1. Diagnostics (audit log, metrics, screenshot, gateway failover)
     register_diagnostic_mcp_tools(

--- a/tests/test_admin_tools.py
+++ b/tests/test_admin_tools.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dcc_mcp_core.admin_tools import register_admin_tools
+
+
+class _Registry:
+    def __init__(self) -> None:
+        self.registered: dict = {}
+
+    def register(self, **kwargs) -> None:
+        self.registered[kwargs["name"]] = kwargs
+
+
+class _Server:
+    def __init__(self) -> None:
+        self.registry = _Registry()
+        self.handlers: dict = {}
+
+    def register_handler(self, name, handler) -> None:
+        self.handlers[name] = handler
+
+
+def test_reload_skills_tool_invokes_adapter_rescan() -> None:
+    server = _Server()
+    calls = 0
+
+    def reload_skills() -> int:
+        nonlocal calls
+        calls += 1
+        return 17
+
+    register_admin_tools(server, dcc_name="houdini", reload_skills=reload_skills)
+
+    result = server.handlers["dcc_admin__reload_skills"]({})
+    assert result == {"success": True, "reloaded": True, "skill_count": 17}
+    assert calls == 1
+    assert server.registry.registered["dcc_admin__reload_skills"]["category"] == "admin"

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -38,17 +38,18 @@ def test_register_all_builtin_skills_runs_every_step(monkeypatch):
         recipes_kwargs.update(kwargs)
 
     monkeypatch.setattr(builtin, "register_diagnostic_mcp_tools", _recorder("diagnostics"))
+    monkeypatch.setattr(builtin, "register_admin_tools", _recorder("admin"))
     monkeypatch.setattr(builtin, "register_introspect_tools", _recorder("introspect"))
     monkeypatch.setattr(builtin, "register_feedback_tool", _recorder("feedback"))
     monkeypatch.setattr(builtin, "register_recipes_tools", _recipes)
     monkeypatch.setattr(builtin, "register_qt_ui_inspector", _recorder("qt"))
     monkeypatch.setattr(builtin, "register_script_materialization_tools", _recorder("materialize"))
 
-    builtin.register_all_builtin_skills(_make_server(), dcc_name="maya")
+    builtin.register_all_builtin_skills(_make_server(), dcc_name="maya", reload_skills=lambda: 0)
 
     # Every step, including the two that previously got skipped after the
     # TypeError, must have executed in order.
-    assert calls == ["diagnostics", "introspect", "feedback", "recipes", "qt", "materialize"]
+    assert calls == ["admin", "diagnostics", "introspect", "feedback", "recipes", "qt", "materialize"]
     # recipes must be invoked with an (empty) skills list, never omitted.
     assert "skills" in recipes_kwargs
     assert recipes_kwargs["skills"] == []
@@ -59,6 +60,7 @@ def test_register_all_builtin_skills_forwards_skills(monkeypatch):
     seen: dict = {}
 
     monkeypatch.setattr(builtin, "register_diagnostic_mcp_tools", lambda *a, **k: None)
+    monkeypatch.setattr(builtin, "register_admin_tools", lambda *a, **k: None)
     monkeypatch.setattr(builtin, "register_introspect_tools", lambda *a, **k: None)
     monkeypatch.setattr(builtin, "register_feedback_tool", lambda *a, **k: None)
     monkeypatch.setattr(builtin, "register_qt_ui_inspector", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- register `dcc_admin__reload_skills` on every adapter
- reuse `DccServerBase.reload_skill_paths()` for runtime catalog refresh
- cover builtin wiring and callback behavior

## Tests
- `pytest -q tests/test_admin_tools.py tests/test_builtin_skills.py tests/test_admin_skill_paths_reload.py`
- `ruff check` on changed Python files