### PR TITLE
fix(cli): call core tools through MCP fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-computer-use"
-version = "0.19.47"
+version = "0.19.48"
 dependencies = [
  "dcc-mcp-capture",
  "pyo3",

--- a/crates/dcc-mcp-cli/src/application/client.rs
+++ b/crates/dcc-mcp-cli/src/application/client.rs
@@ -16,6 +16,8 @@ const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
 pub enum ClientError {
     #[error(transparent)]
     Http(#[from] HttpError),
+    #[error("MCP protocol error: {0}")]
+    Protocol(String),
 }
 
 pub struct DccMcpClient {
@@ -101,14 +103,62 @@ impl DccMcpClient {
 
     pub async fn call(&self, request: CallRequest) -> Result<Value, ClientError> {
         let body = json!({
-            "tool_slug": request.tool_slug,
-            "arguments": request.arguments,
-            "meta": request.meta,
+            "tool_slug": &request.tool_slug,
+            "arguments": &request.arguments,
+            "meta": &request.meta,
         });
-        self.gateway
+        match self
+            .gateway
             .post_json(&self.endpoint.path("/v1/call"), &body)
             .await
-            .map_err(Into::into)
+        {
+            Ok(value) => Ok(value),
+            Err(error) if is_unknown_rest_tool(&error) => self.call_mcp_tool(request).await,
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn call_mcp_tool(&self, request: CallRequest) -> Result<Value, ClientError> {
+        let tool_slug = request.tool_slug;
+        let mut params = json!({
+            "name": &tool_slug,
+            "arguments": request.arguments,
+        });
+        if let Some(meta) = request.meta {
+            params["_meta"] = meta;
+        }
+        let response = self
+            .gateway
+            .post_json_with_headers(
+                &self.endpoint.mcp_url(),
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": "dcc-mcp-cli-call",
+                    "method": "tools/call",
+                    "params": params,
+                }),
+                &[
+                    ("Mcp-Protocol-Version", MCP_PROTOCOL_VERSION),
+                    ("Accept", MCP_STREAMABLE_HTTP_ACCEPT),
+                ],
+            )
+            .await?;
+        if let Some(error) = response.get("error") {
+            return Err(ClientError::Protocol(error.to_string()));
+        }
+        let result = response
+            .get("result")
+            .cloned()
+            .ok_or_else(|| ClientError::Protocol("missing tools/call result".to_string()))?;
+        if result.get("isError").and_then(Value::as_bool) == Some(true) {
+            let message = result
+                .pointer("/content/0/text")
+                .and_then(Value::as_str)
+                .unwrap_or("tools/call failed");
+            return Err(ClientError::Protocol(message.to_string()));
+        }
+        let output = result.get("structuredContent").cloned().unwrap_or(result);
+        Ok(json!({"slug": tool_slug, "output": output}))
     }
 
     pub async fn call_batch(&self, body: Value) -> Result<Value, ClientError> {
@@ -361,6 +411,24 @@ impl DccMcpClient {
             "checks": checks,
         })
     }
+}
+
+fn is_unknown_rest_tool(error: &HttpError) -> bool {
+    let HttpError::Status { status, body } = error else {
+        return false;
+    };
+    if *status != reqwest::StatusCode::BAD_REQUEST {
+        return false;
+    }
+    serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("message")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+        .is_some_and(|message| message.starts_with("invalid tool slug "))
 }
 
 const READINESS_FIELDS: &[&str] = &[

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -292,6 +292,37 @@ fn call_and_call_batch_exit_one_on_tool_failure_after_http_success() {
 }
 
 #[test]
+fn call_falls_back_to_mcp_for_core_tool_missing_from_rest_catalog() {
+    let fixture = spawn_gateway_fixture();
+
+    let status = run_json(&[
+        "--base-url",
+        &fixture.base_url,
+        "call",
+        "jobs_get_status",
+        "--json",
+        r#"{"job_id":"job-42"}"#,
+    ]);
+
+    assert_eq!(status["slug"], "jobs_get_status");
+    assert_eq!(status["output"]["job_id"], "job-42");
+    assert_eq!(status["output"]["status"], "completed");
+
+    let stderr = run_failure_with_env(
+        &[
+            "--base-url",
+            &fixture.base_url,
+            "call",
+            "jobs_get_status",
+            "--json",
+            r#"{"job_id":"job-404"}"#,
+        ],
+        &[],
+    );
+    assert!(stderr.contains("job-404"), "stderr: {stderr}");
+}
+
+#[test]
 fn local_list_reads_file_registry_after_gateway_ensure() {
     let fixture = spawn_local_mcp_fixture();
     let registry = TempDir::new().unwrap();

--- a/crates/dcc-mcp-cli/tests/support/mod.rs
+++ b/crates/dcc-mcp-cli/tests/support/mod.rs
@@ -137,14 +137,48 @@ pub(crate) fn spawn_gateway_fixture() -> GatewayFixture {
                             "jsonrpc": "2.0",
                             "id": body.get("id").cloned().unwrap_or(json!(null)),
                             "result": {
-                                "tools": [{
-                                    "name": "search_tools",
-                                    "description": "Search tools",
-                                    "inputSchema": {"type": "object"}
-                                }]
+                                "tools": [
+                                    {
+                                        "name": "search_tools",
+                                        "description": "Search tools",
+                                        "inputSchema": {"type": "object"}
+                                    },
+                                    {
+                                        "name": "jobs_get_status",
+                                        "description": "Get async job status",
+                                        "inputSchema": {"type": "object"}
+                                    }
+                                ]
                             }
                         })),
                     ),
+                    "tools/call" => {
+                        let name = body
+                            .pointer("/params/name")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default();
+                        let job_id = body
+                            .pointer("/params/arguments/job_id")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default();
+                        let status = json!({
+                            "job_id": job_id,
+                            "tool": "render_write_node",
+                            "status": "completed"
+                        });
+                        (
+                            StatusCode::OK,
+                            Json(json!({
+                                "jsonrpc": "2.0",
+                                "id": body.get("id").cloned().unwrap_or(json!(null)),
+                                "result": {
+                                    "isError": name != "jobs_get_status" || job_id == "job-404",
+                                    "content": [{"type": "text", "text": status.to_string()}],
+                                    "structuredContent": status
+                                }
+                            })),
+                        )
+                    }
                     _ => (
                         StatusCode::OK,
                         Json(json!({
@@ -316,22 +350,37 @@ pub(crate) fn spawn_gateway_fixture() -> GatewayFixture {
         .route(
             "/v1/call",
             post(|Json(body): Json<Value>| async move {
-                if body["tool_slug"] == "maya.abc12345.domain_failure" {
-                    return Json(json!({
-                        "slug": body["tool_slug"],
-                        "output": {
-                            "success": false,
-                            "message": "tool domain failure"
-                        },
-                        "validation_skipped": false,
-                        "request_id": "fixture-domain-failure"
-                    }));
+                if body["tool_slug"] == "jobs_get_status" {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(json!({
+                            "kind": "bad-request",
+                            "message": "invalid tool slug 'jobs_get_status' — expected '<dcc>.<skill>.<action>' or bare action name"
+                        })),
+                    );
                 }
-                Json(json!({
-                    "success": true,
-                    "tool_slug": body["tool_slug"],
-                    "arguments": body["arguments"]
-                }))
+                if body["tool_slug"] == "maya.abc12345.domain_failure" {
+                    return (
+                        StatusCode::OK,
+                        Json(json!({
+                            "slug": body["tool_slug"],
+                            "output": {
+                                "success": false,
+                                "message": "tool domain failure"
+                            },
+                            "validation_skipped": false,
+                            "request_id": "fixture-domain-failure"
+                        })),
+                    );
+                }
+                (
+                    StatusCode::OK,
+                    Json(json!({
+                        "success": true,
+                        "tool_slug": body["tool_slug"],
+                        "arguments": body["arguments"]
+                    })),
+                )
             }),
         )
         .route(


### PR DESCRIPTION
## Summary
- keep REST `/v1/call` as the primary CLI call path
- fall back to standard MCP `tools/call` only when REST explicitly rejects an unregistered tool slug
- propagate MCP tool errors instead of reporting them as successful output

This makes core tools exposed by `tools/list`, such as `jobs_get_status`, callable through `dcc-mcp-cli --base-url ... call` without duplicating the core-tool catalog in the CLI.

## Tests
- `vx cargo test -p dcc-mcp-cli --test cli_e2e call_falls_back_to_mcp_for_core_tool_missing_from_rest_catalog -- --nocapture`
- `vx cargo test -p dcc-mcp-cli`
- `vx cargo clippy -p dcc-mcp-cli --all-targets -- -D warnings`
- `vx cargo fmt --check`
- live adapter endpoint: `jobs_get_status` returned a completed asynchronous job through the fallback

`vx just preflight` reached an existing failure in `dcc-mcp-http-server::skipped_skill_diagnostics_are_visible_through_mcp_discovery`; this PR does not modify that crate.