### PR TITLE
fix: prefer current environment server binary

### DIFF
--- a/pkg/dcc-mcp-server-bin/python/dcc_mcp_server/__init__.py
+++ b/pkg/dcc-mcp-server-bin/python/dcc_mcp_server/__init__.py
@@ -35,10 +35,9 @@ def binary_path() -> Path:
     1. ``DCC_MCP_SERVER_BIN`` env var — operator override.
     2. ``scripts/`` directory next to this package's installation (where
        maturin places ``bindings = "bin"`` artefacts inside the wheel).
-    3. ``shutil.which("dcc-mcp-server")`` — the system PATH lookup that
-       ``pip``'s ``console_scripts`` install path produces.
-    4. ``sys.prefix/Scripts`` (Windows) or ``sys.prefix/bin`` (POSIX) —
-       the venv-relative scripts dir for the *current* interpreter.
+    3. ``sys.prefix/Scripts`` (Windows) or ``sys.prefix/bin`` (POSIX) —
+       the scripts directory for the *current* interpreter environment.
+    4. ``shutil.which("dcc-mcp-server")`` — a final system PATH fallback.
 
     Raises:
         FileNotFoundError: if no installation of the binary is found.
@@ -55,14 +54,14 @@ def binary_path() -> Path:
     if candidate.is_file():
         return candidate
 
-    on_path = shutil.which("dcc-mcp-server")
-    if on_path:
-        return Path(on_path)
-
     scripts_dir = Path(sys.prefix) / ("Scripts" if os.name == "nt" else "bin")
     candidate = scripts_dir / _BINARY_NAME
     if candidate.is_file():
         return candidate
+
+    on_path = shutil.which("dcc-mcp-server")
+    if on_path:
+        return Path(on_path)
 
     raise FileNotFoundError(
         "dcc-mcp-server binary not found. Did you `pip install dcc-mcp-server`? "

--- a/tests/test_server_binary_locator.py
+++ b/tests/test_server_binary_locator.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+_LOCATOR_SOURCE = (
+    Path(__file__).resolve().parents[1] / "pkg" / "dcc-mcp-server-bin" / "python" / "dcc_mcp_server" / "__init__.py"
+)
+
+
+def _load_locator_module():
+    spec = importlib.util.spec_from_file_location("_dcc_mcp_server_locator_under_test", _LOCATOR_SOURCE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_binary_path_prefers_current_interpreter_environment_over_path(monkeypatch, tmp_path):
+    locator = _load_locator_module()
+    binary_name = locator._BINARY_NAME
+    scripts_name = "Scripts" if locator.os.name == "nt" else "bin"
+    interpreter_prefix = tmp_path / "current-environment"
+    interpreter_binary = interpreter_prefix / scripts_name / binary_name
+    interpreter_binary.parent.mkdir(parents=True)
+    interpreter_binary.write_bytes(b"current")
+    stale_path_binary = tmp_path / "stale-path" / binary_name
+    stale_path_binary.parent.mkdir(parents=True)
+    stale_path_binary.write_bytes(b"stale")
+
+    monkeypatch.delenv("DCC_MCP_SERVER_BIN", raising=False)
+    monkeypatch.setattr(locator.sys, "prefix", str(interpreter_prefix))
+    monkeypatch.setattr(locator.shutil, "which", lambda _name: str(stale_path_binary))
+
+    assert locator.binary_path() == interpreter_binary
+
+
+def test_binary_path_keeps_explicit_operator_override_first(monkeypatch, tmp_path):
+    locator = _load_locator_module()
+    override = tmp_path / locator._BINARY_NAME
+    override.write_bytes(b"operator")
+    monkeypatch.setenv("DCC_MCP_SERVER_BIN", str(override))
+    monkeypatch.setattr(locator.shutil, "which", lambda _name: sys.executable)
+
+    assert locator.binary_path() == override


### PR DESCRIPTION
## Summary
- resolve the bundled server from the current interpreter environment before falling back to the ambient PATH
- preserve the explicit `DCC_MCP_SERVER_BIN` override and packaged-wheel lookup order
- add cross-platform regression coverage for a stale PATH entry

## Why
During gateway version takeover, an embedded or virtual-environment client can have a newer `dcc-mcp-server` installed while PATH still points to an older executable. Selecting the older executable after the resident gateway yields leaves the requested successor version unavailable.

## Validation
- `python -m pytest tests/test_server_binary_locator.py tests/test_gateway_guardian.py -q` (55 passed)
- `ruff check pkg/dcc-mcp-server-bin/python/dcc_mcp_server/__init__.py tests/test_server_binary_locator.py`
- isolated real-process 0.19.44 -> 0.19.45 gateway takeover on a random port: final admin version and owned FileRegistry sentinel both 0.19.45, followed by clean shutdown