### PR TITLE
fix: keep update e2e offline

### DIFF
--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -987,6 +987,8 @@ fn doctor_summarizes_local_direct_control_readiness() {
 
 #[test]
 fn update_check_auto_starts_builtin_local_gateway() {
+    let manifest_fixture = spawn_gateway_fixture();
+    let manifest_url = format!("{}/update-manifest.json", manifest_fixture.base_url);
     let port = unused_loopback_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let registry = TempDir::new().unwrap();
@@ -995,6 +997,7 @@ fn update_check_auto_starts_builtin_local_gateway() {
     let envs = [
         ("DCC_MCP_REGISTRY_DIR", registry_s.as_str()),
         ("DCC_MCP_GATEWAY_IDLE_TIMEOUT_SECS", "1"),
+        ("DCC_MCP_UPDATE_MANIFEST_URL", manifest_url.as_str()),
     ];
     let _cleanup = AutoGatewayCleanup {
         host: "127.0.0.1",

--- a/crates/dcc-mcp-cli/tests/support/mod.rs
+++ b/crates/dcc-mcp-cli/tests/support/mod.rs
@@ -82,6 +82,19 @@ pub(crate) fn spawn_gateway_fixture() -> GatewayFixture {
             get(|| async { Json(json!({"ok": true, "service": "dcc-mcp-gateway"})) }),
         )
         .route(
+            "/update-manifest.json",
+            get(|| async {
+                Json(json!({
+                    "dcc-mcp-server": {
+                        "version": "9.9.9",
+                        "url": "https://example.invalid/dcc-mcp-server.zip",
+                        "sha256": "abc123",
+                        "release_notes": "Fixture update"
+                    }
+                }))
+            }),
+        )
+        .route(
             "/mcp",
             post(|headers: HeaderMap, Json(body): Json<Value>| async move {
                 let accept = headers


### PR DESCRIPTION
## Summary
- serve a deterministic update manifest from the existing CLI test fixture
- keep the gateway auto-start update test independent of external network availability

## Validation
- target test passed 5 consecutive runs
- full CLI E2E: 19 passed
- clippy and formatting checks passed