### PR TITLE
fix: propagate reload skill failures

### DIFF
--- a/crates/dcc-mcp-cli/src/application/control_plane.rs
+++ b/crates/dcc-mcp-cli/src/application/control_plane.rs
@@ -200,9 +200,11 @@ impl DccControlPlane {
             }));
         }
 
+        let reloaded = results.iter().all(local_control::reload_result_succeeded);
+
         Ok(json!({
-            "ok": true,
-            "reloaded": true,
+            "ok": reloaded,
+            "reloaded": reloaded,
             "count": results.len(),
             "results": results,
             "source": "gateway",

--- a/crates/dcc-mcp-cli/src/application/local_control.rs
+++ b/crates/dcc-mcp-cli/src/application/local_control.rs
@@ -330,14 +330,28 @@ pub async fn reload_skills_local(
         results.push(payload);
     }
 
+    let reloaded = results.iter().all(reload_result_succeeded);
+
     Ok(json!({
-        "ok": true,
-        "reloaded": true,
+        "ok": reloaded,
+        "reloaded": reloaded,
         "count": results.len(),
         "results": results,
         "source": "local_mcp",
         "registry_dir": registry_dir,
     }))
+}
+
+pub(crate) fn reload_result_succeeded(value: &Value) -> bool {
+    if value.get("success").and_then(Value::as_bool) == Some(false)
+        || value.get("ok").and_then(Value::as_bool) == Some(false)
+        || value.get("reloaded").and_then(Value::as_bool) == Some(false)
+        || value.get("isError").and_then(Value::as_bool) == Some(true)
+        || value.get("error").is_some_and(|error| !error.is_null())
+    {
+        return false;
+    }
+    value.get("result").is_none_or(reload_result_succeeded)
 }
 
 pub async fn stop_instance_local(
@@ -784,5 +798,13 @@ mod tests {
                 "activate_groups": false
             })
         );
+    }
+
+    #[test]
+    fn reload_result_rejects_backend_failure_envelope() {
+        assert!(!reload_result_succeeded(&json!({
+            "success": false,
+            "error": "no-source-file"
+        })));
     }
 }

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -615,7 +615,9 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                 dcc_type,
                 instance_id,
             };
-            control.reload_skills(request).await?
+            let result = control.reload_skills(request).await?;
+            failed = !result.get("ok").and_then(Value::as_bool).unwrap_or(false);
+            result
         }
         Command::StopInstance {
             dcc_type,


### PR DESCRIPTION
## Summary
- derive reload status from backend results
- return a non-zero CLI exit when reload fails
- cover failure-envelope aggregation

## Validation
- focused unit test
- local and remote CLI E2E tests
- live failed-backend exit-code check