### PR TITLE
fix: shut down DCC bridge event loop gracefully

### DIFF
--- a/python/dcc_mcp_core/bridge.py
+++ b/python/dcc_mcp_core/bridge.py
@@ -377,6 +377,7 @@ class DccBridge:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
         self._ws_server = None  # asyncio-ws server handle
+        self._shutdown_event: asyncio.Event | None = None
 
         # Set once the TCP server is bound and accepting connections.
         self._server_ready = threading.Event()
@@ -433,8 +434,10 @@ class DccBridge:
         """Shut down the WebSocket server and close any active connection."""
         self._closed = True
         self._connected = False
-        if self._loop is not None:
-            self._loop.call_soon_threadsafe(self._loop.stop)
+        loop = self._loop
+        shutdown_event = self._shutdown_event
+        if loop is not None and shutdown_event is not None and not loop.is_closed():
+            loop.call_soon_threadsafe(shutdown_event.set)
         if self._thread is not None:
             self._thread.join(timeout=5.0)
             self._thread = None
@@ -514,12 +517,15 @@ class DccBridge:
         # Do NOT call asyncio.set_event_loop(): it was deprecated in 3.10 and
         # removed in Python 3.14.  The loop was created in __init__ via
         # asyncio.new_event_loop() and is fully self-contained in this thread.
+        loop = self._loop
+        if loop is None:
+            return
         try:
-            self._loop.run_until_complete(self._serve())
+            loop.run_until_complete(self._serve())
         except Exception:
             logger.exception("DccBridge event loop crashed")
         finally:
-            self._loop.close()
+            loop.close()
 
     async def _serve(self) -> None:
         try:
@@ -529,12 +535,17 @@ class DccBridge:
                 "The 'websockets' package is required for DccBridge. Install it with: pip install websockets"
             ) from exc
 
-        async with websockets.serve(self._handle_dcc, self._host, self._port) as server:
-            self._ws_server = server
-            self._server_ready.set()
-            logger.debug("DccBridge listening on %s", self.endpoint)
-            # Run until stop() is called.
-            await asyncio.get_running_loop().create_future()
+        shutdown_event = asyncio.Event()
+        self._shutdown_event = shutdown_event
+        try:
+            async with websockets.serve(self._handle_dcc, self._host, self._port) as server:
+                self._ws_server = server
+                self._server_ready.set()
+                logger.debug("DccBridge listening on %s", self.endpoint)
+                await shutdown_event.wait()
+        finally:
+            self._shutdown_event = None
+            self._ws_server = None
 
     async def _handle_dcc(self, ws: Any) -> None:
         """Handle a single DCC plugin WebSocket connection."""

--- a/tests/test_bridge_resilience.py
+++ b/tests/test_bridge_resilience.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
+import sys
 import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -12,6 +15,7 @@ from dcc_mcp_core import BridgeFallbackClient
 from dcc_mcp_core import BridgeRetryPolicy
 from dcc_mcp_core import BridgeRpcError
 from dcc_mcp_core import BridgeTransportStrategy
+from dcc_mcp_core import DccBridge
 from dcc_mcp_core import ReverseBridgeSession
 
 
@@ -46,6 +50,17 @@ class _Strategy(BridgeTransportStrategy):
         return {"strategy": self.name, "method": method, "params": params}
 
 
+class _ServerContext:
+    def __init__(self) -> None:
+        self.closed = threading.Event()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        self.closed.set()
+
+
 def test_bridge_resilience_symbols_exported() -> None:
     for name in (
         "BridgeFallbackClient",
@@ -56,6 +71,21 @@ def test_bridge_resilience_symbols_exported() -> None:
     ):
         assert hasattr(dcc_mcp_core, name)
         assert name in dcc_mcp_core.__all__
+
+
+def test_dcc_bridge_disconnect_closes_server_without_crashing_event_loop(monkeypatch, caplog) -> None:
+    server = _ServerContext()
+    monkeypatch.setitem(sys.modules, "websockets", SimpleNamespace(serve=lambda *_args, **_kwargs: server))
+    bridge = DccBridge(host="127.0.0.1", port=0)
+
+    with caplog.at_level(logging.ERROR, logger="dcc_mcp_core.bridge"):
+        bridge.connect()
+        loop = bridge._loop
+        bridge.disconnect()
+
+    assert server.closed.wait(timeout=1.0)
+    assert loop is not None and loop.is_closed()
+    assert "DccBridge event loop crashed" not in caplog.text
 
 
 def test_retry_policy_retries_operation() -> None:


### PR DESCRIPTION
## Summary
- replace forced event-loop stops with an explicit async shutdown signal
- let the WebSocket server context close active connections before the loop closes
- add a regression test that rejects event-loop crash logging during disconnect

## Validation
- x just dev`n- .venv/Scripts/python.exe -m pytest tests/test_bridge_resilience.py -q (9 passed)
- x ruff check python/dcc_mcp_core/bridge.py tests/test_bridge_resilience.py`n- x ruff format --check python/dcc_mcp_core/bridge.py tests/test_bridge_resilience.py`n- real Godot 4.7 editor bridge + generated roguelike gameplay smoke: ROGUELIKE_SMOKE_OK`n
No skill guidance update is needed because the public bridge API and adapter contracts are unchanged.