### PR TITLE
fix: support in-process app ui calls

### DIFF
--- a/python/dcc_mcp_core/skills/app-ui/scripts/_backend.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/_backend.py
@@ -355,8 +355,8 @@ def _audit_record(
     ).to_dict()
 
 
-def snapshot_tool() -> Dict[str, Any]:
-    params = _read_params()
+def snapshot_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     state = _load_state(session_id)
     policy = _policy_from_params(params)
@@ -383,8 +383,8 @@ def snapshot_tool() -> Dict[str, Any]:
     )
 
 
-def find_tool() -> Dict[str, Any]:
-    params = _read_params()
+def find_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     state = _load_state(session_id)
     policy = _policy_from_params(params)
@@ -445,8 +445,8 @@ def _stale_result(
     )
 
 
-def act_tool() -> Dict[str, Any]:
-    params = _read_params()
+def act_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     state = _load_state(session_id)
     policy = _policy_from_params(params)
@@ -598,8 +598,8 @@ def _condition_matches(snapshot: Dict[str, Any], condition: UiWaitCondition) -> 
     return False
 
 
-def wait_for_tool() -> Dict[str, Any]:
-    params = _read_params()
+def wait_for_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     policy = _policy_from_params(params)
     condition = _condition_from_params(params.get("condition") or {})

--- a/python/dcc_mcp_core/skills/app-ui/scripts/_chrome_backend.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/_chrome_backend.py
@@ -533,8 +533,8 @@ def _backend_unavailable(exc: Exception, state: Optional[Dict[str, Any]] = None)
     )
 
 
-def snapshot_tool() -> Dict[str, Any]:
-    params = _read_params()
+def snapshot_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     state = _load_state(session_id)
     policy = _policy_from_params(params)
@@ -559,8 +559,8 @@ def snapshot_tool() -> Dict[str, Any]:
     )
 
 
-def find_tool() -> Dict[str, Any]:
-    params = _read_params()
+def find_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     state = _load_state(session_id)
     policy = _policy_from_params(params)
@@ -585,8 +585,8 @@ def find_tool() -> Dict[str, Any]:
     )
 
 
-def act_tool() -> Dict[str, Any]:
-    params = _read_params()
+def act_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     state = _load_state(session_id)
     try:
@@ -704,8 +704,8 @@ def _condition_matches(snapshot: Dict[str, Any], condition: UiWaitCondition) -> 
     return False
 
 
-def wait_for_tool() -> Dict[str, Any]:
-    params = _read_params()
+def wait_for_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     policy = _policy_from_params(params)
     condition = _condition_from_params(params.get("condition") or {})

--- a/python/dcc_mcp_core/skills/app-ui/scripts/_entrypoint.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/_entrypoint.py
@@ -7,6 +7,7 @@ import os
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import Optional
 
 from dcc_mcp_core.skill import skill_error
 
@@ -43,7 +44,7 @@ def _load_backend() -> Any:
     return None
 
 
-def _call(name: str) -> Dict[str, Any]:
+def _call(name: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     backend = _load_backend()
     if backend is None:
         selected = os.environ.get("DCC_MCP_APP_UI_BACKEND", "mock")
@@ -61,25 +62,25 @@ def _call(name: str) -> Dict[str, Any]:
                 "windows-uia",
             ],
         )
-    func: Callable[[], Dict[str, Any]] = getattr(backend, name)
-    return func()
+    func: Callable[[Optional[Dict[str, Any]]], Dict[str, Any]] = getattr(backend, name)
+    return func(params)
 
 
-def snapshot_tool() -> Dict[str, Any]:
+def snapshot_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Dispatch app_ui__snapshot to the selected backend."""
-    return _call("snapshot_tool")
+    return _call("snapshot_tool", params)
 
 
-def find_tool() -> Dict[str, Any]:
+def find_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Dispatch app_ui__find to the selected backend."""
-    return _call("find_tool")
+    return _call("find_tool", params)
 
 
-def act_tool() -> Dict[str, Any]:
+def act_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Dispatch app_ui__act to the selected backend."""
-    return _call("act_tool")
+    return _call("act_tool", params)
 
 
-def wait_for_tool() -> Dict[str, Any]:
+def wait_for_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Dispatch app_ui__wait_for to the selected backend."""
-    return _call("wait_for_tool")
+    return _call("wait_for_tool", params)

--- a/python/dcc_mcp_core/skills/app-ui/scripts/_windows_uia_backend.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/_windows_uia_backend.py
@@ -36,29 +36,16 @@ from dcc_mcp_core.adapter_contracts import UiWaitResult
 from dcc_mcp_core.skill import skill_error
 from dcc_mcp_core.skill import skill_success
 
-_POLICY_KEYS = {
-    "allow_snapshot",
-    "allow_find",
-    "allow_mutating_actions",
-    "allow_text_entry",
-    "allow_keyboard_shortcuts",
-    "allow_raw_coordinates",
-    "allowed_window_titles",
-    "allowed_process_ids",
-    "audit_sensitive_values",
-}
-_CONDITION_KEYS = {
-    "kind",
-    "control_id",
-    "query",
-    "role",
-    "label",
-    "text",
-    "value",
-    "checked",
-    "timeout_ms",
-    "interval_ms",
-}
+
+def _key_set(value: str) -> frozenset:
+    return frozenset(value.split())
+
+
+_POLICY_KEYS = _key_set(
+    "allow_snapshot allow_find allow_mutating_actions allow_text_entry allow_keyboard_shortcuts "
+    "allow_raw_coordinates allowed_window_titles allowed_process_ids audit_sensitive_values"
+)
+_CONDITION_KEYS = _key_set("kind control_id query role label text value checked timeout_ms interval_ms")
 
 _UIA_SCRIPT = r"""
 $ErrorActionPreference = "Stop"
@@ -71,6 +58,7 @@ if ([string]::IsNullOrWhiteSpace($rawInput)) {
 
 Add-Type -AssemblyName UIAutomationClient
 Add-Type -AssemblyName UIAutomationTypes
+# DCC_MCP_UIA_HELPERS
 
 $ChildScope = [System.Windows.Automation.TreeScope]::Children
 $TrueCondition = [System.Windows.Automation.Condition]::TrueCondition
@@ -161,8 +149,8 @@ function Candidate-Windows() {
 
 function Scope-Process-Ids() {
   $ids = @()
-  foreach ($pid in As-Array $payload.scope.process_ids) {
-    if ($pid -ne $null -and [int]$pid -gt 0) { $ids += [int]$pid }
+  foreach ($processId in As-Array $payload.scope.process_ids) {
+    if ($processId -ne $null -and [int]$processId -gt 0) { $ids += [int]$processId }
   }
   foreach ($name in As-Array $payload.scope.process_names) {
     if (-not [string]::IsNullOrWhiteSpace([string]$name)) {
@@ -195,6 +183,11 @@ function Match-Scope($element, $processIds) {
 
 function Find-Scoped-Root() {
   $processIds = Scope-Process-Ids
+  $titles = As-Array $payload.scope.window_titles
+  if ($titles.Count -eq 0) {
+    $processRoot = Find-Process-Root $processIds
+    if ($null -ne $processRoot) { return $processRoot }
+  }
   $windows = Candidate-Windows
   for ($i = 0; $i -lt $windows.Count; $i++) {
     $candidate = $windows.Item($i)
@@ -252,12 +245,21 @@ function Invoke-Action($element) {
   if ($action -eq "click") {
     $pattern = $null
     if ($element.TryGetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern, [ref]$pattern)) {
-      $pattern.Invoke()
-      return @{ok = $true; message = "invoked control"}
+      try {
+        $pattern.Invoke()
+        return @{ok = $true; message = "invoked control"}
+      } catch {
+        if (Invoke-NativeButtonClick $element) {
+          return @{ok = $true; message = "invoked native button"}
+        }
+      }
     }
     if ($element.TryGetCurrentPattern([System.Windows.Automation.TogglePattern]::Pattern, [ref]$pattern)) {
       $pattern.Toggle()
       return @{ok = $true; message = "toggled control"}
+    }
+    if (Invoke-NativeButtonClick $element) {
+      return @{ok = $true; message = "invoked native button"}
     }
     try {
       $element.SetFocus()
@@ -308,6 +310,9 @@ try {
     ConvertTo-Json -Depth 64 -Compress
 }
 """
+
+_UIA_HELPERS = Path(__file__).with_name("_windows_uia_helpers.ps1").read_text(encoding="utf-8")
+_UIA_SCRIPT = _UIA_SCRIPT.replace("# DCC_MCP_UIA_HELPERS", _UIA_HELPERS)
 
 
 def _read_params() -> Dict[str, Any]:
@@ -440,7 +445,7 @@ def _run_uia(payload: Dict[str, Any]) -> Dict[str, Any]:
             input=json.dumps(payload),
             capture_output=True,
             text=True,
-            timeout=float(os.environ.get("DCC_MCP_APP_UI_UIA_TIMEOUT_SECS", "8")),
+            timeout=float(os.environ.get("DCC_MCP_APP_UI_UIA_TIMEOUT_SECS", "12")),
         )
     finally:
         with suppress(OSError):
@@ -658,8 +663,8 @@ def _error_from_capture(capture: Dict[str, Any]) -> Dict[str, Any]:
     return skill_error(message, error, error_code=error, backend="windows-uia")
 
 
-def snapshot_tool() -> Dict[str, Any]:
-    params = _read_params()
+def snapshot_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     policy = _policy_from_params(params)
     if not policy.allow_snapshot:
@@ -681,8 +686,8 @@ def snapshot_tool() -> Dict[str, Any]:
     )
 
 
-def find_tool() -> Dict[str, Any]:
-    params = _read_params()
+def find_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     policy = _policy_from_params(params)
     if not policy.allow_find:
@@ -759,8 +764,8 @@ def _stale_result(control_id: str, session_id: str, requested: str, current: str
     )
 
 
-def act_tool() -> Dict[str, Any]:
-    params = _read_params()
+def act_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     policy = _policy_from_params(params)
     action = str(params.get("action") or "")
@@ -894,8 +899,8 @@ def _condition_matches(snapshot: Dict[str, Any], condition: UiWaitCondition) -> 
     return False
 
 
-def wait_for_tool() -> Dict[str, Any]:
-    params = _read_params()
+def wait_for_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     policy = _policy_from_params(params)
     condition = _condition_from_params(params.get("condition") or {})

--- a/python/dcc_mcp_core/skills/app-ui/scripts/_windows_uia_helpers.ps1
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/_windows_uia_helpers.ps1
@@ -1,0 +1,31 @@
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class DccMcpNativeUi {
+  [DllImport("user32.dll", CharSet = CharSet.Auto)]
+  public static extern IntPtr SendMessage(IntPtr hWnd, uint message, IntPtr wParam, IntPtr lParam);
+}
+"@
+
+function Find-Process-Root($processIds) {
+  if ($processIds.Count -ne 1) { return $null }
+  try {
+    $proc = Get-Process -Id ([int]$processIds[0]) -ErrorAction Stop
+    if ($proc.MainWindowHandle -eq [IntPtr]::Zero) { return $null }
+    return [System.Windows.Automation.AutomationElement]::FromHandle($proc.MainWindowHandle)
+  } catch {
+    return $null
+  }
+}
+
+function Invoke-NativeButtonClick($element) {
+  try {
+    $handle = [IntPtr]::new([long]$element.Current.NativeWindowHandle)
+    if ($handle -eq [IntPtr]::Zero) { return $false }
+    [void][DccMcpNativeUi]::SendMessage($handle, 0x00F5, [IntPtr]::Zero, [IntPtr]::Zero)
+    return $true
+  } catch {
+    return $false
+  }
+}

--- a/python/dcc_mcp_core/skills/app-ui/scripts/act.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/act.py
@@ -5,5 +5,11 @@ from __future__ import annotations
 from _entrypoint import act_tool
 from _entrypoint import emit
 
+
+def main(**kwargs):
+    """Run the tool in an in-process DCC executor."""
+    return act_tool(kwargs)
+
+
 if __name__ == "__main__":
     emit(act_tool())

--- a/python/dcc_mcp_core/skills/app-ui/scripts/find.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/find.py
@@ -5,5 +5,11 @@ from __future__ import annotations
 from _entrypoint import emit
 from _entrypoint import find_tool
 
+
+def main(**kwargs):
+    """Run the tool in an in-process DCC executor."""
+    return find_tool(kwargs)
+
+
 if __name__ == "__main__":
     emit(find_tool())

--- a/python/dcc_mcp_core/skills/app-ui/scripts/snapshot.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/snapshot.py
@@ -5,5 +5,11 @@ from __future__ import annotations
 from _entrypoint import emit
 from _entrypoint import snapshot_tool
 
+
+def main(**kwargs):
+    """Run the tool in an in-process DCC executor."""
+    return snapshot_tool(kwargs)
+
+
 if __name__ == "__main__":
     emit(snapshot_tool())

--- a/python/dcc_mcp_core/skills/app-ui/scripts/wait_for.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/wait_for.py
@@ -5,5 +5,11 @@ from __future__ import annotations
 from _entrypoint import emit
 from _entrypoint import wait_for_tool
 
+
+def main(**kwargs):
+    """Run the tool in an in-process DCC executor."""
+    return wait_for_tool(kwargs)
+
+
 if __name__ == "__main__":
     emit(wait_for_tool())

--- a/tests/test_app_ui_skill.py
+++ b/tests/test_app_ui_skill.py
@@ -11,6 +11,7 @@ import sys
 from typing import Any
 
 from conftest import REPO_ROOT
+from dcc_mcp_core._server.inprocess_executor import run_skill_script
 
 _SKILL_DIR = REPO_ROOT / "python" / "dcc_mcp_core" / "skills" / "app-ui"
 _SCRIPTS = _SKILL_DIR / "scripts"
@@ -78,6 +79,54 @@ def test_app_ui_skill_metadata_and_tool_names() -> None:
     action_names = {action["name"] for action in registry.list_actions()}
     assert "app_ui__snapshot" in action_names
     assert "app_ui__wait_for" in action_names
+
+
+def test_app_ui_entrypoints_accept_inprocess_parameters(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """Sidecar hosts must not require subprocess stdin for bundled app-ui."""
+    monkeypatch.setenv("DCC_MCP_APP_UI_BACKEND", "mock")
+    monkeypatch.setenv("DCC_MCP_APP_UI_MOCK_STATE_DIR", str(tmp_path))
+
+    snapshot = run_skill_script(
+        str(_SCRIPTS / "snapshot.py"),
+        {"session_id": "inprocess"},
+    )
+    snapshot_id = snapshot["context"]["snapshot_id"]
+
+    found = run_skill_script(
+        str(_SCRIPTS / "find.py"),
+        {"session_id": "inprocess", "label": "Project name"},
+    )
+    assert found["context"]["matches"][0]["id"] == "project-name"
+
+    changed = run_skill_script(
+        str(_SCRIPTS / "act.py"),
+        {
+            "session_id": "inprocess",
+            "control_id": "project-name",
+            "action": "set_text",
+            "text": "Signal Forge",
+            "snapshot_id": snapshot_id,
+        },
+    )
+    assert changed["success"] is True
+
+    waited = run_skill_script(
+        str(_SCRIPTS / "wait_for.py"),
+        {
+            "session_id": "inprocess",
+            "condition": {
+                "kind": "value_equals",
+                "control_id": "project-name",
+                "value": "Signal Forge",
+                "timeout_ms": 200,
+                "interval_ms": 10,
+            },
+        },
+    )
+    assert waited["success"] is True
 
 
 def test_app_ui_mock_observe_act_wait_verify_loop(tmp_path: Path) -> None:
@@ -369,6 +418,36 @@ def test_app_ui_windows_uia_requires_explicit_scope(tmp_path: Path) -> None:
     assert result["success"] is False
     assert result["error"] == "missing_window"
     assert "whole-desktop snapshots are disabled" in result["message"]
+
+
+def test_app_ui_windows_uia_accepts_process_id_scope() -> None:
+    """PowerShell's read-only $PID automatic variable must not be shadowed."""
+    backend = _load_windows_uia_module()
+    script = backend._dedent_for_tests()
+
+    assert "foreach ($pid in" not in script.lower()
+    assert "foreach ($processId in As-Array $payload.scope.process_ids)" in script
+
+
+def test_app_ui_windows_uia_uses_main_window_handle_for_single_process() -> None:
+    """Heavy DCC providers should not require a whole-desktop UIA scan."""
+    backend = _load_windows_uia_module()
+    script = backend._dedent_for_tests()
+
+    assert "function Find-Process-Root" in script
+    assert "[System.Windows.Automation.AutomationElement]::FromHandle" in script
+    assert "$proc.MainWindowHandle" in script
+
+
+def test_app_ui_windows_uia_click_has_native_button_fallback() -> None:
+    """Native dialogs can expose an InvokePattern that still rejects Invoke()."""
+    backend = _load_windows_uia_module()
+    script = backend._dedent_for_tests()
+
+    assert "function Invoke-NativeButtonClick" in script
+    assert "[DccMcpNativeUi]::SendMessage" in script
+    assert "0x00F5" in script
+    assert "invoked native button" in script
 
 
 def test_app_ui_chrome_cdp_preset_aliases(monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary\n- allow bundled app-ui entrypoints to run through in-process DCC executors\n- pass parameters directly to mock, Windows UIA, and CDP backends\n- preserve subprocess stdin compatibility\n\n## Validation\n- 49 focused tests passed\n- gateway REST/MCP regression passed\n- ruff check and format passed