### PR TITLE
fix: load ABI3 wheels in embedded Windows Python

### DIFF
--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -20,6 +20,9 @@ from dcc_mcp_core._exports import _LAZY
 from dcc_mcp_core._exports import _OPTIONAL
 from dcc_mcp_core._exports import PUBLIC_EXPORTS as __all__
 from dcc_mcp_core._lazy import resolve_lazy_symbol
+from dcc_mcp_core._windows_dll_search import prepare_embedded_python_dll_search
+
+prepare_embedded_python_dll_search()
 
 
 def _metadata_value(name: str, default: str) -> str:

--- a/python/dcc_mcp_core/_windows_dll_search.py
+++ b/python/dcc_mcp_core/_windows_dll_search.py
@@ -1,0 +1,23 @@
+"""Windows DLL search setup for embedded Python hosts."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+_DLL_DIRECTORY_HANDLES: list[Any] = []
+
+
+def prepare_embedded_python_dll_search() -> None:
+    """Expose an embedded Python prefix to ABI3 extension dependencies."""
+    if sys.platform != "win32" or not hasattr(os, "add_dll_directory"):
+        return
+    prefix = Path(sys.prefix).resolve()
+    if not prefix.is_dir():
+        return
+    try:
+        _DLL_DIRECTORY_HANDLES.append(os.add_dll_directory(str(prefix)))
+    except OSError:
+        return

--- a/tests/test_windows_dll_search.py
+++ b/tests/test_windows_dll_search.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+def test_adds_embedded_python_prefix_to_windows_dll_search(monkeypatch, tmp_path):
+    from dcc_mcp_core import _windows_dll_search as windows_dll_search
+
+    added = []
+    handle = object()
+    monkeypatch.setattr(windows_dll_search.sys, "platform", "win32")
+    monkeypatch.setattr(windows_dll_search.sys, "prefix", str(tmp_path))
+    monkeypatch.setattr(windows_dll_search.os, "add_dll_directory", lambda path: added.append(path) or handle)
+    windows_dll_search._DLL_DIRECTORY_HANDLES.clear()
+
+    windows_dll_search.prepare_embedded_python_dll_search()
+
+    assert added == [str(Path(tmp_path).resolve())]
+    assert [handle] == windows_dll_search._DLL_DIRECTORY_HANDLES
+
+
+def test_skips_dll_search_setup_outside_windows(monkeypatch):
+    from dcc_mcp_core import _windows_dll_search as windows_dll_search
+
+    monkeypatch.setattr(windows_dll_search.sys, "platform", "linux")
+    windows_dll_search._DLL_DIRECTORY_HANDLES.clear()
+
+    windows_dll_search.prepare_embedded_python_dll_search()
+
+    assert windows_dll_search._DLL_DIRECTORY_HANDLES == []

--- a/tests/test_windows_dll_search.py
+++ b/tests/test_windows_dll_search.py
@@ -8,7 +8,9 @@ def test_adds_embedded_python_prefix_to_windows_dll_search(monkeypatch, tmp_path
     handle = object()
     monkeypatch.setattr(windows_dll_search.sys, "platform", "win32")
     monkeypatch.setattr(windows_dll_search.sys, "prefix", str(tmp_path))
-    monkeypatch.setattr(windows_dll_search.os, "add_dll_directory", lambda path: added.append(path) or handle, raising=False)
+    monkeypatch.setattr(
+        windows_dll_search.os, "add_dll_directory", lambda path: added.append(path) or handle, raising=False
+    )
     windows_dll_search._DLL_DIRECTORY_HANDLES.clear()
 
     windows_dll_search.prepare_embedded_python_dll_search()

--- a/tests/test_windows_dll_search.py
+++ b/tests/test_windows_dll_search.py
@@ -8,7 +8,7 @@ def test_adds_embedded_python_prefix_to_windows_dll_search(monkeypatch, tmp_path
     handle = object()
     monkeypatch.setattr(windows_dll_search.sys, "platform", "win32")
     monkeypatch.setattr(windows_dll_search.sys, "prefix", str(tmp_path))
-    monkeypatch.setattr(windows_dll_search.os, "add_dll_directory", lambda path: added.append(path) or handle)
+    monkeypatch.setattr(windows_dll_search.os, "add_dll_directory", lambda path: added.append(path) or handle, raising=False)
     windows_dll_search._DLL_DIRECTORY_HANDLES.clear()
 
     windows_dll_search.prepare_embedded_python_dll_search()


### PR DESCRIPTION
## Summary
- register the embedded Python prefix with the Windows DLL loader before native-core probing
- retain DLL directory handles for the process lifetime
- cover Windows and non-Windows behavior

## Validation
- `vx python -m pytest tests/test_windows_dll_search.py -q`
- `vx ruff check python/dcc_mcp_core/__init__.py python/dcc_mcp_core/_windows_dll_search.py tests/test_windows_dll_search.py`
- verified the official 0.19.35 ABI3 extension loads in an embedded Python 3.13 host