### PR TITLE
fix: scope skill imports for custom runners

### DIFF
--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -450,7 +450,13 @@ class HostExecutionBridge:
                     return self._shutdown_error()
                 if not self._is_current_script_generation(script_admission):
                     return self._script_cleared_error()
-                return runner(script_path, params)
+                script_dir = Path(script_path).resolve().parent
+                package_name = _script_package_name(script_dir)
+                _begin_script_call(package_name, str(script_dir))
+                try:
+                    return runner(script_path, params)
+                finally:
+                    _end_script_call(package_name, str(script_dir))
 
             return _run_custom
 

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -174,11 +174,12 @@ Generated `tools.yaml` entries follow the modern contract:
 1. Decide whether the skill is infrastructure, domain, thin-harness, or example.
 2. Give the skill a kebab-case name and each local tool a snake_case name.
 3. Keep host API calls inside scripts, with lazy imports so discovery works without the host running.
-4. Import dependency-light runtime helpers from `dcc_mcp_core.skills_helper` first: JSON/YAML codecs, bounded HTTP helpers, safe file/path helpers, validation, cancellation checks, and result helpers.
-5. Declare `metadata.dcc-mcp.depends` for prerequisite skills, then declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`. Do not rely on runtime Python introspection for missing schemas. For high-frequency tools, add `call_examples` so agents can copy argument payloads without trial-and-error.
-6. Put long examples, recipes, and host-specific notes under `references/`.
-7. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before loading it in an adapter.
-8. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.
+4. Import same-directory helper modules directly; in-process runners expose the executing script's directory only for the call, so scripts must not mutate `sys.path` for sibling imports.
+5. Import dependency-light runtime helpers from `dcc_mcp_core.skills_helper` first: JSON/YAML codecs, bounded HTTP helpers, safe file/path helpers, validation, cancellation checks, and result helpers.
+6. Declare `metadata.dcc-mcp.depends` for prerequisite skills, then declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`. Do not rely on runtime Python introspection for missing schemas. For high-frequency tools, add `call_examples` so agents can copy argument payloads without trial-and-error.
+7. Put long examples, recipes, and host-specific notes under `references/`.
+8. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before loading it in an adapter.
+9. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.
 
 When reviewing existing skills, reject top-level DCC-MCP extension keys such
 as `dcc`, `version`, `tags`, `tools`, `groups`, `depends`, `search-hint`,

--- a/tests/test_inprocess_executor.py
+++ b/tests/test_inprocess_executor.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+import importlib.util
 import os
 from pathlib import Path
 import sys
@@ -109,6 +110,26 @@ def test_run_skill_script_supports_legacy_bare_sibling_imports(tmp_path: Path) -
     p = _write_script(tmp_path, "from _helper import VALUE\ndef main(): return VALUE\n")
     assert run_skill_script(str(p), {}) == 42
     assert str(tmp_path) not in __import__("sys").path
+
+
+def test_host_execution_bridge_scopes_script_path_for_custom_runner(tmp_path: Path) -> None:
+    helper_name = "_custom_bridge_helper"
+    (tmp_path / f"{helper_name}.py").write_text("VALUE = 42\n", encoding="utf-8")
+    script = _write_script(tmp_path, f"from {helper_name} import VALUE\ndef main(): return VALUE\n")
+
+    def legacy_runner(script_path: str, params: Mapping[str, Any]) -> Any:
+        spec = importlib.util.spec_from_file_location("_legacy_skill", script_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module.main(**params)
+
+    before = list(sys.path)
+    try:
+        assert HostExecutionBridge(runner=legacy_runner).execute_script(str(script), {}) == 42
+        assert sys.path == before
+    finally:
+        sys.modules.pop(helper_name, None)
 
 
 def test_run_skill_script_supports_isolated_relative_sibling_imports(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- expose each skill script directory only while a custom in-process runner is active
- reuse the existing reference-counted `sys.path` lifecycle used by the default runner
- document that same-directory helpers do not need script-local path shims

## Root cause

Custom `HostExecutionBridge` runners bypassed the default skill package loader, so legacy DCC file executors could not import helpers beside the entry script unless every skill permanently modified `sys.path`.

## Validation

- focused in-process import regressions: 2 passed
- full in-process module under the available pure-Python environment: 52 passed; 2 extension-dependent tests require the built `_core` module
- Ruff check and format check
- Python 3.7 syntax contract
