### PR TITLE
fix: resolve clippy warnings and Python 3.7 test failure on compact instance query

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
@@ -205,10 +205,10 @@ pub async fn build_payload(gs: &GatewayState, query: &Query) -> Result<Value, St
                 .iter()
                 .filter(|e| {
                     // dcc_type exact match (case-insensitive)
-                    if let Some(dt) = dcc_type {
-                        if !e.dcc_type.eq_ignore_ascii_case(dt) {
-                            return false;
-                        }
+                    if let Some(dt) = dcc_type
+                        && !e.dcc_type.eq_ignore_ascii_case(dt)
+                    {
+                        return false;
                     }
                     // staleness filter
                     let stale = e.is_stale(stale_timeout);
@@ -221,29 +221,23 @@ pub async fn build_payload(gs: &GatewayState, query: &Query) -> Result<Value, St
                     // status filter
                     if let Some(ref s) = status_lower {
                         match s.as_str() {
-                            "available" => {
-                                if e.status.to_string() != "available" || stale {
-                                    return false;
-                                }
+                            "available" if (e.status.to_string() != "available" || stale) => {
+                                return false;
                             }
-                            "busy" => {
-                                if e.status.to_string() != "busy" || stale {
-                                    return false;
-                                }
+                            "busy" if (e.status.to_string() != "busy" || stale) => {
+                                return false;
                             }
-                            "stale" => {
-                                if !stale {
-                                    return false;
-                                }
+                            "stale" if !stale => {
+                                return false;
                             }
                             _ => {} // unknown status values pass through
                         }
                     }
                     // substring query filter
-                    if let Some(ref q) = query_lower {
-                        if !instance_matches_query(e, q) {
-                            return false;
-                        }
+                    if let Some(ref q) = query_lower
+                        && !instance_matches_query(e, q)
+                    {
+                        return false;
                     }
                     true
                 })
@@ -324,7 +318,7 @@ pub fn compact_instance_json(e: &ServiceEntry, stale_timeout: std::time::Duratio
         .get("dispatch_status")
         .map(|s| s.trim().to_ascii_lowercase());
     let dispatch_ready = dispatch_status.as_deref() == Some("ready")
-        && e.metadata.get("mcp_url").is_some()
+        && e.metadata.contains_key("mcp_url")
         && matches!(
             e.status,
             dcc_mcp_transport::discovery::types::ServiceStatus::Available
@@ -395,11 +389,6 @@ pub fn compute_index_health(
     // The caller (build_payload) already tracks stale_count; if needed,
     // a future iteration can thread that through.
     "healthy"
-}
-
-/// Parse a usize from a query parameter value, returning None on failure.
-fn parse_usize_param(params: &std::collections::HashMap<&str, &str>, key: &str) -> Option<usize> {
-    params.get(key).and_then(|v| v.parse::<usize>().ok())
 }
 
 #[cfg(test)]

--- a/tests/test_context_bundle_rez_fixture.py
+++ b/tests/test_context_bundle_rez_fixture.py
@@ -292,7 +292,7 @@ def test_rez_context_bundle_fixture_exposes_distinct_instance_metadata(tmp_path:
         gateway_url = f"http://127.0.0.1:{gateway_port}/mcp"
         # #813 phase 1: list_dcc_instances was replaced by the gateway://instances resource.
         # Retry with backoff — rez fixture backends may still be registering on slow runners.
-        resp = _post_mcp_retry(gateway_url, "resources/read", {"uri": "gateway://instances"})
+        resp = _post_mcp_retry(gateway_url, "resources/read", {"uri": "gateway://instances?verbose=true"})
         instances = json.loads(resp["result"]["contents"][0]["text"])["instances"]
         by_task = {item["metadata"]["task"]: item for item in instances}
 


### PR DESCRIPTION
Apply 7 clippy fixes and 1 Python test fix for the compact filtered instance query introduced in PR #1904.

## Changes

### Rust (instances.rs)
- Replace `HashMap::get().is_some()` with `contains_key()` — clippy `unnecessary_get_then_check`
- Collapse nested `if` blocks in dcc_type/query filters — clippy `collapsible_if`
- Collapse nested `match` + `if` in status filter — clippy `collapsible_match` (3 sites)
- Remove unused `parse_usize_param` helper

### Python (test_context_bundle_rez_fixture.py)
- Add `?verbose=true` to `gateway://instances` resource read — the compact projection (PIP-2725 first slice) intentionally omits `metadata`, but this test accesses `item["metadata"]["task"]`. Verbose mode restores full instance JSON including metadata.

## Validation
- `cargo test -p dcc-mcp-gateway --lib native_resources::instances` — 25 passed, 0 failed
- `cargo fmt --check` — clean
- `cargo clippy -p dcc-mcp-gateway --lib` — zero new warnings in changed files