### PR TITLE
fix: make wheel release upload repository explicit

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -291,4 +291,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
-        run: gh release upload "${{ inputs.release-tag-name }}" dist/*.whl --clobber
+        run: >-
+          gh release upload "${{ inputs.release-tag-name }}" dist/*.whl
+          --repo "${{ github.repository }}" --clobber

--- a/tests/test_build_wheels_workflow.py
+++ b/tests/test_build_wheels_workflow.py
@@ -43,4 +43,7 @@ def test_release_wheels_are_uploaded_once_after_every_build() -> None:
 
     upload = publish["steps"][1]
     assert upload["env"] == {"GH_TOKEN": "${{ github.token }}"}
-    assert 'gh release upload "${{ inputs.release-tag-name }}" dist/*.whl --clobber' in upload["run"]
+    command = upload["run"]
+    assert 'gh release upload "${{ inputs.release-tag-name }}" dist/*.whl' in command
+    assert '--repo "${{ github.repository }}"' in command
+    assert command.endswith("--clobber")


### PR DESCRIPTION
The reusable wheel publication job has no checkout, so GitHub CLI cannot infer a repository. Pass the repository explicitly and lock the contract with a workflow test.\n\nValidation:\n- pytest tests/test_build_wheels_workflow.py -q\n- actionlint .github/workflows/build-wheels.yml