### PR TITLE
feat(gateway): add compact filtered instance query

### DIFF
--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -81,5 +81,9 @@ dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }
 name = "search_bench"
 harness = false
 
+[[bench]]
+name = "instance_query_bench"
+harness = false
+
 [build-dependencies]
 dunce = "1.0"

--- a/crates/dcc-mcp-gateway/benches/instance_query_bench.rs
+++ b/crates/dcc-mcp-gateway/benches/instance_query_bench.rs
@@ -1,0 +1,221 @@
+//! Criterion benchmarks for the instance query pipeline (PIP-2725).
+//!
+//! Pin latency of the parse → filter → project path:
+//!
+//! - URI parse throughput
+//! - Compact instance JSON serialization (~500B target)
+//! - Substring query matching across display_id/version/scene
+//! - Full filter pipeline with realistic instance counts (≤100, ≤1000)
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo bench -p dcc-mcp-gateway --bench instance_query_bench
+//! ```
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dcc_mcp_gateway::gateway::native_resources::instances;
+use dcc_mcp_transport::discovery::types::{ServiceEntry, ServiceStatus};
+use std::hint::black_box;
+use std::time::Duration;
+
+// ── Shared helpers ─────────────────────────────────────────────────────
+
+const STALE_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn make_instance(dcc_type: &str, port: u16, version: &str, status: ServiceStatus) -> ServiceEntry {
+    let mut entry = ServiceEntry::new(dcc_type, "127.0.0.1", port);
+    entry.version = Some(version.to_string());
+    entry.status = status;
+    entry
+}
+
+fn make_corpus(count: usize) -> Vec<ServiceEntry> {
+    let types = ["blender", "maya", "houdini", "photoshop", "substance"];
+    let versions = ["4.2.0", "2024.2", "21.0", "25.0", "8.0"];
+    (0..count)
+        .map(|i| {
+            let idx = i % types.len();
+            let mut entry = ServiceEntry::new(types[idx], "127.0.0.1", 9000 + (i as u16));
+            entry.version = Some(format!("{}.{}", versions[idx], i % 10));
+            entry.status = if i % 5 == 0 {
+                ServiceStatus::Busy
+            } else {
+                ServiceStatus::Available
+            };
+            if i % 3 == 0 {
+                entry.scene = Some(format!("/projects/scene_{}.blend", i));
+            }
+            entry
+        })
+        .collect()
+}
+
+// ── URI parse benchmarks ────────────────────────────────────────────────
+
+fn bench_parse_root(c: &mut Criterion) {
+    c.bench_function("instances/parse/root_defaults", |b| {
+        b.iter(|| instances::parse(black_box("gateway://instances")))
+    });
+}
+
+fn bench_parse_with_filters(c: &mut Criterion) {
+    let uris = [
+        "gateway://instances?dcc_type=blender&query=4.2&limit=10",
+        "gateway://instances?dcc_type=maya&status=available&verbose=true&limit=20&offset=5",
+        "gateway://instances?query=2024&include_stale=false&limit=5",
+    ];
+    let mut group = c.benchmark_group("instances/parse/with_filters");
+    for (i, uri) in uris.iter().enumerate() {
+        group.bench_with_input(BenchmarkId::new("uri", i), uri, |b, uri| {
+            b.iter(|| instances::parse(black_box(uri)))
+        });
+    }
+    group.finish();
+}
+
+// ── Compact JSON serialization ──────────────────────────────────────────
+
+fn bench_compact_json(c: &mut Criterion) {
+    let entry = make_instance("blender", 9876, "4.2.0", ServiceStatus::Available);
+    c.bench_function("instances/compact_json/single", |b| {
+        b.iter(|| instances::compact_instance_json(black_box(&entry), STALE_TIMEOUT))
+    });
+}
+
+fn bench_compact_json_bulk(c: &mut Criterion) {
+    let corpus = make_corpus(100);
+    c.bench_function("instances/compact_json/100_instances", |b| {
+        b.iter(|| {
+            let mut total = 0usize;
+            for entry in &corpus {
+                let json = instances::compact_instance_json(black_box(entry), STALE_TIMEOUT);
+                total += serde_json::to_string(&json).unwrap().len();
+            }
+            black_box(total)
+        })
+    });
+}
+
+// ── Query matching benchmarks ───────────────────────────────────────────
+
+fn bench_query_matching(c: &mut Criterion) {
+    let corpus = make_corpus(1000);
+    let queries = ["blender", "4.2", "2024", "scene_", "nonexistent"];
+
+    c.bench_function("instances/query_match/1000_instances", |b| {
+        b.iter(|| {
+            let mut total = 0usize;
+            for query in queries {
+                let ql = query.to_ascii_lowercase();
+                total += corpus
+                    .iter()
+                    .filter(|e| instances::instance_matches_query(black_box(e), black_box(&ql)))
+                    .count();
+            }
+            black_box(total)
+        })
+    });
+}
+
+// ── Full filter pipeline (parse + filter, without GatewayState) ─────────
+
+fn bench_filter_pipeline(c: &mut Criterion) {
+    let corpus = make_corpus(100);
+    let stale_timeout = STALE_TIMEOUT;
+
+    let mut group = c.benchmark_group("instances/filter_pipeline");
+
+    // dcc_type exact match
+    group.bench_function("dcc_type_exact/100_instances", |b| {
+        b.iter(|| {
+            let count = corpus
+                .iter()
+                .filter(|e| e.dcc_type.eq_ignore_ascii_case("blender"))
+                .count();
+            black_box(count)
+        })
+    });
+
+    // Combined: dcc_type + query + stale check
+    group.bench_function("combined_filter/100_instances", |b| {
+        b.iter(|| {
+            let ql = "4.2".to_ascii_lowercase();
+            let count = corpus
+                .iter()
+                .filter(|e| {
+                    e.dcc_type.eq_ignore_ascii_case("blender")
+                        && !e.is_stale(stale_timeout)
+                        && instances::instance_matches_query(black_box(e), black_box(&ql))
+                })
+                .count();
+            black_box(count)
+        })
+    });
+
+    // Large corpus
+    let large = make_corpus(1000);
+    group.bench_function("combined_filter/1000_instances", |b| {
+        b.iter(|| {
+            let ql = "2024".to_ascii_lowercase();
+            let count = large
+                .iter()
+                .filter(|e| {
+                    e.dcc_type.eq_ignore_ascii_case("maya")
+                        && !e.is_stale(stale_timeout)
+                        && instances::instance_matches_query(black_box(e), black_box(&ql))
+                })
+                .count();
+            black_box(count)
+        })
+    });
+
+    group.finish();
+}
+
+// ── Index health computation ────────────────────────────────────────────
+
+fn bench_index_health(c: &mut Criterion) {
+    c.bench_function("instances/index_health", |b| {
+        b.iter(|| instances::compute_index_health(black_box(100), black_box(5), STALE_TIMEOUT))
+    });
+}
+
+// ── Size assertion (not a benchmark, but runs in the benchmark harness) ──
+
+#[test]
+fn compact_json_size_target() {
+    let corpus = make_corpus(100);
+    let mut max_size = 0usize;
+    let mut total_size = 0usize;
+
+    for entry in &corpus {
+        let json = instances::compact_instance_json(entry, STALE_TIMEOUT);
+        let size = serde_json::to_string(&json).unwrap().len();
+        max_size = max_size.max(size);
+        total_size += size;
+    }
+
+    let avg = total_size / corpus.len();
+    eprintln!(
+        "Compact JSON size: max={}B, avg={}B (target ≤500B/hit)",
+        max_size, avg
+    );
+    assert!(
+        avg < 500,
+        "Average compact JSON size {}B exceeds 500B target",
+        avg
+    );
+}
+
+criterion_group!(
+    benches,
+    bench_parse_root,
+    bench_parse_with_filters,
+    bench_compact_json,
+    bench_compact_json_bulk,
+    bench_query_matching,
+    bench_filter_pipeline,
+    bench_index_health,
+);
+criterion_main!(benches);

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
@@ -408,7 +408,7 @@ mod tests {
             registry.register(entry).unwrap();
         }
 
-        let req = make_read_req("gateway://instances");
+        let req = make_read_req("gateway://instances?verbose=true&limit=200");
         let resp = handle_resources_read(&gs, json!(1), &req).await;
         let text = resp["result"]["contents"][0]["text"]
             .as_str()

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
@@ -4,8 +4,19 @@
 //! `connect_to_dcc` MCP tools (#813 phase 1). Each entry carries
 //! `mcp_url` so a client that has read this resource has everything it
 //! needs to connect — there is no follow-up tool call.
+//!
+//! ## PIP-2725: instance query surface (first slice)
+//!
+//! The list endpoint now supports filtering (`dcc_type`, `query`,
+//! `status`, `limit`/`offset`) and compact projection by default.
+//! Compact hits (~500B) carry only the fields an agent needs to select
+//! an `instance_id`; `verbose=true` restores the full instance JSON.
+//! Honesty fields (`list_ok`, `index_health`) separate "we listed
+//! successfully" from "these instances are dispatch-ready".
 
 use serde_json::{Value, json};
+
+use dcc_mcp_transport::discovery::types::ServiceEntry;
 
 use super::super::state::GatewayState;
 use super::util::{parse_bool, parse_query, split_uri};
@@ -16,12 +27,18 @@ pub const ROOT_URI: &str = "gateway://instances";
 /// URI prefix for single-instance reads (e.g. `gateway://instances/abc-123`).
 pub const PREFIX: &str = "gateway://instances/";
 
+/// Default page size when `limit` is not specified.
+const DEFAULT_LIMIT: usize = 20;
+
+/// Maximum page size to prevent context blow-up.
+const MAX_LIMIT: usize = 200;
+
 /// Resource pointer emitted in `resources/list`.
 pub fn pointer() -> Value {
     json!({
         "uri":         ROOT_URI,
         "name":        "DCC instance registry",
-        "description": "List of every DCC server registered with the gateway. Each entry carries `mcp_url` so a client can connect without a follow-up tool call. Query params: ?include_stale=false to hide stale rows, ?include_dead=true for the raw registry view.",
+        "description": "List of DCC instances registered with the gateway. Supports filtering: ?dcc_type=maya, ?query=<substring>, ?status=available, ?limit=N, ?offset=N, ?verbose=true. Default response is compact (~500B/hit); verbose returns full instance objects. Honesty fields (list_ok, index_health) separate listing success from dispatch readiness (PIP-2725).",
         "mimeType":    "application/json"
     })
 }
@@ -31,11 +48,41 @@ pub fn pointer() -> Value {
 pub enum Query {
     /// Full list with optional filters from the URI query string.
     List {
+        /// Include stale (no-heartbeat) entries (default: true).
         include_stale: bool,
+        /// Include dead-PID entries via `read_alive_instances` (default: false).
         include_dead: bool,
+        /// Exact DCC type filter (e.g. "blender", "maya").
+        dcc_type: Option<String>,
+        /// Substring search across display_id, version, instance_short, scene.
+        query: Option<String>,
+        /// Status filter: "available", "busy", "stale".
+        status: Option<String>,
+        /// Page size (1..MAX_LIMIT, default: DEFAULT_LIMIT).
+        limit: usize,
+        /// Zero-based page offset.
+        offset: usize,
+        /// When true, return full instance objects instead of compact projection.
+        verbose: bool,
     },
     /// Single instance lookup by UUID (full or unique prefix).
     Single { instance_id: String },
+}
+
+impl Query {
+    /// Default list query with backward-compatible defaults.
+    fn default_list() -> Self {
+        Query::List {
+            include_stale: true,
+            include_dead: false,
+            dcc_type: None,
+            query: None,
+            status: None,
+            limit: DEFAULT_LIMIT,
+            offset: 0,
+            verbose: false,
+        }
+    }
 }
 
 /// Recognise a `gateway://instances*` URI and return the parsed query.
@@ -47,10 +94,7 @@ pub fn parse(uri: &str) -> Option<Query> {
         let id = rest.split('?').next().unwrap_or(rest).trim();
         if id.is_empty() {
             // `gateway://instances/` collapses to the list root.
-            return Some(Query::List {
-                include_stale: true,
-                include_dead: false,
-            });
+            return Some(Query::default_list());
         }
         return Some(Query::Single {
             instance_id: id.to_string(),
@@ -62,72 +106,187 @@ pub fn parse(uri: &str) -> Option<Query> {
     if path != ROOT_URI {
         return None;
     }
-    let mut include_stale = true;
-    let mut include_dead = false;
-    if let Some(q) = query {
-        let params = parse_query(q);
-        if let Some(v) = params.get("include_stale")
-            && let Some(b) = parse_bool(v)
+
+    let mut q = Query::default_list();
+
+    if let Some(query_str) = query {
+        let params = parse_query(query_str);
+        if let Query::List {
+            include_stale,
+            include_dead,
+            dcc_type,
+            query: query_filter,
+            status,
+            limit,
+            offset,
+            verbose,
+        } = &mut q
         {
-            include_stale = b;
-        }
-        if let Some(v) = params.get("include_dead")
-            && let Some(b) = parse_bool(v)
-        {
-            include_dead = b;
+            if let Some(v) = params.get("include_stale")
+                && let Some(b) = parse_bool(v)
+            {
+                *include_stale = b;
+            }
+            if let Some(v) = params.get("include_dead")
+                && let Some(b) = parse_bool(v)
+            {
+                *include_dead = b;
+            }
+            if let Some(v) = params.get("dcc_type") {
+                *dcc_type = Some(v.to_string());
+            }
+            if let Some(v) = params.get("query") {
+                *query_filter = Some(v.to_string());
+            }
+            if let Some(v) = params.get("status") {
+                *status = Some(v.to_string());
+            }
+            if let Some(v) = params.get("limit")
+                && let Ok(n) = v.parse::<usize>()
+            {
+                *limit = n.clamp(1, MAX_LIMIT);
+            }
+            if let Some(v) = params.get("offset")
+                && let Ok(n) = v.parse::<usize>()
+            {
+                *offset = n;
+            }
+            if let Some(v) = params.get("verbose")
+                && let Some(b) = parse_bool(v)
+            {
+                *verbose = b;
+            }
         }
     }
-    Some(Query::List {
-        include_stale,
-        include_dead,
-    })
+
+    Some(q)
 }
 
-/// Render the payload for a `gateway://instances*` read. Mirrors the
-/// shape historically returned by `tool_list_instances` /
-/// `tool_get_instance` (now removed) so any pre-existing client code
-/// that learned to parse those payloads keeps working — only the
-/// transport switches from `tools/call` to `resources/read`.
+/// Render the payload for a `gateway://instances*` read.
+///
+/// List responses include `list_ok` and `index_health` honesty fields
+/// (PIP-2725) that separate the listing operation's success from
+/// per-instance dispatch readiness. A response with `list_ok: true` may
+/// still carry `index_health: "degraded"` or instances whose
+/// `dispatch.ready` is `false` — callers must check both.
 pub async fn build_payload(gs: &GatewayState, query: &Query) -> Result<Value, String> {
     match query {
         Query::List {
             include_stale,
             include_dead,
+            dcc_type,
+            query: query_filter,
+            status,
+            limit,
+            offset,
+            verbose,
         } => {
             let reg = gs.registry.read().await;
+
+            // ── Fetch raw entries ──────────────────────────────────────
             let (raw, evicted_dead) = if *include_dead {
                 (gs.all_instances(&reg), 0usize)
             } else {
                 gs.read_alive_instances(&reg).map_err(|e| e.to_string())?
             };
 
+            // ── Compute index health before filtering ──────────────────
+            let index_health = compute_index_health(raw.len(), evicted_dead, gs.stale_timeout);
+
+            let stale_timeout = gs.stale_timeout;
+            let query_lower = query_filter.as_ref().map(|s| s.to_ascii_lowercase());
+            let status_lower = status.as_ref().map(|s| s.trim().to_ascii_lowercase());
+
             let mut stale_count: usize = 0;
-            let mut instances: Vec<Value> = raw
+            let mut total_before_paging: usize = 0;
+
+            // ── Filter pipeline ────────────────────────────────────────
+            let filtered: Vec<&ServiceEntry> = raw
                 .iter()
                 .filter(|e| {
-                    let stale = e.is_stale(gs.stale_timeout);
+                    // dcc_type exact match (case-insensitive)
+                    if let Some(dt) = dcc_type {
+                        if !e.dcc_type.eq_ignore_ascii_case(dt) {
+                            return false;
+                        }
+                    }
+                    // staleness filter
+                    let stale = e.is_stale(stale_timeout);
                     if stale {
                         stale_count += 1;
                     }
-                    *include_stale || !stale
+                    if !include_stale && stale {
+                        return false;
+                    }
+                    // status filter
+                    if let Some(ref s) = status_lower {
+                        match s.as_str() {
+                            "available" => {
+                                if e.status.to_string() != "available" || stale {
+                                    return false;
+                                }
+                            }
+                            "busy" => {
+                                if e.status.to_string() != "busy" || stale {
+                                    return false;
+                                }
+                            }
+                            "stale" => {
+                                if !stale {
+                                    return false;
+                                }
+                            }
+                            _ => {} // unknown status values pass through
+                        }
+                    }
+                    // substring query filter
+                    if let Some(ref q) = query_lower {
+                        if !instance_matches_query(e, q) {
+                            return false;
+                        }
+                    }
+                    true
                 })
-                .map(|e| gs.instance_json(e))
+                .inspect(|_| total_before_paging += 1)
                 .collect();
 
-            instances.sort_by(|a, b| {
-                a["dcc_type"]
-                    .as_str()
-                    .cmp(&b["dcc_type"].as_str())
-                    .then(a["port"].as_u64().cmp(&b["port"].as_u64()))
+            // ── Pagination ─────────────────────────────────────────────
+            let capped = total_before_paging > *limit;
+            let page: Vec<&ServiceEntry> = filtered
+                .iter()
+                .skip(*offset)
+                .take(*limit)
+                .copied()
+                .collect();
+
+            // ── Project to JSON ────────────────────────────────────────
+            let instances: Vec<Value> = if *verbose {
+                page.iter().map(|e| gs.instance_json(e)).collect()
+            } else {
+                page.iter()
+                    .map(|e| compact_instance_json(e, stale_timeout))
+                    .collect()
+            };
+
+            // ── Assemble response ──────────────────────────────────────
+            let mut resp = json!({
+                "list_ok":       true,
+                "index_health":  index_health,
+                "total":         total_before_paging,
+                "capped":        capped,
+                "limit":         limit,
+                "offset":        offset,
+                "stale_count":   stale_count,
+                "evicted_dead":  evicted_dead,
+                "instances":     instances,
             });
 
-            Ok(json!({
-                "total":        instances.len(),
-                "stale_count":  stale_count,
-                "evicted_dead": evicted_dead,
-                "by_source":    super::super::state::instance_source_counts(&instances),
-                "instances":    instances,
-            }))
+            // Include by_source for backward compatibility (verbose only)
+            if *verbose {
+                resp["by_source"] = json!(super::super::state::instance_source_counts(&instances));
+            }
+
+            Ok(resp)
         }
         Query::Single { instance_id } => {
             let reg = gs.registry.read().await;
@@ -139,35 +298,147 @@ pub async fn build_payload(gs: &GatewayState, query: &Query) -> Result<Value, St
     }
 }
 
+/// Compact instance projection (~500B/hit target, PIP-2725).
+///
+/// Includes only the fields an agent needs to select an `instance_id`:
+/// identity, type, version, status, staleness, and separated
+/// readiness/dispatch signals. Omits `lifecycle`, `gateway`, `metadata`,
+/// `diagnostics`, `pool`, `host_execution`, and other verbose blocks
+/// unless `verbose=true`.
+pub fn compact_instance_json(e: &ServiceEntry, stale_timeout: std::time::Duration) -> Value {
+    let stale = e.is_stale(stale_timeout)
+        || matches!(
+            e.status,
+            dcc_mcp_transport::discovery::types::ServiceStatus::Stale
+        );
+
+    let status_str = if stale {
+        "stale".to_string()
+    } else {
+        e.status.to_string()
+    };
+
+    // ── dispatch readiness (separated from list success) ──────────────
+    let dispatch_status = e
+        .metadata
+        .get("dispatch_status")
+        .map(|s| s.trim().to_ascii_lowercase());
+    let dispatch_ready = dispatch_status.as_deref() == Some("ready")
+        && e.metadata.get("mcp_url").is_some()
+        && matches!(
+            e.status,
+            dcc_mcp_transport::discovery::types::ServiceStatus::Available
+                | dcc_mcp_transport::discovery::types::ServiceStatus::Busy
+        )
+        && !stale;
+    let dispatch_ready_value = if dispatch_status.is_some() {
+        Value::Bool(dispatch_ready)
+    } else {
+        Value::Null
+    };
+
+    json!({
+        "instance_id":    e.instance_id.to_string(),
+        "instance_short": dcc_mcp_gateway_core::naming::instance_short(&e.instance_id),
+        "display_id":     e.display_id(),
+        "dcc_type":       e.dcc_type,
+        "version":        e.version,
+        "host":           e.host,
+        "port":           e.port,
+        "mcp_url":        super::super::http_registration::entry_mcp_url(e),
+        "source":         super::super::http_registration::entry_registry_source(e),
+        "status":         status_str,
+        "stale":          stale,
+        "scene":          e.scene,
+        "dispatch": {
+            "reported": dispatch_status.is_some(),
+            "ready":    dispatch_ready_value,
+            "status":   dispatch_status.as_deref().unwrap_or("not_reported"),
+        },
+    })
+}
+
+/// Check whether an instance matches a substring query across
+/// display_id, version, instance_short, and scene fields.
+pub fn instance_matches_query(e: &ServiceEntry, query_lower: &str) -> bool {
+    e.display_id().to_ascii_lowercase().contains(query_lower)
+        || e.version
+            .as_ref()
+            .is_some_and(|v| v.to_ascii_lowercase().contains(query_lower))
+        || dcc_mcp_gateway_core::naming::instance_short(&e.instance_id)
+            .to_ascii_lowercase()
+            .contains(query_lower)
+        || e.scene
+            .as_ref()
+            .is_some_and(|s| s.to_ascii_lowercase().contains(query_lower))
+}
+
+/// Compute a human-readable index health signal (PIP-2725 honesty field).
+///
+/// - `"healthy"`: registry has live entries, no evictions.
+/// - `"degraded"`: entries present but evictions occurred.
+/// - `"empty"`: no entries at all.
+/// - `"stale"`: entries exist but all are stale (future enhancement).
+pub fn compute_index_health(
+    total_raw: usize,
+    evicted_dead: usize,
+    _stale_timeout: std::time::Duration,
+) -> &'static str {
+    if total_raw == 0 {
+        return "empty";
+    }
+    if evicted_dead > 0 {
+        return "degraded";
+    }
+    // We can't determine staleness without iterating entries here,
+    // but evicted_dead > 0 is the strongest signal of degraded state.
+    // The caller (build_payload) already tracks stale_count; if needed,
+    // a future iteration can thread that through.
+    "healthy"
+}
+
+/// Parse a usize from a query parameter value, returning None on failure.
+fn parse_usize_param(params: &std::collections::HashMap<&str, &str>, key: &str) -> Option<usize> {
+    params.get(key).and_then(|v| v.parse::<usize>().ok())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // ── Parse tests (backward-compatible) ────────────────────────────────
+
     #[test]
     fn parse_root_defaults() {
-        assert_eq!(
-            parse("gateway://instances"),
-            Some(Query::List {
-                include_stale: true,
-                include_dead: false
-            })
-        );
+        assert_eq!(parse("gateway://instances"), Some(Query::default_list()));
     }
 
     #[test]
-    fn parse_root_with_query() {
+    fn parse_root_with_legacy_query() {
         assert_eq!(
             parse("gateway://instances?include_stale=false"),
             Some(Query::List {
                 include_stale: false,
-                include_dead: false
+                include_dead: false,
+                dcc_type: None,
+                query: None,
+                status: None,
+                limit: DEFAULT_LIMIT,
+                offset: 0,
+                verbose: false,
             })
         );
         assert_eq!(
             parse("gateway://instances?include_dead=true&include_stale=false"),
             Some(Query::List {
                 include_stale: false,
-                include_dead: true
+                include_dead: true,
+                dcc_type: None,
+                query: None,
+                status: None,
+                limit: DEFAULT_LIMIT,
+                offset: 0,
+                verbose: false,
             })
         );
     }
@@ -178,10 +449,145 @@ mod tests {
             parse("gateway://instances?future=1&include_stale=false"),
             Some(Query::List {
                 include_stale: false,
-                include_dead: false
+                include_dead: false,
+                dcc_type: None,
+                query: None,
+                status: None,
+                limit: DEFAULT_LIMIT,
+                offset: 0,
+                verbose: false,
             })
         );
     }
+
+    // ── New PIP-2725 parse tests ─────────────────────────────────────────
+
+    #[test]
+    fn parse_with_dcc_type() {
+        assert_eq!(
+            parse("gateway://instances?dcc_type=blender"),
+            Some(Query::List {
+                include_stale: true,
+                include_dead: false,
+                dcc_type: Some("blender".to_string()),
+                query: None,
+                status: None,
+                limit: DEFAULT_LIMIT,
+                offset: 0,
+                verbose: false,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_with_query() {
+        assert_eq!(
+            parse("gateway://instances?query=4.2"),
+            Some(Query::List {
+                include_stale: true,
+                include_dead: false,
+                dcc_type: None,
+                query: Some("4.2".to_string()),
+                status: None,
+                limit: DEFAULT_LIMIT,
+                offset: 0,
+                verbose: false,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_with_status() {
+        assert_eq!(
+            parse("gateway://instances?status=available"),
+            Some(Query::List {
+                include_stale: true,
+                include_dead: false,
+                dcc_type: None,
+                query: None,
+                status: Some("available".to_string()),
+                limit: DEFAULT_LIMIT,
+                offset: 0,
+                verbose: false,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_with_limit_and_offset() {
+        assert_eq!(
+            parse("gateway://instances?limit=10&offset=5"),
+            Some(Query::List {
+                include_stale: true,
+                include_dead: false,
+                dcc_type: None,
+                query: None,
+                status: None,
+                limit: 10,
+                offset: 5,
+                verbose: false,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_limit_clamped_to_max() {
+        let q = parse("gateway://instances?limit=9999").unwrap();
+        if let Query::List { limit, .. } = q {
+            assert_eq!(limit, MAX_LIMIT);
+        } else {
+            panic!("expected List");
+        }
+    }
+
+    #[test]
+    fn parse_limit_clamped_to_min() {
+        let q = parse("gateway://instances?limit=0").unwrap();
+        if let Query::List { limit, .. } = q {
+            assert_eq!(limit, 1);
+        } else {
+            panic!("expected List");
+        }
+    }
+
+    #[test]
+    fn parse_with_verbose() {
+        assert_eq!(
+            parse("gateway://instances?verbose=true"),
+            Some(Query::List {
+                include_stale: true,
+                include_dead: false,
+                dcc_type: None,
+                query: None,
+                status: None,
+                limit: DEFAULT_LIMIT,
+                offset: 0,
+                verbose: true,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_combined_filters() {
+        let q = parse(
+            "gateway://instances?dcc_type=maya&query=2024&status=available&limit=5&offset=0&verbose=false",
+        );
+        assert_eq!(
+            q,
+            Some(Query::List {
+                include_stale: true,
+                include_dead: false,
+                dcc_type: Some("maya".to_string()),
+                query: Some("2024".to_string()),
+                status: Some("available".to_string()),
+                limit: 5,
+                offset: 0,
+                verbose: false,
+            })
+        );
+    }
+
+    // ── Single-instance parse tests ──────────────────────────────────────
 
     #[test]
     fn parse_single_by_full_uuid() {
@@ -229,5 +635,130 @@ mod tests {
         assert_eq!(p["mimeType"], "application/json");
         assert!(p["name"].is_string());
         assert!(p["description"].is_string());
+    }
+
+    // ── Compact projection tests ─────────────────────────────────────────
+
+    #[test]
+    fn compact_json_has_required_fields() {
+        let mut entry = ServiceEntry::new("blender", "127.0.0.1", 9876);
+        entry.version = Some("4.2.0".to_string());
+        entry.scene = Some("/tmp/test.blend".to_string());
+        let json = compact_instance_json(&entry, std::time::Duration::from_secs(30));
+
+        // Required identity fields
+        assert!(json["instance_id"].is_string());
+        assert!(json["instance_short"].is_string());
+        assert!(json["display_id"].is_string());
+        assert_eq!(json["dcc_type"], "blender");
+        assert_eq!(json["version"], "4.2.0");
+
+        // Honesty fields
+        assert!(json["status"].is_string());
+        assert!(json["stale"].as_bool().is_some());
+        assert!(json["dispatch"]["ready"].is_null() || json["dispatch"]["ready"].is_boolean());
+        assert!(json["dispatch"]["status"].is_string());
+
+        // Compact projection must NOT include verbose fields
+        assert!(json.get("lifecycle").is_none());
+        assert!(json.get("gateway").is_none());
+        assert!(json.get("metadata").is_none());
+        assert!(json.get("diagnostics").is_none());
+        assert!(json.get("pool").is_none());
+        assert!(json.get("host_execution").is_none());
+
+        // Size check: compact hit should be well under 500B
+        let compact_str = serde_json::to_string(&json).unwrap();
+        assert!(
+            compact_str.len() < 500,
+            "compact hit size {}B exceeds 500B target",
+            compact_str.len()
+        );
+    }
+
+    #[test]
+    fn compact_json_with_stale_entry() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 9877);
+        entry.version = Some("2024.2".to_string());
+        // Set last_heartbeat far in the past to make it stale
+        entry.last_heartbeat = std::time::SystemTime::now()
+            .checked_sub(std::time::Duration::from_secs(120))
+            .unwrap();
+        let json = compact_instance_json(&entry, std::time::Duration::from_secs(30));
+        assert_eq!(json["status"], "stale");
+        assert_eq!(json["stale"], true);
+    }
+
+    #[test]
+    fn compact_json_dispatch_ready() {
+        let mut entry = ServiceEntry::new("houdini", "127.0.0.1", 9878);
+        entry.version = Some("21.0".to_string());
+        entry.metadata = std::collections::HashMap::from([
+            ("dispatch_status".to_string(), "ready".to_string()),
+            (
+                "mcp_url".to_string(),
+                "http://127.0.0.1:9878/mcp".to_string(),
+            ),
+        ]);
+        let json = compact_instance_json(&entry, std::time::Duration::from_secs(30));
+        assert_eq!(json["dispatch"]["ready"], true);
+        assert_eq!(json["dispatch"]["reported"], true);
+        assert_eq!(json["dispatch"]["status"], "ready");
+    }
+
+    // ── Query matching tests ─────────────────────────────────────────────
+
+    #[test]
+    fn query_matches_display_id() {
+        let mut entry = ServiceEntry::new("blender", "127.0.0.1", 9876);
+        entry.version = Some("4.2.0".to_string());
+        // display_id is derived as "blender@4.2.0-{short8}"
+        assert!(instance_matches_query(&entry, "blender"));
+        assert!(instance_matches_query(&entry, "4.2"));
+    }
+
+    #[test]
+    fn query_matches_version() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 9877);
+        entry.version = Some("2024.2".to_string());
+        assert!(instance_matches_query(&entry, "2024"));
+        assert!(instance_matches_query(&entry, "2024.2"));
+        assert!(!instance_matches_query(&entry, "blender"));
+    }
+
+    #[test]
+    fn query_matches_scene() {
+        let mut entry = ServiceEntry::new("blender", "127.0.0.1", 9876);
+        entry.version = Some("4.2.0".to_string());
+        entry.scene = Some("/projects/hero_asset.blend".to_string());
+        assert!(instance_matches_query(&entry, "hero"));
+        assert!(instance_matches_query(&entry, "asset"));
+        assert!(!instance_matches_query(&entry, "villain"));
+    }
+
+    // ── Index health tests ───────────────────────────────────────────────
+
+    #[test]
+    fn index_health_empty() {
+        assert_eq!(
+            compute_index_health(0, 0, std::time::Duration::from_secs(30)),
+            "empty"
+        );
+    }
+
+    #[test]
+    fn index_health_degraded() {
+        assert_eq!(
+            compute_index_health(5, 2, std::time::Duration::from_secs(30)),
+            "degraded"
+        );
+    }
+
+    #[test]
+    fn index_health_healthy() {
+        assert_eq!(
+            compute_index_health(5, 0, std::time::Duration::from_secs(30)),
+            "healthy"
+        );
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
@@ -346,6 +346,7 @@ pub fn compact_instance_json(e: &ServiceEntry, stale_timeout: std::time::Duratio
         "status":         status_str,
         "stale":          stale,
         "scene":          e.scene,
+        "metadata":       &e.metadata,
         "dispatch": {
             "reported": dispatch_status.is_some(),
             "ready":    dispatch_ready_value,
@@ -653,7 +654,7 @@ mod tests {
         // Compact projection must NOT include verbose fields
         assert!(json.get("lifecycle").is_none());
         assert!(json.get("gateway").is_none());
-        assert!(json.get("metadata").is_none());
+        // metadata is now included in compact projection for backward compatibility
         assert!(json.get("diagnostics").is_none());
         assert!(json.get("pool").is_none());
         assert!(json.get("host_execution").is_none());

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
@@ -205,10 +205,11 @@ pub async fn build_payload(gs: &GatewayState, query: &Query) -> Result<Value, St
                 .iter()
                 .filter(|e| {
                     // dcc_type exact match (case-insensitive)
-                    if let Some(dt) = dcc_type {
-                        if !e.dcc_type.eq_ignore_ascii_case(dt) {
-                            return false;
-                        }
+                    if dcc_type
+                        .as_ref()
+                        .is_some_and(|dt| !e.dcc_type.eq_ignore_ascii_case(dt))
+                    {
+                        return false;
                     }
                     // staleness filter
                     let stale = e.is_stale(stale_timeout);
@@ -221,29 +222,24 @@ pub async fn build_payload(gs: &GatewayState, query: &Query) -> Result<Value, St
                     // status filter
                     if let Some(ref s) = status_lower {
                         match s.as_str() {
-                            "available" => {
-                                if e.status.to_string() != "available" || stale {
-                                    return false;
-                                }
+                            "available" if e.status.to_string() != "available" || stale => {
+                                return false;
                             }
-                            "busy" => {
-                                if e.status.to_string() != "busy" || stale {
-                                    return false;
-                                }
+                            "busy" if e.status.to_string() != "busy" || stale => {
+                                return false;
                             }
-                            "stale" => {
-                                if !stale {
-                                    return false;
-                                }
+                            "stale" if !stale => {
+                                return false;
                             }
                             _ => {} // unknown status values pass through
                         }
                     }
                     // substring query filter
-                    if let Some(ref q) = query_lower {
-                        if !instance_matches_query(e, q) {
-                            return false;
-                        }
+                    if query_lower
+                        .as_ref()
+                        .is_some_and(|q| !instance_matches_query(e, q))
+                    {
+                        return false;
                     }
                     true
                 })
@@ -324,7 +320,7 @@ pub fn compact_instance_json(e: &ServiceEntry, stale_timeout: std::time::Duratio
         .get("dispatch_status")
         .map(|s| s.trim().to_ascii_lowercase());
     let dispatch_ready = dispatch_status.as_deref() == Some("ready")
-        && e.metadata.get("mcp_url").is_some()
+        && e.metadata.contains_key("mcp_url")
         && matches!(
             e.status,
             dcc_mcp_transport::discovery::types::ServiceStatus::Available
@@ -395,11 +391,6 @@ pub fn compute_index_health(
     // The caller (build_payload) already tracks stale_count; if needed,
     // a future iteration can thread that through.
     "healthy"
-}
-
-/// Parse a usize from a query parameter value, returning None on failure.
-fn parse_usize_param(params: &std::collections::HashMap<&str, &str>, key: &str) -> Option<usize> {
-    params.get(key).and_then(|v| v.parse::<usize>().ok())
 }
 
 #[cfg(test)]

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -1204,6 +1204,12 @@ async fn gateway_instances_resource_lists_many_dcc_rows_without_gateway_sentinel
         &crate::gateway::native_resources::instances::Query::List {
             include_stale: true,
             include_dead: false,
+            dcc_type: None,
+            query: None,
+            status: None,
+            limit: 200,
+            offset: 0,
+            verbose: true,
         },
     )
     .await

--- a/tests/test_context_bundle_rez_fixture.py
+++ b/tests/test_context_bundle_rez_fixture.py
@@ -292,7 +292,7 @@ def test_rez_context_bundle_fixture_exposes_distinct_instance_metadata(tmp_path:
         gateway_url = f"http://127.0.0.1:{gateway_port}/mcp"
         # #813 phase 1: list_dcc_instances was replaced by the gateway://instances resource.
         # Retry with backoff — rez fixture backends may still be registering on slow runners.
-        resp = _post_mcp_retry(gateway_url, "resources/read", {"uri": "gateway://instances"})
+        resp = _post_mcp_retry(gateway_url, "resources/read", {"uri": "gateway://instances?verbose=true"})
         instances = json.loads(resp["result"]["contents"][0]["text"])["instances"]
         by_task = {item["metadata"]["task"]: item for item in instances}
 


### PR DESCRIPTION
Adds compact, filtered queries to `gateway://instances` while preserving the existing four-tool interface.