### PR TITLE
fix(ci): disable sccache in manylinux builds

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -185,7 +185,10 @@ runs:
         target: ${{ inputs.target }}
         args: ${{ steps.resolve-features.outputs.value }}
         rust-toolchain: ${{ inputs.rust-version }}
-        sccache: ${{ inputs.use-sccache == 'true' }}
+        # sccache's background server can time out while starting inside the
+        # short-lived manylinux container. Keep host builds cached, but make
+        # Linux container builds deterministic instead of relying on a daemon.
+        sccache: ${{ inputs.use-sccache == 'true' && runner.os != 'Linux' }}
         # Core Python 3.7 wheels are part of the old-DCC compatibility surface.
         # Pin Linux builds to the manylinux2014 / glibc 2.17 baseline instead
         # of allowing the runner image to select a newer platform tag.

--- a/scripts/ci/check_python_support.py
+++ b/scripts/ci/check_python_support.py
@@ -418,6 +418,9 @@ def collect_wheel_action_errors(root: Path) -> list[str]:
         errors.append(f"{relative}: core Linux wheels must target manylinux2014 / glibc 2.17")
     if re.search(r"(?m)^\s*manylinux:\s*auto\s*$", text):
         errors.append(f"{relative}: manylinux auto may raise the legacy DCC glibc baseline")
+    sccache = re.search(r"(?m)^\s*sccache:\s*(.+?)\s*$", text)
+    if sccache is None or "runner.os != 'Linux'" not in sccache.group(1):
+        errors.append(f"{relative}: sccache must be disabled in manylinux container builds")
     for fragment in (
         "--platform",
         "linux-x86_64",

--- a/tests/test_python_support_contract.py
+++ b/tests/test_python_support_contract.py
@@ -283,6 +283,10 @@ def test_wheel_action_must_pin_manylinux_and_pass_explicit_platform(tmp_path: Pa
     action.write_text(inverted, encoding="utf-8")
     assert any("manylinux2014" in error for error in collect_wheel_action_errors(tmp_path))
 
+    cached_linux = current.replace(" && runner.os != 'Linux'", "")
+    action.write_text(cached_linux, encoding="utf-8")
+    assert any("sccache must be disabled" in error for error in collect_wheel_action_errors(tmp_path))
+
     unsafe_windows = current.replace('maturin_args=""', 'maturin_args="--find-interpreter"')
     action.write_text(unsafe_windows, encoding="utf-8")
     assert any('maturin_args=""' in error for error in collect_wheel_action_errors(tmp_path))


### PR DESCRIPTION
## Summary
- disable sccache only for Linux manylinux container builds while retaining it for host builds
- lock the container build contract in the Python support checker
- cover future drift with the existing wheel-action contract test

## Root cause
The manylinux build delegates compiler probes to an sccache server started inside a short-lived container. If that daemon does not become ready before the startup timeout, the build fails before compilation begins. Running the server in foreground/no-daemon mode also keeps the container build attached indefinitely, so the deterministic fix is to bypass sccache only for manylinux while preserving caching on Windows and macOS.

## Validation
- `pytest tests/test_python_support_contract.py -q -k wheel_action_must_pin_manylinux_and_pass_explicit_platform`
- `pytest tests/test_python_support_contract.py tests/test_build_wheels_workflow.py tests/test_release_workflow.py -q` (21 passed)
- `python scripts/ci/check_python_support.py`
- `ruff check scripts/ci/check_python_support.py tests/test_python_support_contract.py`
- `actionlint .github/workflows/build-wheels.yml .github/workflows/ci.yml .github/workflows/release.yml`
- `just fmt-check`

Skill documentation is unchanged because this is an internal CI execution fix with no skill contract change.