### PR TITLE
fix: stabilize Qt widget identifiers

### DIFF
--- a/python/dcc_mcp_core/skills/qt_ui_inspector.py
+++ b/python/dcc_mcp_core/skills/qt_ui_inspector.py
@@ -82,15 +82,42 @@ def _no_application() -> dict[str, Any]:
 # ── Widget identifier ─────────────────────────────────────────────────
 
 
+def _native_object_address(widget: Any) -> int | None:
+    """Return the wrapped C++ QObject address when the binding exposes it."""
+    binding_name = next(
+        (
+            cls.__module__.split(".", 1)[0]
+            for cls in widget.__class__.__mro__
+            if cls.__module__.split(".", 1)[0] in ("PySide6", "PySide2", "PyQt6", "PyQt5")
+        ),
+        "",
+    )
+    try:
+        if binding_name in ("PySide6", "PySide2"):
+            shiboken_name = "shiboken6" if binding_name == "PySide6" else "shiboken2"
+            shiboken = __import__(shiboken_name)
+            pointer = int(shiboken.getCppPointer(widget)[0])
+        elif binding_name in ("PyQt6", "PyQt5"):
+            sip = __import__(f"{binding_name}.sip", fromlist=["sip"])
+            pointer = int(sip.unwrapinstance(widget))
+        else:
+            return None
+    except Exception:
+        return None
+    return pointer if pointer > 0 else None
+
+
 def _widget_id(widget: Any) -> str:
-    """Stable identifier ``class:object_name:fingerprint``."""
+    """Wrapper-stable identifier ``class:object_name:fingerprint``."""
     try:
         obj_name = widget.objectName() or ""
     except Exception:
         obj_name = ""
     klass = widget.__class__.__name__
-    fingerprint = id(widget) & 0xFFFFFFFF
-    return f"{klass}:{obj_name}:{fingerprint:08x}"
+    fingerprint = _native_object_address(widget)
+    if fingerprint is None:
+        fingerprint = id(widget)
+    return f"{klass}:{obj_name}:{fingerprint & 0xFFFFFFFFFFFFFFFF:016x}"
 
 
 def _safe_call(fn: Any, default: Any) -> Any:

--- a/tests/test_qt_ui_inspector.py
+++ b/tests/test_qt_ui_inspector.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import sys
+from types import SimpleNamespace
 
 # Force headless Qt platform before any binding is loaded by pytest-qt.
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -78,6 +80,31 @@ class TestInputValidationRunsBeforeBindingLoad:
         r = qt_wait_for_widget()
         assert r["success"] is False
         assert r["error"] == "invalid_input"
+
+
+class TestWidgetIdentifiers:
+    def test_pyside6_wrappers_for_same_native_widget_share_id(self, monkeypatch) -> None:
+        from dcc_mcp_core.skills.qt_ui_inspector import _widget_id
+
+        class FakePySide6Widget:
+            __module__ = "PySide6.QtWidgets"
+
+        class MaterialView(FakePySide6Widget):
+            def objectName(self) -> str:
+                return "material_view"
+
+        monkeypatch.setitem(
+            sys.modules,
+            "shiboken6",
+            SimpleNamespace(getCppPointer=lambda _widget: (0x1234_5678_9ABC_DEF0,)),
+        )
+
+        first_wrapper = MaterialView()
+        second_wrapper = MaterialView()
+
+        assert id(first_wrapper) != id(second_wrapper)
+        assert _widget_id(first_wrapper) == _widget_id(second_wrapper)
+        assert _widget_id(first_wrapper).endswith(":123456789abcdef0")
 
 
 class _FakeRegistry:


### PR DESCRIPTION
## Summary
- derive Qt widget fingerprints from native QObject addresses when Shiboken or SIP is available
- preserve a safe Python-identity fallback for unsupported bindings
- cover custom PySide6 subclasses whose wrappers are recreated between calls

## Validation
- `ruff check python/dcc_mcp_core/skills/qt_ui_inspector.py tests/test_qt_ui_inspector.py`
- `pytest tests/test_qt_ui_inspector.py -q` (19 passed)