### PR TITLE
feat(cli): accept call arguments from files

### DIFF
--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::io::Read;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -136,6 +137,9 @@ enum Command {
         instance_id: Option<String>,
         #[arg(long = "json", default_value = "{}")]
         arguments_json: String,
+        /// Read call arguments from a UTF-8 JSON file, or '-' for stdin.
+        #[arg(long, value_name = "PATH", conflicts_with = "arguments_json")]
+        json_file: Option<PathBuf>,
         #[arg(long)]
         meta_json: Option<String>,
         /// Per-request timeout for the tool call. Increase for renders and other long-running sync tools.
@@ -567,10 +571,11 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
             dcc_type,
             instance_id,
             arguments_json,
+            json_file,
             meta_json,
             timeout_secs,
         } => {
-            let arguments = parse_json_object(&arguments_json, "--json")?;
+            let arguments = read_call_arguments(&arguments_json, json_file.as_deref())?;
             let meta = meta_json
                 .as_deref()
                 .map(|raw| parse_json_object(raw, "--meta-json"))
@@ -1047,6 +1052,23 @@ fn parse_json_object(raw: &str, flag_name: &str) -> anyhow::Result<Value> {
     } else {
         anyhow::bail!("{flag_name} must be a JSON object")
     }
+}
+
+fn read_call_arguments(raw: &str, json_file: Option<&std::path::Path>) -> anyhow::Result<Value> {
+    let Some(path) = json_file else {
+        return parse_json_object(raw, "--json");
+    };
+    let contents = if path == std::path::Path::new("-") {
+        let mut input = String::new();
+        std::io::stdin()
+            .read_to_string(&mut input)
+            .context("failed to read --json-file - from stdin")?;
+        input
+    } else {
+        std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read --json-file {}", path.display()))?
+    };
+    parse_json_object(&contents, "--json-file")
 }
 
 fn build_load_skill_request(

--- a/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
@@ -1,6 +1,33 @@
 use super::*;
 
 #[test]
+fn call_reads_arguments_from_json_file() {
+    use std::io::Write;
+
+    let mut file = tempfile::NamedTempFile::new().expect("create temp JSON file");
+    write!(file, r#"{{"source":"{}"}}"#, "x".repeat(40_000)).expect("write JSON file");
+    let value = read_call_arguments("{}", Some(file.path())).expect("read call arguments");
+
+    assert_eq!(value["source"].as_str().map(str::len), Some(40_000));
+}
+
+#[test]
+fn call_json_file_flag_parses_without_inline_json() {
+    let args = Args::try_parse_from([
+        "dcc-mcp-cli",
+        "call",
+        "godot_project__write_script",
+        "--json-file",
+        "payload.json",
+    ])
+    .expect("parse --json-file");
+    let Command::Call { json_file, .. } = args.command else {
+        panic!("expected call command");
+    };
+    assert_eq!(json_file, Some(PathBuf::from("payload.json")));
+}
+
+#[test]
 fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
     let local = GatewayTarget::Local;
     let remote = GatewayTarget::Remote {
@@ -82,6 +109,7 @@ fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
                 dcc_type: None,
                 instance_id: None,
                 arguments_json: "{}".to_string(),
+                json_file: None,
                 meta_json: None,
                 timeout_secs: 30,
             },

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -83,6 +83,26 @@ fn list_search_describe_and_call_gateway_rest_surface() {
     assert_eq!(call["success"], true);
     assert_eq!(call["arguments"]["radius"], 2);
 
+    let mut payload = NamedTempFile::new().expect("create call payload");
+    serde_json::to_writer(
+        payload.as_file_mut(),
+        &serde_json::json!({"source": "x".repeat(40_000)}),
+    )
+    .expect("write call payload");
+    let file_call = run_json(&[
+        "--base-url",
+        &fixture.base_url,
+        "call",
+        "maya.abc12345.create_sphere",
+        "--json-file",
+        payload.path().to_str().expect("UTF-8 temp path"),
+    ]);
+    assert_eq!(file_call["success"], true);
+    assert_eq!(
+        file_call["arguments"]["source"].as_str().map(str::len),
+        Some(40_000)
+    );
+
     let direct_call = run_json(&[
         "--base-url",
         &fixture.base_url,

--- a/skills/dcc-cli-gateway/SKILL.md
+++ b/skills/dcc-cli-gateway/SKILL.md
@@ -404,6 +404,17 @@ Tool-specific fields (`code`, `file_path`, `radius`, and similar) belong inside
 the `--json` object. Do not pass them as top-level CLI flags unless the CLI adds
 an explicit first-class flag later.
 
+For generated scripts, binary descriptors, or other payloads that may exceed a
+shell's command-line limit, pass the JSON object through a UTF-8 file or stdin:
+
+```bash
+dcc-mcp-cli call godot_project__write_script --json-file payload.json
+generate_payload | dcc-mcp-cli call godot_project__write_script --json-file -
+```
+
+Use `--json` or `--json-file`, never both. `--json-file -` keeps large payloads
+off the process command line, which is especially important on Windows.
+
 See [`references/CLI_CHEATSHEET.md`](references/CLI_CHEATSHEET.md) for command
 patterns and common errors.
 


### PR DESCRIPTION
## Summary
- add `dcc-mcp-cli call --json-file <path>` for large UTF-8 JSON payloads
- support `--json-file -` to read call arguments from stdin
- document the large-payload workflow in the CLI gateway skill

## Motivation
Generated scripts can exceed platform command-line limits before `dcc-mcp-cli` reaches the MCP endpoint. The file/stdin input keeps the payload off the process command line while preserving the existing JSON-object validation.

## Validation
- `cargo test -p dcc-mcp-cli list_search_describe_and_call_gateway_rest_surface -- --nocapture`
- `cargo test -p dcc-mcp-cli call_reads_arguments_from_json_file -- --nocapture`
- `cargo clippy -p dcc-mcp-cli --all-targets -- -D warnings`
- live Godot MCP write of a 37 KB GDScript payload through `--json-file -`