### PR TITLE
fix: tolerate malformed gateway health responses

### DIFF
--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+from http.client import HTTPException
 import json
 import logging
 import os
@@ -41,7 +42,7 @@ def _is_healthy(host: str, port: int, timeout: float) -> bool:
             return int(getattr(resp, "status", 0)) == 200
     except HTTPError as err:
         return int(getattr(err, "code", 0)) == 200
-    except (URLError, OSError, ValueError):
+    except (HTTPException, URLError, OSError, ValueError):
         return False
 
 

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from http.client import BadStatusLine
 import json
 import os
 from pathlib import Path
@@ -39,6 +40,15 @@ class _JsonResp(_Resp):
 
     def read(self):
         return json.dumps(self._payload).encode("utf-8")
+
+
+def test_is_healthy_treats_malformed_http_response_as_unhealthy(monkeypatch):
+    def _raise_bad_status_line(*_args, **_kwargs):
+        raise BadStatusLine("GET /health HTTP/1.1")
+
+    monkeypatch.setattr(gg, "urlopen", _raise_bad_status_line)
+
+    assert gg._is_healthy("127.0.0.1", 9765, timeout=0.5) is False
 
 
 def test_ensure_gateway_daemon_reports_existing_health(monkeypatch):


### PR DESCRIPTION
## Summary
- classify malformed HTTP protocol responses from the gateway health endpoint as unhealthy
- preserve the existing retry, launch, and fallback flow instead of letting the probe exception escape
- add regression coverage for `http.client.BadStatusLine`

## Validation
- `pytest tests/test_gateway_guardian.py -q` (54 passed)
- `ruff check python/dcc_mcp_core/_server/gateway_guardian.py tests/test_gateway_guardian.py`
- `ruff format --check python/dcc_mcp_core/_server/gateway_guardian.py tests/test_gateway_guardian.py`
- `cargo fmt --all -- --check`

No agent-facing skill update is needed because this is private health-probe error handling with no public tool or workflow contract change.