### PR TITLE
docs: make dynamic instance ports the default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,8 +274,8 @@ Gateway resources/prompts:
 | Search public DCC-MCP adapter catalog | MCP `resources/read` on `gateway://catalog?query=...` (or `gateway://catalog/{name}` for a single entry); CLI: `dcc-mcp-server catalog search --query ...` |
 | Disable evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |
 | Make skill discovery hermetic in CI/tests | `DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS=1` excludes implicit operator-owned roots (local/platform defaults, marketplace installs, and Admin custom paths) while preserving explicit, bundled, and `DCC_MCP_*_SKILL_PATHS` paths |
-| MCP HTTP (recommended) | `create_skill_server("<dcc>", McpHttpConfig(port=8765))` |
-| MCP HTTP (manual) | `McpHttpServer(registry, McpHttpConfig(port=8765))` |
+| MCP HTTP (recommended) | `create_skill_server("<dcc>", McpHttpConfig())` — OS-assigned instance port; CLI/gateway discovery |
+| MCP HTTP (manual) | `McpHttpServer(registry, McpHttpConfig())` — pass `port=N` only for an explicit fixed listener |
 | Full-screen capture | `Capturer.new_auto().capture()` |
 | Single-window capture | `Capturer.new_window_auto().capture_window(...)` |
 | Capture DCC output streams | `OutputCapture` — stdout/stderr/script-editor as `output://` resource |

--- a/README.md
+++ b/README.md
@@ -105,10 +105,15 @@ from dcc_mcp_core import McpHttpConfig, create_skill_server
 
 os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/path/to/skills"
 
-server = create_skill_server("maya", McpHttpConfig(port=8765))
+server = create_skill_server("maya", McpHttpConfig())
 handle = server.start()
 print(handle.mcp_url())
 ~~~
+
+Local DCC instances bind an OS-assigned port by default. The resolved URL is
+registered automatically, so the gateway and CLI discover it without a
+hardcoded per-instance port. Pass `port=<number>` only for an explicit fixed
+listener requirement.
 
 For manual handler registration, use McpHttpServer and ToolRegistry. For
 adapter lifecycle, readiness, gateway registration, and hot reload, use

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -97,11 +97,11 @@ registry = ToolRegistry()
 registry.register("get_scene_info", description="Get current scene info",
                   category="scene", tags=[], dcc="maya", version="1.0.0")
 
-server = McpHttpServer(registry, McpHttpConfig(port=8765))
+server = McpHttpServer(registry, McpHttpConfig())
 handle = server.start()
 
 print(f"MCP HTTP server running at {handle.mcp_url()}")
-# MCP host POSTs to http://127.0.0.1:8765/mcp
+# The handle exposes the OS-assigned listener URL.
 
 # Shutdown when done
 handle.shutdown()

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -58,11 +58,14 @@ from dcc_mcp_core import create_skill_server, McpHttpConfig
 os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/path/to/my-skills"
 
 # One call: discover skills + start MCP HTTP server
-server = create_skill_server("maya", McpHttpConfig(port=8765))
+server = create_skill_server("maya", McpHttpConfig())
 handle = server.start()
 print(f"Maya MCP server at {handle.mcp_url()}")
-# AI clients (Claude Desktop, etc.) connect to http://127.0.0.1:8765/mcp
+# The CLI and gateway discover this resolved URL through the shared registry.
 ```
+
+The local instance port is OS-assigned by default. Pass `port=<number>` only
+when an integration explicitly requires a fixed listener.
 
 Or use `SkillCatalog` directly for more control:
 

--- a/docs/zh/api/http.md
+++ b/docs/zh/api/http.md
@@ -20,7 +20,7 @@ HTTP 服务器配置。
 from dcc_mcp_core import McpHttpConfig
 
 cfg = McpHttpConfig(
-    port=8765,                # TCP 端口（0 = 随机可用端口）
+    port=0,                   # 默认由操作系统分配；需要时可显式指定固定端口
     server_name="maya-mcp",   # MCP initialize 响应中的名称
     server_version="1.0.0",   # MCP initialize 响应中的版本
     enable_cors=False,         # 浏览器客户端的 CORS 头
@@ -92,11 +92,11 @@ registry = ToolRegistry()
 registry.register("get_scene_info", description="获取当前场景信息",
                   category="scene", tags=[], dcc="maya", version="1.0.0")
 
-server = McpHttpServer(registry, McpHttpConfig(port=8765))
+server = McpHttpServer(registry, McpHttpConfig())
 handle = server.start()
 
 print(f"MCP HTTP 服务器运行于 {handle.mcp_url()}")
-# MCP 主机 POST 到 http://127.0.0.1:8765/mcp
+# handle 返回操作系统实际分配的监听地址。
 
 # 完成后关闭
 handle.shutdown()

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -57,11 +57,14 @@ from dcc_mcp_core import create_skill_server, McpHttpConfig
 os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/path/to/my-skills"
 
 # 一键：发现 Skills + 启动 MCP HTTP 服务器
-server = create_skill_server("maya", McpHttpConfig(port=8765))
+server = create_skill_server("maya", McpHttpConfig())
 handle = server.start()
 print(f"Maya MCP 服务器地址：{handle.mcp_url()}")
-# AI 客户端（Claude Desktop 等）连接到 http://127.0.0.1:8765/mcp
+# CLI 和网关会通过共享注册表发现这个实际地址。
 ```
+
+本地实例默认使用操作系统分配的端口。只有外部集成明确要求固定监听端口时，
+才传入 `port=<端口号>`。
 
 如需更多控制，可直接使用 `SkillCatalog`：
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -35,7 +35,7 @@
 | Serialize result for transport | `serialize_result()` / `deserialize_result()` with `SerializeFormat` |
 | Wrap values for safe RPyC transport | `wrap_value()` / `unwrap_value()` |
 | Handle multiple versions of an action | `VersionedRegistry` + `VersionConstraint` |
-| Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig(port=8765))` — Skills-First one-call setup; gateway/slim agents use `search_tools` → `describe_tool` → `call_tool` / `call_tools`; wrapper payloads are `{tool_slug, arguments?, meta?}` and backend-specific fields live inside `arguments`; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
+| Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig())` — Skills-First one-call setup with an OS-assigned instance port discoverable through the CLI/gateway; gateway/slim agents use `search_tools` → `describe_tool` → `call_tool` / `call_tools`; wrapper payloads are `{tool_slug, arguments?, meta?}` and backend-specific fields live inside `arguments`; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
 | Bind adapter readiness probe | `AdapterReadinessBinder.bind_inline(server)` / `.bind_headless(server)` / `.bind_queue_dispatcher(server, dispatcher)` — publishes `ReadinessProbe` gating MCP `tools/call`, REST `/v1/readyz`, and REST `/v1/call` (#1331, #1206) |
 | Check DCC adapter readiness | `GET /v1/readyz` → 200 `ready` / 503 `booting` / 503 `not-ready` with per-bit details (process, dcc, catalog, dispatcher, host_bridge, main_thread_executor) (#1331) |
 | Discover gateway DCC instances / direct MCP URLs (#813 phase 1) | `resources/read uri="gateway://instances"` or `gateway://instances/{id}` — entries include `mcp_url`; `resources/list` shows the root pointer only; legacy `list_dcc_instances` / `get_dcc_instance` / `connect_to_dcc` and non-standard `instances/list` are removed |
@@ -1246,7 +1246,7 @@ Python adapters can register MCP prompts directly without touching Rust code, mi
 from dcc_mcp_core import McpHttpServer, McpHttpConfig, ToolRegistry
 
 registry = ToolRegistry()
-cfg = McpHttpConfig(port=8765)
+cfg = McpHttpConfig()
 # Prompts are enabled by default; set cfg.enable_prompts = False only to opt out.
 
 server = McpHttpServer(registry, cfg)
@@ -2952,13 +2952,13 @@ DCC main thread.
 from dcc_mcp_core import McpHttpConfig
 
 config = McpHttpConfig(
-    port=8765,              # use 0 for OS-assigned ephemeral port
+    port=0,                 # default: OS-assigned instance port
     server_name="maya-mcp", # reported in MCP initialize response
     server_version="1.0.0",
     enable_cors=False,      # set True for browser-based MCP clients
     request_timeout_ms=30000,
 )
-print(config.port)          # 8765
+print(config.port)          # 0 before start; read handle.port after binding
 print(config.server_name)   # "maya-mcp"
 print(config.server_version) # "1.0.0"
 ```
@@ -3007,7 +3007,7 @@ registry.register(
 )
 
 # Start server — returns immediately, server runs in background
-server = McpHttpServer(registry, McpHttpConfig(port=8765, server_name="maya-mcp"))
+server = McpHttpServer(registry, McpHttpConfig(server_name="maya-mcp"))
 handle = server.start()   # -> McpServerHandle (alias for McpServerHandle)
 ```
 
@@ -3034,7 +3034,7 @@ os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/studio/maya-skills"
 from dcc_mcp_core import create_skill_server, McpHttpConfig
 
 # One call: creates registry, dispatcher, SkillCatalog, discovers skills from env vars
-server = create_skill_server("maya", McpHttpConfig(port=8765))
+server = create_skill_server("maya", McpHttpConfig())
 handle = server.start()
 print(f"Maya MCP server at {handle.mcp_url()}")
 # Claude Desktop config: {"mcpServers": {"maya": {"url": "<handle.mcp_url()>"}}}
@@ -3308,7 +3308,7 @@ MCP client side.
 
 ```python
 from dcc_mcp_core import McpHttpConfig
-cfg = McpHttpConfig(port=8765)
+cfg = McpHttpConfig()
 cfg.enable_workflows = True     # default False
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -59,7 +59,7 @@
 | Monitor DCC process | `PyProcessWatcher` + `PyCrashRecoveryPolicy` |
 | Sandbox AI actions | `SandboxPolicy` + `SandboxContext` |
 | Share large data zero-copy | `PySharedSceneBuffer.write()` with LZ4 compression |
-| Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig(port=8765))` — Skills-First setup; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
+| Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig())` — Skills-First setup with an OS-assigned instance port discoverable through the CLI/gateway; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
 | Register MCP prompts from Python (issue #792) | `handle = server.prompts(); handle.register_prompt(name, template, description=..., arguments=[...])` — `server.prompts()` returns `PromptHandle`; registration upserts in-place and appears in the next `prompts/list` / `prompts/get` |
 | Build a DCC adapter | `opts = DccServerOptions.from_env("maya", Path(...)); DccServerBase(opts)` — skill/lifecycle/gateway/hot-reload inherited |
 | Apply adapter metadata policy before skills load (#1204) | `DccServerBase.set_skill_load_transform(fn)` / `McpHttpServer.set_skill_load_transform(fn)` — callable receives a mutable `SkillMetadata`, may return `None` or a replacement, and applies consistently to direct Python `load_skill`, MCP `load_skill`, REST `/v1/load_skill`, batch, and group load paths. Use `set_after_load_skill_hook(fn)` only to observe `(skill, registered_actions)` after registration. |
@@ -437,7 +437,7 @@ tools:
 
 ### MCP HTTP Server (`dcc_mcp_core`)
 
-- `McpHttpConfig(port=8765, server_name=None, server_version=None, enable_cors=False, request_timeout_ms=30000)` — server configuration
+- `McpHttpConfig(port=0, server_name=None, server_version=None, enable_cors=False, request_timeout_ms=30000)` — server configuration; `0` delegates instance-port allocation to the OS
   - `.lazy_actions = True` — opt-in: `tools/list` surfaces only 3 meta-tools (`list_actions`, `describe_action`, `call_action`) instead of all tools
   - `.session_ttl_secs` — idle session eviction (default 3600s)
   - `.gateway_port` — default `9765` in Python; first process to bind wins the single gateway/admin, `0` disables gateway/admin
@@ -644,7 +644,7 @@ tools:
 
 ### Server Factory (`dcc_mcp_core.factory`)
 
-- `create_dcc_server(*, instance_holder, lock, server_class, port=8765, register_builtins=True, extra_skill_paths=None, include_bundled=True, enable_hot_reload=False, hot_reload_env_var=None, **server_kwargs) -> McpServerHandle` — create-or-return a singleton DCC MCP server
+- `create_dcc_server(*, instance_holder, lock, server_class, port=None, register_builtins=True, extra_skill_paths=None, include_bundled=True, enable_hot_reload=False, hot_reload_env_var=None, **server_kwargs) -> McpServerHandle` — create-or-return a singleton DCC MCP server; `None` resolves an explicit DCC override or uses an OS-assigned port
 - `make_start_stop(server_class, hot_reload_env_var=None) -> (start_fn, stop_fn)` — generate a `(start_server, stop_server)` function pair
 - `get_server_instance(instance_holder) -> server | None` — return the current singleton instance
 

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -52,10 +52,16 @@ from dcc_mcp_core import create_skill_server, McpHttpConfig
 
 server = create_skill_server(
     "maya",
-    McpHttpConfig(port=8765),
+    McpHttpConfig(),
     extra_paths=["/path/to/dcc-mcp-core/skills"],
 )
+handle = server.start()
+print(handle.mcp_url())
 ```
+
+The local instance port is OS-assigned by default. The CLI and gateway discover
+the resolved URL through the shared registry; pass an explicit port only when
+an external integration requires a fixed listener.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- show OS-assigned instance ports in the primary Python quick starts and HTTP examples
- explain that the CLI and stable gateway discover the resolved listener URL through the registry
- correct the compact API references for `McpHttpConfig(port=0)` and `create_dcc_server(port=None)`
- teach the bundled skills-creator entry point to publish and print its resolved dynamic URL
- keep explicit fixed ports available for remote or integration-specific listeners

## Validation
- `python -m pytest tests/test_agent_instruction_files.py -q` (2 passed)
- `cargo fmt --all -- --check`
- `git diff --check`