### PR TITLE
fix(capture): release GIL during window capture

### DIFF
--- a/crates/dcc-mcp-capture/src/python.rs
+++ b/crates/dcc-mcp-capture/src/python.rs
@@ -195,8 +195,10 @@ impl PyCapturer {
         process_id=None,
         window_title=None
     ))]
+    #[allow(clippy::too_many_arguments)]
     fn capture(
         &self,
+        py: Python<'_>,
         format: &str,
         jpeg_quality: u8,
         scale: f32,
@@ -226,7 +228,7 @@ impl PyCapturer {
             .target(target)
             .build();
 
-        let frame = self.inner.capture(&cfg).map_err(to_py_err)?;
+        let frame = py.detach(|| self.inner.capture(&cfg)).map_err(to_py_err)?;
         Ok(PyCaptureFrame { inner: frame })
     }
 
@@ -254,6 +256,7 @@ impl PyCapturer {
     #[allow(clippy::too_many_arguments)]
     fn capture_window(
         &self,
+        py: Python<'_>,
         process_id: Option<u32>,
         window_handle: Option<u64>,
         window_title: Option<String>,
@@ -282,7 +285,7 @@ impl PyCapturer {
             .timeout_ms(timeout_ms)
             .target(target)
             .build();
-        let frame = self.inner.capture(&cfg).map_err(to_py_err)?;
+        let frame = py.detach(|| self.inner.capture(&cfg)).map_err(to_py_err)?;
         Ok(PyCaptureFrame { inner: frame })
     }
 
@@ -333,7 +336,7 @@ impl PyCapturer {
             .target(CaptureTarget::ProcessId(pid))
             .build();
         let capturer = Capturer::new_window_auto();
-        match capturer.capture(&cfg) {
+        match py.detach(|| capturer.capture(&cfg)) {
             Ok(frame) => Ok(pyo3::types::PyBytes::new(py, &frame.data)
                 .unbind()
                 .into_any()),
@@ -382,14 +385,14 @@ impl PyCapturer {
             .target(CaptureTarget::ProcessId(pid))
             .build();
         let capturer = Capturer::new_window_auto();
-        let frame = match capturer.capture(&cfg) {
+        let frame = match py.detach(|| capturer.capture(&cfg)) {
             Ok(f) => f,
             Err(e) => {
                 tracing::debug!(?pid, error = %e, "capture_region_png capture failed");
                 return Ok(py.None());
             }
         };
-        match crop_png_bytes(&frame.data, x, y, w, h) {
+        match py.detach(|| crop_png_bytes(&frame.data, x, y, w, h)) {
             Ok(bytes) => Ok(pyo3::types::PyBytes::new(py, &bytes).unbind().into_any()),
             Err(e) => {
                 tracing::debug!(?pid, ?x, ?y, ?w, ?h, error = %e, "capture_region_png crop failed");

--- a/crates/dcc-mcp-capture/src/python_tests.rs
+++ b/crates/dcc-mcp-capture/src/python_tests.rs
@@ -1,6 +1,15 @@
 //! Unit tests for the Python capture bindings.
 
 use super::*;
+use std::sync::Once;
+
+static PYTHON_INIT: Once = Once::new();
+
+fn capture(capturer: &PyCapturer, format: &str, jpeg_quality: u8, scale: f32) -> PyCaptureFrame {
+    PYTHON_INIT.call_once(Python::initialize);
+    Python::attach(|py| capturer.capture(py, format, jpeg_quality, scale, 5000, None, None))
+        .unwrap()
+}
 
 #[test]
 fn test_py_capturer_new_mock() {
@@ -11,7 +20,7 @@ fn test_py_capturer_new_mock() {
 #[test]
 fn test_py_capturer_capture_png() {
     let c = PyCapturer::new_mock(100, 100);
-    let frame = c.capture("png", 85, 1.0, 5000, None, None).unwrap();
+    let frame = capture(&c, "png", 85, 1.0);
     assert_eq!(frame.format(), "png");
     assert!(frame.data().starts_with(b"\x89PNG"));
     assert_eq!(frame.width(), 100);
@@ -22,7 +31,7 @@ fn test_py_capturer_capture_png() {
 #[test]
 fn test_py_capturer_capture_jpeg() {
     let c = PyCapturer::new_mock(64, 64);
-    let frame = c.capture("jpeg", 90, 1.0, 5000, None, None).unwrap();
+    let frame = capture(&c, "jpeg", 90, 1.0);
     assert_eq!(frame.format(), "jpeg");
     assert_eq!(frame.mime_type(), "image/jpeg");
 }
@@ -30,7 +39,7 @@ fn test_py_capturer_capture_jpeg() {
 #[test]
 fn test_py_capturer_capture_raw() {
     let c = PyCapturer::new_mock(16, 16);
-    let frame = c.capture("raw_bgra", 85, 1.0, 5000, None, None).unwrap();
+    let frame = capture(&c, "raw_bgra", 85, 1.0);
     assert_eq!(frame.format(), "raw_bgra");
     assert_eq!(frame.byte_len(), 16 * 16 * 4);
 }
@@ -39,7 +48,7 @@ fn test_py_capturer_capture_raw() {
 fn test_py_capturer_stats_accumulate() {
     let c = PyCapturer::new_mock(32, 32);
     for _ in 0..3 {
-        let _ = c.capture("png", 85, 1.0, 5000, None, None).unwrap();
+        let _ = capture(&c, "png", 85, 1.0);
     }
     let (count, bytes, errs) = c.stats();
     assert_eq!(count, 3);
@@ -62,14 +71,14 @@ fn test_py_capturer_repr() {
 #[test]
 fn test_py_capture_frame_repr() {
     let c = PyCapturer::new_mock(10, 10);
-    let frame = c.capture("png", 85, 1.0, 5000, None, None).unwrap();
+    let frame = capture(&c, "png", 85, 1.0);
     assert!(frame.__repr__().contains("10x10"));
 }
 
 #[test]
 fn test_py_capturer_scale_half() {
     let c = PyCapturer::new_mock(200, 100);
-    let frame = c.capture("raw_bgra", 85, 0.5, 5000, None, None).unwrap();
+    let frame = capture(&c, "raw_bgra", 85, 0.5);
     assert_eq!(frame.width(), 100);
     assert_eq!(frame.height(), 50);
 }

--- a/tests/test_capture_window_api.py
+++ b/tests/test_capture_window_api.py
@@ -10,7 +10,9 @@ Windows-specific backend behaviour lives in
 from __future__ import annotations
 
 # Import built-in modules
+import subprocess
 import sys
+import textwrap
 
 # Import third-party modules
 import pytest
@@ -84,6 +86,201 @@ class TestCaptureWindowArgValidation:
                 window_title="__nonexistent-window-title-xyz__",
                 timeout_ms=200,
             )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires a real Win32 window")
+@pytest.mark.parametrize(
+    "capture_api",
+    ["capture", "capture_window", "capture_window_png", "capture_region_png"],
+)
+def test_window_capture_apis_release_gil_while_target_paints(capture_api: str) -> None:
+    """Window capture APIs must not deadlock a Python-backed target window.
+
+    ``PrintWindow`` synchronously asks the target thread to paint. A DCC host
+    can run Python callbacks while processing that message, so the capture
+    binding must release the GIL before entering the native backend.
+    """
+    script = textwrap.dedent(
+        r"""
+        import ctypes
+        import os
+        import sys
+        import threading
+        from ctypes import wintypes
+
+        import dcc_mcp_core
+
+        user32 = ctypes.WinDLL("user32", use_last_error=True)
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        wndproc_type = ctypes.WINFUNCTYPE(
+            ctypes.c_ssize_t,
+            wintypes.HWND,
+            wintypes.UINT,
+            wintypes.WPARAM,
+            wintypes.LPARAM,
+        )
+
+        class WndClass(ctypes.Structure):
+            _fields_ = [
+                ("style", wintypes.UINT),
+                ("lpfnWndProc", wndproc_type),
+                ("cbClsExtra", ctypes.c_int),
+                ("cbWndExtra", ctypes.c_int),
+                ("hInstance", wintypes.HANDLE),
+                ("hIcon", wintypes.HANDLE),
+                ("hCursor", wintypes.HANDLE),
+                ("hbrBackground", wintypes.HANDLE),
+                ("lpszMenuName", wintypes.LPCWSTR),
+                ("lpszClassName", wintypes.LPCWSTR),
+            ]
+
+        kernel32.GetModuleHandleW.argtypes = [wintypes.LPCWSTR]
+        kernel32.GetModuleHandleW.restype = wintypes.HANDLE
+        user32.RegisterClassW.argtypes = [ctypes.POINTER(WndClass)]
+        user32.RegisterClassW.restype = wintypes.ATOM
+        user32.CreateWindowExW.argtypes = [
+            wintypes.DWORD,
+            wintypes.LPCWSTR,
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            wintypes.HWND,
+            wintypes.HANDLE,
+            wintypes.HANDLE,
+            ctypes.c_void_p,
+        ]
+        user32.CreateWindowExW.restype = wintypes.HWND
+        user32.DefWindowProcW.argtypes = [
+            wintypes.HWND,
+            wintypes.UINT,
+            wintypes.WPARAM,
+            wintypes.LPARAM,
+        ]
+        user32.DefWindowProcW.restype = ctypes.c_ssize_t
+        user32.GetMessageW.argtypes = [
+            ctypes.POINTER(wintypes.MSG),
+            wintypes.HWND,
+            wintypes.UINT,
+            wintypes.UINT,
+        ]
+        user32.GetMessageW.restype = wintypes.BOOL
+        user32.TranslateMessage.argtypes = [ctypes.POINTER(wintypes.MSG)]
+        user32.TranslateMessage.restype = wintypes.BOOL
+        user32.DispatchMessageW.argtypes = [ctypes.POINTER(wintypes.MSG)]
+        user32.DispatchMessageW.restype = ctypes.c_ssize_t
+        user32.PostMessageW.argtypes = [
+            wintypes.HWND,
+            wintypes.UINT,
+            wintypes.WPARAM,
+            wintypes.LPARAM,
+        ]
+        user32.PostMessageW.restype = wintypes.BOOL
+
+        ready = threading.Event()
+        window = {}
+        class_name = "DccMcpCaptureGilProbe"
+
+        @wndproc_type
+        def wndproc(hwnd, message, wparam, lparam):
+            if message == 0x0010:  # WM_CLOSE
+                user32.DestroyWindow(hwnd)
+                return 0
+            if message == 0x0002:  # WM_DESTROY
+                user32.PostQuitMessage(0)
+                return 0
+            return user32.DefWindowProcW(hwnd, message, wparam, lparam)
+
+        def run_window():
+            instance = kernel32.GetModuleHandleW(None)
+            spec = WndClass()
+            spec.lpfnWndProc = wndproc
+            spec.hInstance = instance
+            spec.lpszClassName = class_name
+            atom = user32.RegisterClassW(ctypes.byref(spec))
+            if not atom and ctypes.get_last_error() != 1410:  # class already exists
+                window["error"] = ctypes.WinError(ctypes.get_last_error())
+                ready.set()
+                return
+            hwnd = user32.CreateWindowExW(
+                0,
+                class_name,
+                "DCC MCP capture GIL probe",
+                0x10CF0000,  # WS_OVERLAPPEDWINDOW | WS_VISIBLE
+                50,
+                50,
+                320,
+                180,
+                None,
+                None,
+                instance,
+                None,
+            )
+            if not hwnd:
+                window["error"] = ctypes.WinError(ctypes.get_last_error())
+                ready.set()
+                return
+            window["hwnd"] = hwnd
+            ready.set()
+            message = wintypes.MSG()
+            while user32.GetMessageW(ctypes.byref(message), None, 0, 0) > 0:
+                user32.TranslateMessage(ctypes.byref(message))
+                user32.DispatchMessageW(ctypes.byref(message))
+
+        thread = threading.Thread(target=run_window, daemon=True)
+        thread.start()
+        assert ready.wait(3)
+        assert "error" not in window, window.get("error")
+
+        mode = sys.argv[1]
+        if mode == "capture":
+            frame = dcc_mcp_core.Capturer.new_window_auto().capture(
+                window_title="DCC MCP capture GIL probe",
+                timeout_ms=1000,
+            )
+            assert frame.width > 0 and frame.height > 0
+        elif mode == "capture_window":
+            frame = dcc_mcp_core.Capturer.new_window_auto().capture_window(
+                window_handle=window["hwnd"],
+                timeout_ms=1000,
+            )
+            assert frame.width > 0 and frame.height > 0
+        elif mode == "capture_window_png":
+            png = dcc_mcp_core.Capturer.capture_window_png(
+                pid=os.getpid(),
+                timeout_ms=1000,
+            )
+            assert png
+        else:
+            png = dcc_mcp_core.Capturer.capture_region_png(
+                os.getpid(),
+                0,
+                0,
+                32,
+                32,
+                timeout_ms=1000,
+            )
+            assert png
+        user32.PostMessageW(window["hwnd"], 0x0010, 0, 0)
+        thread.join(3)
+        assert not thread.is_alive()
+        """
+    )
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", script, capture_api],
+            capture_output=True,
+            text=True,
+            timeout=8,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(f"window capture deadlocked while holding the GIL: {exc}")
+
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 # ── CaptureFrame optional window fields ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- release the Python GIL around all native window-capture and crop operations
- prevent synchronous `PrintWindow` callbacks from deadlocking DCC Python/Qt event processing
- add a deterministic Win32 regression covering every public Python capture entry point

## Validation
- `pytest tests/test_capture_window_api.py tests/test_capture_hwnd_backend.py -q` (33 passed, 1 skipped)
- `cargo test -p dcc-mcp-capture --all-features --locked` (57 unit tests + 2 doctests)
- `cargo clippy -p dcc-mcp-capture --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `ruff check tests/test_capture_window_api.py`