### PR TITLE
fix: unify log level environment variable

### DIFF
--- a/crates/dcc-mcp-logging/src/config.rs
+++ b/crates/dcc-mcp-logging/src/config.rs
@@ -13,7 +13,7 @@
 //! already been installed by the Python module-init path in
 //! `dcc_mcp_core._core`. See [`reload_handle`].
 
-use crate::constants::{DEFAULT_LOG_LEVEL, ENV_LOG_LEVEL};
+use crate::constants::{DEFAULT_LOG_LEVEL, ENV_LOG_LEVEL, LEGACY_ENV_LOG_LEVEL};
 use std::sync::OnceLock;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::reload::{self, Handle};
@@ -39,7 +39,7 @@ static RELOAD_HANDLE: OnceLock<FileLayerReloadHandle> = OnceLock::new();
 /// Initialize the tracing subscriber (called once from Python module init).
 ///
 /// Installs:
-/// - an `EnvFilter` driven by `MCP_LOG_LEVEL` (fallback [`DEFAULT_LOG_LEVEL`]);
+/// - an `EnvFilter` driven by `DCC_MCP_LOG_LEVEL` (fallback [`DEFAULT_LOG_LEVEL`]);
 /// - a stderr `fmt::Layer` (thread names, targets on);
 /// - a [`reload::Layer`] holding an `Option<BoxedLayer>` for dynamic
 ///   attachment of a rolling-file layer by
@@ -50,6 +50,7 @@ static RELOAD_HANDLE: OnceLock<FileLayerReloadHandle> = OnceLock::new();
 pub fn init_logging() {
     INIT.call_once(|| {
         let filter = EnvFilter::try_from_env(ENV_LOG_LEVEL)
+            .or_else(|_| EnvFilter::try_from_env(LEGACY_ENV_LOG_LEVEL))
             .unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_LEVEL));
 
         let fmt_layer = tracing_subscriber::fmt::layer()

--- a/crates/dcc-mcp-logging/src/constants.rs
+++ b/crates/dcc-mcp-logging/src/constants.rs
@@ -3,7 +3,9 @@
 /// Default log level when [`ENV_LOG_LEVEL`] is not set.
 pub const DEFAULT_LOG_LEVEL: &str = "DEBUG";
 /// Environment variable name for overriding the log level.
-pub const ENV_LOG_LEVEL: &str = "MCP_LOG_LEVEL";
+pub const ENV_LOG_LEVEL: &str = "DCC_MCP_LOG_LEVEL";
+/// Deprecated environment variable accepted for backward compatibility.
+pub const LEGACY_ENV_LOG_LEVEL: &str = "MCP_LOG_LEVEL";
 
 /// Environment variable toggling file-logging. Any non-empty, non-`0`/`false`
 /// value enables it (defaults to disabled).
@@ -43,7 +45,8 @@ mod tests {
 
     #[test]
     fn env_var_names_are_stable() {
-        assert_eq!(ENV_LOG_LEVEL, "MCP_LOG_LEVEL");
+        assert_eq!(ENV_LOG_LEVEL, "DCC_MCP_LOG_LEVEL");
+        assert_eq!(LEGACY_ENV_LOG_LEVEL, "MCP_LOG_LEVEL");
         assert_eq!(ENV_LOG_FILE, "DCC_MCP_LOG_FILE");
         assert_eq!(ENV_LOG_DIR, "DCC_MCP_LOG_DIR");
         assert_eq!(ENV_LOG_FILE_PREFIX, "DCC_MCP_LOG_FILE_PREFIX");

--- a/crates/dcc-mcp-tunnel-agent/src/bin/dcc-mcp-tunnel-agent.rs
+++ b/crates/dcc-mcp-tunnel-agent/src/bin/dcc-mcp-tunnel-agent.rs
@@ -127,7 +127,8 @@ struct Args {
 }
 
 fn init_tracing() {
-    let filter = EnvFilter::try_from_env("MCP_LOG_LEVEL")
+    let filter = EnvFilter::try_from_env("DCC_MCP_LOG_LEVEL")
+        .or_else(|_| EnvFilter::try_from_env("MCP_LOG_LEVEL"))
         .or_else(|_| EnvFilter::try_from_env("RUST_LOG"))
         .unwrap_or_else(|_| EnvFilter::new("info"));
     tracing_subscriber::fmt().with_env_filter(filter).init();

--- a/crates/dcc-mcp-tunnel-relay/src/bin/dcc-mcp-tunnel-relay.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/bin/dcc-mcp-tunnel-relay.rs
@@ -106,7 +106,8 @@ struct Args {
 }
 
 fn init_tracing() {
-    let filter = EnvFilter::try_from_env("MCP_LOG_LEVEL")
+    let filter = EnvFilter::try_from_env("DCC_MCP_LOG_LEVEL")
+        .or_else(|_| EnvFilter::try_from_env("MCP_LOG_LEVEL"))
         .or_else(|_| EnvFilter::try_from_env("RUST_LOG"))
         .unwrap_or_else(|_| EnvFilter::new("info"));
     tracing_subscriber::fmt().with_env_filter(filter).init();

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -203,7 +203,7 @@ Available as module-level attributes:
 | `APP_AUTHOR` | `"dcc-mcp"` | App author |
 | `DEFAULT_DCC` | `"python"` | Default DCC name |
 | `DEFAULT_LOG_LEVEL` | `"DEBUG"` | Default log level |
-| `ENV_LOG_LEVEL` | `"MCP_LOG_LEVEL"` | Env var for log level |
+| `ENV_LOG_LEVEL` | `"DCC_MCP_LOG_LEVEL"` | Env var for log level |
 | `ENV_SKILL_PATHS` | `"DCC_MCP_SKILL_PATHS"` | Env var for global skill paths |
 | `ENV_APP_SKILL_PATHS` | `"DCC_MCP_{APP}_SKILL_PATHS"` | Template for per-app skill paths env var |
 | `SKILL_METADATA_FILE` | `"SKILL.md"` | Skill metadata filename |
@@ -215,7 +215,7 @@ Available as module-level attributes:
 |----------|-------------|
 | `DCC_MCP_SKILL_PATHS` | Global skill search paths (`;` on Windows, `:` on Unix) |
 | `DCC_MCP_{APP}_SKILL_PATHS` | Per-app skill paths, e.g. `DCC_MCP_MAYA_SKILL_PATHS` for Maya |
-| `MCP_LOG_LEVEL` | Log level override (DEBUG, INFO, WARN, ERROR) |
+| `DCC_MCP_LOG_LEVEL` | Log level override (DEBUG, INFO, WARN, ERROR) |
 | `DCC_MCP_LOG_DIR` | Directory for rolling log files (falls back to platform log dir) |
 | `DCC_MCP_LOG_FILE_PREFIX` | Log file stem (default: `dcc-mcp`) |
 | `DCC_MCP_LOG_MAX_SIZE` | Max bytes per file before size-triggered rotation (default: 10 MiB) |

--- a/docs/zh/api/utilities.md
+++ b/docs/zh/api/utilities.md
@@ -203,7 +203,7 @@ print(all_deps)  # ["base-utils", "maya-core", "maya-geometry"]
 | `APP_AUTHOR` | `"dcc-mcp"` | 应用作者 |
 | `DEFAULT_DCC` | `"python"` | 默认 DCC 名称 |
 | `DEFAULT_LOG_LEVEL` | `"DEBUG"` | 默认日志级别 |
-| `ENV_LOG_LEVEL` | `"MCP_LOG_LEVEL"` | 日志级别环境变量 |
+| `ENV_LOG_LEVEL` | `"DCC_MCP_LOG_LEVEL"` | 日志级别环境变量 |
 | `ENV_SKILL_PATHS` | `"DCC_MCP_SKILL_PATHS"` | 全局技能路径环境变量 |
 | `ENV_APP_SKILL_PATHS` | `"DCC_MCP_{APP}_SKILL_PATHS"` | 应用专属技能路径环境变量模板 |
 | `SKILL_METADATA_FILE` | `"SKILL.md"` | 技能元数据文件名 |
@@ -215,7 +215,7 @@ print(all_deps)  # ["base-utils", "maya-core", "maya-geometry"]
 |------|------|
 | `DCC_MCP_SKILL_PATHS` | 全局技能搜索路径（Windows 使用 `;`，Unix 使用 `:` 分隔） |
 | `DCC_MCP_{APP}_SKILL_PATHS` | 应用专属技能路径，如 Maya 使用 `DCC_MCP_MAYA_SKILL_PATHS` |
-| `MCP_LOG_LEVEL` | 日志级别覆盖（DEBUG、INFO、WARN、ERROR） |
+| `DCC_MCP_LOG_LEVEL` | 日志级别覆盖（DEBUG、INFO、WARN、ERROR） |
 
 ::: tip 搜索路径优先级
 调用 `create_skill_server("maya")` 时，技能目录按以下顺序解析：

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2545,7 +2545,7 @@ shutdown_file_logging()
 | `SKILL_SCRIPTS_DIR` | `"scripts"` | Skill scripts subdirectory name |
 | `SKILL_METADATA_DIR` | `"metadata"` | Skill metadata subdirectory name |
 | `ENV_SKILL_PATHS` | `"DCC_MCP_SKILL_PATHS"` | Environment variable for skill search paths |
-| `ENV_LOG_LEVEL` | `"MCP_LOG_LEVEL"` | Environment variable for log level override |
+| `ENV_LOG_LEVEL` | `"DCC_MCP_LOG_LEVEL"` | Environment variable for log level override |
 | `ENV_DISABLE_ACCUMULATED_SKILLS` | `"DCC_MCP_DISABLE_ACCUMULATED_SKILLS"` | Set to `"1"` to disable accumulated/evolved skills discovery |
 | `ENV_DISABLE_DEFAULT_SKILL_PATHS` | `"DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS"` | Set to `"1"` to omit implicit operator-owned skill roots while preserving explicit, bundled, and env paths |
 | `ENV_TEAM_SKILL_PATHS` | `"DCC_MCP_TEAM_SKILL_PATHS"` | Environment variable for team-level skill paths |
@@ -2559,7 +2559,7 @@ shutdown_file_logging()
 |----------|-------------|---------|
 | `DCC_MCP_SKILL_PATHS` | Skill search paths (`:` on Unix, `;` on Windows) | `/skills1:/skills2` |
 | `DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS` | Disable implicit operator-owned skill roots for hermetic CI/tests | `1` |
-| `MCP_LOG_LEVEL` | Log level override | `INFO` / `DEBUG` / `WARN` |
+| `DCC_MCP_LOG_LEVEL` | Log level override | `INFO` / `DEBUG` / `WARN` |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -733,7 +733,7 @@ tools:
 - `APP_NAME = "dcc-mcp"`, `APP_AUTHOR = "dcc-mcp"`
 - `DEFAULT_DCC = "python"`, `DEFAULT_LOG_LEVEL = "DEBUG"`, `DEFAULT_MIME_TYPE = "text/plain"`, `DEFAULT_VERSION = "1.0.0"`
 - `SKILL_METADATA_FILE = "SKILL.md"`, `SKILL_SCRIPTS_DIR = "scripts"`, `SKILL_METADATA_DIR = "metadata"`
-- `ENV_SKILL_PATHS = "DCC_MCP_SKILL_PATHS"`, `ENV_LOG_LEVEL = "MCP_LOG_LEVEL"`, `ENV_DISABLE_ACCUMULATED_SKILLS` — set to "1" to disable accumulated/evolved skills discovery, `ENV_DISABLE_DEFAULT_SKILL_PATHS` — set to "1" for hermetic discovery without implicit operator-owned roots, `ENV_TEAM_SKILL_PATHS` / `ENV_USER_SKILL_PATHS` — team-level and user-level skill path env vars
+- `ENV_SKILL_PATHS = "DCC_MCP_SKILL_PATHS"`, `ENV_LOG_LEVEL = "DCC_MCP_LOG_LEVEL"`, `ENV_DISABLE_ACCUMULATED_SKILLS` — set to "1" to disable accumulated/evolved skills discovery, `ENV_DISABLE_DEFAULT_SKILL_PATHS` — set to "1" for hermetic discovery without implicit operator-owned roots, `ENV_TEAM_SKILL_PATHS` / `ENV_USER_SKILL_PATHS` — team-level and user-level skill path env vars
 - `TOOL_NAME_RE` / `ACTION_ID_RE` — regex patterns for client-safe tool names and internal action IDs
 - `MAX_TOOL_NAME_LEN = 64` — maximum tool name length
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,7 +24,7 @@ class TestConstants:
             ("SKILL_SCRIPTS_DIR", "scripts"),
             ("ENV_SKILL_PATHS", "DCC_MCP_SKILL_PATHS"),
             ("ENV_DISABLE_DEFAULT_SKILL_PATHS", "DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS"),
-            ("ENV_LOG_LEVEL", "MCP_LOG_LEVEL"),
+            ("ENV_LOG_LEVEL", "DCC_MCP_LOG_LEVEL"),
             ("DEFAULT_LOG_LEVEL", "DEBUG"),
             ("DEFAULT_MIME_TYPE", "text/plain"),
             ("DEFAULT_VERSION", "1.0.0"),


### PR DESCRIPTION
## Summary
- Standardize log-level configuration on `DCC_MCP_LOG_LEVEL`.
- Keep `MCP_LOG_LEVEL` as a fallback for existing deployments.
- Apply the same precedence in the core logger and tunnel binaries.

## Validation
- `vx cargo fmt --check`
- `vx cargo test -p dcc-mcp-logging`
- `vx cargo check -p dcc-mcp-tunnel-agent -p dcc-mcp-tunnel-relay`