### PR TITLE
fix(computer-use): isolate unrelated UI overlays

### DIFF
--- a/crates/dcc-mcp-computer-use/src/platform/windows/input.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/input.rs
@@ -248,8 +248,6 @@ fn set_target_foreground(hwnd: HWND) {
 fn focus_recovery_allowed(
     target_process_id: u32,
     blocker_process_id: u32,
-    blocker_process: &str,
-    blocker_class: &str,
 ) -> ComputerUseResult<bool> {
     if blocker_process_id == 0 {
         return Err(ComputerUseError::new(
@@ -261,14 +259,6 @@ fn focus_recovery_allowed(
         return Err(ComputerUseError::new(
             ComputerUseErrorCode::FocusLost,
             "another window owned by the scoped DCC has foreground focus; resolve the in-app modal before retrying",
-        ));
-    }
-    if protected_input_blocker(blocker_process, blocker_class) {
-        return Err(ComputerUseError::new(
-            ComputerUseErrorCode::InvalidTarget,
-            format!(
-                "the scoped DCC cannot recover foreground focus through protected system UI: {blocker_process} / {blocker_class}"
-            ),
         ));
     }
     Ok(true)
@@ -301,17 +291,20 @@ fn focus_target(
     } else {
         blocker_process_and_class(blocker)
     };
-    focus_recovery_allowed(
-        process_id,
-        blocker_process_id,
-        &blocker_process,
-        &blocker_class,
-    )?;
+    focus_recovery_allowed(process_id, blocker_process_id)?;
 
     let elevation = TransientTopmostTarget::raise(hwnd)?;
     set_target_foreground(hwnd);
     thread::sleep(Duration::from_millis(30));
     if unsafe { GetForegroundWindow() } != hwnd {
+        if protected_input_blocker(&blocker_process, &blocker_class) {
+            return Err(ComputerUseError::new(
+                ComputerUseErrorCode::InvalidTarget,
+                format!(
+                    "the scoped DCC could not recover foreground focus through protected system UI: {blocker_process} / {blocker_class}"
+                ),
+            ));
+        }
         return Err(ComputerUseError::new(
             ComputerUseErrorCode::FocusLost,
             format!(
@@ -335,6 +328,34 @@ fn protected_input_blocker(process: &str, class_name: &str) -> bool {
         class_name,
         "Credential Dialog Xaml Host" | "Shell_SystemDialog" | "Shell_SystemDim"
     )
+}
+
+fn point_recovery_failure(
+    blocker_process: &str,
+    blocker_class: &str,
+    blocker_identity: &str,
+) -> ComputerUseError {
+    if protected_input_blocker(blocker_process, blocker_class) {
+        return ComputerUseError::new(
+            ComputerUseErrorCode::InvalidTarget,
+            format!(
+                "the requested pointer coordinate remains blocked by protected system UI: {blocker_identity}"
+            ),
+        );
+    }
+    ComputerUseError::new(
+        ComputerUseErrorCode::InvalidTarget,
+        format!("the requested pointer coordinate is occluded by {blocker_identity}"),
+    )
+}
+
+fn point_belongs_to_target(
+    hit_process_id: u32,
+    hit_root: HWND,
+    target_process_id: u32,
+    target: HWND,
+) -> bool {
+    hit_process_id == target_process_id && hit_root == target
 }
 
 fn blocker_process_and_class(hwnd: HWND) -> (String, String) {
@@ -442,16 +463,6 @@ fn prepare_point_target(
     let mut hit_process_id = 0_u32;
     unsafe { GetWindowThreadProcessId(hit, Some(&mut hit_process_id)) };
     if hit_process_id != process_id {
-        let (process, class_name) = blocker_process_and_class(hit);
-        if protected_input_blocker(&process, &class_name) {
-            return Err(ComputerUseError::new(
-                ComputerUseErrorCode::InvalidTarget,
-                format!(
-                    "the requested pointer coordinate is blocked by protected system UI: {}",
-                    input_blocker_identity(hit)
-                ),
-            ));
-        }
         let elevation = TransientTopmostTarget::raise(target)?;
         thread::sleep(Duration::from_millis(16));
         let retry = unsafe {
@@ -469,19 +480,18 @@ fn prepare_point_target(
         let mut retry_process_id = 0_u32;
         unsafe { GetWindowThreadProcessId(retry, Some(&mut retry_process_id)) };
         let retry_root = unsafe { GetAncestor(retry, GA_ROOT) };
-        if retry_process_id == process_id && retry_root == target {
+        if point_belongs_to_target(retry_process_id, retry_root, process_id, target) {
             return Ok(Some(elevation));
         }
-        return Err(ComputerUseError::new(
-            ComputerUseErrorCode::InvalidTarget,
-            format!(
-                "the requested pointer coordinate is occluded by {}",
-                input_blocker_identity(hit)
-            ),
+        let (retry_process, retry_class) = blocker_process_and_class(retry);
+        return Err(point_recovery_failure(
+            &retry_process,
+            &retry_class,
+            &input_blocker_identity(retry),
         ));
     }
     let hit_root = unsafe { GetAncestor(hit, GA_ROOT) };
-    if hit_root != target {
+    if !point_belongs_to_target(hit_process_id, hit_root, process_id, target) {
         return Err(ComputerUseError::new(
             ComputerUseErrorCode::InvalidTarget,
             "the requested pointer coordinate is outside the scoped top-level window",

--- a/crates/dcc-mcp-computer-use/src/platform/windows/input_tests.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/input_tests.rs
@@ -818,12 +818,12 @@ fn hidden_and_reused_windows_fail_closed() {
         prepare_point_target(200, 240, effect.hwnd, process_id.saturating_add(1)).unwrap_err();
     assert_eq!(occluded.code, ComputerUseErrorCode::InvalidTarget);
 
-    let same_process_wrong_window =
-        prepare_point_target(200, 240, other_window.hwnd, process_id).unwrap_err();
-    assert_eq!(
-        same_process_wrong_window.code,
-        ComputerUseErrorCode::InvalidTarget
-    );
+    assert!(!point_belongs_to_target(
+        process_id,
+        effect.hwnd,
+        process_id,
+        other_window.hwnd,
+    ));
 
     let _ = unsafe { ShowWindow(effect.hwnd, SW_HIDE) };
     let hidden = available_target_rect(effect.hwnd).unwrap_err();
@@ -853,16 +853,30 @@ fn protected_system_ui_is_not_eligible_for_transient_occlusion_recovery() {
 }
 
 #[test]
-fn focus_recovery_policy_allows_only_ordinary_cross_process_blockers() {
-    assert!(focus_recovery_allowed(100, 200, "ChatGPT.exe", "Chrome_WidgetWin_1",).unwrap());
+fn focus_recovery_policy_attempts_all_cross_process_blockers() {
+    assert!(focus_recovery_allowed(100, 200).unwrap());
 
-    let same_process =
-        focus_recovery_allowed(100, 100, "Nuke15.2.exe", "Qt5152QWindowIcon").unwrap_err();
+    let same_process = focus_recovery_allowed(100, 100).unwrap_err();
     assert_eq!(same_process.code, ComputerUseErrorCode::FocusLost);
+}
 
-    let protected =
-        focus_recovery_allowed(100, 200, "PickerHost.exe", "Shell_SystemDialog").unwrap_err();
+#[test]
+fn point_recovery_failure_preserves_protected_ui_boundary() {
+    let protected = point_recovery_failure(
+        "PickerHost.exe",
+        "Shell_SystemDim",
+        "PickerHost / Shell_SystemDim",
+    );
     assert_eq!(protected.code, ComputerUseErrorCode::InvalidTarget);
+    assert!(protected.message.contains("protected system UI"));
+
+    let ordinary = point_recovery_failure(
+        "ChatGPT.exe",
+        "Chrome_WidgetWin_1",
+        "ChatGPT / Chrome_WidgetWin_1",
+    );
+    assert_eq!(ordinary.code, ComputerUseErrorCode::InvalidTarget);
+    assert!(ordinary.message.contains("occluded by"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary\n\n- attempt bounded foreground recovery for any cross-process overlay before rejecting input\n- revalidate the exact process, root window, and pointer coordinate after transient elevation\n- preserve fail-closed handling when protected system UI still owns focus or the target coordinate\n- make same-process modal/root-window validation deterministic\n\n## Validation\n\n- cargo test -p dcc-mcp-computer-use -- --test-threads=1 (71 passed; repeated)\n- cargo clippy -p dcc-mcp-computer-use --all-targets -- -D warnings\n- cargo fmt --all -- --check\n- ABI3 wheel build\n- Windows Nuke smoke: a separate always-on-top window covered the action point; the scoped Nuke window recovered, accepted the click, and window-only capture excluded the unrelated window and control overlay\n