### PR TITLE
perf: deduplicate marketplace catalog fetches

### DIFF
--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -1,6 +1,7 @@
 //! Shared [`MarketplaceService`] — catalog fetch, install/uninstall, source
 //! management, installed state persistence, and integrity verification.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -391,9 +392,28 @@ impl MarketplaceService {
                 .collect()
         };
         let sources = self.list_sources()?;
+        let mut catalogs_by_url = HashMap::new();
+        for pkg in &filtered {
+            if catalogs_by_url.contains_key(&pkg.source_url) {
+                continue;
+            }
+            let source = sources
+                .iter()
+                .find(|source| source.url == pkg.source_url)
+                .cloned()
+                .unwrap_or_else(|| MarketplaceSource {
+                    name: pkg.source_name.clone(),
+                    url: pkg.source_url.clone(),
+                    origin: MarketplaceSourceOrigin::Explicit,
+                });
+            let entries = self.load_source_entries(&source).await?;
+            catalogs_by_url.insert(pkg.source_url.clone(), entries);
+        }
         let mut outdated = Vec::new();
         for pkg in filtered {
-            let entry = self.find_latest_entry_for_package(&sources, &pkg).await?;
+            let entry = catalogs_by_url
+                .get(&pkg.source_url)
+                .and_then(|entries| dcc_mcp_catalog::describe(entries, &pkg.name));
             let (is_outdated, latest_commit) = is_entry_outdated(entry.as_ref(), &pkg);
             if is_outdated && let Some(entry) = entry {
                 let latest_install = entry.install.as_ref();

--- a/crates/dcc-mcp-marketplace/src/service_tests.rs
+++ b/crates/dcc-mcp-marketplace/src/service_tests.rs
@@ -1,5 +1,93 @@
 use super::*;
 
+#[tokio::test]
+async fn outdated_fetches_each_catalog_once() {
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    let body = serde_json::json!({
+        "version": "1",
+        "entries": [
+            {
+                "name": "forest-assets",
+                "description": "Forest assets",
+                "dcc": ["blender"],
+                "version": "2.0.0"
+            },
+            {
+                "name": "rock-assets",
+                "description": "Rock assets",
+                "dcc": ["blender"],
+                "version": "2.0.0"
+            }
+        ]
+    })
+    .to_string();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let address = listener.local_addr().unwrap();
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let stopped = Arc::new(AtomicBool::new(false));
+    let server_count = request_count.clone();
+    let server_stopped = stopped.clone();
+    let server = std::thread::spawn(move || {
+        while !server_stopped.load(Ordering::Acquire) {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    if server_stopped.load(Ordering::Acquire) {
+                        break;
+                    }
+                    let mut request = [0_u8; 2048];
+                    let _ = stream.read(&mut request);
+                    server_count.fetch_add(1, Ordering::AcqRel);
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    )
+                    .unwrap();
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                Err(error) => panic!("catalog test server failed: {error}"),
+            }
+        }
+    });
+
+    let temp = tempfile::tempdir().unwrap();
+    let service = MarketplaceService::new(temp.path().to_path_buf());
+    let source_url = format!("http://{address}/marketplace.json");
+    for name in ["forest-assets", "rock-assets"] {
+        service
+            .upsert_installed(InstalledMarketplacePackage {
+                name: name.into(),
+                dcc: "blender".into(),
+                version: Some("1.0.0".into()),
+                path: temp.path().join(name).display().to_string(),
+                source_name: "local-test".into(),
+                source_url: source_url.clone(),
+                install_type: "git".into(),
+                install_url: None,
+                install_ref: None,
+                resolved_commit: None,
+                installed_at_ms: 1,
+            })
+            .unwrap();
+    }
+
+    let result = service.outdated(Some("blender"), Vec::new()).await.unwrap();
+    stopped.store(true, Ordering::Release);
+    let _ = TcpStream::connect(address);
+    server.join().unwrap();
+
+    assert_eq!(result.count, 2);
+    assert_eq!(request_count.load(Ordering::Acquire), 1);
+}
+
 #[test]
 fn pinned_git_revision_marks_unchanged_version_as_outdated() {
     let entry = CatalogEntry {


### PR DESCRIPTION
## Summary
- fetch each unique marketplace catalog once during outdated checks
- reuse the loaded entries for every installed package from that source
- add an HTTP regression proving two packages trigger one catalog request

## Validation
- `cargo test -p dcc-mcp-marketplace`
- `cargo clippy -p dcc-mcp-marketplace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

No public API or skill guidance changes are required.