### PR TITLE
fix: recreate missing registry sentinels

### DIFF
--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -561,14 +561,22 @@ impl FileRegistry {
                 port = entry.port,
                 "registering service"
             );
-            if self.sentinel_handles.contains_key(&key) {
+            let sentinel_path = self.sentinel_path_for(&key);
+            if self.sentinel_handles.contains_key(&key) && sentinel_path.exists() {
                 // Re-registering a row owned by this process must reuse the
                 // existing sentinel handle. On Windows, opening the same file
                 // again and taking an exclusive lock is not re-entrant and
                 // would deadlock while this transaction still owns the global
                 // registry lock.
-                entry.sentinel_path = Some(self.sentinel_path_for(&key));
+                entry.sentinel_path = Some(sentinel_path);
             } else {
+                // An external cleanup can unlink the sentinel while this
+                // process still owns the open handle. Reusing that orphaned
+                // handle would make every reader prune the recovered row
+                // again. Drop it and recreate the named, locked sentinel.
+                if let Some((_, file)) = self.sentinel_handles.remove(&key) {
+                    let _ = file.unlock();
+                }
                 let (sentinel_path, sentinel_file) = self.create_sentinel(&key)?;
                 entry.sentinel_path = Some(sentinel_path);
                 self.sentinel_handles.insert(key.clone(), sentinel_file);

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -249,6 +249,28 @@ fn test_file_registry_sentinel_survives_dead_pid_while_lock_held() {
 }
 
 #[test]
+fn test_reregister_recreates_missing_owned_sentinel() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+    let entry = ServiceEntry::new("blender", "127.0.0.1", 18812);
+    let key = entry.key();
+    registry.register(entry.clone()).unwrap();
+
+    let sentinel_path = registry.sentinel_path_for(&key);
+    let (_, stale_handle) = registry.sentinel_handles.remove(&key).unwrap();
+    stale_handle.unlock().unwrap();
+    std::fs::remove_file(&sentinel_path).unwrap();
+    registry.sentinel_handles.insert(key.clone(), stale_handle);
+
+    registry.register(entry).unwrap();
+
+    assert!(sentinel_path.exists());
+    let reader = FileRegistry::new(dir.path()).unwrap();
+    assert_eq!(reader.prune_dead_entries().unwrap(), 0);
+    assert!(reader.get(&key).is_some());
+}
+
+#[test]
 fn test_file_registry_sentinel_prunes_after_owner_drops_lock() {
     let dir = tempfile::tempdir().unwrap();
     let key = {


### PR DESCRIPTION
## Summary
- recreate an owned FileRegistry sentinel when its path disappears
- prevent live instances from oscillating in and out of gateway discovery
- cover re-registration with an external reader prune regression

## Validation
- `cargo test -p dcc-mcp-transport`
- `cargo clippy -p dcc-mcp-transport --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

No public API or skill guidance changes are required.