### PR TITLE
fix(capture): select main process window deterministically

### DIFF
--- a/crates/dcc-mcp-capture/src/window.rs
+++ b/crates/dcc-mcp-capture/src/window.rs
@@ -83,9 +83,7 @@ impl WindowFinder {
 
     fn find_by_pid(&self, pid: u32) -> CaptureResult<WindowInfo> {
         let windows = self.enumerate();
-        windows
-            .into_iter()
-            .find(|w| w.pid == pid)
+        select_best_pid_window(windows, pid)
             .ok_or_else(|| CaptureError::TargetNotFound(format!("no window for pid={pid}")))
     }
 
@@ -99,6 +97,28 @@ impl WindowFinder {
                 CaptureError::TargetNotFound(format!("no window with title containing '{title}'"))
             })
     }
+}
+
+/// Select a captureable process window without depending on platform
+/// enumeration order.
+///
+/// A DCC process can own a large main window as well as smaller welcome,
+/// splash, or utility windows.  The largest positive window rectangle is the
+/// most useful generic main-window signal available on every supported
+/// platform.  The handle provides a stable tie-break for an otherwise equal
+/// candidate set.
+fn select_best_pid_window(windows: Vec<WindowInfo>, pid: u32) -> Option<WindowInfo> {
+    windows
+        .into_iter()
+        .filter(|window| window.pid == pid)
+        .filter(|window| window_capture_area(window) > 0)
+        .max_by_key(|window| (window_capture_area(window), window.handle))
+}
+
+fn window_capture_area(window: &WindowInfo) -> u64 {
+    let width = u64::try_from(window.rect[2]).unwrap_or(0);
+    let height = u64::try_from(window.rect[3]).unwrap_or(0);
+    width.saturating_mul(height)
 }
 
 // ── Platform implementations ───────────────────────────────────────────────
@@ -205,6 +225,53 @@ fn windows_info_for_hwnd(handle: u64) -> Option<WindowInfo> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn window(handle: u64, pid: u32, title: &str, width: i32, height: i32) -> WindowInfo {
+        WindowInfo {
+            handle,
+            pid,
+            title: title.to_string(),
+            rect: [0, 0, width, height],
+        }
+    }
+
+    #[test]
+    fn test_select_best_pid_window_prefers_largest_capture_area() {
+        let windows = vec![
+            window(10, 42, "Start Here", 640, 480),
+            window(20, 42, "Houdini FX", 1920, 1080),
+            window(30, 7, "Other process", 3840, 2160),
+            window(40, 42, "Degenerate", 3840, 0),
+        ];
+
+        let selected = select_best_pid_window(windows, 42).unwrap();
+
+        assert_eq!(selected.handle, 20);
+    }
+
+    #[test]
+    fn test_select_best_pid_window_is_independent_of_enumeration_order() {
+        let welcome = window(10, 42, "Start Here", 640, 480);
+        let main = window(20, 42, "Houdini FX", 1920, 1080);
+
+        let forward = select_best_pid_window(vec![welcome.clone(), main.clone()], 42).unwrap();
+        let reverse = select_best_pid_window(vec![main, welcome], 42).unwrap();
+
+        assert_eq!(forward.handle, 20);
+        assert_eq!(reverse.handle, 20);
+    }
+
+    #[test]
+    fn test_select_best_pid_window_uses_stable_handle_tie_break() {
+        let windows = vec![
+            window(10, 42, "Utility", 1000, 800),
+            window(20, 42, "Main", 1000, 800),
+        ];
+
+        let selected = select_best_pid_window(windows, 42).unwrap();
+
+        assert_eq!(selected.handle, 20);
+    }
 
     #[test]
     fn test_finder_primary_display_always_ok() {

--- a/docs/api/capture.md
+++ b/docs/api/capture.md
@@ -136,7 +136,7 @@ Opaque window / display target descriptor. Construct via the static factories be
 |---------|-------------|
 | `CaptureTarget.primary_display()` | The primary display (full-screen capture) |
 | `CaptureTarget.monitor_index(index)` | A specific monitor by 0-based index |
-| `CaptureTarget.process_id(pid)` | The main window belonging to a process |
+| `CaptureTarget.process_id(pid)` | The largest positive-area visible window belonging to a process (stable handle tie-break) |
 | `CaptureTarget.window_title(title)` | The first window whose title contains the substring |
 | `CaptureTarget.window_handle(handle)` | A specific HWND / X11 window ID |
 


### PR DESCRIPTION
## Summary

- choose the largest positive-area visible window when a PID owns multiple top-level windows
- use the HWND as a deterministic tie-break so enumeration order cannot change the target
- document the PID-target selection contract

## Why

A DCC process can own its main application window plus welcome, splash, and utility windows. Windows enumeration order is not a primary-window contract, so selecting the first PID match can capture the wrong surface.

## Verification

- `vx cargo test -p dcc-mcp-capture` (65 passed)
- `vx cargo clippy -p dcc-mcp-capture --all-targets -- -D warnings`
- `vx cargo fmt --all -- --check`
- `git diff --check`

This addresses the deterministic PID-window selection portion of #1947. Blank Qt/GPU client-frame detection and structured DXGI desktop-unavailable errors remain explicitly tracked there; this PR does not add unreliable pixel heuristics.