### PR TITLE
fix: forward subprocess skill parameters

### DIFF
--- a/python/dcc_mcp_core/skill.py
+++ b/python/dcc_mcp_core/skill.py
@@ -584,8 +584,8 @@ def run_main(main_fn: Callable[..., ResultDict], argv: list[str] | None = None) 
         decorated function).
     argv:
         If given, overrides ``sys.argv[1:]`` for argument parsing.  When
-        ``None`` (default) the function is called with no arguments, which
-        causes each parameter's default value to be used.
+        ``None`` (default), parameters are read from the JSON object written
+        to stdin by the skill subprocess executor.
 
     Notes
     -----
@@ -596,13 +596,24 @@ def run_main(main_fn: Callable[..., ResultDict], argv: list[str] | None = None) 
     * Falls back to ``json.dumps`` in DCC environments where only the pure-Python
       wheel is installed.
     * The function currently ignores *argv* (no CLI arg parser is bundled).
-      Future versions may parse ``--key=value`` pairs into kwargs.
+        The subprocess executor's complete stdin JSON payload is authoritative.
     * Exit code ``0`` on success, ``1`` on failure (``result["success"] is False``).
 
     """
     result: ResultDict = {}
     try:
-        result = main_fn()
+        params: dict[str, Any] = {}
+        if not sys.stdin.isatty():
+            try:
+                raw_params = sys.stdin.read()
+            except (OSError, ValueError):
+                raw_params = ""
+            if raw_params.strip():
+                decoded = json.loads(raw_params)
+                if not isinstance(decoded, dict):
+                    raise TypeError("Skill stdin payload must be a JSON object")
+                params = decoded
+        result = main_fn(**params)
     except Exception as exc:
         result = skill_exception(exc)
 

--- a/tests/test_skill_run_main.py
+++ b/tests/test_skill_run_main.py
@@ -1,0 +1,33 @@
+"""Contracts for standalone skill-script parameter transport."""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from dcc_mcp_core.skill import run_main
+from dcc_mcp_core.skill import skill_success
+
+
+def test_run_main_forwards_stdin_json_to_skill(monkeypatch, capsys):
+    """The subprocess executor's stdin payload must reach the skill entry point."""
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO('{"name":"SIGNAL FORGE TITLE","width":1920,"layers":["title","subtitle"]}'),
+    )
+
+    def create_document(name="Untitled", width=640, layers=None):
+        return skill_success("created", name=name, width=width, layers=layers)
+
+    with pytest.raises(SystemExit) as exit_info:
+        run_main(create_document)
+
+    assert exit_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["context"] == {
+        "name": "SIGNAL FORGE TITLE",
+        "width": 1920,
+        "layers": ["title", "subtitle"],
+    }


### PR DESCRIPTION
## Summary
- read the core subprocess executor JSON payload from stdin
- forward typed parameters to Python skill entrypoints
- reject non-object payloads with the normal skill error contract

## Tests
- 23 focused pytest cases
- ruff check and format