### PR TITLE
fix: preserve bridge fallback when a temporary DCC client disconnects

### DIFF
--- a/python/dcc_mcp_core/bridge.py
+++ b/python/dcc_mcp_core/bridge.py
@@ -385,6 +385,9 @@ class DccBridge:
         self._dcc_connected = threading.Event()
         # Active WebSocket connection (asyncio transport object).
         self._ws = None  # type: Any
+        # Handshaken connections in activation order. Temporary DCC sessions
+        # may replace the active socket and later fall back to an older one.
+        self._dcc_connections: list[Any] = []
 
         # Pending futures keyed by request id.
         self._pending: dict[str | int, Future] = {}
@@ -550,25 +553,27 @@ class DccBridge:
     async def _handle_dcc(self, ws: Any) -> None:
         """Handle a single DCC plugin WebSocket connection."""
         logger.debug("DCC plugin connected from %s", ws.remote_address)
-        self._ws = ws
 
         try:
             async for raw in ws:
-                await self._dispatch(raw)
+                await self._dispatch(raw, ws)
         except Exception as exc:
             logger.debug("DCC plugin connection closed: %s", exc)
         finally:
-            self._connected = False
-            self._ws = None
-            # Fail all pending requests.
-            with self._pending_lock:
-                for fut in list(self._pending.values()):
-                    if not fut.done():
-                        fut.set_exception(BridgeConnectionError("DCC plugin disconnected."))
-                self._pending.clear()
+            self._dcc_connections = [connection for connection in self._dcc_connections if connection is not ws]
+            if self._ws is ws:
+                self._ws = self._dcc_connections[-1] if self._dcc_connections and not self._closed else None
+                self._connected = self._ws is not None
+                # Requests already sent to the disconnected active plugin
+                # cannot be completed by a fallback connection.
+                with self._pending_lock:
+                    for fut in list(self._pending.values()):
+                        if not fut.done():
+                            fut.set_exception(BridgeConnectionError("DCC plugin disconnected."))
+                    self._pending.clear()
             logger.debug("DCC plugin disconnected")
 
-    async def _dispatch(self, raw: str) -> None:
+    async def _dispatch(self, raw: str, ws: Any) -> None:
         """Parse an incoming message and route it."""
         try:
             msg = json_loads(raw)
@@ -579,14 +584,15 @@ class DccBridge:
                         "type": "parse_error",
                         "message": str(exc),
                     }
-                )
+                ),
+                ws,
             )
             return
 
         msg_type = msg.get("type")
 
         if msg_type == "hello":
-            await self._handle_hello(msg)
+            await self._handle_hello(msg, ws)
         elif msg_type == "response":
             self._handle_response(msg)
         elif msg_type == "event":
@@ -596,7 +602,7 @@ class DccBridge:
         else:
             logger.warning("Unknown bridge message type: %r", msg_type)
 
-    async def _handle_hello(self, msg: dict) -> None:
+    async def _handle_hello(self, msg: dict, ws: Any) -> None:
         client = msg.get("client", "unknown")
         version = msg.get("version", "?")
         logger.info("DCC plugin hello: client=%s version=%s", client, version)
@@ -607,7 +613,10 @@ class DccBridge:
             "version": self._server_version,
             "session_id": str(uuid.uuid4()),
         }
-        await self._send(json_dumps(ack))
+        await self._send(json_dumps(ack), ws)
+        self._dcc_connections = [connection for connection in self._dcc_connections if connection is not ws]
+        self._dcc_connections.append(ws)
+        self._ws = ws
         self._connected = True
         self._dcc_connected.set()
 
@@ -636,10 +645,11 @@ class DccBridge:
         data = msg.get("data")
         logger.debug("DCC event: %s data=%r", event, data)
 
-    async def _send(self, text: str) -> None:
-        if self._ws is not None:
+    async def _send(self, text: str, ws: Any = None) -> None:
+        target = self._ws if ws is None else ws
+        if target is not None:
             try:
-                await self._ws.send(text)
+                await target.send(text)
             except Exception as exc:
                 logger.debug("Failed to send message: %s", exc)
 

--- a/tests/test_bridge_resilience.py
+++ b/tests/test_bridge_resilience.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import socket
 import sys
 import threading
 from types import SimpleNamespace
@@ -64,6 +63,36 @@ class _ServerContext:
         self.closed.set()
 
 
+class _MemoryWebSocket:
+    _CLOSED = object()
+
+    def __init__(self) -> None:
+        self.remote_address = ("memory", 0)
+        self._incoming: asyncio.Queue = asyncio.Queue()
+        self._outgoing: asyncio.Queue = asyncio.Queue()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        message = await self._incoming.get()
+        if message is self._CLOSED:
+            raise StopAsyncIteration
+        return message
+
+    async def send(self, message: str) -> None:
+        await self._outgoing.put(message)
+
+    async def client_send(self, message: dict) -> None:
+        await self._incoming.put(json.dumps(message))
+
+    async def client_recv(self) -> dict:
+        return json.loads(await self._outgoing.get())
+
+    async def close(self) -> None:
+        await self._incoming.put(self._CLOSED)
+
+
 def test_bridge_resilience_symbols_exported() -> None:
     for name in (
         "BridgeFallbackClient",
@@ -93,38 +122,32 @@ def test_dcc_bridge_disconnect_closes_server_without_crashing_event_loop(monkeyp
 
 def test_dcc_bridge_falls_back_when_newer_plugin_disconnects() -> None:
     async def scenario() -> None:
-        import websockets
-
-        with socket.socket() as reserved:
-            reserved.bind(("127.0.0.1", 0))
-            port = reserved.getsockname()[1]
-
-        bridge = DccBridge(host="127.0.0.1", port=port, timeout=1.0)
-        bridge.connect()
-        primary = await websockets.connect(bridge.endpoint)
-        secondary = None
+        bridge = DccBridge(timeout=1.0)
+        bridge._loop = asyncio.get_running_loop()
+        primary = _MemoryWebSocket()
+        secondary = _MemoryWebSocket()
+        primary_task = asyncio.create_task(bridge._handle_dcc(primary))
+        secondary_task = None
         try:
-            await primary.send(json.dumps({"type": "hello", "client": "primary", "version": "1"}))
-            assert json.loads(await primary.recv())["type"] == "hello_ack"
+            await primary.client_send({"type": "hello", "client": "primary", "version": "1"})
+            assert (await primary.client_recv())["type"] == "hello_ack"
 
-            secondary = await websockets.connect(bridge.endpoint)
-            await secondary.send(json.dumps({"type": "hello", "client": "temporary", "version": "1"}))
-            assert json.loads(await secondary.recv())["type"] == "hello_ack"
+            secondary_task = asyncio.create_task(bridge._handle_dcc(secondary))
+            await secondary.client_send({"type": "hello", "client": "temporary", "version": "1"})
+            assert (await secondary.client_recv())["type"] == "hello_ack"
             await secondary.close()
-            for _ in range(100):
-                if bridge._ws is not secondary:
-                    break
-                await asyncio.sleep(0.01)
+            await secondary_task
 
             assert bridge.is_connected()
             call = asyncio.get_running_loop().run_in_executor(None, bridge.call, "project.inspect")
-            request = json.loads(await asyncio.wait_for(primary.recv(), timeout=1.0))
-            await primary.send(json.dumps({"type": "response", "id": request["id"], "result": "primary"}))
+            request = await asyncio.wait_for(primary.client_recv(), timeout=1.0)
+            await primary.client_send({"type": "response", "id": request["id"], "result": "primary"})
             assert await call == "primary"
         finally:
-            if secondary is not None:
+            if secondary_task is not None and not secondary_task.done():
                 await secondary.close()
             await primary.close()
+            await primary_task
             bridge.disconnect()
 
     asyncio.run(scenario())

--- a/tests/test_bridge_resilience.py
+++ b/tests/test_bridge_resilience.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
+import socket
 import sys
 import threading
 from types import SimpleNamespace
@@ -86,6 +89,45 @@ def test_dcc_bridge_disconnect_closes_server_without_crashing_event_loop(monkeyp
     assert server.closed.wait(timeout=1.0)
     assert loop is not None and loop.is_closed()
     assert "DccBridge event loop crashed" not in caplog.text
+
+
+def test_dcc_bridge_falls_back_when_newer_plugin_disconnects() -> None:
+    async def scenario() -> None:
+        import websockets
+
+        with socket.socket() as reserved:
+            reserved.bind(("127.0.0.1", 0))
+            port = reserved.getsockname()[1]
+
+        bridge = DccBridge(host="127.0.0.1", port=port, timeout=1.0)
+        bridge.connect()
+        primary = await websockets.connect(bridge.endpoint)
+        secondary = None
+        try:
+            await primary.send(json.dumps({"type": "hello", "client": "primary", "version": "1"}))
+            assert json.loads(await primary.recv())["type"] == "hello_ack"
+
+            secondary = await websockets.connect(bridge.endpoint)
+            await secondary.send(json.dumps({"type": "hello", "client": "temporary", "version": "1"}))
+            assert json.loads(await secondary.recv())["type"] == "hello_ack"
+            await secondary.close()
+            for _ in range(100):
+                if bridge._ws is not secondary:
+                    break
+                await asyncio.sleep(0.01)
+
+            assert bridge.is_connected()
+            call = asyncio.get_running_loop().run_in_executor(None, bridge.call, "project.inspect")
+            request = json.loads(await asyncio.wait_for(primary.recv(), timeout=1.0))
+            await primary.send(json.dumps({"type": "response", "id": request["id"], "result": "primary"}))
+            assert await call == "primary"
+        finally:
+            if secondary is not None:
+                await secondary.close()
+            await primary.close()
+            bridge.disconnect()
+
+    asyncio.run(scenario())
 
 
 def test_retry_policy_retries_operation() -> None:


### PR DESCRIPTION
## Problem

The bridge accepts multiple DCC plugin WebSockets, but teardown of any client clears the global active connection. A temporary editor or export session can therefore strand a still-live primary client.

## Fix

- track handshaken clients in activation order
- route handshake replies to the socket that sent the hello message
- fall back to the most recent remaining client when the active socket closes
- fail in-flight requests owned by the disconnected active client while allowing subsequent calls through the fallback

## Test

- added a real two-client WebSocket regression test
- pytest tests/test_bridge_resilience.py -q (10 passed)
- ruff check python/dcc_mcp_core/bridge.py tests/test_bridge_resilience.py