### PR TITLE
fix: expose canonical OpenAPI arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-app-ui"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "serde",
  "serde_json",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "chrono",
  "hex",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "image",
  "libc",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-catalog"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "jsonschema",
  "serde",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-cli"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "anyhow",
  "axum",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-db"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "axum",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway-core"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "chrono",
  "dcc-mcp-gateway-search",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway-ensure"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "anyhow",
  "dcc-mcp-test-utils",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway-search"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "nucleo-matcher",
  "serde",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-host"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-pybridge",
  "dcc-mcp-wire",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-host-rpc"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "axum",
  "axum-test",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http-py"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http-server"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "chrono",
  "dashmap",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http-types"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "base64 0.22.1",
  "dcc-mcp-gateway-core",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-job"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "chrono",
  "dashmap",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-jsonrpc"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-protocols",
  "dcc-mcp-wire",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-marketplace"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-catalog",
  "dcc-mcp-test-utils",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dirs",
  "pyo3",
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-pybridge-derive",
  "pyo3",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge-derive"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-pybridge",
  "parking_lot",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "axum",
  "bytes",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-semantic"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "anyhow",
  "fastembed",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "anyhow",
  "axum",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "bytemuck",
  "ipckit",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sidecar"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "anyhow",
  "axum",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skill-rest"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "axum",
  "axum-test",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1843,14 +1843,14 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-test-utils"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-agent"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "anyhow",
  "clap",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-protocol"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "jsonwebtoken",
  "rmp-serde",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-relay"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "anyhow",
  "axum",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-updater"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-wire"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.19.31"
+version = "0.19.32"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/crates/dcc-mcp-skill-rest/src/openapi.rs
+++ b/crates/dcc-mcp-skill-rest/src/openapi.rs
@@ -109,7 +109,17 @@ pub fn build_openapi_document(server_title: &str, server_version: &str) -> Value
     let mut doc = SkillRestApiDoc::openapi();
     doc.info.title = server_title.to_owned();
     doc.info.version = server_version.to_owned();
-    serde_json::to_value(&doc).unwrap_or_else(|_| serde_json::json!({}))
+    let mut value = serde_json::to_value(&doc).unwrap_or_else(|_| serde_json::json!({}));
+    if let Some(properties) = value
+        .pointer_mut("/components/schemas/CallRequest/properties")
+        .and_then(Value::as_object_mut)
+        && let Some(arguments_schema) = properties.get("params").cloned()
+    {
+        // `serde(alias = "arguments")` is accepted at runtime but is not
+        // represented by utoipa, so publish both wire-compatible field names.
+        properties.insert("arguments".to_owned(), arguments_schema);
+    }
+    value
 }
 
 /// Build the Scalar HTML API reference for the generated OpenAPI document.
@@ -201,7 +211,7 @@ mod tests {
         let props = schema["properties"]
             .as_object()
             .expect("CallRequest must declare properties");
-        for field in ["tool_slug", "params"] {
+        for field in ["tool_slug", "arguments", "params"] {
             assert!(
                 props.contains_key(field),
                 "CallRequest is missing property {field}: {props:#?}"

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -192,6 +192,10 @@ as `/admin?panel=traces&trace=<request_id>` and historical
 | `params` | ❌ | Backward-compatible alias for `arguments`. Prefer `arguments` in new clients so REST and MCP examples stay identical. |
 | `meta` | ❌ | MCP-style sidecar. Missing / `null` normalizes to absent. If provided, it must be an object (or an object-shaped JSON string). Honored keys: `progressToken`, `dcc.async`, `dcc.wait_for_terminal`. |
 
+The OpenAPI `CallRequest` schema declares both `arguments` and `params` so
+generated clients can use the canonical field without breaking integrations
+that still emit the compatibility alias.
+
 The canonical normalization rules live in `dcc-mcp-wire`; Python host wrappers can reuse them via `dcc_mcp_core.host.normalize_tool_arguments()` and `normalize_tool_meta()` instead of hand-rolling JSON coercion.
 
 ### Wrapper payloads and object-shaped arguments

--- a/tests/vrs/README.md
+++ b/tests/vrs/README.md
@@ -85,6 +85,7 @@ python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tes
 | `traces/gateway-rest-describe-unknown-slug.jsonl` | No | Well-formed unknown slug → `404`, `error.kind` = `unknown-slug`. |
 | `traces/gateway-rest-call-missing-tool-slug.jsonl` | No | `POST /v1/call` without `tool_slug` → `400`, `bad-request`. |
 | `traces/gateway-rest-call-unknown-slug.jsonl` | No | Unknown slug on call path → `404`, `unknown-slug` (matches refresh-retry semantics). |
+| `traces/core-openapi-call-request-aliases.jsonl` | No | Per-DCC OpenAPI `CallRequest` declares canonical `arguments` and the backward-compatible `params` alias for generated clients. |
 | `traces/core-1153-rest-compact-errors.jsonl` | No | Compact TOON negotiation on `/v1/describe` and `/v1/call_batch` preserves bad-request details; `/v1/call` can still force JSON. |
 | `traces/core-1157-rest-compact-default.jsonl` | No | REST defaults to compact TOON, explicit JSON opt-out still works, and token accounting headers are present. |
 | `traces/maya-215-execute-python-regression.jsonl` | Yes (Maya) | After harmless `execute_python`, triggers `TypeError` via bad `polySphere` arg; follow-up call must still succeed (maya#215 / #199 class). |

--- a/tests/vrs/traces/core-openapi-call-request-aliases.jsonl
+++ b/tests/vrs/traces/core-openapi-call-request-aliases.jsonl
@@ -1,0 +1,2 @@
+{"_vrs":{"version":1,"trace_id":"core-openapi-call-request-aliases"}}
+{"id":"openapi-declares-canonical-and-compatible-call-arguments","http":{"method":"GET","path":"/v1/openapi.json"},"expect":{"status":200,"json_subset":{"openapi":"3.1.0","components":{"schemas":{"CallRequest":{"properties":{"arguments":{"type":"object"},"params":{"type":"object"}}}}}}}}


### PR DESCRIPTION
## Summary
- declare both canonical arguments and compatible params in per-DCC CallRequest OpenAPI schemas
- add a contract test and replayable VRS trace
- synchronize the generated 0.19.32 workspace lockfile

## Validation
- dcc-mcp-skill-rest: 100 tests passed
- cargo fmt --check
- clippy -D warnings
- VRS dry-run

No adapter or skill guidance change is needed; runtime payload handling is unchanged.