### PR TITLE
fix(gateway): refresh cold capability index for batch calls

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_batch_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_batch_tests.rs
@@ -10,6 +10,21 @@ async fn spawn_echo_backend() -> (u16, tokio::sync::oneshot::Sender<()>) {
             axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
         )
         .route(
+            "/v1/search",
+            axum::routing::post(|| async {
+                axum::Json(json!({
+                    "total": 1,
+                    "hits": [{
+                        "action": "echo",
+                        "skill": "test-skill",
+                        "summary": "Echo test tool",
+                        "has_schema": true,
+                        "loaded": true
+                    }]
+                }))
+            }),
+        )
+        .route(
             "/v1/describe",
             axum::routing::post(move |axum::Json(body): axum::Json<Value>| async move {
                 let slug = body.get("tool_slug").and_then(Value::as_str).unwrap_or("");
@@ -57,6 +72,70 @@ async fn spawn_echo_backend() -> (u16, tokio::sync::oneshot::Sender<()>) {
     });
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     (port, tx)
+}
+
+#[tokio::test]
+async fn gateway_rest_v1_call_batch_refreshes_a_cold_live_instance_index() {
+    let (backend_port, stop_backend) = spawn_echo_backend().await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
+        dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+    ));
+    let instance_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+    {
+        let r = registry.read().await;
+        let mut entry = dcc_mcp_transport::discovery::types::ServiceEntry::new(
+            "maya",
+            "127.0.0.1",
+            backend_port,
+        );
+        entry.instance_id = instance_id;
+        r.register(entry).unwrap();
+    }
+
+    let mut gs = test_gateway_state("1.2.3");
+    gs.registry = registry;
+    assert!(gs.capability_index.snapshot().records.is_empty());
+
+    let app = crate::gateway::router::build_gateway_router(gs);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let gateway_port = listener.local_addr().unwrap().port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let body: Value = reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{gateway_port}/v1/call_batch"))
+        .header("Accept", "application/json")
+        .json(&json!({
+            "calls": [{
+                "id": "first-cold-call",
+                "tool_slug": format!("maya.{instance_id}.echo"),
+                "arguments": {"value": 42}
+            }]
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert_eq!(body["success"], true, "{body:#}");
+    assert_eq!(body["results"][0]["id"], "first-cold-call");
+    assert_eq!(body["results"][0]["ok"], true, "{body:#}");
+
+    let _ = shutdown_tx.send(());
+    let _ = server.await;
+    let _ = stop_backend.send(());
 }
 
 #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -619,12 +619,9 @@ pub async fn tool_call_tool(
     };
     let forwarded_meta = args.get("meta").cloned().or_else(|| meta.cloned());
     let search_id = search_id_from_inputs(args, meta);
-    // No refresh here on purpose: `call_tool` is the hot path and
-    // we trust that the caller used `describe_tool` / `search_tools`
-    // to obtain the slug, both of which refresh. An unknown-slug
-    // error from `describe_service` will trigger one refresh at the
-    // end of this function if the record is missing, keeping the
-    // happy path fast.
+    // No eager refresh here: `call_tool` is the hot path and callers often
+    // arrive from `describe_tool` / `search_tools`. If the cached route is
+    // absent or stale, refresh once after that concrete routing error.
     match crate::gateway::capability_service::call_service(
         gs,
         slug,
@@ -651,10 +648,9 @@ pub async fn tool_call_tool(
                 is_error,
             )
         }
-        Err(err) if err.kind == "unknown-slug" => {
-            // Refresh once in case the caller supplied a slug that
-            // just became valid (e.g. a skill loaded between
-            // `search_tools` and `call_tool`), then retry.
+        Err(err) if call_error_needs_refresh(&err) => {
+            // Refresh once when the slug just became valid or a live instance
+            // has not reached this gateway's capability index yet.
             crate::gateway::capability_service::refresh_all_live_backends(
                 gs,
                 crate::gateway::capability::RefreshReason::Periodic,
@@ -726,6 +722,12 @@ pub async fn tool_call_tool(
     }
 }
 
+pub(super) fn call_error_needs_refresh(
+    err: &crate::gateway::capability_service::ServiceError,
+) -> bool {
+    matches!(err.kind.as_str(), "unknown-slug" | "instance-offline")
+}
+
 /// Maximum number of backend invocations allowed in one `call_tools` /
 /// `POST /v1/call_batch` request (token + backend fairness guardrail).
 pub const MAX_CALL_TOOLS_BATCH: usize = 25;
@@ -735,7 +737,7 @@ pub const MAX_CALL_TOOLS_BATCH: usize = 25;
 /// Request shape: `{ "calls": [ { "tool_slug", "arguments"?, "meta"? }, ... ],
 /// "stop_on_error"?: bool }`. Each entry is routed through
 /// [`crate::gateway::capability_service::call_service`] with the same
-/// unknown-slug refresh-and-retry semantics as [`tool_call_tool`].
+/// route-index refresh-and-retry semantics as [`tool_call_tool`].
 ///
 /// Returns `Ok(Value)` with `{ "success": bool, "results": [...] }` where each
 /// result item includes `index`, optional client-supplied `id`, `tool_slug`,
@@ -815,7 +817,7 @@ pub async fn gateway_call_batch_inner(
             .await
             {
                 Ok(result) => Ok(result),
-                Err(err) if err.kind == "unknown-slug" => {
+                Err(err) if call_error_needs_refresh(&err) => {
                     crate::gateway::capability_service::refresh_all_live_backends(
                         gs,
                         crate::gateway::capability::RefreshReason::Periodic,

--- a/crates/dcc-mcp-gateway/src/gateway/tools_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools_tests.rs
@@ -205,3 +205,25 @@ fn describe_refresh_is_conditional_on_generation_and_index_hit() {
         None
     ));
 }
+
+#[test]
+fn calls_refresh_only_after_route_index_errors() {
+    use crate::gateway::capability_service::ServiceError;
+
+    assert!(call_error_needs_refresh(&ServiceError::new(
+        "unknown-slug",
+        "missing capability",
+    )));
+    assert!(call_error_needs_refresh(&ServiceError::new(
+        "instance-offline",
+        "live instance not indexed yet",
+    )));
+    assert!(!call_error_needs_refresh(&ServiceError::new(
+        "backend-error",
+        "tool execution failed",
+    )));
+    assert!(!call_error_needs_refresh(&ServiceError::new(
+        "policy-denied",
+        "request rejected",
+    )));
+}


### PR DESCRIPTION
## Summary

- refresh the gateway capability index once when a routed call sees an unknown slug or an unindexed/offline instance
- preserve the lazy hot path and never retry backend execution or policy failures
- cover a first-request REST batch call against a live instance with an initially empty capability index

## Validation

- `vx cargo test -p dcc-mcp-gateway --lib` — 543 passed
- cold-index REST batch regression — 10/10 repeated runs passed
- `vx cargo check --workspace --all-targets`
- `vx cargo clippy --workspace -- -D warnings`
- `vx just fmt-check`

No skill or public API documentation update is needed because this only restores existing route-index recovery semantics.