### PR TITLE
fix: preserve refreshed registry rows during probes

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/tasks/health.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks/health.rs
@@ -206,33 +206,47 @@ pub(crate) fn spawn_health_check_task(
 
                 if count > effective_failures {
                     let r = registry.read().await;
-                    #[cfg(feature = "admin")]
-                    let removed = r.deregister(&entry.key()).ok().flatten();
-                    #[cfg(not(feature = "admin"))]
-                    let _ = r.deregister(&entry.key());
+                    let removed = match r.deregister_if_unchanged(entry) {
+                        Ok(removed) => removed,
+                        Err(error) => {
+                            tracing::warn!(
+                                dcc_type = %entry.dcc_type,
+                                instance_id = %entry.instance_id,
+                                %error,
+                                "Health check failed to deregister unreachable instance"
+                            );
+                            None
+                        }
+                    };
                     failure_counts.remove(&key);
-                    let reason = format!("{} consecutive health-check failures", count);
-                    tracing::info!(
-                        dcc_type = %entry.dcc_type,
-                        instance_id = %entry.instance_id,
-                        consecutive_failures = count,
-                        "Auto-deregistered after consecutive health-check failures"
-                    );
-                    #[cfg(feature = "admin")]
-                    persist_deregistered_instance(
-                        &cfg.admin_sqlite_lane,
-                        removed.as_ref().unwrap_or(entry),
-                        &reason,
-                    );
-                    crate::gateway::event_log::record_event(
-                        &event_log,
-                        #[cfg(feature = "prometheus")]
-                        &cfg.metrics,
-                        crate::gateway::event_log::EventKind::AutoDeregister,
-                        &entry.dcc_type,
-                        &id8,
-                        Some(reason),
-                    );
+                    if removed.is_some() {
+                        let reason = format!("{} consecutive health-check failures", count);
+                        tracing::info!(
+                            dcc_type = %entry.dcc_type,
+                            instance_id = %entry.instance_id,
+                            consecutive_failures = count,
+                            "Auto-deregistered after consecutive health-check failures"
+                        );
+                        #[cfg(feature = "admin")]
+                        if let Some(removed) = removed.as_ref() {
+                            persist_deregistered_instance(&cfg.admin_sqlite_lane, removed, &reason);
+                        }
+                        crate::gateway::event_log::record_event(
+                            &event_log,
+                            #[cfg(feature = "prometheus")]
+                            &cfg.metrics,
+                            crate::gateway::event_log::EventKind::AutoDeregister,
+                            &entry.dcc_type,
+                            &id8,
+                            Some(reason),
+                        );
+                    } else {
+                        tracing::debug!(
+                            dcc_type = %entry.dcc_type,
+                            instance_id = %entry.instance_id,
+                            "Health-check result was stale — keeping refreshed instance"
+                        );
+                    }
                 }
             }
         }

--- a/crates/dcc-mcp-gateway/src/gateway/tasks/probe.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks/probe.rs
@@ -5,6 +5,13 @@ use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntr
 use dcc_mcp_transport::error::TransportResult;
 use futures::future::join_all;
 
+fn evict_probe_snapshot(
+    registry: &FileRegistry,
+    observed: &ServiceEntry,
+) -> TransportResult<Option<ServiceEntry>> {
+    registry.deregister_if_unchanged(observed)
+}
+
 /// On gateway startup, probe every registered instance's TCP port and
 /// deregister any that are unreachable. Complements `prune_dead_pids`
 /// which only checks PID liveness — a process may be alive but its MCP
@@ -41,7 +48,6 @@ pub(crate) async fn probe_and_evict_dead_instances(
     let futures: Vec<_> = entries
         .into_iter()
         .map(|entry| {
-            let key = entry.key();
             let addr = format!("{}:{}", entry.host, entry.port);
             let dcc_type = entry.dcc_type.clone();
             let instance_id = entry.instance_id;
@@ -52,24 +58,31 @@ pub(crate) async fn probe_and_evict_dead_instances(
                 )
                 .await
                 .is_ok_and(|r| r.is_ok());
-                (key, reachable, addr, dcc_type, instance_id)
+                (entry, reachable, addr, dcc_type, instance_id)
             }
         })
         .collect();
 
     let outcomes = join_all(futures).await;
     let mut evicted = Vec::new();
-    for (key, reachable, addr, dcc_type, instance_id) in outcomes {
+    for (observed, reachable, addr, dcc_type, instance_id) in outcomes {
         if !reachable {
-            let removed = registry.deregister(&key)?;
-            tracing::info!(
-                dcc_type = %dcc_type,
-                instance_id = %instance_id,
-                addr = %addr,
-                "Startup probe: instance unreachable — deregistered"
-            );
+            let removed = evict_probe_snapshot(registry, &observed)?;
             if let Some(entry) = removed {
+                tracing::info!(
+                    dcc_type = %dcc_type,
+                    instance_id = %instance_id,
+                    addr = %addr,
+                    "Startup probe: instance unreachable — deregistered"
+                );
                 evicted.push(entry);
+            } else {
+                tracing::debug!(
+                    dcc_type = %dcc_type,
+                    instance_id = %instance_id,
+                    addr = %addr,
+                    "Startup probe result was stale — keeping refreshed instance"
+                );
             }
         }
     }
@@ -179,5 +192,23 @@ mod tests {
             registry.get(&key).is_none(),
             "startup probe must remove unreachable rows from the live registry"
         );
+    }
+
+    #[test]
+    fn stale_probe_does_not_remove_refreshed_row() {
+        let dir = tempdir().unwrap();
+        let registry = FileRegistry::new(dir.path()).unwrap();
+        let entry = ServiceEntry::new("houdini", "127.0.0.1", 18814);
+        let key = entry.key();
+        registry.register(entry).unwrap();
+
+        let observed = registry.get(&key).unwrap();
+        std::thread::sleep(Duration::from_millis(1));
+        assert!(registry.heartbeat(&key).unwrap());
+
+        let removed = evict_probe_snapshot(&registry, &observed).unwrap();
+
+        assert!(removed.is_none());
+        assert!(registry.get(&key).is_some());
     }
 }

--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -629,25 +629,47 @@ impl FileRegistry {
     /// Deregister a service by key.
     pub fn deregister(&self, key: &ServiceKey) -> TransportResult<Option<ServiceEntry>> {
         self.with_write_transaction(|| {
-            let removed = self.services.remove(key).map(|(_, entry)| entry);
-            if let Some((_, file)) = self.sentinel_handles.remove(key) {
-                let _ = file.unlock();
-            }
-            if let Some(entry) = &removed
-                && let Some(path) = &entry.sentinel_path
-            {
-                let _ = fs::remove_file(path);
-            }
-            if removed.is_some() {
-                tracing::info!(
-                    dcc_type = %key.dcc_type,
-                    instance_id = %key.instance_id,
-                    "deregistered service"
-                );
-            }
+            let removed = self.remove_entry(key);
             let changed = removed.is_some();
             Ok((removed, changed))
         })
+    }
+
+    /// Deregister an asynchronously observed row only if its owner has not refreshed it.
+    pub fn deregister_if_unchanged(
+        &self,
+        observed: &ServiceEntry,
+    ) -> TransportResult<Option<ServiceEntry>> {
+        let key = observed.key();
+        self.with_write_transaction(|| {
+            let unchanged = self.services.get(&key).is_some_and(|current| {
+                current.registered_at == observed.registered_at
+                    && current.last_heartbeat == observed.last_heartbeat
+            });
+            let removed = unchanged.then(|| self.remove_entry(&key)).flatten();
+            let changed = removed.is_some();
+            Ok((removed, changed))
+        })
+    }
+
+    fn remove_entry(&self, key: &ServiceKey) -> Option<ServiceEntry> {
+        let removed = self.services.remove(key).map(|(_, entry)| entry);
+        if let Some((_, file)) = self.sentinel_handles.remove(key) {
+            let _ = file.unlock();
+        }
+        if let Some(entry) = &removed
+            && let Some(path) = &entry.sentinel_path
+        {
+            let _ = fs::remove_file(path);
+        }
+        if removed.is_some() {
+            tracing::info!(
+                dcc_type = %key.dcc_type,
+                instance_id = %key.instance_id,
+                "deregistered service"
+            );
+        }
+        removed
     }
 
     /// Get a service entry by key.


### PR DESCRIPTION
## Summary
- preserve a live registry row when its heartbeat changes while an asynchronous reachability probe is in flight
- reuse the existing transactional removal path for sentinel and registry cleanup
- emit auto-deregistration persistence and events only when the observed row was actually removed

## Tests
- `cargo test -p dcc-mcp-gateway stale_probe_does_not_remove_refreshed_row`
- `cargo test -p dcc-mcp-transport`
- `cargo test -p dcc-mcp-gateway`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`