### PR TITLE
feat(process): support isolated child launch settings

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -245,6 +245,27 @@ def create_sphere(radius: float = 1.0, name: str = "sphere") -> dict:
     )
 ```
 
+### Pattern 10: Launch an isolated DCC child
+
+Use child-only environment overrides instead of mutating `os.environ` when
+multiple artist and automation sessions share a machine:
+
+```python
+from dcc_mcp_core import PyDccLauncher
+
+launcher = PyDccLauncher()
+info = launcher.launch(
+    name="nuke-mcp",
+    executable="Nuke15.2",
+    args=["--disable-nuke-frameserver", "project.nk"],
+    environment={
+        "NUKE_DISABLE_FRAMESERVER": "1",
+        "DCC_MCP_NUKE_PORT": "0",
+    },
+    working_directory="/projects/solar-system",
+)
+```
+
 ## Creating a Custom Skill (Zero Python Code)
 
 ```bash

--- a/crates/dcc-mcp-process/src/launcher.rs
+++ b/crates/dcc-mcp-process/src/launcher.rs
@@ -15,7 +15,7 @@ use tokio::time;
 use tracing::{debug, info, warn};
 
 use crate::error::ProcessError;
-use crate::types::{DccProcessConfig, ProcessInfo, ProcessStatus};
+use crate::types::{DccLaunchOptions, DccProcessConfig, ProcessInfo, ProcessStatus};
 
 /// Manages the lifecycle (spawn, terminate, kill) of DCC application processes.
 ///
@@ -45,10 +45,27 @@ impl DccLauncher {
     ///
     /// Returns a `ProcessInfo` snapshot reflecting the newly spawned PID.
     pub async fn launch(&self, config: &DccProcessConfig) -> Result<ProcessInfo, ProcessError> {
+        self.launch_with_options(config, &DccLaunchOptions::default())
+            .await
+    }
+
+    /// Spawn the DCC process with child-specific environment and working-directory settings.
+    ///
+    /// `options` affect only the new child. The parent process environment and
+    /// working directory remain unchanged.
+    pub async fn launch_with_options(
+        &self,
+        config: &DccProcessConfig,
+        options: &DccLaunchOptions,
+    ) -> Result<ProcessInfo, ProcessError> {
         info!(name = %config.name, executable = %config.executable, "launching DCC process");
 
         let mut cmd = Command::new(&config.executable);
         cmd.args(&config.args);
+        cmd.envs(&options.environment);
+        if let Some(working_directory) = &options.working_directory {
+            cmd.current_dir(working_directory);
+        }
         // Detach stdin so the DCC doesn't block on terminal input.
         cmd.stdin(std::process::Stdio::null());
 
@@ -303,6 +320,99 @@ mod tests {
                     tracing::warn!("skipping launch_real_process: {e}");
                 }
             }
+        }
+
+        #[tokio::test]
+        async fn launch_with_options_applies_child_environment_and_working_directory() {
+            use std::fs;
+            use std::path::PathBuf;
+            use std::time::{SystemTime, UNIX_EPOCH};
+
+            const ENV_KEY: &str = "DCC_MCP_PROCESS_TEST_CHILD_6E0B39B4";
+            assert!(std::env::var_os(ENV_KEY).is_none());
+
+            let suffix = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock must be after Unix epoch")
+                .as_nanos();
+            let test_directory = std::env::temp_dir().join(format!(
+                "dcc-mcp-process-launch-{}-{suffix}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&test_directory).expect("create test working directory");
+            let output_path = test_directory.join("child.txt");
+            let ready_path = test_directory.join("child.ready");
+            let release_directory = test_directory
+                .parent()
+                .expect("test directory must have a parent");
+
+            let (executable, args): (&str, Vec<String>) = core::cfg_select! {
+                windows => (
+                    "powershell.exe",
+                    vec![
+                        "-NoProfile".to_string(),
+                        "-NonInteractive".to_string(),
+                        "-Command".to_string(),
+                        format!(
+                            "$env:{ENV_KEY} | Set-Content -LiteralPath child.txt -Encoding ascii; (Get-Location).Path | Add-Content -LiteralPath child.txt -Encoding ascii; Set-Location -LiteralPath $env:DCC_MCP_PROCESS_TEST_RELEASE_CWD; 'ready' | Set-Content -LiteralPath $env:DCC_MCP_PROCESS_TEST_READY -Encoding ascii; Start-Sleep -Seconds 30"
+                        ),
+                    ],
+                ),
+                _ => (
+                    "sh",
+                    vec![
+                        "-c".to_string(),
+                        format!(
+                            "printf '%s\\n%s\\n' \"${ENV_KEY}\" \"$PWD\" > child.txt; cd \"$DCC_MCP_PROCESS_TEST_RELEASE_CWD\"; printf ready > \"$DCC_MCP_PROCESS_TEST_READY\"; sleep 30"
+                        ),
+                    ],
+                ),
+            };
+
+            let mut config = DccProcessConfig::new("isolated-child", executable);
+            config.args = args;
+            let options = DccLaunchOptions::new()
+                .with_environment([
+                    (ENV_KEY.to_string(), "child-only".to_string()),
+                    (
+                        "DCC_MCP_PROCESS_TEST_READY".to_string(),
+                        ready_path.to_string_lossy().into_owned(),
+                    ),
+                    (
+                        "DCC_MCP_PROCESS_TEST_RELEASE_CWD".to_string(),
+                        release_directory.to_string_lossy().into_owned(),
+                    ),
+                ])
+                .with_working_directory(test_directory.to_string_lossy());
+            let launcher = DccLauncher::new();
+
+            launcher
+                .launch_with_options(&config, &options)
+                .await
+                .expect("launch isolated child");
+
+            let deadline = time::Instant::now() + Duration::from_secs(5);
+            while !ready_path.is_file() {
+                assert!(
+                    time::Instant::now() < deadline,
+                    "child did not release its cwd and write the ready marker"
+                );
+                time::sleep(Duration::from_millis(25)).await;
+            }
+            let output = fs::read_to_string(&output_path)
+                .expect("read child environment and working directory");
+
+            let mut lines = output.lines();
+            assert_eq!(lines.next(), Some("child-only"));
+            let child_cwd = PathBuf::from(lines.next().expect("child cwd line"));
+            assert_eq!(
+                fs::canonicalize(child_cwd).expect("canonicalize child cwd"),
+                fs::canonicalize(&test_directory).expect("canonicalize expected cwd")
+            );
+            assert!(std::env::var_os(ENV_KEY).is_none());
+
+            let _ = launcher.kill("isolated-child").await;
+            fs::remove_dir_all(test_directory).expect("remove test working directory");
         }
     }
 }

--- a/crates/dcc-mcp-process/src/lib.rs
+++ b/crates/dcc-mcp-process/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! | Module | Purpose |
 //! |--------|---------|
-//! | [`types`] | Core data types: `ProcessInfo`, `ProcessStatus`, `DccProcessConfig` |
+//! | [`types`] | Core data types: `ProcessInfo`, `ProcessStatus`, `DccProcessConfig`, `DccLaunchOptions` |
 //! | [`error`] | `ProcessError` enum |
 //! | [`monitor`] | `ProcessMonitor` — live resource snapshots via `sysinfo` |
 //! | [`launcher`] | `DccLauncher` — async spawn/terminate/kill |
@@ -59,7 +59,7 @@ pub use launcher::DccLauncher;
 pub use monitor::ProcessMonitor;
 pub use pump::{PumpStats, PumpedDispatcher};
 pub use recovery::{BackoffStrategy, CrashRecoveryPolicy};
-pub use types::{DccProcessConfig, ProcessInfo, ProcessStatus};
+pub use types::{DccLaunchOptions, DccProcessConfig, ProcessInfo, ProcessStatus};
 pub use watcher::{ProcessEvent, ProcessWatcher, WatcherHandle};
 
 #[cfg(feature = "python-bindings")]

--- a/crates/dcc-mcp-process/src/python/launcher.rs
+++ b/crates/dcc-mcp-process/src/python/launcher.rs
@@ -10,7 +10,7 @@ use pyo3_stub_gen_derive::{gen_stub_pyclass, gen_stub_pymethods};
 
 use super::helpers::{map_process_err, runtime, status_to_str};
 use crate::launcher::DccLauncher;
-use crate::types::DccProcessConfig;
+use crate::types::{DccLaunchOptions, DccProcessConfig};
 
 /// Async DCC process launcher (spawn / terminate / kill).
 ///
@@ -48,9 +48,23 @@ impl PyDccLauncher {
     ///     Command-line arguments.
     /// launch_timeout_ms : int, optional
     ///     Milliseconds to wait for the process to start (default 30000).
+    /// environment : dict[str, str], optional
+    ///     Child-only environment overrides. The parent process is not mutated.
+    /// working_directory : str, optional
+    ///     Working directory for the child process.
     ///
     /// Returns a dict with ``pid``, ``name``, and ``status``.
-    #[pyo3(signature = (name, executable, args=None, launch_timeout_ms=30000))]
+    #[pyo3(signature = (
+        name,
+        executable,
+        args=None,
+        launch_timeout_ms=30000,
+        environment=None,
+        working_directory=None
+    ))]
+    // The Python API keeps the two isolation settings as explicit optional
+    // keywords so existing positional calls remain source compatible.
+    #[allow(clippy::too_many_arguments)]
     pub fn launch<'py>(
         &self,
         py: Python<'py>,
@@ -58,17 +72,24 @@ impl PyDccLauncher {
         executable: &str,
         args: Option<Vec<String>>,
         launch_timeout_ms: u64,
+        environment: Option<std::collections::HashMap<String, String>>,
+        working_directory: Option<String>,
     ) -> PyResult<Bound<'py, PyDict>> {
         let mut config = DccProcessConfig::new(name, executable);
         if let Some(a) = args {
             config.args = a;
         }
+        let mut launch_options = DccLaunchOptions::new();
+        if let Some(environment) = environment {
+            launch_options.environment = environment.into_iter().collect();
+        }
+        launch_options.working_directory = working_directory;
         config.launch_timeout_ms = launch_timeout_ms;
 
         let inner = Arc::clone(&self.inner);
         let rt = runtime()?;
         let info = rt
-            .block_on(inner.launch(&config))
+            .block_on(inner.launch_with_options(&config, &launch_options))
             .map_err(map_process_err)?;
 
         let d = PyDict::new(py);

--- a/crates/dcc-mcp-process/src/types.rs
+++ b/crates/dcc-mcp-process/src/types.rs
@@ -1,5 +1,7 @@
 //! Core data types for DCC process management.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 /// The current lifecycle status of a monitored DCC process.
@@ -131,6 +133,48 @@ impl DccProcessConfig {
     }
 }
 
+/// Per-launch process settings that do not change monitoring or recovery policy.
+///
+/// Keeping these settings separate preserves the source-compatible layout of
+/// [`DccProcessConfig`] while allowing callers to isolate individual DCC child
+/// processes from the parent environment.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DccLaunchOptions {
+    /// Environment variables added to or overriding the inherited child environment.
+    pub environment: BTreeMap<String, String>,
+    /// Optional working directory for the launched process.
+    pub working_directory: Option<String>,
+}
+
+impl DccLaunchOptions {
+    /// Create options that inherit the parent environment and working directory.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Builder-style method to add environment overrides for the child process.
+    #[must_use]
+    pub fn with_environment(
+        mut self,
+        environment: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        self.environment = environment
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect();
+        self
+    }
+
+    /// Builder-style method to set the child process working directory.
+    #[must_use]
+    pub fn with_working_directory(mut self, path: impl Into<String>) -> Self {
+        self.working_directory = Some(path.into());
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -255,6 +299,39 @@ mod tests {
             let back: DccProcessConfig = serde_json::from_str(&json).unwrap();
             assert_eq!(back.name, "ue5");
             assert_eq!(back.executable, "UnrealEditor.exe");
+        }
+    }
+
+    mod test_dcc_launch_options {
+        use super::*;
+
+        #[test]
+        fn new_has_inherited_defaults() {
+            let options = DccLaunchOptions::new();
+            assert!(options.environment.is_empty());
+            assert!(options.working_directory.is_none());
+        }
+
+        #[test]
+        fn builder_with_environment_and_working_directory() {
+            let options = DccLaunchOptions::new()
+                .with_environment([("NUKE_DISABLE_FRAMESERVER", "1")])
+                .with_working_directory("/tmp/nuke-mcp");
+            assert_eq!(
+                options.environment.get("NUKE_DISABLE_FRAMESERVER"),
+                Some(&"1".to_string())
+            );
+            assert_eq!(options.working_directory.as_deref(), Some("/tmp/nuke-mcp"));
+        }
+
+        #[test]
+        fn serialize_roundtrip() {
+            let options = DccLaunchOptions::new()
+                .with_environment([("UE_SILENT", "1")])
+                .with_working_directory("/projects/game");
+            let json = serde_json::to_string(&options).unwrap();
+            let back: DccLaunchOptions = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, options);
         }
     }
 }

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -77,7 +77,7 @@ launcher = PyDccLauncher()
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `launch(name, executable, args=None, launch_timeout_ms=30000)` | `dict` | Spawn a DCC process |
+| `launch(name, executable, args=None, launch_timeout_ms=30000, environment=None, working_directory=None)` | `dict` | Spawn a DCC process with child-only environment and cwd overrides |
 | `terminate(name, timeout_ms=5000)` | `None` | Gracefully terminate |
 | `kill(name)` | `None` | Force kill |
 | `pid_of(name)` | `int \| None` | Get PID by name |
@@ -92,6 +92,8 @@ info = launcher.launch(
     executable="/usr/autodesk/maya/bin/maya",
     args=["-prompt", "-batch"],
     launch_timeout_ms=30000,
+    environment={"MAYA_DISABLE_CIP": "1"},
+    working_directory="/projects/shot-010",
 )
 print(f"Launched PID: {info['pid']}")
 

--- a/docs/guide/process.md
+++ b/docs/guide/process.md
@@ -107,12 +107,21 @@ print(f"Launched PID: {info['pid']}")
 
 ```python
 info = launcher.launch(
-    name="maya",
-    executable="/usr/autodesk/maya/bin/maya",
-    args=["-prompt", "-script", "init.py"],
+    name="nuke-mcp",
+    executable="/opt/Nuke15.2/Nuke15.2",
+    args=["--disable-nuke-frameserver", "project.nk"],
     launch_timeout_ms=60000,
+    environment={
+        "NUKE_DISABLE_FRAMESERVER": "1",
+        "DCC_MCP_NUKE_PORT": "0",
+    },
+    working_directory="/projects/solar-system",
 )
 ```
+
+Environment values and the working directory apply only to the launched child.
+The parent process environment is unchanged, so multiple isolated DCC sessions
+can use different runtime policies safely.
 
 ### Process Lifecycle
 

--- a/docs/zh/api/process.md
+++ b/docs/zh/api/process.md
@@ -77,7 +77,7 @@ launcher = PyDccLauncher()
 
 | 方法 | 返回 | 描述 |
 |------|------|------|
-| `launch(name, executable, args=None, launch_timeout_ms=30000)` | `dict` | 启动 DCC 进程 |
+| `launch(name, executable, args=None, launch_timeout_ms=30000, environment=None, working_directory=None)` | `dict` | 使用子进程专属环境和工作目录启动 DCC 进程 |
 | `terminate(name, timeout_ms=5000)` | `None` | 优雅终止 |
 | `kill(name)` | `None` | 强制杀死 |
 | `pid_of(name)` | `int \| None` | 按名称获取 PID |
@@ -92,6 +92,8 @@ info = launcher.launch(
     executable="/usr/autodesk/maya/bin/maya",
     args=["-prompt", "-batch"],
     launch_timeout_ms=30000,
+    environment={"MAYA_DISABLE_CIP": "1"},
+    working_directory="/projects/shot-010",
 )
 print(f"已启动 PID: {info['pid']}")
 

--- a/docs/zh/guide/process.md
+++ b/docs/zh/guide/process.md
@@ -107,12 +107,20 @@ print(f"已启动 PID: {info['pid']}")
 
 ```python
 info = launcher.launch(
-    name="maya",
-    executable="/usr/autodesk/maya/bin/maya",
-    args=["-prompt", "-script", "init.py"],
+    name="nuke-mcp",
+    executable="/opt/Nuke15.2/Nuke15.2",
+    args=["--disable-nuke-frameserver", "project.nk"],
     launch_timeout_ms=60000,
+    environment={
+        "NUKE_DISABLE_FRAMESERVER": "1",
+        "DCC_MCP_NUKE_PORT": "0",
+    },
+    working_directory="/projects/solar-system",
 )
 ```
+
+环境变量和工作目录只应用于启动的子进程，不会修改父进程环境，因此多个隔离
+DCC 会话可以安全地使用不同的运行策略。
 
 ### 进程生命周期
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1672,19 +1672,25 @@ launcher = PyDccLauncher()
 
 # Launch a DCC process
 info = launcher.launch(
-    name="maya-2025",                        # logical name for tracking
-    executable="/usr/autodesk/maya/bin/maya",
-    args=["-batch", "-file", "scene.mb"],
+    name="nuke-mcp",                         # logical name for tracking
+    executable="/opt/Nuke15.2/Nuke15.2",
+    args=["--disable-nuke-frameserver", "project.nk"],
     launch_timeout_ms=30000,
+    environment={
+        "NUKE_DISABLE_FRAMESERVER": "1",
+        "DCC_MCP_NUKE_PORT": "0",
+    },
+    working_directory="/projects/solar-system",
 )
-# info: {"pid": 12345, "name": "maya-2025", "status": "running"}
+# info: {"pid": 12345, "name": "nuke-mcp", "status": "starting"}
+# environment/cwd overrides apply only to the child process.
 
 # Manage
-launcher.terminate("maya-2025", timeout_ms=5000)  # graceful SIGTERM
-launcher.kill("maya-2025")                         # force SIGKILL
-pid = launcher.pid_of("maya-2025")                 # -> int|None
+launcher.terminate("nuke-mcp", timeout_ms=5000)  # graceful SIGTERM
+launcher.kill("nuke-mcp")                         # force SIGKILL
+pid = launcher.pid_of("nuke-mcp")                 # -> int|None
 count = launcher.running_count()                   # int
-restarts = launcher.restart_count("maya-2025")     # int
+restarts = launcher.restart_count("nuke-mcp")     # int
 ```
 
 ### PyProcessMonitor

--- a/llms.txt
+++ b/llms.txt
@@ -465,7 +465,7 @@ tools:
 
 ### Process Management (`dcc_mcp_core`)
 
-- `PyDccLauncher()` → `.launch(name, executable, args=None, launch_timeout_ms=30000) -> dict` (dict: `pid`, `name`, `status`), `.terminate(name, timeout_ms=5000)`, `.kill(name)`, `.pid_of(name) -> int|None`, `.running_count() -> int`
+- `PyDccLauncher()` → `.launch(name, executable, args=None, launch_timeout_ms=30000, environment=None, working_directory=None) -> dict` (dict: `pid`, `name`, `status`); environment/cwd overrides apply only to the child. Also exposes `.terminate(name, timeout_ms=5000)`, `.kill(name)`, `.pid_of(name) -> int|None`, `.running_count() -> int`
 - `PyProcessMonitor()` → `.track(pid, name)`, `.refresh()`, `.query(pid) -> dict|None`, `.list_all() -> list`, `.is_alive(pid) -> bool`
 - `PyProcessWatcher(poll_interval_ms=500)` → `.track(pid, name)`, `.start()`, `.stop()`, `.poll_events() -> list[dict]`
 - `PyCrashRecoveryPolicy(max_restarts=3)` → `.use_exponential_backoff(initial_ms, max_delay_ms)`, `.use_fixed_backoff(delay_ms)`, `.should_restart(status) -> bool`, `.next_delay_ms(name, attempt) -> int`

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -1324,7 +1324,7 @@ class PyDccLauncher:
     ```
     """
     def __new__(cls) -> PyDccLauncher: ...
-    def launch(self, name: builtins.str, executable: builtins.str, args: typing.Optional[typing.Sequence[builtins.str]] = None, launch_timeout_ms: builtins.int = 30000) -> dict:
+    def launch(self, name: builtins.str, executable: builtins.str, args: typing.Optional[typing.Sequence[builtins.str]] = None, launch_timeout_ms: builtins.int = 30000, environment: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None, working_directory: typing.Optional[builtins.str] = None) -> dict:
         r"""
         Spawn a DCC process.
 
@@ -1338,6 +1338,10 @@ class PyDccLauncher:
             Command-line arguments.
         launch_timeout_ms : int, optional
             Milliseconds to wait for the process to start (default 30000).
+        environment : dict[str, str], optional
+            Child-only environment overrides. The parent process is not mutated.
+        working_directory : str, optional
+            Working directory for the child process.
 
         Returns a dict with ``pid``, ``name``, and ``status``.
         """

--- a/tests/test_launcher_policy_monitor_validator_eventbus.py
+++ b/tests/test_launcher_policy_monitor_validator_eventbus.py
@@ -10,7 +10,12 @@ All tests are fully self-contained with no external dependencies.
 from __future__ import annotations
 
 import contextlib
+import json
 import os
+from pathlib import Path
+import sys
+import tempfile
+import time
 
 import pytest
 
@@ -114,6 +119,51 @@ class TestPyDccLauncherLaunch:
         launcher = PyDccLauncher()
         with pytest.raises((RuntimeError, OSError, Exception)):
             launcher.launch("bad-exe", "/no/such/executable/ever", launch_timeout_ms=500)
+
+    def test_launch_applies_child_environment_and_working_directory(self, monkeypatch):
+        launcher = PyDccLauncher()
+        child_env_key = "DCC_MCP_TEST_CHILD_ENV_6E0B39B4"
+        monkeypatch.setenv(child_env_key, "parent-value")
+        with tempfile.TemporaryDirectory() as working_directory:
+            output_path = Path(working_directory) / "child.json"
+            ready_path = Path(working_directory) / "child.ready"
+            script = (
+                "import json, os, pathlib, time; "
+                "pathlib.Path(os.environ['DCC_MCP_TEST_OUTPUT']).write_text("
+                "json.dumps({'env': os.environ.get(os.environ['DCC_MCP_TEST_ENV_KEY']), "
+                "'cwd': os.getcwd()}), encoding='utf-8'); "
+                "os.chdir(os.environ['DCC_MCP_TEST_RELEASE_CWD']); "
+                "pathlib.Path(os.environ['DCC_MCP_TEST_READY']).write_text("
+                "'ready', encoding='utf-8'); time.sleep(30)"
+            )
+            try:
+                launcher.launch(
+                    "isolated-child",
+                    sys.executable,
+                    args=["-c", script],
+                    environment={
+                        child_env_key: "child-only",
+                        "DCC_MCP_TEST_ENV_KEY": child_env_key,
+                        "DCC_MCP_TEST_OUTPUT": str(output_path),
+                        "DCC_MCP_TEST_READY": str(ready_path),
+                        "DCC_MCP_TEST_RELEASE_CWD": str(Path(working_directory).parent),
+                    },
+                    working_directory=working_directory,
+                )
+                deadline = time.time() + 10.0
+                while not ready_path.exists() and time.time() < deadline:
+                    time.sleep(0.05)
+                assert ready_path.exists()
+                with output_path.open(encoding="utf-8") as stream:
+                    result = json.load(stream)
+                assert result["env"] == "child-only"
+                assert os.path.normcase(str(Path(result["cwd"]).resolve())) == os.path.normcase(
+                    str(Path(working_directory).resolve())
+                )
+                assert os.environ[child_env_key] == "parent-value"
+            finally:
+                with contextlib.suppress(Exception):
+                    launcher.kill("isolated-child")
 
     def test_restart_count_after_launch(self):
         import sys


### PR DESCRIPTION
## Summary

- add a source-compatible `DccLaunchOptions` type and `DccLauncher::launch_with_options`
- let `PyDccLauncher.launch` apply child-only environment overrides and a child working directory
- keep the parent process environment/cwd unchanged and preserve every existing positional call
- document isolated DCC launch policies, including dynamic adapter ports and disabling a child Nuke Frame Server

## Compatibility

`DccProcessConfig` keeps its existing public field layout. The new Rust type is `#[non_exhaustive]`, and the existing `DccLauncher::launch(config)` delegates to default options. Python adds only trailing optional keyword arguments.

## Validation

- `cargo test -p dcc-mcp-process` (92 unit tests + doctest)
- Rust child environment/cwd regression: 10/10 stress passes on Windows
- Python child override/parent preservation/cwd regression: 20/20 stress passes on Windows
- `cargo clippy -p dcc-mcp-process --all-targets --features python-bindings -- -D warnings`
- generated Python stub drift check
- Ruff check and format check
- independent compatibility review