### PR TITLE
fix: preserve registry rows across legacy guardian writes

### DIFF
--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -14,6 +14,7 @@ use dashmap::DashMap;
 use fs4::{FileExt, TryLockError};
 use sysinfo::{Pid, ProcessesToUpdate, System};
 use tracing;
+use uuid::Uuid;
 
 use super::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceKey, ServiceStatus};
 use crate::error::{TransportError, TransportResult};
@@ -96,6 +97,41 @@ fn maps_equal(left: &EntryMap, right: &EntryMap) -> bool {
         && left
             .iter()
             .all(|(key, entry)| right.get(key) == Some(entry))
+}
+
+fn parse_registry_entries(content: &str) -> Result<Vec<ServiceEntry>, serde_json::Error> {
+    serde_json::from_str::<Vec<serde_json::Value>>(content)?
+        .into_iter()
+        .map(|value| {
+            serde_json::from_value(value.clone())
+                .or_else(|error| legacy_gateway_sentinel(&value).ok_or(error))
+        })
+        .collect()
+}
+
+fn legacy_gateway_sentinel(value: &serde_json::Value) -> Option<ServiceEntry> {
+    let row = value.as_object()?;
+    (row.get("dcc_type")?.as_str()? == GATEWAY_SENTINEL_DCC_TYPE).then_some(())?;
+    let host = row.get("host")?.as_str()?;
+    let port = u16::try_from(row.get("port")?.as_u64()?).ok()?;
+    let mut entry = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, host, port);
+    entry.instance_id = Uuid::new_v5(
+        &Uuid::NAMESPACE_URL,
+        format!("dcc-mcp://gateway/{host}:{port}").as_bytes(),
+    );
+    entry.version = row
+        .get("version")
+        .and_then(|value| value.as_str())
+        .map(str::to_owned);
+    entry.adapter_version = row
+        .get("adapter_version")
+        .and_then(|value| value.as_str())
+        .map(str::to_owned);
+    entry.adapter_dcc = row
+        .get("adapter_dcc")
+        .and_then(|value| value.as_str())
+        .map(str::to_owned);
+    Some(entry)
 }
 
 fn ensure_registry_dir(path: &Path) -> TransportResult<()> {
@@ -1330,7 +1366,7 @@ impl FileRegistry {
             return Ok(Vec::new());
         }
 
-        match serde_json::from_str(&content) {
+        match parse_registry_entries(&content) {
             Ok(entries) => Ok(entries),
             Err(e) => {
                 self.quarantine_corrupted_registry_file(&path, &e);

--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -119,19 +119,13 @@ fn legacy_gateway_sentinel(value: &serde_json::Value) -> Option<ServiceEntry> {
         &Uuid::NAMESPACE_URL,
         format!("dcc-mcp://gateway/{host}:{port}").as_bytes(),
     );
-    entry.version = row
-        .get("version")
-        .and_then(|value| value.as_str())
-        .map(str::to_owned);
-    entry.adapter_version = row
-        .get("adapter_version")
-        .and_then(|value| value.as_str())
-        .map(str::to_owned);
-    entry.adapter_dcc = row
-        .get("adapter_dcc")
-        .and_then(|value| value.as_str())
-        .map(str::to_owned);
-    Some(entry)
+    let defaults = serde_json::to_value(entry).ok()?;
+    let mut normalized = value.clone();
+    let normalized_row = normalized.as_object_mut()?;
+    for (key, default) in defaults.as_object()? {
+        normalized_row.entry(key.clone()).or_insert(default.clone());
+    }
+    serde_json::from_value(normalized).ok()
 }
 
 fn ensure_registry_dir(path: &Path) -> TransportResult<()> {

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -1299,6 +1299,16 @@ fn test_legacy_python_gateway_sentinel_preserves_live_entries() {
         registry.get(&live_key).is_some(),
         "one legacy gateway row must not erase a valid live DCC row"
     );
-    assert_eq!(registry.list_instances(GATEWAY_SENTINEL_DCC_TYPE).len(), 1);
+    let sentinels = registry.list_instances(GATEWAY_SENTINEL_DCC_TYPE);
+    assert_eq!(sentinels.len(), 1);
+    assert_eq!(
+        sentinels[0]
+            .last_heartbeat
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        1_714_567_678,
+        "compatibility parsing must not refresh an expired sentinel"
+    );
     assert!(corrupted_registry_files(dir.path()).is_empty());
 }

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -1269,3 +1269,36 @@ fn test_float_timestamp_registry_file_parses() {
         .as_secs();
     assert_eq!(got_secs, 1712345678);
 }
+
+/// Python gateway guardians before the typed sentinel migration wrote a
+/// reduced ``__gateway__`` row alongside valid Rust entries. One legacy row
+/// must not make every live DCC disappear from the registry.
+#[test]
+fn test_legacy_python_gateway_sentinel_preserves_live_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let services_json = dir.path().join(REGISTRY_FILE);
+
+    let live = ServiceEntry::new("houdini", "127.0.0.1", 9887);
+    let live_key = live.key();
+    let content = serde_json::json!([
+        live,
+        {
+            "dcc_type": GATEWAY_SENTINEL_DCC_TYPE,
+            "host": "127.0.0.1",
+            "port": 9765,
+            "version": "0.19.13",
+            "last_heartbeat": 1_714_567_678.25,
+            "adapter_dcc": "blender"
+        }
+    ]);
+    std::fs::write(&services_json, serde_json::to_string(&content).unwrap()).unwrap();
+
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    assert!(
+        registry.get(&live_key).is_some(),
+        "one legacy gateway row must not erase a valid live DCC row"
+    );
+    assert_eq!(registry.list_instances(GATEWAY_SENTINEL_DCC_TYPE).len(), 1);
+    assert!(corrupted_registry_files(dir.path()).is_empty());
+}

--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -17,6 +17,7 @@ from urllib.error import HTTPError
 from urllib.error import URLError
 from urllib.request import Request
 from urllib.request import urlopen
+import uuid
 
 from dcc_mcp_core.daemon_launch import launch_detached
 from dcc_mcp_core.install_lifecycle import default_registry_dir
@@ -364,9 +365,8 @@ def _try_version_takeover(
         reason="python_gateway_guardian_version_takeover",
     )
 
-    # Write sentinel entry so gateways without /gateway/yield can still notice
-    # the newer challenger from their 15 s cleanup loop.
-    sentinel_ok = _write_sentinel_entry(
+    # Gateways without /gateway/yield still need the registry fallback.
+    sentinel_ok = cooperative_yield_requested or _write_sentinel_entry(
         registry_dir,
         gateway_host=gateway_host,
         gateway_port=gateway_port,
@@ -787,6 +787,36 @@ def _get_core_version() -> str:
 # ── Sentinel entry helper (for version-aware takeover) ──
 
 
+@contextlib.contextmanager
+def _registry_write_lock(path: Path):
+    """Take the same first-byte lock covered by Rust ``services.lock``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+b") as handle:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+
+            def unlock():
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+            def unlock():
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+        try:
+            yield
+        finally:
+            handle.seek(0)
+            with contextlib.suppress(OSError):
+                unlock()
+
+
 def _write_sentinel_entry(
     registry_dir: str | None,
     *,
@@ -805,43 +835,38 @@ def _write_sentinel_entry(
     """
     import json as _json
 
-    try:
-        registry_path = _resolve_registry_dir(registry_dir)
-        services_file = registry_path / "services.json"
-        if services_file.exists():
-            raw = services_file.read_text(encoding="utf-8")
-            data = _json.loads(raw) if raw.strip() else []
-        else:
-            data = []
-    except Exception:
-        return False
-
+    registry_path = _resolve_registry_dir(registry_dir)
+    services_file = registry_path / "services.json"
+    now = time.time()
     sentinel_entry: dict[str, object] = {
         "dcc_type": "__gateway__",
+        "instance_id": str(uuid.uuid5(uuid.NAMESPACE_URL, f"dcc-mcp://gateway/{gateway_host}:{gateway_port}")),
         "host": gateway_host,
         "port": gateway_port,
         "version": crate_version,
-        "last_heartbeat": time.time(),
+        "registered_at": now,
+        "last_heartbeat": now,
+        "status": "available",
     }
     if adapter_version:
         sentinel_entry["adapter_version"] = adapter_version
     if adapter_dcc:
         sentinel_entry["adapter_dcc"] = adapter_dcc
 
-    # FileRegistry uses a list format.  Remove existing sentinels before
-    # appending the new one.
-    if isinstance(data, list):
-        data = [e for e in data if not (isinstance(e, dict) and e.get("dcc_type") == "__gateway__")]
-        data.append(sentinel_entry)
-    elif isinstance(data, dict):
-        sentinel_key = f"__gateway__:{gateway_host}:{gateway_port}"
-        data[sentinel_key] = sentinel_entry
-    else:
-        data = [sentinel_entry]
-
     try:
-        registry_path.mkdir(parents=True, exist_ok=True)
-        services_file.write_text(_json.dumps(data, indent=2), encoding="utf-8")
+        with _registry_write_lock(registry_path / "services.lock"):
+            raw = services_file.read_text(encoding="utf-8") if services_file.exists() else ""
+            data = _json.loads(raw) if raw.strip() else []
+            if isinstance(data, list):
+                data = [e for e in data if not (isinstance(e, dict) and e.get("dcc_type") == "__gateway__")]
+                data.append(sentinel_entry)
+            elif isinstance(data, dict):
+                data[f"__gateway__:{gateway_host}:{gateway_port}"] = sentinel_entry
+            else:
+                data = [sentinel_entry]
+            temp_file = registry_path / f".tmp.{os.getpid()}.guardian.json"
+            temp_file.write_text(_json.dumps(data, indent=2), encoding="utf-8")
+            temp_file.replace(services_file)
         return True
     except Exception:
         return False

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -957,6 +957,11 @@ def test_get_core_version_env_override(monkeypatch):
 def test_write_and_read_sentinel_entry(tmp_path):
     """P0-3: _write_sentinel_entry and _read_gateway_version_from_registry roundtrip."""
     reg = str(tmp_path / "dcc-mcp-registry")
+    Path(reg).mkdir()
+    (Path(reg) / "services.json").write_text(
+        json.dumps([{"dcc_type": "houdini", "instance_id": "live-row"}]),
+        encoding="utf-8",
+    )
     # Write a sentinel.
     ok = gg._write_sentinel_entry(
         reg,
@@ -968,6 +973,12 @@ def test_write_and_read_sentinel_entry(tmp_path):
     )
     assert ok is True
     assert (tmp_path / "dcc-mcp-registry" / "services.json").exists()
+    rows = json.loads((Path(reg) / "services.json").read_text(encoding="utf-8"))
+    assert rows[0]["instance_id"] == "live-row"
+    sentinel = rows[1]
+    assert sentinel["instance_id"]
+    assert sentinel["registered_at"] == sentinel["last_heartbeat"]
+    assert sentinel["status"] == "available"
 
     # Read it back.
     ver = gg._read_gateway_version_from_registry(
@@ -1132,6 +1143,11 @@ def test_try_version_takeover_uses_admin_health_and_cooperative_yield(monkeypatc
     monkeypatch.setattr(gg, "_read_gateway_version_from_registry", lambda *a, **k: None)
     monkeypatch.setattr(gg, "_read_gateway_version_from_admin_health", lambda *a, **k: "0.18.20")
     monkeypatch.setattr(gg, "_request_gateway_yield", lambda *a, **k: yield_requests.append(k) or True)
+    monkeypatch.setattr(
+        gg,
+        "_write_sentinel_entry",
+        lambda *a, **k: pytest.fail("cooperative yield must not rewrite FileRegistry"),
+    )
     monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: False)
     monkeypatch.setattr(gg, "_wait_managed_gateway_ready", lambda *a, **k: True)
 


### PR DESCRIPTION
## Summary
- preserve valid DCC registrations when a mixed-version Python guardian writes a legacy gateway sentinel
- make new guardian fallback writes use the shared registry lock, a typed sentinel, and atomic replacement
- skip the file fallback when cooperative HTTP yield already succeeded

## Root cause
The Python version-takeover fallback wrote a reduced `__gateway__` object directly to `services.json`. The Rust reader deserialized the array as one unit, so that single legacy row made the complete snapshot fail parsing and temporarily removed every live instance. The same fallback also bypassed `services.lock`, allowing a read-modify-write race with heartbeats.

## Validation
- regression reproduced before the fix: the legacy sentinel erased a valid Houdini row
- `cargo test -p dcc-mcp-transport --lib --quiet` (181 passed)
- `cargo clippy -p dcc-mcp-transport --all-targets -- -D warnings`
- `PYTHONPATH=python python -m pytest tests/test_gateway_guardian.py -q` (53 passed)
- `ruff check python/dcc_mcp_core/_server/gateway_guardian.py tests/test_gateway_guardian.py`
- `cargo fmt --all -- --check`

No public API or agent-skill guidance changes are required.