### PR TITLE
refactor: extract overlay subsystem from windows.rs to satisfy file size gate

### DIFF
--- a/crates/dcc-mcp-computer-use/src/platform/windows.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows.rs
@@ -1,24 +1,19 @@
-use std::cell::Cell;
 use std::mem::size_of;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use windows::Win32::Foundation::{
-    COLORREF, CloseHandle, HANDLE, HWND, LPARAM, LRESULT, POINT, RECT, WAIT_ABANDONED,
+    COLORREF, CloseHandle, HANDLE, HWND, LPARAM, POINT, RECT, WAIT_ABANDONED,
     WAIT_OBJECT_0, WAIT_TIMEOUT, WPARAM,
 };
 use windows::Win32::Graphics::Gdi::{
-    BeginPaint, CLEARTYPE_QUALITY, CLIP_DEFAULT_PRECIS, CombineRgn, CreateEllipticRgn, CreateFontW,
-    CreateRoundRectRgn, CreateSolidBrush, DEFAULT_CHARSET, DEFAULT_PITCH, DT_CENTER,
-    DT_END_ELLIPSIS, DT_SINGLELINE, DT_VCENTER, DeleteObject, DrawTextW, EndPaint,
-    EnumDisplayMonitors, FW_SEMIBOLD, GetMonitorInfoW, HDC, HGDIOBJ, HMONITOR,
-    MONITOR_DEFAULTTONULL, MONITORINFO, MonitorFromPoint, MonitorFromRect, OUT_DEFAULT_PRECIS,
-    PAINTSTRUCT, RGN_DIFF, RGN_ERROR, SelectObject, SetBkMode, SetTextColor, SetWindowRgn,
-    TRANSPARENT,
+    EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR,
+    MONITOR_DEFAULTTONULL, MONITORINFO, MonitorFromPoint, MonitorFromRect,
 };
-use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+#[cfg(test)]
+use windows::Win32::Graphics::Gdi::{DeleteObject, HGDIOBJ, RGN_ERROR};
 use windows::Win32::System::RemoteDesktop::{
     NOTIFY_FOR_THIS_SESSION, WTS_CONNECTSTATE_CLASS, WTS_CURRENT_SESSION, WTSActive,
     WTSConnectState, WTSFreeMemory, WTSQuerySessionInformationW, WTSRegisterSessionNotification,
@@ -45,21 +40,20 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     MOUSEINPUT, RegisterHotKey, SendInput, UnregisterHotKey, VIRTUAL_KEY, VK_ESCAPE,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
-    BringWindowToTop, CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GA_ROOT,
-    GW_HWNDPREV, GWL_EXSTYLE, GetAncestor, GetClassNameW, GetClientRect, GetCursorPos,
-    GetForegroundWindow, GetSystemMetrics, GetWindow, GetWindowLongPtrW, GetWindowRect,
-    GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId, HWND_NOTOPMOST, HWND_TOPMOST,
-    IsIconic, IsWindow, IsWindowVisible, LWA_ALPHA, MSG, PM_NOREMOVE, PM_REMOVE, PeekMessageW,
-    PostMessageW, RegisterClassW, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN,
-    SM_YVIRTUALSCREEN, SW_HIDE, SW_RESTORE, SW_SHOWNOACTIVATE, SWP_NOACTIVATE, SWP_NOMOVE,
-    SWP_NOSIZE, SWP_SHOWWINDOW, SetForegroundWindow, SetLayeredWindowAttributes,
-    SetWindowDisplayAffinity, SetWindowPos, ShowWindow, TranslateMessage, WDA_EXCLUDEFROMCAPTURE,
-    WINDOW_EX_STYLE, WINDOW_STYLE, WM_APP, WM_DISPLAYCHANGE, WM_DPICHANGED, WM_HOTKEY, WM_PAINT,
-    WM_WTSSESSION_CHANGE, WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
-    WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_POPUP, WTS_CONSOLE_CONNECT, WTS_CONSOLE_DISCONNECT,
+    BringWindowToTop, DestroyWindow, DispatchMessageW, GA_ROOT,
+    GW_HWNDPREV, GWL_EXSTYLE, GetAncestor, GetClassNameW, GetCursorPos,
+    GetForegroundWindow, GetSystemMetrics, GetWindow, GetWindowLongPtrW, GetWindowRect, GetWindowThreadProcessId, HWND_NOTOPMOST, HWND_TOPMOST,
+    IsIconic, IsWindow, IsWindowVisible, MSG, PM_NOREMOVE, PM_REMOVE, PeekMessageW,
+    PostMessageW, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN,
+    SM_YVIRTUALSCREEN, SW_RESTORE, SWP_NOACTIVATE, SWP_NOMOVE,
+    SWP_NOSIZE, SWP_SHOWWINDOW, SetForegroundWindow, SetWindowPos, ShowWindow, TranslateMessage, WM_APP, WM_DISPLAYCHANGE, WM_DPICHANGED, WM_HOTKEY,
+    WM_WTSSESSION_CHANGE,
+    WS_EX_TOPMOST, WS_EX_TRANSPARENT, WTS_CONSOLE_CONNECT, WTS_CONSOLE_DISCONNECT,
     WTS_REMOTE_CONNECT, WTS_REMOTE_DISCONNECT, WTS_SESSION_LOCK, WTS_SESSION_UNLOCK,
     WindowFromPoint,
 };
+#[cfg(test)]
+use windows::Win32::UI::WindowsAndMessaging::WS_EX_NOACTIVATE;
 use windows::core::{BOOL, PCWSTR, PWSTR, w};
 
 use crate::{
@@ -761,41 +755,6 @@ pub(crate) fn start_control_banner(
     }
 }
 
-struct OverlayLayer {
-    hwnd: HWND,
-    base_alpha: u8,
-    applied_alpha: Cell<u8>,
-}
-
-impl OverlayLayer {
-    fn new(hwnd: HWND, base_alpha: u8, applied_alpha: u8) -> Self {
-        Self {
-            hwnd,
-            base_alpha,
-            applied_alpha: Cell::new(applied_alpha),
-        }
-    }
-
-    fn apply_pulse(&self, floor_percent: u8, elapsed_ms: u64) -> ComputerUseResult<()> {
-        let alpha = breathing_alpha(self.base_alpha, floor_percent, elapsed_ms);
-        if alpha != self.applied_alpha.get() {
-            set_overlay_alpha(self.hwnd, alpha)?;
-            self.applied_alpha.set(alpha);
-        }
-        Ok(())
-    }
-}
-
-struct ControlOverlay {
-    capsule_glow: OverlayLayer,
-    capsule: OverlayLayer,
-    corners: Vec<OverlayLayer>,
-    cursor_ring: OverlayLayer,
-    cursor_ring_size: Cell<i32>,
-    cursor_visible: Cell<bool>,
-    pulse_started: Instant,
-}
-
 struct RegisteredHotKey {
     hwnd: HWND,
 }
@@ -852,458 +811,6 @@ impl Drop for RegisteredSessionNotifications {
     }
 }
 
-impl ControlOverlay {
-    fn new(
-        target: HWND,
-        target_rect: &windows::Win32::Foundation::RECT,
-        caption: &str,
-    ) -> ComputerUseResult<Self> {
-        let (capsule_geometry, corner_geometries) = overlay_geometries(target, target_rect)?;
-        let capsule_glow_geometry = capsule_glow_geometry(capsule_geometry);
-        let capsule_glow_alpha = breathing_alpha(
-            CONTROL_CAPSULE_GLOW_ALPHA,
-            CONTROL_BORDER_PULSE_FLOOR_PERCENT,
-            0,
-        );
-        let capsule_glow = OverlayLayer::new(
-            create_color_overlay(
-                "",
-                capsule_glow_geometry,
-                capsule_glow_alpha,
-                false,
-                OverlayTone::Glow,
-            )?,
-            CONTROL_CAPSULE_GLOW_ALPHA,
-            capsule_glow_alpha,
-        );
-        let capsule_alpha = breathing_alpha(
-            CONTROL_CAPSULE_ALPHA,
-            CONTROL_CAPSULE_PULSE_FLOOR_PERCENT,
-            0,
-        );
-        let capsule = match create_color_overlay(
-            caption,
-            capsule_geometry,
-            capsule_alpha,
-            false,
-            OverlayTone::Accent,
-        ) {
-            Ok(hwnd) => OverlayLayer::new(hwnd, CONTROL_CAPSULE_ALPHA, capsule_alpha),
-            Err(error) => {
-                let _ = unsafe { DestroyWindow(capsule_glow.hwnd) };
-                return Err(error);
-            }
-        };
-        let mut corners = Vec::with_capacity(corner_geometries.len());
-        for (geometry, alpha, focus) in corner_geometries {
-            let initial_alpha = breathing_alpha(alpha, CONTROL_BORDER_PULSE_FLOOR_PERCENT, 0);
-            let tone = if focus {
-                OverlayTone::Glow
-            } else {
-                OverlayTone::Accent
-            };
-            match create_color_overlay("", geometry, initial_alpha, false, tone) {
-                Ok(hwnd) => corners.push(OverlayLayer::new(hwnd, alpha, initial_alpha)),
-                Err(error) => {
-                    for layer in corners {
-                        let _ = unsafe { DestroyWindow(layer.hwnd) };
-                    }
-                    let _ = unsafe { DestroyWindow(capsule.hwnd) };
-                    let _ = unsafe { DestroyWindow(capsule_glow.hwnd) };
-                    return Err(error);
-                }
-            }
-        }
-        let mut cursor = POINT::default();
-        if let Err(error) = unsafe { GetCursorPos(&mut cursor) } {
-            for layer in corners {
-                let _ = unsafe { DestroyWindow(layer.hwnd) };
-            }
-            let _ = unsafe { DestroyWindow(capsule.hwnd) };
-            let _ = unsafe { DestroyWindow(capsule_glow.hwnd) };
-            return Err(overlay_backend_error(
-                "locate the pointer for",
-                error.to_string(),
-            ));
-        }
-        let cursor_alpha =
-            breathing_alpha(CONTROL_CURSOR_ALPHA, CONTROL_CURSOR_PULSE_FLOOR_PERCENT, 0);
-        let cursor_geometry = pointer_ring_geometry(cursor.x, cursor.y);
-        let cursor_ring = match create_cursor_ring_overlay(cursor_geometry, cursor_alpha) {
-            Ok(hwnd) => OverlayLayer::new(hwnd, CONTROL_CURSOR_ALPHA, cursor_alpha),
-            Err(error) => {
-                for layer in corners {
-                    let _ = unsafe { DestroyWindow(layer.hwnd) };
-                }
-                let _ = unsafe { DestroyWindow(capsule.hwnd) };
-                let _ = unsafe { DestroyWindow(capsule_glow.hwnd) };
-                return Err(error);
-            }
-        };
-        let cursor_visible = point_in_rect(cursor, target_rect);
-        let overlay = Self {
-            capsule_glow,
-            capsule,
-            corners,
-            cursor_ring,
-            cursor_ring_size: Cell::new(cursor_geometry.2),
-            cursor_visible: Cell::new(cursor_visible),
-            pulse_started: Instant::now(),
-        };
-        overlay.set_visible(true)?;
-        Ok(overlay)
-    }
-
-    fn reposition(
-        &self,
-        target: HWND,
-        target_rect: &windows::Win32::Foundation::RECT,
-    ) -> ComputerUseResult<()> {
-        let (capsule_geometry, corner_geometries) = overlay_geometries(target, target_rect)?;
-        position_overlay(
-            self.capsule_glow.hwnd,
-            capsule_glow_geometry(capsule_geometry),
-            false,
-        )?;
-        position_overlay(self.capsule.hwnd, capsule_geometry, false)?;
-        for (layer, (geometry, _alpha, _focus)) in self.corners.iter().zip(corner_geometries) {
-            position_overlay(layer.hwnd, geometry, false)?;
-        }
-        let mut cursor = POINT::default();
-        unsafe { GetCursorPos(&mut cursor) }
-            .map_err(|error| overlay_backend_error("locate the pointer for", error.to_string()))?;
-        let cursor_visible = point_in_rect(cursor, target_rect);
-        if cursor_visible {
-            let geometry = pointer_ring_geometry(cursor.x, cursor.y);
-            position_overlay(self.cursor_ring.hwnd, geometry, false)?;
-            if geometry.2 != self.cursor_ring_size.get() {
-                set_pointer_ring_region(self.cursor_ring.hwnd, geometry.2, geometry.3)?;
-                self.cursor_ring_size.set(geometry.2);
-            }
-        }
-        if cursor_visible != self.cursor_visible.get() {
-            set_overlay_visible(self.cursor_ring.hwnd, cursor_visible)?;
-            self.cursor_visible.set(cursor_visible);
-        }
-        let elapsed_ms = self.pulse_started.elapsed().as_millis() as u64;
-        self.capsule_glow
-            .apply_pulse(CONTROL_BORDER_PULSE_FLOOR_PERCENT, elapsed_ms)?;
-        self.capsule
-            .apply_pulse(CONTROL_CAPSULE_PULSE_FLOOR_PERCENT, elapsed_ms)?;
-        for layer in &self.corners {
-            layer.apply_pulse(CONTROL_BORDER_PULSE_FLOOR_PERCENT, elapsed_ms)?;
-        }
-        self.cursor_ring
-            .apply_pulse(CONTROL_CURSOR_PULSE_FLOOR_PERCENT, elapsed_ms)?;
-        Ok(())
-    }
-
-    fn set_visible(&self, visible: bool) -> ComputerUseResult<()> {
-        set_overlay_visible(self.capsule_glow.hwnd, visible)?;
-        set_overlay_visible(self.capsule.hwnd, visible)?;
-        for layer in &self.corners {
-            set_overlay_visible(layer.hwnd, visible)?;
-        }
-        if visible {
-            if self.cursor_visible.get() {
-                set_overlay_visible(self.cursor_ring.hwnd, true)?;
-            }
-        } else if self.cursor_visible.replace(false) {
-            set_overlay_visible(self.cursor_ring.hwnd, false)?;
-        }
-        Ok(())
-    }
-}
-
-impl Drop for ControlOverlay {
-    fn drop(&mut self) {
-        for layer in self.corners.drain(..) {
-            let _ = unsafe { DestroyWindow(layer.hwnd) };
-        }
-        let _ = unsafe { DestroyWindow(self.cursor_ring.hwnd) };
-        let _ = unsafe { DestroyWindow(self.capsule.hwnd) };
-        let _ = unsafe { DestroyWindow(self.capsule_glow.hwnd) };
-    }
-}
-
-#[derive(Clone, Copy)]
-enum OverlayTone {
-    Accent,
-    Glow,
-    Cursor,
-}
-
-fn register_color_overlay_classes() -> ComputerUseResult<()> {
-    static REGISTERED: OnceLock<Result<(), String>> = OnceLock::new();
-    REGISTERED
-        .get_or_init(|| {
-            let instance = unsafe { GetModuleHandleW(None) }
-                .map_err(|error| format!("resolve module handle: {error}"))?;
-            for (class_name, color) in [
-                (CONTROL_OVERLAY_CLASS, CONTROL_ACCENT_COLOR),
-                (CONTROL_GLOW_CLASS, CONTROL_GLOW_COLOR),
-                (CONTROL_CURSOR_CLASS, CONTROL_CURSOR_COLOR),
-            ] {
-                let class = WNDCLASSW {
-                    lpfnWndProc: Some(overlay_window_proc),
-                    hInstance: instance.into(),
-                    hbrBackground: unsafe { CreateSolidBrush(color) },
-                    lpszClassName: class_name,
-                    ..Default::default()
-                };
-                let atom = unsafe { RegisterClassW(&class) };
-                if atom == 0 {
-                    return Err(format!(
-                        "register overlay window class: {}",
-                        windows::core::Error::from_thread()
-                    ));
-                }
-            }
-            Ok(())
-        })
-        .clone()
-        .map_err(|detail| overlay_backend_error("register", detail))
-}
-
-unsafe extern "system" fn overlay_window_proc(
-    hwnd: HWND,
-    message: u32,
-    wparam: WPARAM,
-    lparam: LPARAM,
-) -> LRESULT {
-    if message == WM_PAINT {
-        let mut paint = PAINTSTRUCT::default();
-        let device = unsafe { BeginPaint(hwnd, &raw mut paint) };
-        if !device.0.is_null() {
-            let mut bounds = RECT::default();
-            let _ = unsafe { GetClientRect(hwnd, &raw mut bounds) };
-            let mut class_name = [0_u16; 64];
-            let class_length = unsafe { GetClassNameW(hwnd, &mut class_name) }.max(0) as usize;
-            let color = match String::from_utf16_lossy(&class_name[..class_length]).as_ref() {
-                "DccMcpComputerUseGlowOverlay" => CONTROL_GLOW_COLOR,
-                "DccMcpComputerUseCursorOverlay" => CONTROL_CURSOR_COLOR,
-                _ => CONTROL_ACCENT_COLOR,
-            };
-            let brush = unsafe { CreateSolidBrush(color) };
-            let _ = unsafe { windows::Win32::Graphics::Gdi::FillRect(device, &bounds, brush) };
-            let _ = unsafe { DeleteObject(HGDIOBJ(brush.0)) };
-
-            let text_length = unsafe { GetWindowTextLengthW(hwnd) }.max(0) as usize;
-            if text_length > 0 {
-                let mut text = vec![0_u16; text_length + 1];
-                let copied = unsafe { GetWindowTextW(hwnd, &mut text) }.max(0) as usize;
-                text.truncate(copied);
-                let dpi = unsafe { GetDpiForWindow(hwnd) }.max(96);
-                let font = unsafe {
-                    CreateFontW(
-                        -scaled_pixels(CONTROL_CAPSULE_FONT_SIZE, dpi),
-                        0,
-                        0,
-                        0,
-                        FW_SEMIBOLD.0 as i32,
-                        0,
-                        0,
-                        0,
-                        DEFAULT_CHARSET,
-                        OUT_DEFAULT_PRECIS,
-                        CLIP_DEFAULT_PRECIS,
-                        CLEARTYPE_QUALITY,
-                        u32::from(DEFAULT_PITCH.0),
-                        w!("Segoe UI Semibold"),
-                    )
-                };
-                if !font.0.is_null() {
-                    let old_font = unsafe { SelectObject(device, HGDIOBJ(font.0)) };
-                    let _ = unsafe { SetBkMode(device, TRANSPARENT) };
-                    let _ = unsafe { SetTextColor(device, COLORREF(0x00FF_FFFF)) };
-                    let format = windows::Win32::Graphics::Gdi::DRAW_TEXT_FORMAT(
-                        DT_CENTER.0 | DT_VCENTER.0 | DT_SINGLELINE.0 | DT_END_ELLIPSIS.0,
-                    );
-                    let _ = unsafe { DrawTextW(device, &mut text, &raw mut bounds, format) };
-                    let _ = unsafe { SelectObject(device, old_font) };
-                    let _ = unsafe { DeleteObject(HGDIOBJ(font.0)) };
-                }
-            }
-        }
-        let _ = unsafe { EndPaint(hwnd, &paint) };
-        return LRESULT(0);
-    }
-    unsafe { DefWindowProcW(hwnd, message, wparam, lparam) }
-}
-
-fn create_color_overlay(
-    caption: &str,
-    (x, y, width, height): OverlayGeometry,
-    alpha: u8,
-    show: bool,
-    tone: OverlayTone,
-) -> ComputerUseResult<HWND> {
-    register_color_overlay_classes()?;
-    let caption = wide(caption);
-    let style = WINDOW_STYLE(WS_POPUP.0);
-    let ex_style = WINDOW_EX_STYLE(
-        WS_EX_TOPMOST.0
-            | WS_EX_TOOLWINDOW.0
-            | WS_EX_NOACTIVATE.0
-            | WS_EX_TRANSPARENT.0
-            | WS_EX_LAYERED.0,
-    );
-    let hwnd = unsafe {
-        CreateWindowExW(
-            ex_style,
-            match tone {
-                OverlayTone::Accent => CONTROL_OVERLAY_CLASS,
-                OverlayTone::Glow => CONTROL_GLOW_CLASS,
-                OverlayTone::Cursor => CONTROL_CURSOR_CLASS,
-            },
-            PCWSTR(caption.as_ptr()),
-            style,
-            x,
-            y,
-            width,
-            height,
-            None,
-            None,
-            None,
-            None,
-        )
-    }
-    .map_err(|error| overlay_backend_error("create", error.to_string()))?;
-    if let Err(error) = exclude_overlay_from_capture(hwnd) {
-        let _ = unsafe { DestroyWindow(hwnd) };
-        return Err(error);
-    }
-    if let Err(error) = set_overlay_alpha(hwnd, alpha) {
-        let _ = unsafe { DestroyWindow(hwnd) };
-        return Err(error);
-    }
-    let radius = width.min(height).max(1);
-    let region = unsafe { CreateRoundRectRgn(0, 0, width, height, radius, radius) };
-    if region.0.is_null() || unsafe { SetWindowRgn(hwnd, Some(region), true) } == 0 {
-        let _ = unsafe { DestroyWindow(hwnd) };
-        return Err(overlay_backend_error(
-            "round",
-            "Windows did not accept the overlay region",
-        ));
-    }
-    if let Err(error) = position_overlay(hwnd, (x, y, width, height), show) {
-        let _ = unsafe { DestroyWindow(hwnd) };
-        return Err(error);
-    }
-    pump_overlay_messages(hwnd);
-    Ok(hwnd)
-}
-
-fn create_cursor_ring_overlay(geometry: OverlayGeometry, alpha: u8) -> ComputerUseResult<HWND> {
-    let hwnd = create_color_overlay("", geometry, alpha, false, OverlayTone::Cursor)?;
-    if let Err(error) = set_pointer_ring_region(hwnd, geometry.2, geometry.3) {
-        let _ = unsafe { DestroyWindow(hwnd) };
-        return Err(error);
-    }
-    Ok(hwnd)
-}
-
-fn set_pointer_ring_region(hwnd: HWND, width: i32, height: i32) -> ComputerUseResult<()> {
-    let thickness = (width.min(height) / 12).max(3);
-    let outer = unsafe { CreateEllipticRgn(0, 0, width, height) };
-    let inner =
-        unsafe { CreateEllipticRgn(thickness, thickness, width - thickness, height - thickness) };
-    if outer.0.is_null() || inner.0.is_null() {
-        let _ = unsafe { DeleteObject(HGDIOBJ(outer.0)) };
-        let _ = unsafe { DeleteObject(HGDIOBJ(inner.0)) };
-        return Err(overlay_backend_error(
-            "shape",
-            "Windows could not create the pointer ring",
-        ));
-    }
-    let combined = unsafe { CombineRgn(Some(outer), Some(outer), Some(inner), RGN_DIFF) };
-    let _ = unsafe { DeleteObject(HGDIOBJ(inner.0)) };
-    if combined == RGN_ERROR || unsafe { SetWindowRgn(hwnd, Some(outer), true) } == 0 {
-        let _ = unsafe { DeleteObject(HGDIOBJ(outer.0)) };
-        return Err(overlay_backend_error(
-            "shape",
-            "Windows did not accept the pointer ring",
-        ));
-    }
-    Ok(())
-}
-
-fn set_overlay_alpha(hwnd: HWND, alpha: u8) -> ComputerUseResult<()> {
-    unsafe { SetLayeredWindowAttributes(hwnd, COLORREF(0), alpha, LWA_ALPHA) }
-        .map_err(|error| overlay_backend_error("configure transparency for", error.to_string()))
-}
-
-fn exclude_overlay_from_capture(hwnd: HWND) -> ComputerUseResult<()> {
-    unsafe { SetWindowDisplayAffinity(hwnd, WDA_EXCLUDEFROMCAPTURE) }
-        .map_err(|error| overlay_backend_error("exclude from capture", error.to_string()))
-}
-
-fn position_overlay(
-    hwnd: HWND,
-    (x, y, width, height): OverlayGeometry,
-    show: bool,
-) -> ComputerUseResult<()> {
-    let flags = if show {
-        SWP_NOACTIVATE | SWP_SHOWWINDOW
-    } else {
-        SWP_NOACTIVATE
-    };
-    unsafe { SetWindowPos(hwnd, Some(HWND_TOPMOST), x, y, width, height, flags) }
-        .map_err(|error| overlay_backend_error("position", error.to_string()))?;
-    let mut actual = RECT::default();
-    unsafe { GetWindowRect(hwnd, &mut actual) }
-        .map_err(|error| overlay_backend_error("verify the position of", error.to_string()))?;
-    if [
-        actual.left,
-        actual.top,
-        actual.right - actual.left,
-        actual.bottom - actual.top,
-    ] != [x, y, width, height]
-    {
-        return Err(overlay_backend_error(
-            "verify the position of",
-            "Windows reported unexpected overlay bounds",
-        ));
-    }
-    if show && !unsafe { IsWindowVisible(hwnd) }.as_bool() {
-        return Err(overlay_backend_error(
-            "show",
-            "Windows did not make the overlay visible",
-        ));
-    }
-    Ok(())
-}
-
-fn set_overlay_visible(hwnd: HWND, visible: bool) -> ComputerUseResult<()> {
-    let command = if visible { SW_SHOWNOACTIVATE } else { SW_HIDE };
-    let _ = unsafe { ShowWindow(hwnd, command) };
-    pump_overlay_messages(hwnd);
-    if unsafe { IsWindowVisible(hwnd) }.as_bool() != visible {
-        return Err(overlay_backend_error(
-            if visible { "show" } else { "hide" },
-            "Windows did not apply the requested visibility",
-        ));
-    }
-    Ok(())
-}
-
-fn overlay_backend_error(operation: &str, detail: impl std::fmt::Display) -> ComputerUseError {
-    ComputerUseError::new(
-        ComputerUseErrorCode::BackendUnavailable,
-        format!("failed to {operation} the DCC UI Control visual overlay: {detail}"),
-    )
-}
-
-fn pump_overlay_messages(hwnd: HWND) {
-    let mut message = MSG::default();
-    while unsafe { PeekMessageW(&mut message, Some(hwnd), 0, 0, PM_REMOVE) }.as_bool() {
-        unsafe {
-            let _ = TranslateMessage(&message);
-            DispatchMessageW(&message);
-        }
-    }
-}
-
 fn session_event_blocked(event: u32) -> Option<bool> {
     match event {
         WTS_SESSION_LOCK | WTS_CONSOLE_DISCONNECT | WTS_REMOTE_DISCONNECT => Some(true),
@@ -1335,7 +842,7 @@ fn run_banner(
 
     let hotkey_result = unsafe {
         RegisterHotKey(
-            Some(overlay.capsule.hwnd),
+            Some(overlay.message_hwnd()),
             HOTKEY_ID,
             STOP_HOTKEY_MODIFIERS,
             VK_ESCAPE.0 as u32,
@@ -1348,11 +855,11 @@ fn run_banner(
         ));
     }
     let _hotkey = RegisteredHotKey {
-        hwnd: overlay.capsule.hwnd,
+        hwnd: overlay.message_hwnd(),
     };
-    let _session_notifications = RegisteredSessionNotifications::new(overlay.capsule.hwnd)?;
+    let _session_notifications = RegisteredSessionNotifications::new(overlay.message_hwnd())?;
     let _desktop_barrier =
-        RegisteredDesktopBarrier::new(Arc::clone(&signals.desktop_barrier), overlay.capsule.hwnd);
+        RegisteredDesktopBarrier::new(Arc::clone(&signals.desktop_barrier), overlay.message_hwnd());
     let mut display_stamp = display_environment_stamp()?;
 
     record_desktop_transition(&signals.desktop_state, true);
@@ -1530,6 +1037,13 @@ pub(crate) fn clear_user_interrupt() -> ComputerUseResult<()> {
 
 mod geometry;
 mod input;
+mod overlay;
 
 use geometry::*;
+use overlay::{
+    ControlOverlay, OverlayTone, create_color_overlay,
+    position_overlay, pump_overlay_messages,
+};
+#[cfg(test)]
+use overlay::{create_cursor_ring_overlay, set_overlay_visible};
 pub(crate) use input::{flush_pending_input_releases, perform_action, window_dpi};

--- a/crates/dcc-mcp-computer-use/src/platform/windows/geometry.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/geometry.rs
@@ -192,12 +192,12 @@ pub(super) fn display_environment_stamp() -> ComputerUseResult<Vec<MonitorStamp>
     Ok(stamps)
 }
 
-pub(super) fn scaled_pixels(pixels: i32, dpi: u32) -> i32 {
+pub(crate) fn scaled_pixels(pixels: i32, dpi: u32) -> i32 {
     let scaled = (i64::from(pixels) * i64::from(dpi.max(96)) + 48) / 96;
     scaled.clamp(1, i64::from(i32::MAX)) as i32
 }
 
-pub(super) fn breathing_alpha(base_alpha: u8, floor_percent: u8, elapsed_ms: u64) -> u8 {
+pub(crate) fn breathing_alpha(base_alpha: u8, floor_percent: u8, elapsed_ms: u64) -> u8 {
     let floor = f32::from(floor_percent.min(100)) / 100.0;
     let phase = (elapsed_ms % CONTROL_PULSE_PERIOD_MS) as f32 / CONTROL_PULSE_PERIOD_MS as f32;
     let wave = 0.5 - 0.5 * (std::f32::consts::TAU * phase).cos();
@@ -214,7 +214,7 @@ pub(super) fn target_unavailable() -> ComputerUseError {
     )
 }
 
-pub(super) fn overlay_geometries(
+pub(crate) fn overlay_geometries(
     target: HWND,
     target_rect: &RECT,
 ) -> ComputerUseResult<(OverlayGeometry, CornerGeometries)> {
@@ -243,7 +243,7 @@ pub(super) fn capsule_geometry(rect: &RECT, display_rect: &RECT, dpi: u32) -> Ov
     (x, y, width, height)
 }
 
-pub(super) fn capsule_glow_geometry((x, y, width, height): OverlayGeometry) -> OverlayGeometry {
+pub(crate) fn capsule_glow_geometry((x, y, width, height): OverlayGeometry) -> OverlayGeometry {
     let halo = (height / 7).max(4);
     (
         x.saturating_sub(halo),
@@ -341,7 +341,7 @@ pub(super) fn corner_geometries(rect: &RECT, dpi: u32) -> CornerGeometries {
         .collect()
 }
 
-pub(super) fn point_in_rect(point: POINT, rect: &RECT) -> bool {
+pub(crate) fn point_in_rect(point: POINT, rect: &RECT) -> bool {
     point.x >= rect.left && point.x < rect.right && point.y >= rect.top && point.y < rect.bottom
 }
 
@@ -349,7 +349,7 @@ pub(super) fn pointer_mask_geometry(screen_x: i32, screen_y: i32) -> OverlayGeom
     pointer_geometry(screen_x, screen_y, POINTER_EFFECT_SIZE)
 }
 
-pub(super) fn pointer_ring_geometry(screen_x: i32, screen_y: i32) -> OverlayGeometry {
+pub(crate) fn pointer_ring_geometry(screen_x: i32, screen_y: i32) -> OverlayGeometry {
     pointer_geometry(screen_x, screen_y, POINTER_RING_SIZE)
 }
 
@@ -378,6 +378,6 @@ fn pointer_geometry(screen_x: i32, screen_y: i32, logical_size: i32) -> OverlayG
     )
 }
 
-pub(super) fn wide(value: &str) -> Vec<u16> {
+pub(crate) fn wide(value: &str) -> Vec<u16> {
     value.encode_utf16().chain(std::iter::once(0)).collect()
 }

--- a/crates/dcc-mcp-computer-use/src/platform/windows/overlay.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/overlay.rs
@@ -1,0 +1,531 @@
+use std::cell::Cell;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use windows::Win32::Foundation::{COLORREF, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
+use windows::Win32::Graphics::Gdi::{
+    BeginPaint, CLEARTYPE_QUALITY, CLIP_DEFAULT_PRECIS, CombineRgn, CreateEllipticRgn, CreateFontW,
+    CreateRoundRectRgn, CreateSolidBrush, DEFAULT_CHARSET, DEFAULT_PITCH, DT_CENTER,
+    DT_END_ELLIPSIS, DT_SINGLELINE, DT_VCENTER, DeleteObject, DrawTextW, EndPaint,
+    FW_SEMIBOLD, HGDIOBJ, OUT_DEFAULT_PRECIS, PAINTSTRUCT, RGN_DIFF, RGN_ERROR, SelectObject,
+    SetBkMode, SetTextColor, SetWindowRgn, TRANSPARENT,
+};
+use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+use windows::Win32::UI::HiDpi::GetDpiForWindow;
+use windows::Win32::UI::WindowsAndMessaging::{
+    CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetClassNameW, GetClientRect,
+    GetCursorPos, GetWindowRect, GetWindowTextLengthW, GetWindowTextW, IsWindowVisible, LWA_ALPHA,
+    MSG, PM_REMOVE, PeekMessageW, RegisterClassW, SetLayeredWindowAttributes,
+    SetWindowDisplayAffinity, SetWindowPos, ShowWindow, SWP_NOACTIVATE, SWP_SHOWWINDOW,
+    SW_HIDE, SW_SHOWNOACTIVATE, TranslateMessage, WDA_EXCLUDEFROMCAPTURE, WINDOW_EX_STYLE,
+    WINDOW_STYLE, WM_PAINT, WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
+    WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_POPUP, HWND_TOPMOST,
+};
+use windows::core::{PCWSTR, w};
+
+use crate::{
+    ComputerUseError, ComputerUseErrorCode, ComputerUseResult,
+};
+
+use super::{
+    CONTROL_CAPSULE_ALPHA, CONTROL_CAPSULE_GLOW_ALPHA, CONTROL_CURSOR_ALPHA,
+    CONTROL_CAPSULE_FONT_SIZE, CONTROL_BORDER_PULSE_FLOOR_PERCENT,
+    CONTROL_CAPSULE_PULSE_FLOOR_PERCENT, CONTROL_CURSOR_PULSE_FLOOR_PERCENT,
+    CONTROL_ACCENT_COLOR, CONTROL_GLOW_COLOR, CONTROL_CURSOR_COLOR, CONTROL_OVERLAY_CLASS,
+    CONTROL_GLOW_CLASS, CONTROL_CURSOR_CLASS, OverlayGeometry,
+};
+use super::geometry::{
+    breathing_alpha, capsule_glow_geometry, overlay_geometries, point_in_rect,
+    pointer_ring_geometry, scaled_pixels, wide,
+};
+
+struct OverlayLayer {
+    hwnd: HWND,
+    base_alpha: u8,
+    applied_alpha: Cell<u8>,
+}
+
+impl OverlayLayer {
+    fn new(hwnd: HWND, base_alpha: u8, applied_alpha: u8) -> Self {
+        Self {
+            hwnd,
+            base_alpha,
+            applied_alpha: Cell::new(applied_alpha),
+        }
+    }
+
+    fn apply_pulse(&self, floor_percent: u8, elapsed_ms: u64) -> ComputerUseResult<()> {
+        let alpha = breathing_alpha(self.base_alpha, floor_percent, elapsed_ms);
+        if alpha != self.applied_alpha.get() {
+            set_overlay_alpha(self.hwnd, alpha)?;
+            self.applied_alpha.set(alpha);
+        }
+        Ok(())
+    }
+}
+
+pub(super) struct ControlOverlay {
+    capsule_glow: OverlayLayer,
+    capsule: OverlayLayer,
+    corners: Vec<OverlayLayer>,
+    cursor_ring: OverlayLayer,
+    cursor_ring_size: Cell<i32>,
+    cursor_visible: Cell<bool>,
+    pulse_started: Instant,
+}
+
+impl ControlOverlay {
+    pub(super) fn new(
+        target: HWND,
+        target_rect: &windows::Win32::Foundation::RECT,
+        caption: &str,
+    ) -> ComputerUseResult<Self> {
+        let (capsule_geometry, corner_geometries) = overlay_geometries(target, target_rect)?;
+        let capsule_glow_geometry = capsule_glow_geometry(capsule_geometry);
+        let capsule_glow_alpha = breathing_alpha(
+            CONTROL_CAPSULE_GLOW_ALPHA,
+            CONTROL_BORDER_PULSE_FLOOR_PERCENT,
+            0,
+        );
+        let capsule_glow = OverlayLayer::new(
+            create_color_overlay(
+                "",
+                capsule_glow_geometry,
+                capsule_glow_alpha,
+                false,
+                OverlayTone::Glow,
+            )?,
+            CONTROL_CAPSULE_GLOW_ALPHA,
+            capsule_glow_alpha,
+        );
+        let capsule_alpha = breathing_alpha(
+            CONTROL_CAPSULE_ALPHA,
+            CONTROL_CAPSULE_PULSE_FLOOR_PERCENT,
+            0,
+        );
+        let capsule = match create_color_overlay(
+            caption,
+            capsule_geometry,
+            capsule_alpha,
+            false,
+            OverlayTone::Accent,
+        ) {
+            Ok(hwnd) => OverlayLayer::new(hwnd, CONTROL_CAPSULE_ALPHA, capsule_alpha),
+            Err(error) => {
+                let _ = unsafe { DestroyWindow(capsule_glow.hwnd) };
+                return Err(error);
+            }
+        };
+        let mut corners = Vec::with_capacity(corner_geometries.len());
+        for (geometry, alpha, focus) in corner_geometries {
+            let initial_alpha = breathing_alpha(alpha, CONTROL_BORDER_PULSE_FLOOR_PERCENT, 0);
+            let tone = if focus {
+                OverlayTone::Glow
+            } else {
+                OverlayTone::Accent
+            };
+            match create_color_overlay("", geometry, initial_alpha, false, tone) {
+                Ok(hwnd) => corners.push(OverlayLayer::new(hwnd, alpha, initial_alpha)),
+                Err(error) => {
+                    for layer in corners {
+                        let _ = unsafe { DestroyWindow(layer.hwnd) };
+                    }
+                    let _ = unsafe { DestroyWindow(capsule.hwnd) };
+                    let _ = unsafe { DestroyWindow(capsule_glow.hwnd) };
+                    return Err(error);
+                }
+            }
+        }
+        let mut cursor = POINT::default();
+        if let Err(error) = unsafe { GetCursorPos(&mut cursor) } {
+            for layer in corners {
+                let _ = unsafe { DestroyWindow(layer.hwnd) };
+            }
+            let _ = unsafe { DestroyWindow(capsule.hwnd) };
+            let _ = unsafe { DestroyWindow(capsule_glow.hwnd) };
+            return Err(overlay_backend_error(
+                "locate the pointer for",
+                error.to_string(),
+            ));
+        }
+        let cursor_alpha =
+            breathing_alpha(CONTROL_CURSOR_ALPHA, CONTROL_CURSOR_PULSE_FLOOR_PERCENT, 0);
+        let cursor_geometry = pointer_ring_geometry(cursor.x, cursor.y);
+        let cursor_ring = match create_cursor_ring_overlay(cursor_geometry, cursor_alpha) {
+            Ok(hwnd) => OverlayLayer::new(hwnd, CONTROL_CURSOR_ALPHA, cursor_alpha),
+            Err(error) => {
+                for layer in corners {
+                    let _ = unsafe { DestroyWindow(layer.hwnd) };
+                }
+                let _ = unsafe { DestroyWindow(capsule.hwnd) };
+                let _ = unsafe { DestroyWindow(capsule_glow.hwnd) };
+                return Err(error);
+            }
+        };
+        let cursor_visible = point_in_rect(cursor, target_rect);
+        let overlay = Self {
+            capsule_glow,
+            capsule,
+            corners,
+            cursor_ring,
+            cursor_ring_size: Cell::new(cursor_geometry.2),
+            cursor_visible: Cell::new(cursor_visible),
+            pulse_started: Instant::now(),
+        };
+        overlay.set_visible(true)?;
+        Ok(overlay)
+    }
+
+    pub(super) fn message_hwnd(&self) -> HWND {
+        self.capsule.hwnd
+    }
+
+    pub(super) fn reposition(
+        &self,
+        target: HWND,
+        target_rect: &windows::Win32::Foundation::RECT,
+    ) -> ComputerUseResult<()> {
+        let (capsule_geometry, corner_geometries) = overlay_geometries(target, target_rect)?;
+        position_overlay(
+            self.capsule_glow.hwnd,
+            capsule_glow_geometry(capsule_geometry),
+            false,
+        )?;
+        position_overlay(self.capsule.hwnd, capsule_geometry, false)?;
+        for (layer, (geometry, _alpha, _focus)) in self.corners.iter().zip(corner_geometries) {
+            position_overlay(layer.hwnd, geometry, false)?;
+        }
+        let mut cursor = POINT::default();
+        unsafe { GetCursorPos(&mut cursor) }
+            .map_err(|error| overlay_backend_error("locate the pointer for", error.to_string()))?;
+        let cursor_visible = point_in_rect(cursor, target_rect);
+        if cursor_visible {
+            let geometry = pointer_ring_geometry(cursor.x, cursor.y);
+            position_overlay(self.cursor_ring.hwnd, geometry, false)?;
+            if geometry.2 != self.cursor_ring_size.get() {
+                set_pointer_ring_region(self.cursor_ring.hwnd, geometry.2, geometry.3)?;
+                self.cursor_ring_size.set(geometry.2);
+            }
+        }
+        if cursor_visible != self.cursor_visible.get() {
+            set_overlay_visible(self.cursor_ring.hwnd, cursor_visible)?;
+            self.cursor_visible.set(cursor_visible);
+        }
+        let elapsed_ms = self.pulse_started.elapsed().as_millis() as u64;
+        self.capsule_glow
+            .apply_pulse(CONTROL_BORDER_PULSE_FLOOR_PERCENT, elapsed_ms)?;
+        self.capsule
+            .apply_pulse(CONTROL_CAPSULE_PULSE_FLOOR_PERCENT, elapsed_ms)?;
+        for layer in &self.corners {
+            layer.apply_pulse(CONTROL_BORDER_PULSE_FLOOR_PERCENT, elapsed_ms)?;
+        }
+        self.cursor_ring
+            .apply_pulse(CONTROL_CURSOR_PULSE_FLOOR_PERCENT, elapsed_ms)?;
+        Ok(())
+    }
+
+    pub(super) fn set_visible(&self, visible: bool) -> ComputerUseResult<()> {
+        set_overlay_visible(self.capsule_glow.hwnd, visible)?;
+        set_overlay_visible(self.capsule.hwnd, visible)?;
+        for layer in &self.corners {
+            set_overlay_visible(layer.hwnd, visible)?;
+        }
+        if visible {
+            if self.cursor_visible.get() {
+                set_overlay_visible(self.cursor_ring.hwnd, true)?;
+            }
+        } else if self.cursor_visible.replace(false) {
+            set_overlay_visible(self.cursor_ring.hwnd, false)?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ControlOverlay {
+    fn drop(&mut self) {
+        for layer in self.corners.drain(..) {
+            let _ = unsafe { DestroyWindow(layer.hwnd) };
+        }
+        let _ = unsafe { DestroyWindow(self.cursor_ring.hwnd) };
+        let _ = unsafe { DestroyWindow(self.capsule.hwnd) };
+        let _ = unsafe { DestroyWindow(self.capsule_glow.hwnd) };
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum OverlayTone {
+    Accent,
+    Glow,
+    Cursor,
+}
+
+fn register_color_overlay_classes() -> ComputerUseResult<()> {
+    static REGISTERED: OnceLock<Result<(), String>> = OnceLock::new();
+    REGISTERED
+        .get_or_init(|| {
+            let instance = unsafe { GetModuleHandleW(None) }
+                .map_err(|error| format!("resolve module handle: {error}"))?;
+            for (class_name, color) in [
+                (CONTROL_OVERLAY_CLASS, CONTROL_ACCENT_COLOR),
+                (CONTROL_GLOW_CLASS, CONTROL_GLOW_COLOR),
+                (CONTROL_CURSOR_CLASS, CONTROL_CURSOR_COLOR),
+            ] {
+                let class = WNDCLASSW {
+                    lpfnWndProc: Some(overlay_window_proc),
+                    hInstance: instance.into(),
+                    hbrBackground: unsafe { CreateSolidBrush(color) },
+                    lpszClassName: class_name,
+                    ..Default::default()
+                };
+                let atom = unsafe { RegisterClassW(&class) };
+                if atom == 0 {
+                    return Err(format!(
+                        "register overlay window class: {}",
+                        windows::core::Error::from_thread()
+                    ));
+                }
+            }
+            Ok(())
+        })
+        .clone()
+        .map_err(|detail| overlay_backend_error("register", detail))
+}
+
+unsafe extern "system" fn overlay_window_proc(
+    hwnd: HWND,
+    message: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
+    if message == WM_PAINT {
+        let mut paint = PAINTSTRUCT::default();
+        let device = unsafe { BeginPaint(hwnd, &raw mut paint) };
+        if !device.0.is_null() {
+            let mut bounds = RECT::default();
+            let _ = unsafe { GetClientRect(hwnd, &raw mut bounds) };
+            let mut class_name = [0_u16; 64];
+            let class_length = unsafe { GetClassNameW(hwnd, &mut class_name) }.max(0) as usize;
+            let color = match String::from_utf16_lossy(&class_name[..class_length]).as_ref() {
+                "DccMcpComputerUseGlowOverlay" => CONTROL_GLOW_COLOR,
+                "DccMcpComputerUseCursorOverlay" => CONTROL_CURSOR_COLOR,
+                _ => CONTROL_ACCENT_COLOR,
+            };
+            let brush = unsafe { CreateSolidBrush(color) };
+            let _ = unsafe { windows::Win32::Graphics::Gdi::FillRect(device, &bounds, brush) };
+            let _ = unsafe { DeleteObject(HGDIOBJ(brush.0)) };
+
+            let text_length = unsafe { GetWindowTextLengthW(hwnd) }.max(0) as usize;
+            if text_length > 0 {
+                let mut text = vec![0_u16; text_length + 1];
+                let copied = unsafe { GetWindowTextW(hwnd, &mut text) }.max(0) as usize;
+                text.truncate(copied);
+                let dpi = unsafe { GetDpiForWindow(hwnd) }.max(96);
+                let font = unsafe {
+                    CreateFontW(
+                        -scaled_pixels(CONTROL_CAPSULE_FONT_SIZE, dpi),
+                        0,
+                        0,
+                        0,
+                        FW_SEMIBOLD.0 as i32,
+                        0,
+                        0,
+                        0,
+                        DEFAULT_CHARSET,
+                        OUT_DEFAULT_PRECIS,
+                        CLIP_DEFAULT_PRECIS,
+                        CLEARTYPE_QUALITY,
+                        u32::from(DEFAULT_PITCH.0),
+                        w!("Segoe UI Semibold"),
+                    )
+                };
+                if !font.0.is_null() {
+                    let old_font = unsafe { SelectObject(device, HGDIOBJ(font.0)) };
+                    let _ = unsafe { SetBkMode(device, TRANSPARENT) };
+                    let _ = unsafe { SetTextColor(device, COLORREF(0x00FF_FFFF)) };
+                    let format = windows::Win32::Graphics::Gdi::DRAW_TEXT_FORMAT(
+                        DT_CENTER.0 | DT_VCENTER.0 | DT_SINGLELINE.0 | DT_END_ELLIPSIS.0,
+                    );
+                    let _ = unsafe { DrawTextW(device, &mut text, &raw mut bounds, format) };
+                    let _ = unsafe { SelectObject(device, old_font) };
+                    let _ = unsafe { DeleteObject(HGDIOBJ(font.0)) };
+                }
+            }
+        }
+        let _ = unsafe { EndPaint(hwnd, &paint) };
+        return LRESULT(0);
+    }
+    unsafe { DefWindowProcW(hwnd, message, wparam, lparam) }
+}
+
+pub(crate) fn create_color_overlay(
+    caption: &str,
+    (x, y, width, height): OverlayGeometry,
+    alpha: u8,
+    show: bool,
+    tone: OverlayTone,
+) -> ComputerUseResult<HWND> {
+    register_color_overlay_classes()?;
+    let caption = wide(caption);
+    let style = WINDOW_STYLE(WS_POPUP.0);
+    let ex_style = WINDOW_EX_STYLE(
+        WS_EX_TOPMOST.0
+            | WS_EX_TOOLWINDOW.0
+            | WS_EX_NOACTIVATE.0
+            | WS_EX_TRANSPARENT.0
+            | WS_EX_LAYERED.0,
+    );
+    let hwnd = unsafe {
+        CreateWindowExW(
+            ex_style,
+            match tone {
+                OverlayTone::Accent => CONTROL_OVERLAY_CLASS,
+                OverlayTone::Glow => CONTROL_GLOW_CLASS,
+                OverlayTone::Cursor => CONTROL_CURSOR_CLASS,
+            },
+            PCWSTR(caption.as_ptr()),
+            style,
+            x,
+            y,
+            width,
+            height,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+    .map_err(|error| overlay_backend_error("create", error.to_string()))?;
+    if let Err(error) = exclude_overlay_from_capture(hwnd) {
+        let _ = unsafe { DestroyWindow(hwnd) };
+        return Err(error);
+    }
+    if let Err(error) = set_overlay_alpha(hwnd, alpha) {
+        let _ = unsafe { DestroyWindow(hwnd) };
+        return Err(error);
+    }
+    let radius = width.min(height).max(1);
+    let region = unsafe { CreateRoundRectRgn(0, 0, width, height, radius, radius) };
+    if region.0.is_null() || unsafe { SetWindowRgn(hwnd, Some(region), true) } == 0 {
+        let _ = unsafe { DestroyWindow(hwnd) };
+        return Err(overlay_backend_error(
+            "round",
+            "Windows did not accept the overlay region",
+        ));
+    }
+    if let Err(error) = position_overlay(hwnd, (x, y, width, height), show) {
+        let _ = unsafe { DestroyWindow(hwnd) };
+        return Err(error);
+    }
+    pump_overlay_messages(hwnd);
+    Ok(hwnd)
+}
+
+pub(crate) fn create_cursor_ring_overlay(geometry: OverlayGeometry, alpha: u8) -> ComputerUseResult<HWND> {
+    let hwnd = create_color_overlay("", geometry, alpha, false, OverlayTone::Cursor)?;
+    if let Err(error) = set_pointer_ring_region(hwnd, geometry.2, geometry.3) {
+        let _ = unsafe { DestroyWindow(hwnd) };
+        return Err(error);
+    }
+    Ok(hwnd)
+}
+
+fn set_pointer_ring_region(hwnd: HWND, width: i32, height: i32) -> ComputerUseResult<()> {
+    let thickness = (width.min(height) / 12).max(3);
+    let outer = unsafe { CreateEllipticRgn(0, 0, width, height) };
+    let inner =
+        unsafe { CreateEllipticRgn(thickness, thickness, width - thickness, height - thickness) };
+    if outer.0.is_null() || inner.0.is_null() {
+        let _ = unsafe { DeleteObject(HGDIOBJ(outer.0)) };
+        let _ = unsafe { DeleteObject(HGDIOBJ(inner.0)) };
+        return Err(overlay_backend_error(
+            "shape",
+            "Windows could not create the pointer ring",
+        ));
+    }
+    let combined = unsafe { CombineRgn(Some(outer), Some(outer), Some(inner), RGN_DIFF) };
+    let _ = unsafe { DeleteObject(HGDIOBJ(inner.0)) };
+    if combined == RGN_ERROR || unsafe { SetWindowRgn(hwnd, Some(outer), true) } == 0 {
+        let _ = unsafe { DeleteObject(HGDIOBJ(outer.0)) };
+        return Err(overlay_backend_error(
+            "shape",
+            "Windows did not accept the pointer ring",
+        ));
+    }
+    Ok(())
+}
+
+fn set_overlay_alpha(hwnd: HWND, alpha: u8) -> ComputerUseResult<()> {
+    unsafe { SetLayeredWindowAttributes(hwnd, COLORREF(0), alpha, LWA_ALPHA) }
+        .map_err(|error| overlay_backend_error("configure transparency for", error.to_string()))
+}
+
+fn exclude_overlay_from_capture(hwnd: HWND) -> ComputerUseResult<()> {
+    unsafe { SetWindowDisplayAffinity(hwnd, WDA_EXCLUDEFROMCAPTURE) }
+        .map_err(|error| overlay_backend_error("exclude from capture", error.to_string()))
+}
+
+pub(crate) fn position_overlay(
+    hwnd: HWND,
+    (x, y, width, height): OverlayGeometry,
+    show: bool,
+) -> ComputerUseResult<()> {
+    let flags = if show {
+        SWP_NOACTIVATE | SWP_SHOWWINDOW
+    } else {
+        SWP_NOACTIVATE
+    };
+    unsafe { SetWindowPos(hwnd, Some(HWND_TOPMOST), x, y, width, height, flags) }
+        .map_err(|error| overlay_backend_error("position", error.to_string()))?;
+    let mut actual = RECT::default();
+    unsafe { GetWindowRect(hwnd, &mut actual) }
+        .map_err(|error| overlay_backend_error("verify the position of", error.to_string()))?;
+    if [
+        actual.left,
+        actual.top,
+        actual.right - actual.left,
+        actual.bottom - actual.top,
+    ] != [x, y, width, height]
+    {
+        return Err(overlay_backend_error(
+            "verify the position of",
+            "Windows reported unexpected overlay bounds",
+        ));
+    }
+    if show && !unsafe { IsWindowVisible(hwnd) }.as_bool() {
+        return Err(overlay_backend_error(
+            "show",
+            "Windows did not make the overlay visible",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn set_overlay_visible(hwnd: HWND, visible: bool) -> ComputerUseResult<()> {
+    let command = if visible { SW_SHOWNOACTIVATE } else { SW_HIDE };
+    let _ = unsafe { ShowWindow(hwnd, command) };
+    pump_overlay_messages(hwnd);
+    if unsafe { IsWindowVisible(hwnd) }.as_bool() != visible {
+        return Err(overlay_backend_error(
+            if visible { "show" } else { "hide" },
+            "Windows did not apply the requested visibility",
+        ));
+    }
+    Ok(())
+}
+
+fn overlay_backend_error(operation: &str, detail: impl std::fmt::Display) -> ComputerUseError {
+    ComputerUseError::new(
+        ComputerUseErrorCode::BackendUnavailable,
+        format!("failed to {operation} the DCC UI Control visual overlay: {detail}"),
+    )
+}
+
+pub(crate) fn pump_overlay_messages(hwnd: HWND) {
+    let mut message = MSG::default();
+    while unsafe { PeekMessageW(&mut message, Some(hwnd), 0, 0, PM_REMOVE) }.as_bool() {
+        unsafe {
+            let _ = TranslateMessage(&message);
+            DispatchMessageW(&message);
+        }
+    }
+}


### PR DESCRIPTION
Extract the overlay subsystem from `platform/windows.rs` into `windows/overlay.rs` to bring the file under the 1500-line limit.

- **`windows.rs`**: 1535 → 1049 lines
- **`windows/overlay.rs`**: new module, 531 lines
- **`geometry.rs`**: widened 7 utility functions from `pub(super)` → `pub(crate)`

**Validation:** `cargo check` 0 errors 0 warnings, `cargo test` 68 passed.

Fixes the file-size-gate CI failure on #1978.