### PR TITLE
feat(marketplace): support animated showcase media

### DIFF
--- a/admin-ui/tests/marketplace.spec.ts
+++ b/admin-ui/tests/marketplace.spec.ts
@@ -395,11 +395,14 @@ test.describe('Marketplace Panel', () => {
   });
 
   test('opens detail modal on card click and shows package metadata', async ({ page }) => {
-    await page.route('**/marketplace-showcase.webp', async (route) => {
+    await page.route('**/marketplace-showcase.gif', async (route) => {
       await route.fulfill({
         status: 200,
-        contentType: 'image/svg+xml',
-        body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900"><rect width="1600" height="900" fill="#0b1f45"/><path d="M180 600 560 220l310 270 250-210 300 320" fill="none" stroke="#16b9e6" stroke-width="36"/></svg>',
+        contentType: 'image/gif',
+        body: Buffer.from(
+          'R0lGODlhBAAEAPAAAAsfRQAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQAAAAAACwAAAAABAAEAAACBISPCQUAIfkEAAUAAAAsAAAAAAQABACAFrnmAAAAAgSEjwkFADs=',
+          'base64',
+        ),
       });
     });
     await mockMarketplaceApi(page, {
@@ -413,7 +416,7 @@ test.describe('Marketplace Panel', () => {
           min_core_version: '0.15.0',
           maintainer: 'td-core',
           icon: '/missing-marketplace-icon.png',
-          showcase: '/marketplace-showcase.webp',
+          showcase: '/marketplace-showcase.gif',
           url: 'https://github.com/dcc-mcp/maya-modeling',
           source_name: 'builtin',
           install: { type: 'git', url: 'https://github.com/dcc-mcp/maya-modeling.git' },

--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -73,7 +73,8 @@ pub struct CatalogEntry {
     /// Icon path or URL (e.g. `"icon.png"` for repo-relative, or an absolute URL).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icon: Option<String>,
-    /// 16:9 showcase image path relative to the repository root, or an absolute URL.
+    /// 16:9 showcase image or animated GIF path relative to the repository root,
+    /// or an absolute URL.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub showcase: Option<String>,
 }
@@ -356,7 +357,7 @@ const MARKETPLACE_V1_SCHEMA_JSON: &str = r##"{
         "icon":        { "type": "string" },
         "showcase": {
           "type": "string",
-          "pattern": "^(https?://[^\\s]+|[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)*\\.(png|jpg|jpeg|webp|avif))$"
+          "pattern": "^(https?://[^\\s]+|[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)*\\.(png|jpg|jpeg|webp|avif|gif))$"
         },
         "install": {
           "type": "object",
@@ -946,6 +947,26 @@ entries:
             Some(
                 "https://raw.githubusercontent.com/dcc-mcp/example/0123456789012345678901234567890123456789/docs/images/showcase.webp"
             )
+        );
+        assert!(validate_entry(&entries[0]).is_ok());
+    }
+
+    #[test]
+    fn test_load_and_validate_entry_with_repo_relative_gif_showcase_passes() {
+        let entries = load_from_str(
+            r#"{
+              "entries": [{
+                "name": "animated-showcase-skill",
+                "description": "A skill with an animated marketplace cover",
+                "showcase": "docs/showcase/procedural-demo.gif"
+              }]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            entries[0].showcase.as_deref(),
+            Some("docs/showcase/procedural-demo.gif")
         );
         assert!(validate_entry(&entries[0]).is_ok());
     }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/marketplace_ws.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/marketplace_ws.rs
@@ -41,6 +41,7 @@ use uuid::Uuid;
 
 use dcc_mcp_marketplace::MarketplaceService;
 
+use super::super::admin::marketplace::resolve_icon_url;
 use super::super::admin::skill_reload::reload_skill_paths_and_refresh_backends;
 use super::super::admin::state::AdminState;
 use super::super::capability::RefreshReason;
@@ -384,6 +385,12 @@ async fn handle_catalog_list(state: &MarketplaceWsState, id: Option<Value>) -> S
             let entries: Vec<Value> = hits
                 .into_iter()
                 .map(|hit| {
+                    let icon =
+                        resolve_icon_url(hit.entry.icon.as_deref(), Some(hit.source.url.as_str()));
+                    let showcase = dcc_mcp_marketplace::resolve_catalog_asset_url(
+                        hit.entry.showcase.as_deref(),
+                        hit.entry.install.as_ref(),
+                    );
                     serde_json::json!({
                         "name": hit.entry.name,
                         "description": hit.entry.description,
@@ -394,6 +401,8 @@ async fn handle_catalog_list(state: &MarketplaceWsState, id: Option<Value>) -> S
                         "min_core_version": hit.entry.min_core_version,
                         "maintainer": hit.entry.maintainer,
                         "requires": hit.entry.requires,
+                        "icon": icon,
+                        "showcase": showcase,
                         "source_name": hit.source.name,
                         "source_url": hit.source.url,
                     })

--- a/crates/dcc-mcp-marketplace/src/source.rs
+++ b/crates/dcc-mcp-marketplace/src/source.rs
@@ -168,6 +168,19 @@ mod tests {
     }
 
     #[test]
+    fn resolves_animated_showcase_at_pinned_github_revision() {
+        assert_eq!(
+            resolve_catalog_asset_url(
+                Some("docs/showcase/procedural-demo.gif"),
+                Some(&github_install())
+            ),
+            Some(
+                "https://raw.githubusercontent.com/dcc-mcp/dcc-example/0123456789012345678901234567890123456789/docs/showcase/procedural-demo.gif".into()
+            )
+        );
+    }
+
+    #[test]
     fn rejects_catalog_asset_parent_traversal() {
         assert_eq!(
             resolve_catalog_asset_url(Some("../secret.png"), Some(&github_install())),

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -171,6 +171,9 @@ The Browse tab displays available skill packages in a searchable visual catalog.
 Cards use the package's pinned 16:9 workflow showcase when available, then keep
 the package name, description, DCC actions, version, and tags compact below it.
 The image falls back to the package or DCC icon when no showcase is published.
+Publishers declare one `showcase` file in their repository's `marketplace.json`.
+Repository-relative PNG, JPEG, WebP, AVIF, and animated GIF paths are resolved
+against the entry's immutable 40-character Git revision before display.
 
 Users can filter the catalog by:
 - **Search query**: text search across name, description, and tags.

--- a/marketplace-ui/src/App.tsx
+++ b/marketplace-ui/src/App.tsx
@@ -557,6 +557,16 @@ export default function App() {
                 {filteredCatalog.map((entry) => (
                   <div key={entry.name} className="marketplace-card" onClick={() => setDetailEntry(entry)}>
                     <div>
+                      {entry.showcase && (
+                        <img
+                          className="marketplace-card-showcase"
+                          src={entry.showcase}
+                          alt=""
+                          loading="lazy"
+                          decoding="async"
+                          referrerPolicy="no-referrer"
+                        />
+                      )}
                       <div className="marketplace-card-head">
                         {entry.icon ? (
                           <img className="marketplace-card-icon" src={entry.icon} alt={entry.name} />
@@ -744,6 +754,15 @@ export default function App() {
         <div className="modal-backdrop" onClick={() => setDetailEntry(null)}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
             <button className="modal-close" onClick={() => setDetailEntry(null)}>&times;</button>
+            {detailEntry.showcase && (
+              <img
+                className="marketplace-detail-showcase"
+                src={detailEntry.showcase}
+                alt=""
+                decoding="async"
+                referrerPolicy="no-referrer"
+              />
+            )}
             <h2 className="text-2xl font-bold text-slate-900 mb-4">{detailEntry.name}</h2>
             <div className="space-y-4">
               <div>

--- a/marketplace-ui/src/styles.css
+++ b/marketplace-ui/src/styles.css
@@ -234,6 +234,22 @@ body {
   border-color: #cbd5e1;
 }
 
+.marketplace-card-showcase,
+.marketplace-detail-showcase {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: 0.5rem;
+}
+
+.marketplace-card-showcase {
+  margin-bottom: 1rem;
+}
+
+.marketplace-detail-showcase {
+  margin-bottom: 1.5rem;
+}
+
 .marketplace-card-head {
   display: flex;
   align-items: center;

--- a/skills/marketplace-publish-extension/SKILL.md
+++ b/skills/marketplace-publish-extension/SKILL.md
@@ -70,8 +70,10 @@ push the change.
 
 1. Point the tool at a local extension directory containing `SKILL.md`.
 2. The tool reads the SKILL.md frontmatter and any accompanying metadata.
-3. Additional CLI-supplied fields (install url, ref, skill roots, tags, maintainer, icon,
-   etc.) are merged in.
+3. Additional CLI-supplied fields (install url, ref, skill roots, tags,
+   maintainer, icon, and `showcase`) are merged in. Use a repository-relative
+   16:9 PNG, JPEG, WebP, AVIF, or animated GIF path; the marketplace resolves
+   it at the pinned 40-character Git revision.
 4. A `CatalogEntry` is built and upserted into the target `marketplace.json`.
    New catalogs use the v1 `skills` layout and preserve v1-only fields when an
    existing entry is updated.


### PR DESCRIPTION
## Summary

- allow repository-relative animated GIF files in the existing single `showcase` catalog field
- resolve and return icon/showcase media from the standalone marketplace WebSocket catalog endpoint
- render animated showcase media in standalone marketplace cards and details
- document the immutable-revision media contract

## Validation

- `vx cargo fmt --all --check`
- `vx cargo test -p dcc-mcp-catalog` (29 passed)
- `vx cargo test -p dcc-mcp-marketplace resolves_animated_showcase_at_pinned_github_revision`
- `vx cargo check -p dcc-mcp-gateway`
- marketplace UI build + tests (3 passed)
- admin UI build + unit tests (73 passed)
- targeted Playwright marketplace GIF test (1 passed)
