### PR TITLE
fix(ci): resolve Rust format check and Windows compile smoke failures

### DIFF
--- a/crates/dcc-mcp-capture/src/backend/wgc.rs
+++ b/crates/dcc-mcp-capture/src/backend/wgc.rs
@@ -229,8 +229,7 @@ mod imp {
     use windows::Win32::System::WinRT::Graphics::Capture::IGraphicsCaptureItemInterop;
     use windows::Win32::System::WinRT::{RO_INIT_MULTITHREADED, RoInitialize, RoUninitialize};
     use windows::Win32::UI::HiDpi::{
-        DPI_AWARENESS_CONTEXT, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, GetDpiForWindow,
-        SetThreadDpiAwarenessContext,
+        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, GetDpiForWindow, SetThreadDpiAwarenessContext,
     };
     use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
     use windows::core::{Interface, factory};

--- a/crates/dcc-mcp-capture/src/backend/win_dpi.rs
+++ b/crates/dcc-mcp-capture/src/backend/win_dpi.rs
@@ -34,9 +34,8 @@ mod imp {
 
     impl ThreadDpiAwareness {
         pub(crate) fn enter(context: &str) -> CaptureResult<Self> {
-            let previous = unsafe {
-                SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
-            };
+            let previous =
+                unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
             if previous.0.is_null() {
                 return Err(CaptureError::Platform(format!(
                     "Windows refused per-monitor-v2 DPI awareness for the {context}"

--- a/crates/dcc-mcp-computer-use/src/platform/windows.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows.rs
@@ -266,6 +266,17 @@ fn create_manual_reset_event(name: &str) -> windows::core::Result<OwnedKernelHan
     Ok(OwnedKernelHandle::new(handle))
 }
 
+/// Returns `Some(true)` when the kernel object is signaled, `Some(false)` when
+/// it is not, and `None` when the wait itself fails (e.g. the handle is invalid).
+#[allow(dead_code)]
+fn event_signaled(event: &OwnedKernelHandle) -> Option<bool> {
+    match unsafe { WaitForSingleObject(event.get(), 0) } {
+        WAIT_OBJECT_0 => Some(true),
+        WAIT_TIMEOUT => Some(false),
+        _ => None,
+    }
+}
+
 /// Acquire (and if necessary, initialize) the cross-process interrupt event.
 ///
 /// Returns the raw HANDLE value so callers do not need to hold the mutex lock
@@ -277,7 +288,9 @@ fn create_manual_reset_event(name: &str) -> windows::core::Result<OwnedKernelHan
 /// resets the `Option` to `None`, allowing the next caller to retry creation
 /// and recover without a process restart.
 fn user_interrupt_event_raw() -> Option<HANDLE> {
-    let mut guard = USER_INTERRUPT_EVENT.lock().unwrap_or_else(|p| p.into_inner());
+    let mut guard = USER_INTERRUPT_EVENT
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     if guard.is_none() {
         *guard = create_manual_reset_event(USER_INTERRUPT_EVENT_NAME).ok();
     }
@@ -296,8 +309,8 @@ fn require_user_interrupt_event_raw() -> ComputerUseResult<HANDLE> {
 
 fn set_user_interrupt() {
     USER_INTERRUPTED.store(true, Ordering::Release);
-    let signaled = user_interrupt_event_raw()
-        .is_some_and(|event| unsafe { SetEvent(event) }.is_ok());
+    let signaled =
+        user_interrupt_event_raw().is_some_and(|event| unsafe { SetEvent(event) }.is_ok());
     if !signaled {
         USER_INTERRUPT_EVENT_FAILED.store(true, Ordering::Release);
     }
@@ -1112,7 +1125,9 @@ pub(crate) fn clear_user_interrupt() -> ComputerUseResult<()> {
     // user_interrupt_event_raw() retries creation on the next call, allowing
     // recovery from transient kernel-object exhaustion without a process restart.
     {
-        let mut guard = USER_INTERRUPT_EVENT.lock().unwrap_or_else(|p| p.into_inner());
+        let mut guard = USER_INTERRUPT_EVENT
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         if guard.is_none() {
             *guard = create_manual_reset_event(USER_INTERRUPT_EVENT_NAME).ok();
         }


### PR DESCRIPTION
## Summary

Fixes the 2 Rust CI failures on [PR #1931](https://github.com/dcc-mcp/dcc-mcp-core/pull/1931) (head `f5b591ee`).

## Root Causes & Fixes

### 1. Rust format check (ubuntu)

`cargo fmt --check` failed on 4 code locations across 2 files:
- `crates/dcc-mcp-capture/src/backend/win_dpi.rs:34` — line-break formatting
- `crates/dcc-mcp-computer-use/src/platform/windows.rs:277,296,1112` — line-break formatting

**Fix:** Ran `cargo fmt` which auto-corrected all 4 locations.

### 2. Rust compile smoke (windows)

`cargo check --workspace --all-targets` failed with:
```
error[E0425]: cannot find function `event_signaled` in this scope
   --> crates/dcc-mcp-computer-use/src/platform/windows/input_tests.rs:716:16
```

The function `event_signaled` was referenced in test code (`input_tests.rs`) but never defined.

**Fix:** Added `event_signaled` helper next to `create_manual_reset_event` in `windows.rs`, following the same `WaitForSingleObject` pattern used throughout the module:
```rust
fn event_signaled(event: &OwnedKernelHandle) -> Option<bool> {
    match unsafe { WaitForSingleObject(event.get(), 0) } {
        WAIT_OBJECT_0 => Some(true),
        WAIT_TIMEOUT => Some(false),
        _ => None,
    }
}
```

### Bonus cleanup

- Removed unused `DPI_AWARENESS_CONTEXT` import from `wgc.rs`

## Validation

- `cargo fmt --check` — **PASS**
- `cargo check --workspace --all-targets` — **PASS** (38 crates, 0 errors, 0 warnings from changed crates)