### PR TITLE
fix(host): stop pumps before dispatcher shutdown

### DIFF
--- a/python/dcc_mcp_core/host/_adapter.py
+++ b/python/dcc_mcp_core/host/_adapter.py
@@ -228,20 +228,24 @@ class HostAdapter:
         Idempotent — safe to call multiple times. ``timeout`` is the
         upper bound on how long to wait for a headless thread to
         exit; interactive mode stops immediately (the DCC's next
-        frame removes the timer).
+        frame removes the timer). The tick driver is detached or joined
+        before dispatcher shutdown so a blocking tick cannot hold the
+        queue drain lock during teardown.
         """
         self._stop_event.set()
-        with contextlib.suppress(Exception):
-            self._dispatcher.shutdown()
         if self._attached:
             with contextlib.suppress(Exception):
                 self.detach_tick()
             self._attached = False
-        if self._headless_thread is not None:
-            self._headless_thread.join(timeout=timeout)
-            if self._headless_thread.is_alive():  # pragma: no cover - diagnostic
-                raise RuntimeError(f"HostAdapter {self._name!r} headless thread did not stop within {timeout}s")
-            self._headless_thread = None
+        try:
+            if self._headless_thread is not None:
+                self._headless_thread.join(timeout=timeout)
+                if self._headless_thread.is_alive():  # pragma: no cover - diagnostic
+                    raise RuntimeError(f"HostAdapter {self._name!r} headless thread did not stop within {timeout}s")
+                self._headless_thread = None
+        finally:
+            with contextlib.suppress(Exception):
+                self._dispatcher.shutdown()
 
     def run_headless(self, stop_event: threading.Event | None = None) -> None:
         """Drive the dispatcher on the *calling* thread until stopped.

--- a/python/dcc_mcp_core/host/_standalone.py
+++ b/python/dcc_mcp_core/host/_standalone.py
@@ -99,18 +99,22 @@ class StandaloneHost:
         Idempotent — safe to call multiple times or after a failed ``start``.
         ``timeout`` is the upper bound on how long to wait for the driver
         thread to exit; tick loops return within ``tick_interval`` (or
-        ``_BLOCKING_TIMEOUT_MS``) so the default 5 s is usually ample.
+        ``_BLOCKING_TIMEOUT_MS``) so the default 5 s is usually ample. The
+        driver exits before dispatcher shutdown so an active blocking tick
+        cannot hold the queue drain lock during teardown.
         """
         self._stop_event.set()
-        # Swallow shutdown failures during teardown so a stale dispatcher
-        # can't mask cleanup on the way out.
-        with contextlib.suppress(Exception):
-            self._dispatcher.shutdown()
-        if self._thread is not None:
-            self._thread.join(timeout=timeout)
-            if self._thread.is_alive():  # pragma: no cover - diagnostic only
-                raise RuntimeError(f"StandaloneHost thread {self._thread_name!r} did not stop within {timeout}s")
-            self._thread = None
+        try:
+            if self._thread is not None:
+                self._thread.join(timeout=timeout)
+                if self._thread.is_alive():  # pragma: no cover - diagnostic only
+                    raise RuntimeError(f"StandaloneHost thread {self._thread_name!r} did not stop within {timeout}s")
+                self._thread = None
+        finally:
+            # Swallow shutdown failures during teardown so a stale dispatcher
+            # can't mask cleanup on the way out.
+            with contextlib.suppress(Exception):
+                self._dispatcher.shutdown()
 
     @property
     def is_running(self) -> bool:

--- a/tests/test_host_adapter.py
+++ b/tests/test_host_adapter.py
@@ -247,3 +247,52 @@ def test_background_start_runs_headless_thread() -> None:
     finally:
         host.stop()
     assert not host.is_running
+
+
+def test_background_stop_joins_tick_loop_before_dispatcher_shutdown() -> None:
+    """Stopping a headless host must not race an active blocking tick."""
+
+    class _BlockingTickDispatcher:
+        def __init__(self) -> None:
+            self.tick_started = threading.Event()
+            self.allow_tick_finish = threading.Event()
+            self.tick_finished = threading.Event()
+            self.shutdown_called = threading.Event()
+            self.shutdown_while_ticking = False
+
+        def tick_blocking(self, _max_jobs: int, _timeout_ms: int) -> None:
+            self.tick_started.set()
+            self.allow_tick_finish.wait(timeout=2.0)
+            self.tick_finished.set()
+
+        def shutdown(self) -> None:
+            self.shutdown_while_ticking = not self.tick_finished.is_set()
+            self.shutdown_called.set()
+
+        def is_shutdown(self) -> bool:
+            return self.shutdown_called.is_set()
+
+    dispatcher = _BlockingTickDispatcher()
+    host = _TimerHost(dispatcher, background=True)
+    host.start()
+    assert dispatcher.tick_started.wait(timeout=1.0)
+
+    stop_errors = []
+
+    def _stop_host() -> None:
+        try:
+            host.stop(timeout=1.0)
+        except BaseException as exc:
+            stop_errors.append(exc)
+
+    stop_thread = threading.Thread(target=_stop_host, daemon=True)
+    stop_thread.start()
+    shutdown_raced_tick = dispatcher.shutdown_called.wait(timeout=0.25)
+    dispatcher.allow_tick_finish.set()
+    stop_thread.join(timeout=1.0)
+
+    assert not stop_thread.is_alive()
+    assert not stop_errors
+    assert dispatcher.shutdown_called.is_set()
+    assert not shutdown_raced_tick
+    assert not dispatcher.shutdown_while_ticking

--- a/tests/test_host_dispatcher.py
+++ b/tests/test_host_dispatcher.py
@@ -217,6 +217,52 @@ def test_stop_is_idempotent(dispatcher: QueueDispatcher) -> None:
     assert not h.is_running
 
 
+def test_standalone_stop_joins_tick_loop_before_dispatcher_shutdown() -> None:
+    """Standalone teardown must not race dispatcher shutdown with a blocking tick."""
+
+    class _BlockingTickDispatcher:
+        def __init__(self) -> None:
+            self.tick_started = threading.Event()
+            self.allow_tick_finish = threading.Event()
+            self.tick_finished = threading.Event()
+            self.shutdown_called = threading.Event()
+            self.shutdown_while_ticking = False
+
+        def tick_blocking(self, _max_jobs: int, _timeout_ms: int) -> None:
+            self.tick_started.set()
+            self.allow_tick_finish.wait(timeout=2.0)
+            self.tick_finished.set()
+
+        def shutdown(self) -> None:
+            self.shutdown_while_ticking = not self.tick_finished.is_set()
+            self.shutdown_called.set()
+
+    dispatcher = _BlockingTickDispatcher()
+    host = StandaloneHost(dispatcher)
+    host.start()
+    assert dispatcher.tick_started.wait(timeout=1.0)
+
+    stop_errors = []
+
+    def _stop_host() -> None:
+        try:
+            host.stop(timeout=1.0)
+        except BaseException as exc:
+            stop_errors.append(exc)
+
+    stop_thread = threading.Thread(target=_stop_host, daemon=True)
+    stop_thread.start()
+    shutdown_raced_tick = dispatcher.shutdown_called.wait(timeout=0.25)
+    dispatcher.allow_tick_finish.set()
+    stop_thread.join(timeout=1.0)
+
+    assert not stop_thread.is_alive()
+    assert not stop_errors
+    assert dispatcher.shutdown_called.is_set()
+    assert not shutdown_raced_tick
+    assert not dispatcher.shutdown_while_ticking
+
+
 # ---------------------------------------------------------------------------
 # Concurrency
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- stop headless host pump threads before shutting down their dispatchers
- preserve best-effort dispatcher cleanup with `finally` when a pump misses its join deadline
- add deterministic event-driven regressions for both `HostAdapter` and `StandaloneHost`

## Problem

A headless pump can be inside `BlockingDispatcher.tick_blocking()` when normal teardown begins. The blocking tick owns the queue receiver for up to its bounded wait, while the old stop order called dispatcher shutdown before joining the pump. The synchronous shutdown path exhausted its short spin budget first and emitted a misleading drain-lock warning during otherwise successful process exit.

## Validation

- `vx just dev`
- `python -m pytest tests/test_host_adapter.py tests/test_host_dispatcher.py -q` (32 passed)
- `ruff check` and `ruff format --check` for all touched files
- packaged headless Houdini smoke on an ephemeral instance port with gateway integration disabled; normal stop completed with exit code 0 and no drain-lock warning

## Compatibility

No public API or adapter wiring changes. Existing join-timeout errors remain visible, and dispatcher shutdown still runs on every stop path. The adapter-development skill needs no update because the documented lifecycle contract is unchanged.