### PR TITLE
docs: make dcc-mcp-cli the default agent path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,13 @@ falling back to raw scripting or scoped Computer Use.
 - **Human IDE users** continue using MCP configuration. The gateway serves both paths simultaneously.
 - **CLI-first does not deprecate MCP** — the gateway always exposes both MCP and REST side by side.
 
+**CLI availability and updates:**
+- If `dcc-mcp-cli` is missing, obtain user consent before running an official
+  installer from `scripts/install-cli.sh` or `scripts/install-cli.ps1`.
+- Keep official builds current with `dcc-mcp-cli update check`, then
+  `dcc-mcp-cli update apply`. The apply step stages the latest CLI for the next
+  launch; it does not replace a running `dcc-mcp-server`.
+
 ## Response Language
 
 - Reply to the user in **Simplified Chinese** (中文简体) by default.

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -48,6 +48,29 @@ automation.
 
 CLI-first does **not** deprecate MCP. The gateway always exposes both MCP and REST side by side.
 
+### Install and keep the CLI current
+
+If `dcc-mcp-cli` is missing, obtain the user's consent before installing the
+latest official release:
+
+```bash
+# Linux/macOS
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+```
+
+Keep an official build current through the release manifest:
+
+```bash
+dcc-mcp-cli update check
+dcc-mcp-cli update apply
+```
+
+`update apply` downloads and stages the latest CLI for the next launch. It does
+not update a running `dcc-mcp-server`; update that server in its own environment.
+
 ### Computer Use is an agent-directed fallback
 
 Do not start with GUI automation. Discover and call structured DCC skills,

--- a/README.md
+++ b/README.md
@@ -59,16 +59,27 @@ exposes them. New gateway integrations should use the canonical names above.
 
 ## Quick start: operate a DCC
 
-Install the standalone CLI when you need the operator/CI control plane without
-setting up Python:
+`dcc-mcp-cli` is the preferred control path for every shell-capable agent.
+If it is missing, obtain the user's consent before installing the latest
+official release:
 
 ~~~bash
 # Linux/macOS
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | bash
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
 
 # Windows PowerShell
-powershell -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
 ~~~
+
+Keep an official build current through the release manifest:
+
+~~~bash
+dcc-mcp-cli update check
+dcc-mcp-cli update apply
+~~~
+
+`update apply` downloads and stages the latest CLI for the next launch. It does
+not update a running `dcc-mcp-server`; update that server in its own environment.
 
 Then discover a live capability before calling it:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -90,15 +90,26 @@ instance row -> gateway 统一路由所有 live DCC instance。
 
 ### 安装独立 CLI
 
-如果你只需要 operator/CI 控制面，不想先准备 Python 环境，直接安装 release 二进制：
+`dcc-mcp-cli` 是所有具备 shell 能力的 Agent 的首选控制路径。如果尚未安装，
+先征得用户同意，再安装最新的官方 release 二进制：
 
 ```bash
 # Linux/macOS
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | bash
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
 
 # Windows PowerShell
-powershell -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
 ```
+
+官方构建通过 release manifest 保持最新：
+
+```bash
+dcc-mcp-cli update check
+dcc-mcp-cli update apply
+```
+
+`update apply` 会下载并暂存最新版 CLI，在下一次启动时生效；它不会更新正在
+运行的 `dcc-mcp-server`，server 需要在自己的运行环境中单独更新。
 
 安装后：
 
@@ -268,14 +279,15 @@ Admin 重点能力：
 
 ### 安装独立 CLI
 
-如果你只需要 operator/CI 控制面，不想先准备 Python 环境，直接安装 release 二进制：
+对于具备 shell 能力的 Agent，独立 CLI 是首选控制路径。尚未安装时，先征得
+用户同意，再安装官方 release 二进制：
 
 ```bash
 # Linux/macOS
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | bash
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
 
 # Windows PowerShell
-powershell -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
 ```
 
 默认会下载最新 GitHub Release 里的对应资产：
@@ -291,7 +303,7 @@ powershell -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/s
 ```bash
 export DCC_MCP_VERSION=v0.x.y
 export DCC_MCP_INSTALL_DIR="$HOME/bin"
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | bash
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
 ```
 
 ```powershell

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -7,13 +7,15 @@ five deployment scenarios they cover. Flags on each binary map 1:1 onto an
 same configuration surface.
 
 `dcc-mcp-cli` and `dcc-mcp-server` are published as raw GitHub Release
-assets on every release. The CLI can be installed directly from a URL:
+assets on every release. It is the preferred control path for shell-capable
+agents. If it is missing, obtain the user's consent before installing it from
+the official URL:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | bash
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
 
 # Windows PowerShell
-powershell -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
 ```
 
 Pin a release by setting `DCC_MCP_VERSION=v0.17.17` or passing

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -14,6 +14,17 @@ powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc
 This installs the standalone `dcc-mcp-cli` control-plane binary from the
 latest GitHub Release. Pin a release with `DCC_MCP_VERSION=v0.17.17`.
 
+For agents, obtain user consent before installing or downloading a new binary.
+Keep an official installation current with:
+
+```bash
+dcc-mcp-cli update check
+dcc-mcp-cli update apply
+```
+
+`update apply` stages the latest CLI for the next launch. It does not replace a
+running `dcc-mcp-server`; update that server in its own environment.
+
 The CLI is also available as a standalone ZIP archive
 (`dcc-mcp-cli-<version>-<platform>.zip`) from each
 [GitHub Release](https://github.com/dcc-mcp/dcc-mcp-core/releases).

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -5,13 +5,14 @@
 `DCC_MCP_*` 环境变量，所以任何部署清单都能驱动同一套配置面板。
 
 `dcc-mcp-cli` 与 `dcc-mcp-server` 会在每个 Release 作为原生 GitHub
-Release 资产发布。CLI 可以通过 URL 直接安装：
+Release 资产发布。它是所有具备 shell 能力的 Agent 的首选控制路径。如果尚未
+安装，先征得用户同意，再通过官方 URL 安装：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | bash
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
 
 # Windows PowerShell
-powershell -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
 ```
 
 需要固定版本时，设置 `DCC_MCP_VERSION=v0.17.17`，或给安装脚本传

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -14,6 +14,17 @@ powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc
 这会从最新 GitHub Release 安装独立的 `dcc-mcp-cli` 控制面二进制。
 需要固定版本时设置 `DCC_MCP_VERSION=v0.17.17`。
 
+Agent 在安装或下载新二进制前必须先征得用户同意。官方安装可以通过以下命令
+保持最新：
+
+```bash
+dcc-mcp-cli update check
+dcc-mcp-cli update apply
+```
+
+`update apply` 会暂存最新版 CLI，并在下一次启动时生效；它不会替换正在运行的
+`dcc-mcp-server`，server 需要在自己的运行环境中单独更新。
+
 CLI 也提供了独立 ZIP 包（`dcc-mcp-cli-<version>-<platform>.zip`），
 可从每个 [GitHub Release](https://github.com/dcc-mcp/dcc-mcp-core/releases) 下载。
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3546,14 +3546,24 @@ See `docs/guide/remote-server.md` for the Docker / systemd / k8s / reverse-proxy
 
 When an AI agent needs to interact with DCC software, follow this priority order:
 
-### 1. Skill Discovery (always start here)
-```python
-# Find relevant skills by keyword
-result = search_skills(query="create sphere maya")
-# Load the skill to register its tools
-load_skill(skill_name="maya-geometry")
-# Now the skill's tools appear in tools/list
+### 1. CLI + Skill Discovery (always start here)
+
+Use `dcc-mcp-cli` for every shell-capable agent. Native MCP is the fallback for
+MCP-only clients or an explicit user choice.
+
+```bash
+dcc-mcp-cli dcc-types
+dcc-mcp-cli list
+dcc-mcp-cli search --query "create sphere" --dcc-type maya
+dcc-mcp-cli describe <tool-slug>
+dcc-mcp-cli load-skill maya-geometry --dcc-type maya
+dcc-mcp-cli call <tool-slug> --json '{"radius":2.0}'
 ```
+
+If the CLI is missing, obtain user consent before using the official release
+installers in `README.md`. Keep it current with `dcc-mcp-cli update check`,
+then `dcc-mcp-cli update apply`. The apply step stages the next CLI launch and
+does not replace a running server.
 
 ### 2. Skill-Based Tools (preferred over raw API calls)
 - Use skill tools (e.g. `maya_geometry__create_sphere`) — they have validated schemas, error handling, and `next-tools` guidance

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,10 @@
 
 ## 🚨 CRITICAL: Skills-First Philosophy
 
-**When interacting with DCC applications (Maya, Blender, Houdini, etc.), ALWAYS prefer dcc-mcp-core Skills over raw CLI or scripting.**
+**When interacting with DCC applications (Maya, Blender, Houdini, etc.), use
+`dcc-mcp-cli` as the control path for every shell-capable agent and invoke
+dcc-mcp-core Skills through it. Do not confuse the typed CLI with raw DCC
+scripting.**
 
 ### Why Skills-First?
 
@@ -21,10 +24,10 @@
 ### Skills-First Workflow (MEMORIZE!)
 
 ```
-1. DISCOVER: search_skills(query="keyword") → find the right skill
-2. CHECK: Read the skill's description and tools
-3. ACTIVATE: load_skill("skill-name") → expose the tools and cascade-activate declared tool groups by default
-4. EXECUTE: Call the specific tool with validated parameters
+1. DISCOVER: `dcc-mcp-cli search --query "keyword" --dcc-type <dcc>`
+2. CHECK: `dcc-mcp-cli describe <tool-slug>`
+3. ACTIVATE: `dcc-mcp-cli load-skill <skill-name> --dcc-type <dcc>` when required
+4. EXECUTE: `dcc-mcp-cli call <tool-slug> --json '{...}'`
 
 `search_tools` tokenizes backend tool names and summaries; literal underscores are honored but not required (`create_sphere` and `sphere` both match). Multi-word natural-language phrases ("create sphere", "rig framework") match word-split tokens across both names and descriptions.
 5. FOLLOW UP: Check next-tools.on-success for suggested next steps
@@ -33,8 +36,13 @@
 
 **❌ DON'T**: Run Maya/Blender/Python scripts directly via subprocess
 **❌ DON'T**: Guess tool names without searching
-**✅ DO**: Always use `search_skills()` before assuming a tool exists
+**✅ DO**: Always use `dcc-mcp-cli search` before assuming a tool exists
 **✅ DO**: Always check `next-tools` in results for workflow guidance
+
+If `dcc-mcp-cli` is missing, obtain user consent before using the official
+release installers in `README.md`. Keep it current with
+`dcc-mcp-cli update check`, then `dcc-mcp-cli update apply`; apply stages the
+next CLI launch and does not replace a running server.
 
 **New to this project?** Read [`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md) FIRST.
 

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -35,6 +35,15 @@ install lifecycle, or cross-DCC verification.
 For individual skill packages (`SKILL.md`, `tools.yaml`, scripts, groups, and
 skill taxonomy), load `dcc-mcp-skills-creator` instead.
 
+## CLI-First Control Path
+
+Use the `dcc-mcp` skill and `dcc-mcp-cli` for discovery, validation, and live
+DCC control whenever the agent can run shell commands. If the CLI is missing,
+follow the consent-gated official installation instructions in `dcc-mcp`.
+Before long-lived validation, run `dcc-mcp-cli update check`; use
+`dcc-mcp-cli update apply` to stage the latest CLI for the next launch. This
+does not replace a running server binary.
+
 ## Runtime Vocabulary
 
 - DCC startup hook: adapter code running inside the host at application startup; it prepares env/instance data and launches the service path without blocking the DCC UI/main thread.

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -64,6 +64,15 @@ The local instance port is OS-assigned by default. The CLI and gateway discover
 the resolved URL through the shared registry; pass an explicit port only when
 an external integration requires a fixed listener.
 
+## CLI-First Control Path
+
+Use the `dcc-mcp` skill and `dcc-mcp-cli` for skill discovery, loading,
+validation, and live calls whenever the agent can run shell commands. If the
+CLI is missing, follow the consent-gated official installation instructions in
+`dcc-mcp`. Keep it current with `dcc-mcp-cli update check`, then
+`dcc-mcp-cli update apply`; the apply step stages the next CLI launch and does
+not replace a running server binary.
+
 ## Quick Start
 
 ### Create a new skill

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -82,31 +82,50 @@ different DCC application.
 
 ## Agent Path vs IDE Path
 
-DCC-MCP supports two integration paths. Pick the one that matches how the user
-works — do not force IDE users onto the CLI, and do not ask agents to configure
-MCP when they can run shell.
+DCC-MCP supports two integration paths. `dcc-mcp-cli` is the default for every
+shell-capable agent. Native MCP remains the fallback for MCP-only IDE clients
+or when the user explicitly chooses that integration.
 
 | Dimension | **Agent path** (this skill) | **IDE path** (native MCP) |
 |-----------|----------------------------|---------------------------|
-| **Who** | OpenClaw, Hermes, Codex CLI, CI bots, custom agent runtimes, any host with shell | Cursor, Claude Desktop, VS Code MCP, other MCP-native clients |
+| **Who** | OpenClaw, Hermes, Codex CLI, CI bots, custom agent runtimes, and any other host with shell access | MCP-only Cursor, Claude Desktop, VS Code MCP, or another client without shell access |
 | **Transport** | `dcc-mcp-cli` → local MCP or remote gateway REST | MCP Streamable HTTP → gateway `/mcp` |
 | **Discovery surface** | `search` → `describe` → `call` via CLI or bundled Python helper | Gateway MCP tools: `search`, `describe`, `load_skill`, `call` |
-| **Setup** | Install this skill; optional `dcc-mcp-cli` on `PATH` or `--ensure-cli` with consent | Add gateway URL to IDE MCP settings (see repo `docs/guide/*`) |
-| **When to choose** | Host has no MCP connector, runs headless, or studio wants one forkable skill | User already works inside an IDE with MCP configured |
+| **Setup** | Install this skill and keep the official `dcc-mcp-cli` on `PATH`; installation/download requires user consent | Add gateway URL to IDE MCP settings (see repo `docs/guide/*`) |
+| **When to choose** | Default whenever the agent can run shell commands | The client cannot run shell commands or the user explicitly requests native MCP |
 | **Resources / prompts** | Not covered here; use REST `/v1/context` or IDE MCP if needed | `resources/read`, `prompts/get`, SSE subscribe via MCP |
 
 **Decision rules for agents loading this skill:**
 
 1. **Use this routing policy first** for every DCC-control request, whether the
    host is MCP-native or shell-only.
-2. **MCP-native host** — call the gateway/DCC structured tools directly
+2. **Shell-capable host** — use `dcc-mcp-cli`
+   (`inventory` → `search` → `describe` or `load-skill` → `call`), even when a
+   native MCP connector is also available.
+3. **MCP-only host** — call the gateway/DCC structured tools directly
    (`inventory` → `search` → `describe` or `load_skill` → `call`). Do not ask the
    user to switch clients or manually repeat the operation.
-3. **Shell-only host** — use `dcc-mcp-cli` (`search` → `describe` → `call`).
 4. **Do not mix paths in one turn** — pick CLI+REST or MCP for the whole task,
    not both.
 5. **Zero instances** — stop, explain, ask consent before bootstrap; see
    [`references/ZERO_INSTANCES_CLI.md`](references/ZERO_INSTANCES_CLI.md).
+
+### CLI installation
+
+If `dcc-mcp-cli` is missing, obtain the user's consent before installing the
+latest official release:
+
+```bash
+# Linux/macOS
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+```
+
+After installation, use `dcc-mcp-cli update check` and
+`dcc-mcp-cli update apply` to keep the CLI current. The apply step stages the
+new CLI for the next launch; it does not update a running `dcc-mcp-server`.
 
 ### Computer Use fallback
 

--- a/skills/dcc-mcp/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-mcp/references/CLI_CHEATSHEET.md
@@ -3,32 +3,37 @@
 Default profile: `local`. Remote gateways are selected with
 `dcc-mcp-cli gateway set <name>` or one-off `--gateway <name>`.
 
-Primary tool: `dcc-mcp-cli` — the CLI is the **default path for AI agents**.
-Fallback: `python scripts/dcc_gateway.py` when the CLI binary is unavailable.
+Primary tool: `dcc-mcp-cli` — the CLI is the **default path for every
+shell-capable AI agent**. Native MCP is the fallback for MCP-only clients or an
+explicit user choice.
 
 ## CLI setup
 
-`dcc-mcp-cli` ships with the gateway. If missing, ask user permission then
-ensure it:
+If `dcc-mcp-cli` is missing, obtain user consent before installing the latest
+official release:
+
+```bash
+# Linux/macOS
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+```
+
+Keep an official build current through the release manifest:
+
+```bash
+dcc-mcp-cli update check
+dcc-mcp-cli update apply
+```
+
+`update apply` downloads and stages the latest CLI for the next launch. It does
+not update a running `dcc-mcp-server`; update that server in its own environment.
+
+For repository development only, the consent-gated bootstrap/fallback is:
 
 ```bash
 vx python scripts/dcc_gateway.py --ensure-cli list
-```
-
-If the CLI binary is not yet on `$PATH`, the gateway downloads it from GitHub
-Releases and places it under `~/.dcc-mcp/bin/`. Add this directory to `$PATH`
-for direct `dcc-mcp-cli` access.
-
-If download fails, the Python fallback runs automatically.
-
-If Python is not available as `python` / `py`, install vx first:
-
-```bash
-# Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
-
-# Windows PowerShell
-powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
 ```
 
 ## Discovery and health

--- a/skills/marketplace-create-extension/SKILL.md
+++ b/skills/marketplace-create-extension/SKILL.md
@@ -27,6 +27,13 @@ metadata:
 
 # Marketplace Create Extension
 
+## CLI-First Control Path
+
+For marketplace and live-DCC operations, use the `dcc-mcp` skill and
+`dcc-mcp-cli` whenever shell access is available. Its consent-gated install and
+`update check` → `update apply` contract is the single source of truth; do not
+invent a package-local CLI bootstrap path.
+
 Scaffold a new marketplace extension package with the standard dcc-mcp
 skill layout and MIT-0 licensing. Follows the same patterns as
 `dcc-mcp-skills-creator`.

--- a/skills/marketplace-publish-extension/SKILL.md
+++ b/skills/marketplace-publish-extension/SKILL.md
@@ -28,6 +28,13 @@ metadata:
 
 # Marketplace Publish Extension
 
+## CLI-First Control Path
+
+For marketplace and live-DCC operations, use the `dcc-mcp` skill and
+`dcc-mcp-cli` whenever shell access is available. Its consent-gated install and
+`update check` → `update apply` contract is the single source of truth; do not
+invent a package-local CLI bootstrap path.
+
 Publish (register or update) a dcc-mcp extension package to a marketplace
 catalog (`marketplace.json`).
 


### PR DESCRIPTION
## Summary
- make dcc-mcp-cli the default control path for shell-capable agents
- document consent-gated official installation and self-update commands
- keep server binary updates explicitly separate

## Validation
- dcc-mcp-cli skill lint: 0 errors, 0 warnings
- VitePress documentation build