### PR TITLE
fix: ignore transport metadata in Qt inspector calls

### DIFF
--- a/python/dcc_mcp_core/skills/qt_ui_inspector.py
+++ b/python/dcc_mcp_core/skills/qt_ui_inspector.py
@@ -483,6 +483,7 @@ def register_qt_ui_inspector(server: Any, *, dcc_name: str = "dcc") -> None:
     def _handler(fn):
         def wrapper(params: Any) -> Any:
             args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
+            args.pop("_meta", None)
             return fn(**args)
 
         return wrapper

--- a/tests/test_qt_ui_inspector.py
+++ b/tests/test_qt_ui_inspector.py
@@ -116,9 +116,9 @@ class TestRegisterQtUiInspector:
         register_qt_ui_inspector(server)
         handler = server.handlers["qt_ui_inspector__list_windows"]
         # dict form
-        r_dict = handler({"include_hidden": True})
+        r_dict = handler({"include_hidden": True, "_meta": {"trace_id": "dict"}})
         # json-string form
-        r_json = handler('{"include_hidden": true}')
+        r_json = handler('{"include_hidden": true, "_meta": {"trace_id": "json"}}')
         # Both must fail with qt-binding-unavailable (Qt is forced missing)
         _assert_unavailable(r_dict)
         _assert_unavailable(r_json)


### PR DESCRIPTION
## Summary
- drop transport-only \_meta\ before dispatching Qt inspector keyword arguments
- cover dict and JSON-string call payloads

## Validation
- focused handler regression check
- Ruff check
- git diff --check