### PR TITLE
perf(gateway): skip unchanged registry metadata writes

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -41,6 +41,19 @@ fn apply_live_snapshot(entry: &mut ServiceEntry, snapshot: &LiveSnapshot) {
     entry.touch();
 }
 
+fn metadata_patch_changes_entry(
+    entry: &ServiceEntry,
+    metadata: &std::collections::HashMap<String, String>,
+) -> bool {
+    metadata.iter().any(|(name, value)| {
+        if value.is_empty() {
+            entry.metadata.contains_key(name)
+        } else {
+            entry.metadata.get(name) != Some(value)
+        }
+    })
+}
+
 fn refresh_or_republish_registration(
     registry: &FileRegistry,
     key: &ServiceKey,
@@ -62,7 +75,14 @@ fn refresh_or_republish_registration(
         };
         let refresh_result = match primary_result {
             Ok(true) if !snapshot.metadata.is_empty() => {
-                registry.update_instance_metadata(key, &snapshot.metadata)
+                let metadata_changed = registry
+                    .get(key)
+                    .is_none_or(|entry| metadata_patch_changes_entry(&entry, &snapshot.metadata));
+                if metadata_changed {
+                    registry.update_instance_metadata(key, &snapshot.metadata)
+                } else {
+                    Ok(true)
+                }
             }
             other => other,
         };
@@ -1097,6 +1117,58 @@ fn cooperative_yield_fallback_detail(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unchanged_metadata_patch_does_not_require_registry_update() {
+        let mut entry = ServiceEntry::new("houdini", "127.0.0.1", 56693);
+        entry.metadata.insert(
+            "gateway_runtime_mode".to_string(),
+            "daemon-backed".to_string(),
+        );
+        let patch = std::collections::HashMap::from([(
+            "gateway_runtime_mode".to_string(),
+            "daemon-backed".to_string(),
+        )]);
+
+        assert!(!metadata_patch_changes_entry(&entry, &patch));
+    }
+
+    #[test]
+    fn changed_or_new_metadata_patch_requires_registry_update() {
+        let mut entry = ServiceEntry::new("houdini", "127.0.0.1", 56693);
+        entry
+            .metadata
+            .insert("gateway_runtime_mode".to_string(), "embedded".to_string());
+        let changed = std::collections::HashMap::from([(
+            "gateway_runtime_mode".to_string(),
+            "daemon-backed".to_string(),
+        )]);
+        let new = std::collections::HashMap::from([(
+            "gateway_guardian_enabled".to_string(),
+            "true".to_string(),
+        )]);
+
+        assert!(metadata_patch_changes_entry(&entry, &changed));
+        assert!(metadata_patch_changes_entry(&entry, &new));
+    }
+
+    #[test]
+    fn metadata_removal_requires_update_only_when_key_exists() {
+        let mut entry = ServiceEntry::new("houdini", "127.0.0.1", 56693);
+        entry.metadata.insert(
+            "gateway_runtime_mode".to_string(),
+            "daemon-backed".to_string(),
+        );
+        let remove_existing =
+            std::collections::HashMap::from([("gateway_runtime_mode".to_string(), String::new())]);
+        let remove_missing = std::collections::HashMap::from([(
+            "gateway_guardian_enabled".to_string(),
+            String::new(),
+        )]);
+
+        assert!(metadata_patch_changes_entry(&entry, &remove_existing));
+        assert!(!metadata_patch_changes_entry(&entry, &remove_missing));
+    }
 
     #[test]
     fn cooperative_yield_fallback_reads_structured_optional_capability() {

--- a/crates/dcc-mcp-gateway/src/gateway/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tests.rs
@@ -612,29 +612,137 @@ async fn test_gateway_heartbeat_merges_live_instance_metadata() {
     });
     let handle = runner.start(entry, Some(provider)).await.unwrap();
 
+    let metadata_heartbeat = wait_for_metadata_heartbeat(
+        &runner,
+        &key,
+        "gateway_guardian_enabled",
+        Some("true"),
+        None,
+        "heartbeat did not merge live metadata into FileRegistry",
+    )
+    .await;
+    {
+        let reg = runner.registry.read().await;
+        let row = reg.get(&key).expect("registered row");
+        assert_eq!(
+            row.metadata.get("gateway_runtime_mode").map(String::as_str),
+            Some("daemon-backed")
+        );
+    }
+    wait_for_metadata_heartbeat(
+        &runner,
+        &key,
+        "gateway_guardian_enabled",
+        Some("true"),
+        Some(metadata_heartbeat),
+        "stable live metadata prevented the next heartbeat refresh",
+    )
+    .await;
+
+    drop(handle);
+    drop(occupied);
+}
+
+async fn wait_for_metadata_heartbeat(
+    runner: &GatewayRunner,
+    key: &ServiceKey,
+    name: &str,
+    expected_value: Option<&str>,
+    after_heartbeat: Option<std::time::SystemTime>,
+    failure_message: &str,
+) -> std::time::SystemTime {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
     loop {
         {
             let reg = runner.registry.read().await;
-            let row = reg.get(&key).expect("registered row");
-            if row
-                .metadata
-                .get("gateway_guardian_enabled")
-                .is_some_and(|value| value == "true")
-            {
-                assert_eq!(
-                    row.metadata.get("gateway_runtime_mode").map(String::as_str),
-                    Some("daemon-backed")
-                );
-                break;
+            let row = reg.get(key).expect("registered row");
+            let metadata_matches = row.metadata.get(name).map(String::as_str) == expected_value;
+            let heartbeat_advanced =
+                after_heartbeat.is_none_or(|heartbeat| row.last_heartbeat > heartbeat);
+            if metadata_matches && heartbeat_advanced {
+                return row.last_heartbeat;
             }
         }
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "heartbeat did not merge live metadata into FileRegistry"
-        );
+        assert!(tokio::time::Instant::now() < deadline, "{failure_message}");
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
+}
+
+#[tokio::test]
+async fn test_gateway_heartbeat_applies_dynamic_metadata_updates_and_removals() {
+    let dir = tempfile::tempdir().unwrap();
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = occupied.local_addr().unwrap().port();
+
+    let cfg = GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        gateway_port: port,
+        heartbeat_secs: 1,
+        registry_dir: Some(dir.path().to_path_buf()),
+        ..GatewayConfig::default()
+    };
+    let runner = GatewayRunner::new(cfg).unwrap();
+
+    let entry = ServiceEntry::new("houdini", "127.0.0.1", 0);
+    let key = entry.key();
+    let live_metadata =
+        std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::from([(
+            "gateway_runtime_mode".to_string(),
+            "daemon-backed".to_string(),
+        )])));
+    let provider_metadata = live_metadata.clone();
+    let provider: MetadataProvider = std::sync::Arc::new(move || LiveSnapshot {
+        metadata: provider_metadata.lock().unwrap().clone(),
+        ..LiveSnapshot::default()
+    });
+    let handle = runner.start(entry, Some(provider)).await.unwrap();
+
+    let initial_heartbeat = wait_for_metadata_heartbeat(
+        &runner,
+        &key,
+        "gateway_runtime_mode",
+        Some("daemon-backed"),
+        None,
+        "heartbeat did not publish initial dynamic metadata",
+    )
+    .await;
+    let stable_heartbeat = wait_for_metadata_heartbeat(
+        &runner,
+        &key,
+        "gateway_runtime_mode",
+        Some("daemon-backed"),
+        Some(initial_heartbeat),
+        "stable dynamic metadata prevented heartbeat refresh",
+    )
+    .await;
+
+    live_metadata
+        .lock()
+        .unwrap()
+        .insert("gateway_runtime_mode".to_string(), "embedded".to_string());
+    let updated_heartbeat = wait_for_metadata_heartbeat(
+        &runner,
+        &key,
+        "gateway_runtime_mode",
+        Some("embedded"),
+        Some(stable_heartbeat),
+        "heartbeat did not publish changed dynamic metadata",
+    )
+    .await;
+
+    live_metadata
+        .lock()
+        .unwrap()
+        .insert("gateway_runtime_mode".to_string(), String::new());
+    wait_for_metadata_heartbeat(
+        &runner,
+        &key,
+        "gateway_runtime_mode",
+        None,
+        Some(updated_heartbeat),
+        "heartbeat did not remove dynamic metadata for an empty value",
+    )
+    .await;
 
     drop(handle);
     drop(occupied);


### PR DESCRIPTION
## Summary
- skip the secondary FileRegistry metadata transaction when the live metadata patch would not change the row
- keep the primary heartbeat refresh unchanged
- preserve dynamic metadata updates and empty-value removals

## Validation
- `cargo test -p dcc-mcp-gateway gateway_heartbeat_applies_dynamic_metadata_updates_and_removals`
- `cargo fmt --all -- --check`
- `git diff --check`