### PR TITLE
perf(gateway): coalesce registry heartbeat snapshot

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -102,8 +102,7 @@ pub struct LiveSnapshot {
     pub scene: Option<String>,
     /// DCC application version string.
     pub version: Option<String>,
-    /// All open documents.  Non-empty → `update_documents` is called;
-    /// empty → only `scene`/`version` are updated via `update_metadata`.
+    /// All open documents. Empty preserves the existing document list.
     pub documents: Vec<String>,
     /// Human-readable instance label (e.g. `"PS-Marketing"`).
     pub display_name: Option<String>,
@@ -113,17 +112,17 @@ pub struct LiveSnapshot {
 
 /// Closure type for supplying live instance metadata to the heartbeat task.
 ///
-/// Called on every heartbeat tick; the returned [`LiveSnapshot`] is written
-/// to `FileRegistry` via `update_documents` (when `documents` is non-empty)
-/// or `update_metadata` (single-document DCCs), plus `update_instance_metadata`
-/// when arbitrary string metadata is present.
+/// Called on every heartbeat tick; the returned [`LiveSnapshot`] is applied to
+/// `FileRegistry` in one write transaction.
 pub type MetadataProvider = Arc<dyn Fn() -> LiveSnapshot + Send + Sync>;
 
 use tokio::sync::{RwLock, broadcast, watch};
 use tokio::task::AbortHandle;
 
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
-use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceKey};
+use dcc_mcp_transport::discovery::types::{
+    GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceKey, ServiceSnapshot,
+};
 
 mod bind;
 mod config;

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -41,19 +41,6 @@ fn apply_live_snapshot(entry: &mut ServiceEntry, snapshot: &LiveSnapshot) {
     entry.touch();
 }
 
-fn metadata_patch_changes_entry(
-    entry: &ServiceEntry,
-    metadata: &std::collections::HashMap<String, String>,
-) -> bool {
-    metadata.iter().any(|(name, value)| {
-        if value.is_empty() {
-            entry.metadata.contains_key(name)
-        } else {
-            entry.metadata.get(name) != Some(value)
-        }
-    })
-}
-
 fn refresh_or_republish_registration(
     registry: &FileRegistry,
     key: &ServiceKey,
@@ -63,29 +50,26 @@ fn refresh_or_republish_registration(
 ) {
     let (refresh_result, snapshot) = if let Some(provider) = provider {
         let snapshot = provider();
-        let primary_result = if snapshot.documents.is_empty() {
-            registry.update_metadata(key, snapshot.scene.as_deref(), snapshot.version.as_deref())
+        let documents = if snapshot.documents.is_empty() {
+            None
         } else {
-            registry.update_documents(
-                key,
-                snapshot.scene.as_deref(),
-                &snapshot.documents,
-                snapshot.display_name.as_deref(),
-            )
+            Some(snapshot.documents.as_slice())
         };
-        let refresh_result = match primary_result {
-            Ok(true) if !snapshot.metadata.is_empty() => {
-                let metadata_changed = registry
-                    .get(key)
-                    .is_none_or(|entry| metadata_patch_changes_entry(&entry, &snapshot.metadata));
-                if metadata_changed {
-                    registry.update_instance_metadata(key, &snapshot.metadata)
-                } else {
-                    Ok(true)
-                }
-            }
-            other => other,
+        let display_name = if documents.is_some() {
+            snapshot.display_name.as_deref()
+        } else {
+            None
         };
+        let refresh_result = registry.update_snapshot(
+            key,
+            ServiceSnapshot {
+                scene: snapshot.scene.as_deref(),
+                version: snapshot.version.as_deref(),
+                documents,
+                display_name,
+                metadata: Some(&snapshot.metadata),
+            },
+        );
         (refresh_result, Some(snapshot))
     } else {
         (registry.heartbeat(key), None)
@@ -190,8 +174,8 @@ impl GatewayRunner {
     ///
     /// Pass `metadata_provider` to keep the `scene` and `version` fields in the
     /// `FileRegistry` in sync with the running DCC application.  The closure is
-    /// called on every heartbeat tick and the returned `(scene, version)` pair is
-    /// written via `FileRegistry::update_metadata`.  This ensures that
+    /// called on every heartbeat tick and the returned snapshot is written via
+    /// `FileRegistry::update_snapshot`. This ensures that
     /// `list_dcc_instances` always shows the currently open scene — even when the
     /// user opens a different file after the server was started.
     pub async fn start(
@@ -212,10 +196,9 @@ impl GatewayRunner {
 
         // ── Heartbeat task ────────────────────────────────────────────────
         //
-        // Besides touching the timestamp, every tick also calls update_metadata
-        // when a metadata_provider is present.  This keeps the `scene` field
-        // in FileRegistry current so that list_dcc_instances always reflects
-        // the currently open DCC scene without requiring a server restart.
+        // Besides touching the timestamp, every tick atomically applies the
+        // metadata provider's live snapshot. This keeps instance fields current
+        // without taking the cross-process registry lock more than once.
         //
         // The task is wrapped in a restart loop so that a panic does not silently
         // abort heartbeats (issue #554).
@@ -1117,58 +1100,6 @@ fn cooperative_yield_fallback_detail(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn unchanged_metadata_patch_does_not_require_registry_update() {
-        let mut entry = ServiceEntry::new("houdini", "127.0.0.1", 56693);
-        entry.metadata.insert(
-            "gateway_runtime_mode".to_string(),
-            "daemon-backed".to_string(),
-        );
-        let patch = std::collections::HashMap::from([(
-            "gateway_runtime_mode".to_string(),
-            "daemon-backed".to_string(),
-        )]);
-
-        assert!(!metadata_patch_changes_entry(&entry, &patch));
-    }
-
-    #[test]
-    fn changed_or_new_metadata_patch_requires_registry_update() {
-        let mut entry = ServiceEntry::new("houdini", "127.0.0.1", 56693);
-        entry
-            .metadata
-            .insert("gateway_runtime_mode".to_string(), "embedded".to_string());
-        let changed = std::collections::HashMap::from([(
-            "gateway_runtime_mode".to_string(),
-            "daemon-backed".to_string(),
-        )]);
-        let new = std::collections::HashMap::from([(
-            "gateway_guardian_enabled".to_string(),
-            "true".to_string(),
-        )]);
-
-        assert!(metadata_patch_changes_entry(&entry, &changed));
-        assert!(metadata_patch_changes_entry(&entry, &new));
-    }
-
-    #[test]
-    fn metadata_removal_requires_update_only_when_key_exists() {
-        let mut entry = ServiceEntry::new("houdini", "127.0.0.1", 56693);
-        entry.metadata.insert(
-            "gateway_runtime_mode".to_string(),
-            "daemon-backed".to_string(),
-        );
-        let remove_existing =
-            std::collections::HashMap::from([("gateway_runtime_mode".to_string(), String::new())]);
-        let remove_missing = std::collections::HashMap::from([(
-            "gateway_guardian_enabled".to_string(),
-            String::new(),
-        )]);
-
-        assert!(metadata_patch_changes_entry(&entry, &remove_existing));
-        assert!(!metadata_patch_changes_entry(&entry, &remove_missing));
-    }
 
     #[test]
     fn cooperative_yield_fallback_reads_structured_optional_capability() {

--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -16,7 +16,9 @@ use sysinfo::{Pid, ProcessesToUpdate, System};
 use tracing;
 use uuid::Uuid;
 
-use super::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceKey, ServiceStatus};
+use super::types::{
+    GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceKey, ServiceSnapshot, ServiceStatus,
+};
 use crate::error::{TransportError, TransportResult};
 
 /// Return `true` when `pid` refers to a currently running OS process.
@@ -232,6 +234,9 @@ pub struct FileRegistry {
     /// uniqueness in the temp path. Cross-process writers are serialized by
     /// `services.lock`.
     write_lock: Mutex<()>,
+    /// Number of durable write transactions committed by this handle.
+    #[cfg(test)]
+    committed_write_transactions: std::sync::atomic::AtomicUsize,
     /// Maximum time a write transaction may wait for the in-process mutex and
     /// cross-process `services.lock` before returning an observable error.
     write_lock_timeout: Duration,
@@ -263,6 +268,8 @@ impl FileRegistry {
             sentinel_handles: DashMap::new(),
             last_mtime: Mutex::new(None),
             write_lock: Mutex::new(()),
+            #[cfg(test)]
+            committed_write_transactions: std::sync::atomic::AtomicUsize::new(0),
             write_lock_timeout,
             write_lock_backoff: write_lock_backoff.max(Duration::from_millis(1)),
         };
@@ -415,6 +422,9 @@ impl FileRegistry {
                     self.rollback_failed_transaction(&baseline, &baseline_owned_sentinels);
                     return Err(err);
                 }
+                #[cfg(test)]
+                self.committed_write_transactions
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }
             Ok(value)
         })();
@@ -772,29 +782,54 @@ impl FileRegistry {
         scene: Option<&str>,
         version: Option<&str>,
     ) -> TransportResult<bool> {
+        self.update_snapshot(
+            key,
+            ServiceSnapshot {
+                scene,
+                version,
+                ..ServiceSnapshot::default()
+            },
+        )
+    }
+
+    /// Apply live service metadata and refresh its heartbeat in one write transaction.
+    pub fn update_snapshot(
+        &self,
+        key: &ServiceKey,
+        snapshot: ServiceSnapshot<'_>,
+    ) -> TransportResult<bool> {
         self.with_write_transaction(|| {
-            let found = if let Some(mut entry) = self.services.get_mut(key) {
-                let e = entry.value_mut();
-                if let Some(s) = scene {
-                    e.scene = if s.is_empty() {
-                        None
-                    } else {
-                        Some(s.to_string())
-                    };
-                }
-                if let Some(v) = version {
-                    e.version = if v.is_empty() {
-                        None
-                    } else {
-                        Some(v.to_string())
-                    };
-                }
-                e.touch(); // also refresh heartbeat
-                true
-            } else {
-                false
+            let Some(mut entry) = self.services.get_mut(key) else {
+                return Ok((false, false));
             };
-            Ok((found, found))
+            let entry = entry.value_mut();
+            if let Some(scene) = snapshot.scene {
+                entry.scene = (!scene.is_empty()).then(|| scene.to_string());
+            }
+            if let Some(version) = snapshot.version {
+                entry.version = (!version.is_empty()).then(|| version.to_string());
+            }
+            if let Some(documents) = snapshot.documents {
+                entry.documents = documents
+                    .iter()
+                    .filter(|document| !document.is_empty())
+                    .cloned()
+                    .collect();
+            }
+            if let Some(display_name) = snapshot.display_name {
+                entry.display_name = (!display_name.is_empty()).then(|| display_name.to_string());
+            }
+            if let Some(metadata) = snapshot.metadata {
+                for (name, value) in metadata {
+                    if value.is_empty() {
+                        entry.metadata.remove(name);
+                    } else {
+                        entry.metadata.insert(name.clone(), value.clone());
+                    }
+                }
+            }
+            entry.touch();
+            Ok((true, true))
         })
     }
 
@@ -821,41 +856,15 @@ impl FileRegistry {
         documents: &[String],
         display_name: Option<&str>,
     ) -> TransportResult<bool> {
-        self.with_write_transaction(|| {
-            let found = if let Some(mut entry) = self.services.get_mut(key) {
-                let e = entry.value_mut();
-
-                if let Some(doc) = active_document {
-                    e.scene = if doc.is_empty() {
-                        None
-                    } else {
-                        Some(doc.to_string())
-                    };
-                }
-
-                // Always replace the documents list (caller owns the authoritative set).
-                e.documents = documents
-                    .iter()
-                    .filter(|d| !d.is_empty())
-                    .cloned()
-                    .collect();
-
-                if let Some(name) = display_name {
-                    e.display_name = if name.is_empty() {
-                        None
-                    } else {
-                        Some(name.to_string())
-                    };
-                }
-
-                e.touch();
-                true
-            } else {
-                false
-            };
-
-            Ok((found, found))
-        })
+        self.update_snapshot(
+            key,
+            ServiceSnapshot {
+                scene: active_document,
+                documents: Some(documents),
+                display_name,
+                ..ServiceSnapshot::default()
+            },
+        )
     }
 
     /// Merge arbitrary string metadata for a service and refresh heartbeat.
@@ -868,24 +877,13 @@ impl FileRegistry {
         key: &ServiceKey,
         metadata: &std::collections::HashMap<String, String>,
     ) -> TransportResult<bool> {
-        self.with_write_transaction(|| {
-            let found = if let Some(mut entry) = self.services.get_mut(key) {
-                let e = entry.value_mut();
-                for (name, value) in metadata {
-                    if value.is_empty() {
-                        e.metadata.remove(name);
-                    } else {
-                        e.metadata.insert(name.clone(), value.clone());
-                    }
-                }
-                e.touch();
-                true
-            } else {
-                false
-            };
-
-            Ok((found, found))
-        })
+        self.update_snapshot(
+            key,
+            ServiceSnapshot {
+                metadata: Some(metadata),
+                ..ServiceSnapshot::default()
+            },
+        )
     }
 
     /// Set the OS process ID for a registered service.

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -843,6 +843,130 @@ fn test_file_registry_update_metadata() {
 // ── read_alive auto-eviction (issue #523) ─────────────────────────────────
 
 #[test]
+fn test_file_registry_update_snapshot_persists_complete_metadata_patch() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    let mut entry = ServiceEntry::new("houdini", "127.0.0.1", 18812);
+    entry.last_heartbeat = std::time::UNIX_EPOCH;
+    entry.metadata.insert("preserved".into(), "yes".into());
+    entry.metadata.insert("remove_me".into(), "old".into());
+    let key = entry.key();
+    registry.register(entry).unwrap();
+
+    let documents = vec!["solar_system.hip".to_string(), String::new()];
+    let metadata = std::collections::HashMap::from([
+        (
+            "gateway_runtime_mode".to_string(),
+            "daemon-backed".to_string(),
+        ),
+        ("remove_me".to_string(), String::new()),
+    ]);
+    let snapshot = super::super::types::ServiceSnapshot {
+        scene: Some("solar_system.hip"),
+        version: Some("21.0"),
+        documents: Some(&documents),
+        display_name: Some("Houdini-Solar"),
+        metadata: Some(&metadata),
+    };
+    let transactions_before = registry
+        .committed_write_transactions
+        .load(std::sync::atomic::Ordering::Relaxed);
+
+    assert!(registry.update_snapshot(&key, snapshot).unwrap());
+    assert_eq!(
+        registry
+            .committed_write_transactions
+            .load(std::sync::atomic::Ordering::Relaxed)
+            - transactions_before,
+        1,
+        "a complete snapshot must commit exactly one registry write transaction"
+    );
+
+    let reread = FileRegistry::new(dir.path()).unwrap();
+    let updated = reread.get(&key).unwrap();
+    assert_eq!(updated.scene.as_deref(), Some("solar_system.hip"));
+    assert_eq!(updated.version.as_deref(), Some("21.0"));
+    assert_eq!(updated.documents, vec!["solar_system.hip"]);
+    assert_eq!(updated.display_name.as_deref(), Some("Houdini-Solar"));
+    assert_eq!(
+        updated.metadata.get("preserved").map(String::as_str),
+        Some("yes")
+    );
+    assert_eq!(
+        updated
+            .metadata
+            .get("gateway_runtime_mode")
+            .map(String::as_str),
+        Some("daemon-backed")
+    );
+    assert!(!updated.metadata.contains_key("remove_me"));
+    assert!(updated.last_heartbeat > std::time::UNIX_EPOCH);
+}
+
+#[test]
+fn test_concurrent_snapshot_writers_preserve_complete_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let seed = FileRegistry::new(dir.path()).unwrap();
+    let houdini = ServiceEntry::new("houdini", "127.0.0.1", 18812);
+    let nuke = ServiceEntry::new("nuke", "127.0.0.1", 18813);
+    let houdini_key = houdini.key();
+    let nuke_key = nuke.key();
+    seed.register(houdini).unwrap();
+    seed.register(nuke).unwrap();
+
+    let houdini_registry = FileRegistry::new(dir.path()).unwrap();
+    let nuke_registry = FileRegistry::new(dir.path()).unwrap();
+    let houdini_thread = std::thread::spawn(move || {
+        for frame in 0..25 {
+            let scene = format!("solar-{frame}.hip");
+            let metadata =
+                std::collections::HashMap::from([("frame".to_string(), frame.to_string())]);
+            houdini_registry
+                .update_snapshot(
+                    &houdini_key,
+                    super::super::types::ServiceSnapshot {
+                        scene: Some(&scene),
+                        metadata: Some(&metadata),
+                        ..super::super::types::ServiceSnapshot::default()
+                    },
+                )
+                .unwrap();
+        }
+    });
+    let nuke_thread = std::thread::spawn(move || {
+        for frame in 0..25 {
+            let scene = format!("comp-{frame}.nk");
+            let metadata =
+                std::collections::HashMap::from([("frame".to_string(), frame.to_string())]);
+            nuke_registry
+                .update_snapshot(
+                    &nuke_key,
+                    super::super::types::ServiceSnapshot {
+                        scene: Some(&scene),
+                        metadata: Some(&metadata),
+                        ..super::super::types::ServiceSnapshot::default()
+                    },
+                )
+                .unwrap();
+        }
+    });
+    houdini_thread.join().unwrap();
+    nuke_thread.join().unwrap();
+
+    let reread = FileRegistry::new(dir.path()).unwrap();
+    let houdini = reread.list_instances("houdini").pop().unwrap();
+    let nuke = reread.list_instances("nuke").pop().unwrap();
+    assert_eq!(houdini.scene.as_deref(), Some("solar-24.hip"));
+    assert_eq!(
+        houdini.metadata.get("frame").map(String::as_str),
+        Some("24")
+    );
+    assert_eq!(nuke.scene.as_deref(), Some("comp-24.nk"));
+    assert_eq!(nuke.metadata.get("frame").map(String::as_str), Some("24"));
+}
+
+#[test]
 fn test_read_alive_evicts_ghost_and_returns_live() {
     let dir = tempfile::tempdir().unwrap();
     let registry = FileRegistry::new(dir.path()).unwrap();

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -149,6 +149,24 @@ impl LeaseOwnerError {
     }
 }
 
+/// Borrowed metadata patch applied to one service row in a single registry transaction.
+///
+/// `None` leaves a field unchanged. Empty strings clear optional string fields,
+/// `Some(&[])` clears the document list, and empty metadata values remove keys.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ServiceSnapshot<'a> {
+    /// Currently active scene or document.
+    pub scene: Option<&'a str>,
+    /// DCC application version.
+    pub version: Option<&'a str>,
+    /// Complete open-document list when the caller owns that state.
+    pub documents: Option<&'a [String]>,
+    /// Human-readable instance label.
+    pub display_name: Option<&'a str>,
+    /// Arbitrary metadata patch; empty values remove matching keys.
+    pub metadata: Option<&'a HashMap<String, String>>,
+}
+
 /// A discovered DCC service instance.
 ///
 /// Keyed by `(dcc_type, instance_id)` — supports multiple instances of the same DCC type.

--- a/crates/dcc-mcp-transport/src/lib.rs
+++ b/crates/dcc-mcp-transport/src/lib.rs
@@ -50,7 +50,7 @@ pub use dcc_link::{
     DccLinkFrame, DccLinkType, GracefulIpcChannelAdapter, IpcChannelAdapter, SocketServerAdapter,
 };
 pub use discovery::ServiceRegistry;
-pub use discovery::types::{ServiceEntry, ServiceKey, ServiceStatus};
+pub use discovery::types::{ServiceEntry, ServiceKey, ServiceSnapshot, ServiceStatus};
 pub use error::{TransportError, TransportResult};
 pub use event_bridge::{EventBridge, EventBridgeService, NoopBridge};
 pub use ipc::{IpcConfig, PlatformCapabilities, TransportAddress, TransportScheme};


### PR DESCRIPTION
## Summary

- add a borrowed `ServiceSnapshot` patch that updates all live service fields in one `FileRegistry` write transaction
- switch provider-backed gateway heartbeats from two registry transactions to one snapshot update while preserving legacy update APIs
- add regressions for exactly one committed transaction and concurrent independent registry writers

## Why

A provider-backed heartbeat could acquire the cross-process registry lock once for scene/documents and again for arbitrary metadata. Coalescing the live snapshot into one durable transaction reduces lock contention without increasing timeouts or suppressing slow-lock diagnostics.

## Compatibility

- existing `update_metadata`, `update_documents`, and `update_instance_metadata` signatures and semantics remain available
- no-provider heartbeats keep the existing heartbeat path
- missing-row recovery behavior is unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p dcc-mcp-transport` (184 unit tests plus integration and doctests)
- `cargo test -p dcc-mcp-gateway` (525 tests plus doctests)
- focused concurrent-writer and single-transaction snapshot regressions

## Skill / documentation impact

No skill or operator documentation change is required; this is a backward-compatible registry and heartbeat implementation change.