### PR TITLE
fix(computer-use): recover scoped DCC foreground

### DIFF
--- a/crates/dcc-mcp-computer-use/src/platform/windows/input.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/input.rs
@@ -63,7 +63,7 @@ pub(crate) fn perform_action(
         observation.desktop_generation,
     );
     guard.synchronize()?;
-    focus_target(window_handle, observation.process_id)?;
+    let _focus_elevation = focus_target(window_handle, observation.process_id)?;
     guard.check()?;
     ensure_observation_target(window_handle, observation)?;
 
@@ -215,15 +215,7 @@ fn pointer_effect_dwell(request: &ComputerUseAction) -> Duration {
     )
 }
 
-fn focus_target(window_handle: u64, process_id: u32) -> ComputerUseResult<()> {
-    ensure_interactive_desktop()?;
-    let hwnd = HWND(window_handle as *mut core::ffi::c_void);
-    restore_target_for_input(hwnd, process_id)?;
-    let _ = available_target_rect_for_process(hwnd, process_id)?;
-    if unsafe { GetForegroundWindow() } == hwnd {
-        return Ok(());
-    }
-
+fn set_target_foreground(hwnd: HWND) {
     // AttachThreadInput requires a USER message queue. Adapter worker threads
     // often do not have one until they call PeekMessage at least once.
     let mut queue_probe = MSG::default();
@@ -251,14 +243,83 @@ fn focus_target(window_handle: u64, process_id: u32) -> ComputerUseResult<()> {
     if attached_foreground {
         let _ = unsafe { AttachThreadInput(current_thread, foreground_thread, false) };
     }
+}
+
+fn focus_recovery_allowed(
+    target_process_id: u32,
+    blocker_process_id: u32,
+    blocker_process: &str,
+    blocker_class: &str,
+) -> ComputerUseResult<bool> {
+    if blocker_process_id == 0 {
+        return Err(ComputerUseError::new(
+            ComputerUseErrorCode::FocusLost,
+            "Windows did not report a foreground window after focusing the scoped DCC",
+        ));
+    }
+    if blocker_process_id == target_process_id {
+        return Err(ComputerUseError::new(
+            ComputerUseErrorCode::FocusLost,
+            "another window owned by the scoped DCC has foreground focus; resolve the in-app modal before retrying",
+        ));
+    }
+    if protected_input_blocker(blocker_process, blocker_class) {
+        return Err(ComputerUseError::new(
+            ComputerUseErrorCode::InvalidTarget,
+            format!(
+                "the scoped DCC cannot recover foreground focus through protected system UI: {blocker_process} / {blocker_class}"
+            ),
+        ));
+    }
+    Ok(true)
+}
+
+fn focus_target(
+    window_handle: u64,
+    process_id: u32,
+) -> ComputerUseResult<Option<TransientTopmostTarget>> {
+    ensure_interactive_desktop()?;
+    let hwnd = HWND(window_handle as *mut core::ffi::c_void);
+    restore_target_for_input(hwnd, process_id)?;
+    let _ = available_target_rect_for_process(hwnd, process_id)?;
+    if unsafe { GetForegroundWindow() } == hwnd {
+        return Ok(None);
+    }
+
+    set_target_foreground(hwnd);
+    thread::sleep(Duration::from_millis(30));
+    let blocker = unsafe { GetForegroundWindow() };
+    if blocker == hwnd {
+        return Ok(None);
+    }
+    let mut blocker_process_id = 0_u32;
+    if !blocker.0.is_null() {
+        unsafe { GetWindowThreadProcessId(blocker, Some(&mut blocker_process_id)) };
+    }
+    let (blocker_process, blocker_class) = if blocker.0.is_null() {
+        (String::new(), String::new())
+    } else {
+        blocker_process_and_class(blocker)
+    };
+    focus_recovery_allowed(
+        process_id,
+        blocker_process_id,
+        &blocker_process,
+        &blocker_class,
+    )?;
+
+    let elevation = TransientTopmostTarget::raise(hwnd)?;
+    set_target_foreground(hwnd);
     thread::sleep(Duration::from_millis(30));
     if unsafe { GetForegroundWindow() } != hwnd {
         return Err(ComputerUseError::new(
             ComputerUseErrorCode::FocusLost,
-            "the scoped DCC window did not remain in the foreground",
+            format!(
+                "the scoped DCC window did not remain in the foreground after recovering from {blocker_process} / {blocker_class}"
+            ),
         ));
     }
-    Ok(())
+    Ok(Some(elevation))
 }
 
 fn protected_input_blocker(process: &str, class_name: &str) -> bool {
@@ -537,7 +598,7 @@ fn move_to(
     // No input has been sent yet. Reacquire the already-scoped target after
     // the desktop-barrier handshake so a caller window cannot steal focus in
     // the small gap between initial preparation and the first pointer move.
-    focus_target(window_handle, observation.process_id)?;
+    let _focus_elevation = focus_target(window_handle, observation.process_id)?;
     ensure_observation_target(window_handle, observation)?;
     let _elevation = if require_target_hit {
         prepare_point_target(
@@ -813,7 +874,7 @@ fn keypress(
     // This is the first and only input in a keypress action, so reacquiring the
     // validated target after the barrier is safe. Multi-step actions continue
     // to fail closed if focus changes after their first input.
-    focus_target(window_handle, process_id)?;
+    let _focus_elevation = focus_target(window_handle, process_id)?;
     guard.check()?;
     send_inputs(&inputs)?;
     guard.check()

--- a/crates/dcc-mcp-computer-use/src/platform/windows/input_tests.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/input_tests.rs
@@ -853,6 +853,19 @@ fn protected_system_ui_is_not_eligible_for_transient_occlusion_recovery() {
 }
 
 #[test]
+fn focus_recovery_policy_allows_only_ordinary_cross_process_blockers() {
+    assert!(focus_recovery_allowed(100, 200, "ChatGPT.exe", "Chrome_WidgetWin_1",).unwrap());
+
+    let same_process =
+        focus_recovery_allowed(100, 100, "Nuke15.2.exe", "Qt5152QWindowIcon").unwrap_err();
+    assert_eq!(same_process.code, ComputerUseErrorCode::FocusLost);
+
+    let protected =
+        focus_recovery_allowed(100, 200, "PickerHost.exe", "Shell_SystemDialog").unwrap_err();
+    assert_eq!(protected.code, ComputerUseErrorCode::InvalidTarget);
+}
+
+#[test]
 fn minimized_window_is_identity_checked_then_restored_for_input() {
     use windows::Win32::System::Threading::GetCurrentProcessId;
     use windows::Win32::UI::WindowsAndMessaging::SW_MINIMIZE;


### PR DESCRIPTION
## Summary
- retry scoped DCC foreground activation through a temporary topmost elevation when an ordinary cross-process window wins the initial focus race
- keep the elevation alive for the complete action and restore the original topmost state through RAII
- continue to reject same-process modal blockers and protected system UI

## Validation
- `vx cargo test -p dcc-mcp-computer-use -- --test-threads=1` (70 passed)
- `vx cargo clippy -p dcc-mcp-computer-use --all-targets -- -D warnings`
- `git diff --check`
- real scoped Nuke app-ui capture reached the coordinate hit-test while another ordinary desktop window owned foreground focus; protected Windows system UI remained fail-closed