### PR TITLE
Fix app-ui imports in legacy DCC hosts

### DIFF
--- a/python/dcc_mcp_core/skills/app-ui/scripts/act.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/act.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+import sys
+
 if __package__:
     from ._entrypoint import act_tool
     from ._entrypoint import emit
 else:
+    _SCRIPTS_DIR = Path(__file__).resolve().parent
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
     from _entrypoint import act_tool
     from _entrypoint import emit
 

--- a/python/dcc_mcp_core/skills/app-ui/scripts/find.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/find.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+import sys
+
 if __package__:
     from ._entrypoint import emit
     from ._entrypoint import find_tool
 else:
+    _SCRIPTS_DIR = Path(__file__).resolve().parent
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
     from _entrypoint import emit
     from _entrypoint import find_tool
 

--- a/python/dcc_mcp_core/skills/app-ui/scripts/snapshot.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/snapshot.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+import sys
+
 if __package__:
     from ._entrypoint import emit
     from ._entrypoint import snapshot_tool
 else:
+    _SCRIPTS_DIR = Path(__file__).resolve().parent
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
     from _entrypoint import emit
     from _entrypoint import snapshot_tool
 

--- a/python/dcc_mcp_core/skills/app-ui/scripts/wait_for.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/wait_for.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+import sys
+
 if __package__:
     from ._entrypoint import emit
     from ._entrypoint import wait_for_tool
 else:
+    _SCRIPTS_DIR = Path(__file__).resolve().parent
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
     from _entrypoint import emit
     from _entrypoint import wait_for_tool
 

--- a/tests/test_app_ui_skill.py
+++ b/tests/test_app_ui_skill.py
@@ -23,6 +23,26 @@ _SKILL_DIR = REPO_ROOT / "python" / "dcc_mcp_core" / "skills" / "app-ui"
 _SCRIPTS = _SKILL_DIR / "scripts"
 
 
+@pytest.mark.parametrize("script_name", ["snapshot", "find", "act", "wait_for"])
+def test_app_ui_entrypoints_resolve_sibling_modules_without_script_path(
+    script_name: str,
+    monkeypatch: Any,
+) -> None:
+    """Legacy DCC file executors do not put the skill directory on sys.path."""
+    script_dir = str(_SCRIPTS)
+    monkeypatch.setattr(sys, "path", [entry for entry in sys.path if entry != script_dir])
+    monkeypatch.delitem(sys.modules, "_entrypoint", raising=False)
+    spec = importlib.util.spec_from_file_location(
+        f"_test_app_ui_direct_{script_name}",
+        _SCRIPTS / f"{script_name}.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert callable(module.main)
+
+
 def _load_cdp_runtime_module() -> Any:
     spec = importlib.util.spec_from_file_location("_test_app_ui_cdp_runtime", _SCRIPTS / "_cdp_runtime.py")
     assert spec is not None


### PR DESCRIPTION
Allow bundled app-ui entry points to resolve sibling helpers when a legacy DCC file executor does not update sys.path. Adds regression coverage for snapshot, find, act, and wait_for.