### PR TITLE
fix(job): preserve lifecycle timestamps across updates

### DIFF
--- a/crates/dcc-mcp-http-server/src/notifications.rs
+++ b/crates/dcc-mcp-http-server/src/notifications.rs
@@ -291,18 +291,11 @@ fn progress_mapping(event: &JobEvent) -> (u64, u64, String) {
 }
 
 fn started_at(event: &JobEvent) -> Option<String> {
-    match event.status {
-        JobStatus::Pending => None,
-        _ => Some(event.updated_at.to_rfc3339()),
-    }
+    event.started_at.map(|at| at.to_rfc3339())
 }
 
 fn completed_at(event: &JobEvent) -> Option<String> {
-    if event.status.is_terminal() {
-        Some(event.updated_at.to_rfc3339())
-    } else {
-        None
-    }
+    event.completed_at.map(|at| at.to_rfc3339())
 }
 
 #[cfg(test)]
@@ -433,6 +426,12 @@ mod tests {
             updates.last().unwrap()["params"]["error"],
             Value::String("boom".into()),
         );
+        assert_eq!(
+            updates.first().unwrap()["params"]["started_at"],
+            updates.last().unwrap()["params"]["started_at"],
+        );
+        assert!(updates.first().unwrap()["params"]["completed_at"].is_null());
+        assert!(!updates.last().unwrap()["params"]["completed_at"].is_null());
     }
 
     #[test]

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/jobs.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/jobs.rs
@@ -3,7 +3,7 @@
 use chrono;
 use serde_json::{Value, json};
 
-use dcc_mcp_job::job::{Job, JobStatus};
+use dcc_mcp_job::job::Job;
 use dcc_mcp_jsonrpc::{CallToolResult, ToolContent};
 
 use crate::server_state::ServerState;
@@ -14,16 +14,7 @@ pub(in crate::rmcp_tool_call_dispatch) fn compute_job_timestamps(
     Option<chrono::DateTime<chrono::Utc>>,
     Option<chrono::DateTime<chrono::Utc>>,
 ) {
-    let started_at = match job.status {
-        JobStatus::Pending => None,
-        _ => Some(job.updated_at),
-    };
-    let completed_at = if job.status.is_terminal() {
-        Some(job.updated_at)
-    } else {
-        None
-    };
-    (started_at, completed_at)
+    (job.started_at, job.completed_at)
 }
 
 pub(in crate::rmcp_tool_call_dispatch) fn handle_jobs_get_status(
@@ -142,5 +133,35 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_jobs_cleanup(
         structured_content: Some(envelope),
         is_error: false,
         meta: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dcc_mcp_job::job::{JobManager, JobProgress};
+
+    #[test]
+    fn reported_start_timestamp_does_not_move_when_job_completes() {
+        let jobs = JobManager::new();
+        let handle = jobs.create("render.sequence");
+        let id = handle.read().id.clone();
+        jobs.start(&id).unwrap();
+        let started_at = compute_job_timestamps(&handle.read()).0;
+
+        jobs.update_progress(
+            &id,
+            JobProgress {
+                current: 1,
+                total: 2,
+                message: None,
+            },
+        )
+        .unwrap();
+        jobs.complete(&id, json!({"ok": true})).unwrap();
+
+        let (reported_start, reported_completion) = compute_job_timestamps(&handle.read());
+        assert_eq!(reported_start, started_at);
+        assert_eq!(reported_completion, Some(handle.read().updated_at));
     }
 }

--- a/crates/dcc-mcp-job/src/job/manager.rs
+++ b/crates/dcc-mcp-job/src/job/manager.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::{Duration, Utc};
 use dashmap::DashMap;
 use parking_lot::RwLock;
 use tokio_util::sync::CancellationToken;
@@ -94,6 +94,7 @@ impl JobManager {
                 job.status = JobStatus::Interrupted;
                 job.error = Some("server restart".to_string());
                 job.updated_at = now;
+                job.completed_at = Some(now);
                 // Persist the new terminal state before we hand the row
                 // back out so a second crash does not re-flip it.
                 storage.put(&job)?;
@@ -120,14 +121,6 @@ impl JobManager {
         }
     }
 
-    fn persist_status(&self, job_id: &str, status: JobStatus, at: DateTime<Utc>) {
-        if let Some(storage) = &self.storage
-            && let Err(e) = storage.update_status(job_id, status, at)
-        {
-            tracing::warn!(job_id = %job_id, error = %e, "JobStorage.update_status failed");
-        }
-    }
-
     /// Register a subscriber invoked on every status transition.
     ///
     /// Subscribers are called synchronously while the internal write lock is
@@ -150,6 +143,8 @@ impl JobManager {
             error: job.error.clone(),
             updated_at: job.updated_at,
             created_at: job.created_at,
+            started_at: job.started_at,
+            completed_at: job.completed_at,
         };
         let subs = self.subscribers.read().clone();
         for sub in subs {
@@ -209,11 +204,13 @@ impl JobManager {
             );
             return None;
         }
+        let now = Utc::now();
         job.status = JobStatus::Running;
-        job.updated_at = Utc::now();
+        job.started_at = Some(now);
+        job.updated_at = now;
         let snapshot = job.clone();
         drop(job);
-        self.persist_status(&snapshot.id, snapshot.status, snapshot.updated_at);
+        self.persist_put(&snapshot);
         self.emit(&snapshot);
         Some(())
     }
@@ -231,9 +228,11 @@ impl JobManager {
             );
             return None;
         }
+        let now = Utc::now();
         job.status = JobStatus::Completed;
         job.result = Some(result);
-        job.updated_at = Utc::now();
+        job.completed_at = Some(now);
+        job.updated_at = now;
         let snapshot = job.clone();
         drop(job);
         self.persist_put(&snapshot);
@@ -254,9 +253,11 @@ impl JobManager {
             );
             return None;
         }
+        let now = Utc::now();
         job.status = JobStatus::Failed;
         job.error = Some(error.into());
-        job.updated_at = Utc::now();
+        job.completed_at = Some(now);
+        job.updated_at = now;
         let snapshot = job.clone();
         drop(job);
         self.persist_put(&snapshot);
@@ -272,12 +273,14 @@ impl JobManager {
         let mut job = entry.write();
         match job.status {
             JobStatus::Pending | JobStatus::Running => {
+                let now = Utc::now();
                 job.status = JobStatus::Cancelled;
-                job.updated_at = Utc::now();
+                job.completed_at = Some(now);
+                job.updated_at = now;
                 job.cancel_token.cancel();
                 let snapshot = job.clone();
                 drop(job);
-                self.persist_status(&snapshot.id, snapshot.status, snapshot.updated_at);
+                self.persist_put(&snapshot);
                 self.emit(&snapshot);
                 Some(())
             }

--- a/crates/dcc-mcp-job/src/job/tests.rs
+++ b/crates/dcc-mcp-job/src/job/tests.rs
@@ -37,6 +37,38 @@ fn full_lifecycle_create_start_progress_complete_get() {
 }
 
 #[test]
+fn lifecycle_timestamps_survive_progress_and_completion() {
+    let jm = JobManager::new();
+    let handle = jm.create("render.sequence");
+    let id = handle.read().id.clone();
+
+    assert!(handle.read().started_at.is_none());
+    assert!(handle.read().completed_at.is_none());
+
+    jm.start(&id).unwrap();
+    let started_at = handle.read().started_at.expect("start timestamp");
+    assert!(handle.read().completed_at.is_none());
+
+    jm.update_progress(
+        &id,
+        JobProgress {
+            current: 1,
+            total: 2,
+            message: Some("halfway".into()),
+        },
+    )
+    .unwrap();
+    assert_eq!(handle.read().started_at, Some(started_at));
+    assert!(handle.read().completed_at.is_none());
+
+    jm.complete(&id, json!({"ok": true})).unwrap();
+    let job = handle.read();
+    assert_eq!(job.started_at, Some(started_at));
+    assert_eq!(job.completed_at, Some(job.updated_at));
+    assert!(job.completed_at >= job.started_at);
+}
+
+#[test]
 fn cancel_before_start_marks_cancelled_and_triggers_token() {
     let jm = JobManager::new();
     let handle = jm.create("slow.tool");

--- a/crates/dcc-mcp-job/src/job/types.rs
+++ b/crates/dcc-mcp-job/src/job/types.rs
@@ -32,6 +32,10 @@ pub struct JobEvent {
     pub updated_at: DateTime<Utc>,
     /// Wall-clock time when the job was created.
     pub created_at: DateTime<Utc>,
+    /// Wall-clock time when execution began.
+    pub started_at: Option<DateTime<Utc>>,
+    /// Wall-clock time when the job entered a terminal state.
+    pub completed_at: Option<DateTime<Utc>>,
 }
 
 /// Boxed subscriber callback. See [`crate::job::JobManager::subscribe`].
@@ -98,6 +102,10 @@ pub struct Job {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     pub created_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
     pub updated_at: DateTime<Utc>,
     /// Cooperative cancellation signal for the running tool.
     ///
@@ -124,6 +132,8 @@ impl Job {
             result: None,
             error: None,
             created_at: now,
+            started_at: None,
+            completed_at: None,
             updated_at: now,
             cancel_token,
         }
@@ -141,6 +151,8 @@ impl Job {
             "result": self.result,
             "error": self.error,
             "created_at": self.created_at,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
             "updated_at": self.updated_at,
         })
     }

--- a/crates/dcc-mcp-job/src/job_storage/mod.rs
+++ b/crates/dcc-mcp-job/src/job_storage/mod.rs
@@ -85,8 +85,8 @@ pub trait JobStorage: Send + Sync + std::fmt::Debug {
     fn list(&self, filter: JobFilter) -> Result<Vec<Job>, JobStorageError>;
 
     /// Narrow write path for status transitions — more efficient than a
-    /// full [`Self::put`] when the caller only touched `status` /
-    /// `updated_at`. Implementations MAY fall back to a full put.
+    /// full [`Self::put`] when the caller only touched lifecycle state.
+    /// Implementations must also preserve `started_at` / `completed_at`.
     fn update_status(
         &self,
         job_id: &str,
@@ -172,6 +172,12 @@ impl JobStorage for InMemoryStorage {
         if let Some(row) = rows.get_mut(job_id) {
             row.status = status;
             row.updated_at = at;
+            if status == JobStatus::Running && row.started_at.is_none() {
+                row.started_at = Some(at);
+            }
+            if status.is_terminal() {
+                row.completed_at = Some(at);
+            }
         }
         Ok(())
     }
@@ -206,6 +212,8 @@ pub struct PersistedJob {
     pub result: Option<serde_json::Value>,
     pub error: Option<String>,
     pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -220,6 +228,8 @@ impl PersistedJob {
             result: job.result.clone(),
             error: job.error.clone(),
             created_at: job.created_at,
+            started_at: job.started_at,
+            completed_at: job.completed_at,
             updated_at: job.updated_at,
         }
     }
@@ -242,6 +252,8 @@ impl PersistedJob {
             result: self.result.clone(),
             error: self.error.clone(),
             created_at: self.created_at,
+            started_at: self.started_at,
+            completed_at: self.completed_at,
             updated_at: self.updated_at,
             cancel_token,
         }
@@ -284,20 +296,31 @@ mod tests {
         for id in [&a, &b] {
             store.put(&mgr.get(id).unwrap().read()).unwrap();
         }
+        let started_at = Utc::now();
         store
-            .update_status(&a, JobStatus::Running, Utc::now())
+            .update_status(&a, JobStatus::Running, started_at)
             .unwrap();
         let running = store
             .list(JobFilter::by_status(JobStatus::Running))
             .unwrap();
         assert_eq!(running.len(), 1);
         assert_eq!(running[0].id, a);
+        assert_eq!(running[0].started_at, Some(started_at));
+        assert!(running[0].completed_at.is_none());
 
         let pending = store
             .list(JobFilter::by_status(JobStatus::Pending))
             .unwrap();
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].id, b);
+
+        let completed_at = started_at + chrono::Duration::seconds(1);
+        store
+            .update_status(&a, JobStatus::Completed, completed_at)
+            .unwrap();
+        let completed = store.get(&a).unwrap().unwrap();
+        assert_eq!(completed.started_at, Some(started_at));
+        assert_eq!(completed.completed_at, Some(completed_at));
     }
 
     #[test]

--- a/crates/dcc-mcp-job/src/job_storage/sqlite.rs
+++ b/crates/dcc-mcp-job/src/job_storage/sqlite.rs
@@ -27,6 +27,8 @@ CREATE TABLE IF NOT EXISTS jobs (
     status TEXT NOT NULL,
     progress_json TEXT,
     created_at TEXT NOT NULL,
+    started_at TEXT,
+    completed_at TEXT,
     updated_at TEXT NOT NULL,
     error TEXT,
     result_json TEXT
@@ -66,6 +68,7 @@ impl SqliteStorage {
         )
         .map_err(map_err)?;
         conn.execute_batch(SCHEMA).map_err(map_err)?;
+        ensure_lifecycle_columns(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -76,6 +79,7 @@ impl SqliteStorage {
     pub fn open_in_memory() -> Result<Self, JobStorageError> {
         let conn = Connection::open_in_memory().map_err(map_err)?;
         conn.execute_batch(SCHEMA).map_err(map_err)?;
+        ensure_lifecycle_columns(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -102,13 +106,15 @@ impl JobStorage for SqliteStorage {
         let conn = self.conn.lock();
         conn.execute(
             "INSERT INTO jobs (job_id, parent_job_id, tool, status, \
-                progress_json, created_at, updated_at, error, result_json) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9) \
+                progress_json, created_at, started_at, completed_at, updated_at, error, result_json) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) \
              ON CONFLICT(job_id) DO UPDATE SET \
                 parent_job_id=excluded.parent_job_id, \
                 tool=excluded.tool, \
                 status=excluded.status, \
                 progress_json=excluded.progress_json, \
+                started_at=excluded.started_at, \
+                completed_at=excluded.completed_at, \
                 updated_at=excluded.updated_at, \
                 error=excluded.error, \
                 result_json=excluded.result_json",
@@ -119,6 +125,8 @@ impl JobStorage for SqliteStorage {
                 status,
                 progress_json,
                 row.created_at.to_rfc3339(),
+                row.started_at.map(|at| at.to_rfc3339()),
+                row.completed_at.map(|at| at.to_rfc3339()),
                 row.updated_at.to_rfc3339(),
                 row.error,
                 result_json,
@@ -133,7 +141,7 @@ impl JobStorage for SqliteStorage {
         let row = conn
             .query_row(
                 "SELECT job_id, parent_job_id, tool, status, progress_json, \
-                        created_at, updated_at, error, result_json \
+                        created_at, started_at, completed_at, updated_at, error, result_json \
                  FROM jobs WHERE job_id = ?1",
                 params![job_id],
                 row_to_persisted,
@@ -146,7 +154,7 @@ impl JobStorage for SqliteStorage {
     fn list(&self, filter: JobFilter) -> Result<Vec<Job>, JobStorageError> {
         let mut sql = String::from(
             "SELECT job_id, parent_job_id, tool, status, progress_json, \
-                    created_at, updated_at, error, result_json \
+                    created_at, started_at, completed_at, updated_at, error, result_json \
              FROM jobs WHERE 1=1",
         );
         let mut bound: Vec<String> = Vec::new();
@@ -185,7 +193,18 @@ impl JobStorage for SqliteStorage {
     ) -> Result<(), JobStorageError> {
         let conn = self.conn.lock();
         conn.execute(
-            "UPDATE jobs SET status = ?1, updated_at = ?2 WHERE job_id = ?3",
+            "UPDATE jobs SET \
+                status = ?1, \
+                updated_at = ?2, \
+                started_at = CASE \
+                    WHEN ?1 = 'running' THEN COALESCE(started_at, ?2) \
+                    ELSE started_at \
+                END, \
+                completed_at = CASE \
+                    WHEN ?1 IN ('completed', 'failed', 'cancelled', 'interrupted') THEN ?2 \
+                    ELSE completed_at \
+                END \
+             WHERE job_id = ?3",
             params![status_to_str(status), at.to_rfc3339(), job_id],
         )
         .map_err(map_err)?;
@@ -221,6 +240,25 @@ impl JobStorage for SqliteStorage {
 
 fn map_err(e: rusqlite::Error) -> JobStorageError {
     JobStorageError::Backend(e.to_string())
+}
+
+fn ensure_lifecycle_columns(conn: &Connection) -> Result<(), JobStorageError> {
+    for column in ["started_at", "completed_at"] {
+        let exists = conn
+            .query_row(
+                "SELECT 1 FROM pragma_table_info('jobs') WHERE name = ?1",
+                params![column],
+                |_| Ok(()),
+            )
+            .optional()
+            .map_err(map_err)?
+            .is_some();
+        if !exists {
+            conn.execute(&format!("ALTER TABLE jobs ADD COLUMN {column} TEXT"), [])
+                .map_err(map_err)?;
+        }
+    }
+    Ok(())
 }
 
 fn status_to_str(s: JobStatus) -> &'static str {
@@ -263,9 +301,11 @@ fn row_to_persisted(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersistedJob> {
     let status_str: String = row.get(3)?;
     let progress_json: Option<String> = row.get(4)?;
     let created_at_str: String = row.get(5)?;
-    let updated_at_str: String = row.get(6)?;
-    let error: Option<String> = row.get(7)?;
-    let result_json: Option<String> = row.get(8)?;
+    let started_at_str: Option<String> = row.get(6)?;
+    let completed_at_str: Option<String> = row.get(7)?;
+    let updated_at_str: String = row.get(8)?;
+    let error: Option<String> = row.get(9)?;
+    let result_json: Option<String> = row.get(10)?;
 
     // Map JobStorageError into rusqlite::Error so query_map's Result type
     // is satisfied; the wrapper at the top of each backend method
@@ -281,15 +321,29 @@ fn row_to_persisted(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersistedJob> {
     };
     let result: Option<serde_json::Value> = match result_json {
         Some(s) => Some(serde_json::from_str(&s).map_err(|e| {
-            rusqlite::Error::FromSqlConversionFailure(8, rusqlite::types::Type::Text, e.into())
+            rusqlite::Error::FromSqlConversionFailure(10, rusqlite::types::Type::Text, e.into())
         })?),
         None => None,
     };
     let created_at = parse_rfc3339(&created_at_str).map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(5, rusqlite::types::Type::Text, e.into())
     })?;
+    let started_at = started_at_str
+        .as_deref()
+        .map(parse_rfc3339)
+        .transpose()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, e.into())
+        })?;
+    let completed_at = completed_at_str
+        .as_deref()
+        .map(parse_rfc3339)
+        .transpose()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(7, rusqlite::types::Type::Text, e.into())
+        })?;
     let updated_at = parse_rfc3339(&updated_at_str).map_err(|e| {
-        rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, e.into())
+        rusqlite::Error::FromSqlConversionFailure(8, rusqlite::types::Type::Text, e.into())
     })?;
 
     Ok(PersistedJob {
@@ -301,6 +355,8 @@ fn row_to_persisted(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersistedJob> {
         result,
         error,
         created_at,
+        started_at,
+        completed_at,
         updated_at,
     })
 }
@@ -366,23 +422,63 @@ mod tests {
         let id = handle.read().id.clone();
         store.put(&handle.read()).unwrap();
 
+        let started_at = Utc::now();
         store
-            .update_status(&id, JobStatus::Running, Utc::now())
+            .update_status(&id, JobStatus::Running, started_at)
             .unwrap();
         let got = store.get(&id).unwrap().unwrap();
         assert_eq!(got.status, JobStatus::Running);
+        assert_eq!(got.started_at, Some(started_at));
+        assert!(got.completed_at.is_none());
 
         // full put with a result field exercises the ON CONFLICT path
         {
             let mut job = handle.write();
             job.status = JobStatus::Completed;
             job.result = Some(json!({"ok": true}));
-            job.updated_at = Utc::now();
+            job.started_at = Some(started_at);
+            job.completed_at = Some(Utc::now());
+            job.updated_at = job.completed_at.unwrap();
         }
         store.put(&handle.read()).unwrap();
         let got = store.get(&id).unwrap().unwrap();
         assert_eq!(got.status, JobStatus::Completed);
         assert_eq!(got.result.as_ref().unwrap(), &json!({"ok": true}));
+        assert_eq!(got.started_at, Some(started_at));
+        assert_eq!(got.completed_at, Some(got.updated_at));
+    }
+
+    #[test]
+    fn sqlite_open_migrates_existing_job_table() {
+        let path = std::env::temp_dir().join(format!(
+            "dcc-mcp-job-lifecycle-{}.sqlite3",
+            uuid::Uuid::new_v4()
+        ));
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE jobs (\
+                    job_id TEXT PRIMARY KEY, parent_job_id TEXT, tool TEXT NOT NULL, \
+                    status TEXT NOT NULL, progress_json TEXT, created_at TEXT NOT NULL, \
+                    updated_at TEXT NOT NULL, error TEXT, result_json TEXT\
+                );",
+            )
+            .unwrap();
+        }
+
+        let store = SqliteStorage::open(&path).unwrap();
+        let mgr = JobManager::new();
+        let handle = mgr.create("render.sequence");
+        let id = handle.read().id.clone();
+        mgr.start(&id).unwrap();
+        mgr.complete(&id, json!({"ok": true})).unwrap();
+        store.put(&handle.read()).unwrap();
+
+        let got = store.get(&id).unwrap().unwrap();
+        assert!(got.started_at.is_some());
+        assert_eq!(got.completed_at, Some(got.updated_at));
+        drop(store);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep explicit `started_at` and `completed_at` values on tracked jobs instead of deriving both from mutable `updated_at`
- surface the stable lifecycle timestamps through `jobs_get_status` and job-update notifications
- persist the fields in memory and SQLite, including a nullable migration for existing databases

## Why
A running job updates `updated_at` whenever progress changes and again when it becomes terminal. Deriving `started_at` from that field caused the reported start time to move, and completed jobs could report identical start and completion timestamps.

## Validation
- `cargo test -p dcc-mcp-job --features job-persist-sqlite` (18 passed)
- `cargo test -p dcc-mcp-http-server reported_start_timestamp_does_not_move_when_job_completes`
- `cargo test -p dcc-mcp-http-server job_updated_channel_fires_on_every_transition`
- `cargo clippy -p dcc-mcp-job --features job-persist-sqlite -- -D warnings`
- `cargo clippy -p dcc-mcp-http-server -- -D warnings`
- `cargo fmt --all -- --check`

The full local HTTP-server suite reached 51/52; the remaining skipped-skill diagnostic assertion reproduces unchanged on `origin/main` in the same environment and is outside this diff.