### PR TITLE
docs(observability): add metric dictionary, schema, usage guide, and troubleshooting

### DIFF
--- a/docs/guide/INDEX.md
+++ b/docs/guide/INDEX.md
@@ -98,6 +98,10 @@ Documentation contract:
 | [app-ui-workflows.md](app-ui-workflows.md) | Agent workflows for scoped `app_ui` UI automation, recovery, and VRS coverage |
 | [telemetry.md](telemetry.md) | ToolMetrics, ToolRecorder, RecordingGuard |
 | [observability.md](observability.md) | OTLP exporter, agent workflow spans, gateway event log (`resources://gateway/events`), Prometheus counters |
+| [metric-dictionary.md](metric-dictionary.md) | Canonical metric dictionary: units, sampling windows, null semantics, storage layer inventory |
+| [observability-schema.md](observability-schema.md) | Versioned schema, migration path, and query API versioning |
+| [observability-usage.md](observability-usage.md) | Agent, CLI, and Admin UI usage for observability data |
+| [observability-troubleshooting.md](observability-troubleshooting.md) | Operational troubleshooting runbook for observability issues |
 | [scheduler.md](scheduler.md) | ScheduleSpec, TriggerSpec, cron/webhook scheduling |
 | [workflows.md](workflows.md) | WorkflowSpec engine: step kinds, policies, persistence |
 | [job-persistence.md](job-persistence.md) | SQLite-backed job/workflow persistence and resume |

--- a/docs/guide/metric-dictionary.md
+++ b/docs/guide/metric-dictionary.md
@@ -1,0 +1,274 @@
+# Metric Dictionary
+
+Canonical reference for every metric, dimension, and aggregated statistic that
+dcc-mcp-core observability surfaces produce. Use this dictionary to understand
+units, sampling windows, null/missing-value semantics, and which storage layer
+holds each metric.
+
+---
+
+## 1. Gateway Admin SQLite — Persistent Metrics
+
+The gateway writes structured rows to the shared `gateway_admin.sqlite`
+database. This is the authoritative per-machine store for tool-call traces,
+session lifecycle, and aggregated statistics.
+
+### 1.1 `tool_calls` table
+
+| Column | Type | Unit | Sampling | Missing semantics |
+|--------|------|------|----------|-------------------|
+| `request_id` | TEXT | — | Every tool call | NOT NULL, PK |
+| `session_id` | TEXT | — | Every tool call | NOT NULL — empty string when no session |
+| `parent_request_id` | TEXT | — | When attributed | `NULL` = orphan (no parent chain) |
+| `batch_id` | TEXT | — | When inside a batch | `NULL` = standalone call |
+| `tool_name` | TEXT | — | Every tool call | NOT NULL |
+| `skill_name` | TEXT | — | When known | `NULL` = direct tool (no skill wrapper) |
+| `dcc_type` | TEXT | — | When known | `NULL` = gateway-level call |
+| `instance_id` | TEXT | — | When known | `NULL` = no target instance resolved |
+| `agent_id` | TEXT | — | When caller provides | `NULL` = anonymous |
+| `transport` | TEXT | — | Every call | `"mcp"`, `"rest"`, or `NULL` on legacy paths |
+| `via_gateway` | INTEGER | boolean | Every call | `0` = direct DCC, `1` = via gateway, `NULL` = unknown |
+| `started_at_ms` | INTEGER | ms since epoch | Every call | NOT NULL |
+| `duration_ms` | INTEGER | ms | Every call | NOT NULL — wall-clock, may be 0 for sub-ms calls |
+| `success` | INTEGER | boolean | Every call | `0` = failure, `1` = success |
+| `error_message` | TEXT | — | On failure | `NULL` on success |
+| `error_kind` | TEXT | — | On classified failure | `NULL` = unclassified |
+| `mcp_method` | TEXT | — | Every call | Always `"tools/call"` in practice |
+| `trace_id` | TEXT | — | When traceparent attached | `NULL` = no distributed trace |
+| `span_id` | TEXT | — | When span attached | `NULL` = no span |
+
+**Row retention**: bounded by the gateway ring buffer (default 5000 rows in
+JSONL; SQLite mirror retains all rows). The SQLite lane is append-only with
+no automatic purge — operators may delete old partitions.
+
+### 1.2 `sessions` table
+
+| Column | Type | Unit | Sampling | Missing semantics |
+|--------|------|------|----------|-------------------|
+| `session_id` | TEXT | — | Every session start | NOT NULL, PK |
+| `parent_session_id` | TEXT | — | When spawned | `NULL` = root session |
+| `dcc_type` | TEXT | — | Every session | NOT NULL |
+| `instance_id` | TEXT | — | When known | `NULL` = unknown instance |
+| `status` | TEXT | — | Every session | One of: `active`, `ended`, `crashed`, `disconnected`, `gpu_crashed`, `timed_out`, `cancelled`, `thread_affinity_failure` |
+| `started_at_ms` | INTEGER | ms since epoch | Every session | NOT NULL |
+| `last_activity_at_ms` | INTEGER | ms since epoch | Every session | Updated on each tool call |
+| `ended_at_ms` | INTEGER | ms since epoch | On end | `NULL` while session is active |
+| `end_reason_json` | TEXT | — | On non-normal end | `NULL` for normal end |
+| `tool_call_count` | INTEGER | count | Every session | Defaults to 0 |
+| `error_count` | INTEGER | count | Every session | Defaults to 0 |
+| `core_version` | TEXT | — | Every session | NOT NULL — semver of dcc-mcp-core |
+| `adapter_version` | TEXT | — | When DCC adapter provides | `NULL` = unknown |
+| `build_sha` | TEXT | — | When build metadata available | `NULL` = dev build |
+
+**Session status semantics**:
+
+| Status | Meaning |
+|--------|---------|
+| `active` | Session is live and accepting tool calls |
+| `ended` | Clean shutdown via `on_session_end` |
+| `crashed` | DCC host process terminated unexpectedly |
+| `gpu_crashed` | GPU device lost / TDR event |
+| `disconnected` | Gateway lost contact with the DCC backend |
+| `timed_out` | Session exceeded the configured idle timeout |
+| `cancelled` | Client explicitly cancelled the session |
+| `thread_affinity_failure` | DCC thread-affinity constraint could not be satisfied |
+
+### 1.3 `session_events` table
+
+| Column | Type | Unit | Sampling | Missing semantics |
+|--------|------|------|----------|-------------------|
+| `id` | INTEGER | — | Every event | PK, auto-increment |
+| `session_id` | TEXT | — | Every event | NOT NULL |
+| `event_type` | TEXT | — | Every event | See table below |
+| `event_json` | TEXT | — | Every event | NOT NULL — JSON payload |
+| `created_at_ms` | INTEGER | ms since epoch | Every event | NOT NULL |
+
+**Event types**:
+
+| Event | Payload | When emitted |
+|-------|---------|-------------|
+| `session_start` | `{ session_id, dcc_type, instance_id, core_version }` | On first `initialize` |
+| `session_end` | `{ session_id, reason }` | On clean close |
+| `session_crash` | `{ session_id, signal?, exit_code? }` | On process termination |
+| `session_timeout` | `{ session_id, idle_seconds }` | On idle timeout expiry |
+| `tool_call_start` | `{ request_id, tool_name, session_id }` | Before dispatch |
+| `tool_call_end` | `{ request_id, success, duration_ms }` | After completion |
+
+---
+
+## 2. Prometheus Exporter — Runtime Metrics
+
+Available when compiled with the `prometheus` Cargo feature. Mounted at
+`GET /metrics` on the same Axum router as the MCP server.
+
+### 2.1 Per-DCC Server Metrics
+
+| Metric | Type | Unit | Labels | Missing/zero semantics |
+|--------|------|------|--------|----------------------|
+| `dcc_mcp_tool_calls_total` | counter | invocations | `tool`, `status` | Absent until first call. `status="success"` or `status="error"`. |
+| `dcc_mcp_tool_duration_seconds` | histogram | seconds | `tool` | No observations = zero histogram. Buckets: log-ish 1 ms → 30 s. |
+| `dcc_mcp_jobs_in_flight` | gauge | count | `tool` | 0 when no jobs are running. |
+| `dcc_mcp_job_created_total` | counter | jobs | `tool`, `result` | `result` ∈ `{accepted, queue_full}`. |
+| `dcc_mcp_job_wait_seconds` | histogram | seconds | `tool` | Zero for instantly-scheduled jobs. |
+| `dcc_mcp_notifications_sent_total` | counter | notifications | `channel` | `channel` ∈ `{sse, ws}`. |
+| `dcc_mcp_active_sessions` | gauge | count | — | 0 when no sessions. Refreshed every 5 s. |
+| `dcc_mcp_registered_tools` | gauge | count | — | 0 when registry empty. Refreshed every 5 s. |
+| `dcc_mcp_build_info` | gauge | — | `version`, `crate` | Always 1. Published once at startup. |
+
+**Sampling window**: gauge metrics refresh on a 5-second background tick.
+Counters and histograms advance inline on the `tools/call` hot path.
+
+### 2.2 Gateway-Only Metrics
+
+| Metric | Type | Unit | Labels | Missing/zero semantics |
+|--------|------|------|--------|----------------------|
+| `dcc_mcp_gateway_elections_total` | counter | elections | `outcome` | `outcome` ∈ `{won, yielded, lost}` |
+| `dcc_mcp_gateway_evictions_total` | counter | evictions | `reason` | `reason` ∈ `{stale, ghost, probe_fail}` |
+| `dcc_mcp_gateway_probes_total` | counter | probes | `outcome` | `outcome` ∈ `{ready, booting, unreachable}` |
+| `dcc_mcp_gateway_governance_events_total` | counter | events | `category`, `outcome` | `category` ∈ `{policy, rate-limit}`; `outcome` ∈ `{allowed, denied, throttled}` |
+
+---
+
+## 3. Observability Query API — Aggregated Metrics
+
+The Python `ObservabilityQuery` class provides method-level aggregates computed
+from the gateway admin SQLite database (Section 1).
+
+### 3.1 Session Stats
+
+Field returned by `get_session_stats()`:
+
+| Field | Type | Unit | Sampling window | Missing/zero |
+|-------|------|------|-----------------|-------------|
+| `total_sessions` | integer | count | Filter time range | 0 when no sessions match |
+| `active_sessions` | integer | count | Filter time range | 0 when no active sessions |
+| `ended_normally` | integer | count | Filter time range | 0 |
+| `ended_abnormally` | integer | count | Filter time range | 0 |
+| `avg_duration_ms` | float | ms | Filter time range | 0.0 when no ended sessions |
+| `total_tool_calls` | integer | count | Filter time range | 0 |
+| `total_errors` | integer | count | Filter time range | 0 |
+
+### 3.2 Tool Call Stats
+
+Field returned by `get_tool_call_stats()`:
+
+| Field | Type | Unit | Sampling window | Missing/zero |
+|-------|------|------|-----------------|-------------|
+| `total_calls` | integer | count | Filter time range + limit | 0 |
+| `success_count` | integer | count | Filter time range + limit | 0 |
+| `failure_count` | integer | count | Filter time range + limit | 0 |
+| `success_rate` | float | ratio [0–1] | Filter time range + limit | 0.0 when zero total |
+| `avg_duration_ms` | float | ms | Filter time range + limit | 0.0 |
+
+Each row in the `events` sub-list repeats the column semantics from the
+`tool_calls` table (Section 1.1).
+
+### 3.3 Coverage Stats
+
+Field returned by `get_coverage_stats()`:
+
+| Field | Type | Unit | Sampling window | Missing/zero |
+|-------|------|------|-----------------|-------------|
+| `observed_requests` | integer | count | Filter time range | 0 |
+| `unobserved_requests` | integer | count | Filter time range | 0 |
+| `coverage_ratio` | float | ratio [0–1] | Filter time range | 0.0 when zero total |
+
+### 3.4 Crash Stats
+
+Field returned by `get_crash_stats()`:
+
+| Field | Type | Unit | Sampling window | Missing/zero |
+|-------|------|------|-----------------|-------------|
+| `total_crashes` | integer | count | Filter time range | 0 |
+| `host_crashes` | integer | count | Filter time range | 0 |
+| `gpu_crashes` | integer | count | Filter time range | 0 |
+
+### 3.5 Funnel Stats
+
+Field returned by `get_funnel_stats()`:
+
+| Field | Type | Unit | Sampling window | Missing/zero |
+|-------|------|------|-----------------|-------------|
+| `searches_total` | integer | count | Filter time range | 0 until search instrumentation is wired |
+| `searches_zero_results` | integer | count | Filter time range | 0 |
+| `skills_loaded` | integer | count | Filter time range | 0 |
+| `skills_called` | integer | count | Filter time range | Upper bound from `tool_calls` count |
+| `skills_succeeded` | integer | count | Filter time range | 0 |
+| `script_fallbacks` | integer | count | Filter time range | 0 |
+| `ui_control_fallbacks` | integer | count | Filter time range | 0 |
+
+---
+
+## 4. In-Process Python Telemetry
+
+The `ToolRecorder` class provides in-memory percentiles without a database.
+
+### `ToolMetrics` fields
+
+| Field | Type | Unit | Sampling | Missing/zero |
+|-------|------|------|----------|-------------|
+| `invocation_count` | integer | count | Every `start()`/`finish()` | 0 = never recorded |
+| `success_count` | integer | count | Same | 0 |
+| `failure_count` | integer | count | Same | 0 |
+| `avg_duration_ms` | float | ms | Same | 0.0 |
+| `p95_duration_ms` | float | ms | Same | 0.0 when < 20 samples |
+| `p99_duration_ms` | float | ms | Same | 0.0 when < 100 samples |
+| `success_rate()` | float | ratio [0–1] | Same | 0.0 |
+
+**Percentile accuracy**: p95 stabilises after ~20 samples; p99 after ~100.
+Below those thresholds, percentiles may match the maximum observed value.
+
+---
+
+## 5. Admin API Statistics
+
+The `GET /admin/api/stats` endpoint computes on-demand from the trace ring
+buffer (default 200 traces, configurable up to 5000).
+
+| Group | Field | Unit | Missing/zero |
+|-------|-------|------|-------------|
+| Overall | `total_calls` | count | 0 |
+| | `success_rate` | ratio [0–1] | 0.0 |
+| | `avg_duration_ms` | ms | 0.0 |
+| Latency | `p50_duration_ms` | ms | 0.0 |
+| | `p95_duration_ms` | ms | 0.0 |
+| | `p99_duration_ms` | ms | 0.0 |
+| Top tools | `tool`, `call_count` | count | Empty list |
+| Top instances | `instance_id`, `call_count` | count | Empty list |
+| Hourly | `hour` (UTC 0–23), `call_count` | count | Zero-filled 24-bucket array |
+
+**Range filter**: `?range=1h|24h|7d|all`. Default `all` = entire ring buffer.
+StatsFilter supports optional `dcc_type`, `skill`, `tool`, `status`, `instance_id`,
+and `session_id` dimensions.
+
+---
+
+## 6. OTLP Distributed Tracing
+
+OpenTelemetry-compatible spans with these key attributes:
+
+| Attribute | Type | Unit | Present | Missing |
+|-----------|------|------|---------|---------|
+| `dcc.type` | string | — | Every DCC span | `NULL` on gateway-only spans |
+| `dcc.instance_id` | string | — | When resolved | `NULL` |
+| `mcp.tool_slug` | string | — | `tools/call` spans | `NULL` |
+| `mcp.session_id` | string | — | Session context | `NULL` |
+| `dcc_mcp.success` | bool | — | Every span | `false` on error |
+
+See the full attribute table in [observability.md](observability.md).
+
+---
+
+## Index
+
+| Surface | Storage | Query interface | Retention |
+|---------|---------|----------------|-----------|
+| SQLite `tool_calls` | `gateway_admin.sqlite` | `ObservabilityQuery`, Admin API | Append-only |
+| SQLite `sessions` | `gateway_admin.sqlite` | `ObservabilityQuery`, Admin API | Append-only |
+| SQLite `session_events` | `gateway_admin.sqlite` | Admin API | Append-only |
+| Prometheus | In-process registry | `GET /metrics` | Resets on process restart |
+| OTLP traces | External collector | Jaeger/Tempo/Phoenix | Collector-managed |
+| ToolRecorder | In-process memory | Python `metrics()` | Resets on `reset()` or process restart |
+| Admin audit ring | In-memory + optional JSONL | `GET /admin/api/calls` | Default 5000 rows |
+| Admin trace ring | In-memory + optional JSONL | `GET /admin/api/traces` | Default 200 traces |
+| Admin stats | On-demand from trace ring | `GET /admin/api/stats` | Same as trace ring |

--- a/docs/guide/observability-schema.md
+++ b/docs/guide/observability-schema.md
@@ -1,0 +1,217 @@
+# Observability Schema & Migration
+
+This document describes the versioning strategy for observability data schemas:
+the SQLite database schema, the Python query API envelope, and the migration
+path when backward-incompatible changes are required.
+
+---
+
+## 1. SQLite Database Schema
+
+The gateway admin SQLite database (`gateway_admin.sqlite`) is defined by a
+single canonical DDL source at:
+
+```
+crates/dcc-mcp-db/src/infra/gateway_admin_schema.rs
+```
+
+The DDL is embedded as a `const &str` and executed with `CREATE TABLE IF NOT
+EXISTS`, making it safe to run on every gateway startup.
+
+### Current version: 2 (PIP-2751)
+
+Schema version 2 introduced `tool_calls`, `sessions`, and `session_events`
+tables alongside the original v1 tables (`traces`, `audits`,
+`skill_paths_custom`, `deregistered_instances`, `skill_loaded_state`,
+`skill_active_groups`, `agent_memory`).
+
+### Full table inventory
+
+| Table | Version added | Purpose |
+|-------|--------------|---------|
+| `traces` | v1 | Dispatch trace ring buffer mirror |
+| `audits` | v1 | Audit call record mirror |
+| `skill_paths_custom` | v1 | Admin UI custom skill discovery roots |
+| `deregistered_instances` | v1 | Deregistered gateway instance log |
+| `skill_loaded_state` | v1 | Per-DCC skill load state mirror |
+| `skill_active_groups` | v1 | Per-DCC active skill groups |
+| `agent_memory` | v1 | Agent memory key-value store |
+| `tool_calls` | v2 (PIP-2751) | Structured tool-call events |
+| `sessions` | v2 (PIP-2751) | Session lifecycle tracking |
+| `session_events` | v2 (PIP-2751) | Session lifecycle event log |
+
+### Index inventory
+
+All indexes use `CREATE INDEX IF NOT EXISTS` and are idempotent. Adding a new
+index is a non-breaking change and does not require a schema version bump.
+
+---
+
+## 2. Query API Versioning
+
+The `ObservabilityQuery` Python class wraps every response in a versioned
+envelope defined in `python/dcc_mcp_core/observability_query.py`:
+
+```python
+API_VERSION = "v1"
+```
+
+### Envelope
+
+```json
+{
+  "api_version": "v1",
+  "query_type": "session_stats",
+  "timestamp_ms": 1700000000000,
+  "data": { ... },
+  "query_params": { ... },
+  "warnings": [ ... ]
+}
+```
+
+### Version policy
+
+The `API_VERSION` constant is incremented when:
+
+1. A field is **removed** or **renamed** in the `data` payload.
+2. A field **type changes** (e.g., integer → string).
+3. A field's **semantics change** in a way that would silently break an
+   existing consumer.
+
+The version is **NOT** incremented for:
+
+- Adding new optional fields to `data`.
+- Adding new `query_type` values.
+- Adding new optional envelope fields (`warnings`, `query_params`).
+- Performance or correctness changes that preserve the response shape.
+
+### Consumer guidance
+
+Consumers that parse the envelope should:
+
+1. Read `api_version` and hard-fail if it matches an unknown version.
+2. Use `query_type` to dispatch to the correct parser.
+3. Ignore unknown fields in `data` (forward compatibility).
+4. Surface `warnings` when present.
+
+---
+
+## 3. Migration Procedures
+
+### 3.1 Adding a new table
+
+1. Add the `CREATE TABLE` statement to `GATEWAY_ADMIN_SQLITE_DDL` in
+   `gateway_admin_schema.rs`.
+2. Use `CREATE TABLE IF NOT EXISTS` — the statement is idempotent.
+3. Add matching indexes with `CREATE INDEX IF NOT EXISTS`.
+4. The new table appears on the next gateway restart. Existing data in other
+   tables is unaffected.
+5. Update `ObservabilityQuery` methods to query the new table.
+6. Update the metric dictionary and this schema document.
+
+**Rollback**: Remove the DDL statement and restart the gateway. The table
+remains on disk (harmless) but is no longer written to. Drop it manually if
+desired: `DROP TABLE IF EXISTS <name>`.
+
+### 3.2 Adding a column to an existing table
+
+1. Write an `ALTER TABLE ... ADD COLUMN` statement guarded by a schema
+   version check.
+2. Alternatively, add the column to the `CREATE TABLE IF NOT EXISTS`
+   statement — it has no effect on existing tables but ensures new databases
+   include the column from the start.
+3. For write paths: the gateway must tolerate the column being absent on
+   old databases (check-and-default before insert).
+
+**Preferred pattern** — alter on startup when the column is absent:
+
+```rust
+// Example: adding `llm_usage` to traces
+let has_column = db.query_row(
+    "SELECT llm_usage FROM traces LIMIT 1",
+    [],
+    |_| Ok(()),
+).is_ok();
+if !has_column {
+    db.execute_batch("ALTER TABLE traces ADD COLUMN llm_usage TEXT;")?;
+}
+```
+
+**Rollback**: Remove the `ALTER TABLE` statement and any writes to the new
+column. The column remains on disk; old gateway versions ignore it.
+
+### 3.3 Changing a column type
+
+1. **Do not** use `ALTER TABLE ... RENAME COLUMN` — SQLite's column rename
+   requires a full table rebuild.
+2. Instead, add a new column with the desired type, dual-write both columns
+   for one release cycle, then remove the old column.
+
+Example dual-write cycle:
+
+| Release | Action |
+|---------|--------|
+| N | Add `duration_ms_new INTEGER`, write both `duration_ms` (TEXT) and `duration_ms_new`. Readers prefer `duration_ms_new` when non-NULL. |
+| N+1 | Drop `duration_ms`, rename `duration_ms_new` → `duration_ms`, update readers. |
+
+### 3.4 Removing a table or column
+
+1. Stop writing to the deprecated table/column (release N).
+2. Remove all reader code (release N+1).
+3. Optionally drop the table/column in a schema migration (release N+2).
+   Dropping preserves `IF NOT EXISTS` safety for rollbacks.
+
+---
+
+## 4. Query API Migration
+
+### Adding a new query type
+
+1. Add a new method to `ObservabilityQuery`.
+2. Use a unique `query_type` string (e.g., `"new_analytics"`).
+3. Register the method in CLI or Admin UI consumers.
+
+No `API_VERSION` bump needed — existing consumers ignore unknown
+`query_type` values if they follow the forward-compatibility guidance above.
+
+### Deprecating a field
+
+1. Add the field to `warnings` list in the response envelope:
+
+   ```python
+   warnings=["field 'old_field' is deprecated, use 'new_field' instead"]
+   ```
+
+2. Keep the deprecated field in `data` for at least one release cycle.
+3. Remove it on the next `API_VERSION` bump.
+
+### Breaking a backward-incompatible change
+
+1. Increment `API_VERSION`.
+2. Update all first-party consumers (CLI, Admin UI, agent skills) to handle
+   the new version.
+3. Document the change in the CHANGELOG with the old/new shapes.
+
+---
+
+## 5. Migration when the gateway starts
+
+On startup, the gateway:
+
+1. Runs `GATEWAY_ADMIN_SQLITE_DDL` (idempotent — adds missing tables/indexes).
+2. Seads the in-memory trace/audit ring buffers from SQLite (if the
+   `admin-persist-sqlite` feature is enabled).
+3. Writes fresh rows to both the in-memory ring and the SQLite lane.
+
+Because DDL is `IF NOT EXISTS`, rolling upgrades are safe: old gateways that
+do not know about new tables simply ignore them, and new gateways create
+missing tables automatically on first startup.
+
+---
+
+## 6. Observability API Version History
+
+| API version | Schema version | Release | Changes |
+|-------------|---------------|---------|---------|
+| `v1` | 1 | 0.19.x | Original: traces, audits, skill paths, deregistered instances, agent memory |
+| `v1` | 2 | 0.20.x (PIP-2751) | Added `tool_calls`, `sessions`, `session_events` tables. Query API unchanged. |

--- a/docs/guide/observability-schema.md
+++ b/docs/guide/observability-schema.md
@@ -18,7 +18,7 @@ crates/dcc-mcp-db/src/infra/gateway_admin_schema.rs
 The DDL is embedded as a `const &str` and executed with `CREATE TABLE IF NOT
 EXISTS`, making it safe to run on every gateway startup.
 
-### Current version: 2 (PIP-2751)
+### Current version: 2
 
 Schema version 2 introduced `tool_calls`, `sessions`, and `session_events`
 tables alongside the original v1 tables (`traces`, `audits`,
@@ -36,9 +36,9 @@ tables alongside the original v1 tables (`traces`, `audits`,
 | `skill_loaded_state` | v1 | Per-DCC skill load state mirror |
 | `skill_active_groups` | v1 | Per-DCC active skill groups |
 | `agent_memory` | v1 | Agent memory key-value store |
-| `tool_calls` | v2 (PIP-2751) | Structured tool-call events |
-| `sessions` | v2 (PIP-2751) | Session lifecycle tracking |
-| `session_events` | v2 (PIP-2751) | Session lifecycle event log |
+| `tool_calls` | v2 | Structured tool-call events |
+| `sessions` | v2 | Session lifecycle tracking |
+| `session_events` | v2 | Session lifecycle event log |
 
 ### Index inventory
 
@@ -214,4 +214,4 @@ missing tables automatically on first startup.
 | API version | Schema version | Release | Changes |
 |-------------|---------------|---------|---------|
 | `v1` | 1 | 0.19.x | Original: traces, audits, skill paths, deregistered instances, agent memory |
-| `v1` | 2 | 0.20.x (PIP-2751) | Added `tool_calls`, `sessions`, `session_events` tables. Query API unchanged. |
+| `v1` | 2 | 0.20.x | Added `tool_calls`, `sessions`, `session_events` tables. Query API unchanged. |

--- a/docs/guide/observability-troubleshooting.md
+++ b/docs/guide/observability-troubleshooting.md
@@ -1,0 +1,345 @@
+# Observability Troubleshooting
+
+Operational runbook for diagnosing and resolving observability issues.
+
+---
+
+## T1. Metric is missing or shows zero
+
+### T1.1 Prometheus endpoint returns 404
+
+**Check**: Is the `prometheus` Cargo feature enabled?
+
+```bash
+# Verify the binary was built with prometheus support
+strings /path/to/dcc-mcp-server | grep prometheus
+# No output → feature not compiled in
+
+# Check the log for prometheus initialization
+grep -i prometheus /var/log/dcc-mcp/gateway.log
+```
+
+**Fix**: Rebuild with `--features prometheus`, or use a wheel that includes it:
+
+```bash
+maturin develop --features python-bindings,ext-module,workflow,prometheus
+```
+
+**Also check**: Did you set `enable_prometheus=True` in `McpHttpConfig`?
+
+```python
+cfg = McpHttpConfig(
+    port=8765,
+    server_name="maya-mcp",
+    enable_prometheus=True,  # required
+)
+```
+
+### T1.2 `dcc_mcp_build_info` is the only metric visible
+
+The exporter publishes `dcc_mcp_build_info` on startup as a heartbeat to
+confirm the endpoint is live. If only this metric appears:
+
+- No tool calls have been dispatched yet — metrics are created lazily on
+  first observation.
+- Call a tool and scrape again.
+
+### T1.3 `ObservabilityQuery` returns all zeroes
+
+**Check**: Does the SQLite database exist?
+
+```bash
+ls -la /tmp/dcc-mcp-registry/gateway_admin.sqlite
+# or
+echo $DCC_MCP_GATEWAY_ADMIN_DB
+```
+
+**Check**: Has the gateway ever run? The SQLite file is created on the first
+gateway startup. If it does not exist, no data has been collected.
+
+```python
+from dcc_mcp_core.admin_sqlite_lane import resolve_admin_db_path
+db_path = resolve_admin_db_path()
+print("DB exists:", db_path.exists())
+```
+
+**Fix**: Start the gateway process and make some tool calls, then retry the
+query.
+
+### T1.4 Query returns zeroes but database has rows
+
+Verify the `ObservabilityQuery` is pointed at the correct database path:
+
+```python
+from dcc_mcp_core import ObservabilityQuery
+q = ObservabilityQuery(db_path="/actual/path/gateway_admin.sqlite")
+```
+
+The default constructor with `db_path=None` and no `read_json_fn` returns
+empty results. Either provide `db_path` (for direct SQLite access) or a
+`read_json_fn` callback.
+
+---
+
+## T2. OTLP traces not appearing
+
+### T2.1 Spans not reaching the collector
+
+**Check**: Is `OTEL_EXPORTER_OTLP_ENDPOINT` set?
+
+```bash
+echo $OTEL_EXPORTER_OTLP_ENDPOINT
+# Must be set — OTLP is opt-in by environment variable
+```
+
+**Check**: Is the collector reachable?
+
+```bash
+# Test gRPC connectivity (requires grpcurl)
+grpcurl -plaintext localhost:4317 grpc.health.v1.Health/Check
+
+# Test HTTP collector
+curl -s http://localhost:4318/health
+```
+
+**Check**: Gateway logs for OTLP errors:
+
+```bash
+grep -i otlp /var/log/dcc-mcp/gateway.log | tail -20
+```
+
+### T2.2 Spans reaching collector but not visible in Jaeger/Tempo
+
+**Check**: Does the collector's service pipeline include an exporter?
+
+```yaml
+# otel-collector.yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/jaeger]   # ← must be present
+```
+
+**Check**: Is the backend's query port accessible?
+
+| Tool | UI port |
+|------|---------|
+| Jaeger | 16686 |
+| Tempo | 3200 (also 4317 for OTLP) |
+| Phoenix | 6006 |
+
+### T2.3 Only some DCC instances produce traces
+
+**Check**: Per-DCC environment:
+
+```bash
+# Each DCC process needs its own OTEL_* vars
+# Gateway passes through OTEL environment to child processes
+# But some DCCs may strip environment. Verify:
+cat /proc/<dcc-pid>/environ | tr '\0' '\n' | grep OTEL
+```
+
+---
+
+## T3. Admin UI issues
+
+### T3.1 `GET /admin` returns 404
+
+**Check**: Is the gateway process running?
+
+```bash
+ps aux | grep dcc-mcp-server
+```
+
+**Check**: What port is the gateway on?
+
+```bash
+# Default port is 0 (OS-assigned). Check the gateway log:
+grep "listening on" /var/log/dcc-mcp/gateway.log
+```
+
+**Fix**: The admin UI is served by the elected gateway, not by per-DCC
+servers. Connect to the gateway's port, not a DCC server's port.
+
+### T3.2 Admin tables are empty ("No data")
+
+**Check**: Audit ring buffer capacity:
+
+```bash
+# Default is 5000 rows. Check if the ring has ever been populated:
+curl -s http://localhost:8765/admin/api/calls | python -c "import sys,json; print(len(json.load(sys.stdin)))"
+```
+
+**Check**: Has `DCC_MCP_GATEWAY_AUDIT_DIR` been set? If not, data is
+in-memory only and resets on gateway restart.
+
+**Check**: Has traffic actually passed through the gateway?
+
+```bash
+# Verify the registry has backends registered
+curl -s http://localhost:8765/admin/api/workers
+```
+
+### T3.3 Stats show 0 calls despite activity
+
+The stats endpoint computes from the trace ring buffer (default 200 traces).
+If your traffic exceeds 200 requests, older entries are evicted. Increase the
+trace ring capacity:
+
+```bash
+DCC_MCP_TRACE_LOG_CAPACITY=2000 dcc-mcp-server
+```
+
+Or use the SQLite-backed path (`admin-persist-sqlite` feature) for access to
+all historical data.
+
+---
+
+## T4. ToolRecorder (Python) issues
+
+### T4.1 `metrics()` returns `None`
+
+```python
+metrics = recorder.metrics("create_sphere")
+if metrics is None:
+    print("This tool has never been recorded.")
+```
+
+**Fix**: Ensure `recorder.start("create_sphere", "maya")` was called and
+`guard.finish()` was invoked. The metric is only registered after a
+completed recording cycle.
+
+### T4.2 Percentiles are always 0.0
+
+Percentiles require a minimum sample count:
+
+- p95 stabilises after ~20 samples.
+- p99 stabilises after ~100 samples.
+
+Below these thresholds, percentiles may default to 0.0 or match the maximum
+observed value, depending on the internal histogram state.
+
+### T4.3 `p95_duration_ms` equals `avg_duration_ms`
+
+This happens when the sample count is too low for meaningful percentile
+computation (< 20 samples). Increase the sample size or use
+`avg_duration_ms` instead.
+
+---
+
+## T5. Schema / database issues
+
+### T5.1 Cannot open `gateway_admin.sqlite`
+
+**Check**: File permissions:
+
+```bash
+ls -la /tmp/dcc-mcp-registry/gateway_admin.sqlite
+# Must be readable by the user running the agent/CLI
+```
+
+**Check**: WAL journal mode — the file may have `-wal` and `-shm`
+companions:
+
+```bash
+ls -la /tmp/dcc-mcp-registry/gateway_admin.sqlite*
+```
+
+All three files must be present and accessible for read operations.
+
+**Check**: Is another process holding a write lock?
+
+```bash
+# On Linux/Mac:
+lsof /tmp/dcc-mcp-registry/gateway_admin.sqlite
+```
+
+### T5.2 `no such table: tool_calls`
+
+The database was created by an older gateway version (schema v1). The DDL
+is `CREATE TABLE IF NOT EXISTS`, so restarting the gateway creates missing
+tables automatically.
+
+```bash
+# Verify current schema version
+sqlite3 /tmp/dcc-mcp-registry/gateway_admin.sqlite ".tables"
+# Should show: tool_calls, sessions, session_events, ...
+```
+
+**Fix**: Restart the gateway to trigger the DDL bootstrap.
+
+### T5.3 Database is growing too large
+
+The SQLite lane is append-only. If the database grows beyond acceptable
+bounds, consider:
+
+1. Adding a cleanup job:
+   ```sql
+   DELETE FROM tool_calls WHERE started_at_ms < strftime('%s', 'now', '-30 days') * 1000;
+   DELETE FROM sessions WHERE started_at_ms < strftime('%s', 'now', '-30 days') * 1000;
+   DELETE FROM session_events WHERE created_at_ms < strftime('%s', 'now', '-30 days') * 1000;
+   ```
+
+2. Running VACUUM after large deletes:
+   ```sql
+   VACUUM;
+   ```
+
+3. Building the gateway without `admin-persist-sqlite` to use only the
+   in-memory ring buffer (data resets on restart).
+
+---
+
+## T6. Common configuration mistakes
+
+| Symptom | Likely cause |
+|---------|-------------|
+| Prometheus endpoint 404 | `prometheus` feature not compiled or `enable_prometheus=False` |
+| OTLP traces not appearing | `OTEL_EXPORTER_OTLP_ENDPOINT` not set |
+| `ObservabilityQuery` returns zeros | Wrong `db_path` or gateway has never run |
+| Admin UI "No data" | `DCC_MCP_GATEWAY_AUDIT_DIR` not set (in-memory only) |
+| Stats inaccurate | Trace ring capacity too small (default 200) |
+| SQLite not persisting | `admin-persist-sqlite` feature not compiled in |
+| ToolRecorder percentiles zero | Fewer than 20 samples |
+| `skill_paths_custom` reads fail | File exists but table missing; first gateway startup hasn't finished DDL |
+
+---
+
+## Quick diagnostic script
+
+```python
+"""Run this on a machine to verify observability is working."""
+import os, sys
+from pathlib import Path
+
+# 1. Check Prometheus
+port = os.environ.get("DCC_MCP_HTTP_PORT", "8765")
+import urllib.request
+try:
+    resp = urllib.request.urlopen(f"http://localhost:{port}/metrics")
+    print(f"[OK] Prometheus endpoint reachable on port {port}")
+except Exception as e:
+    print(f"[WARN] Prometheus endpoint: {e}")
+
+# 2. Check OTLP
+if "OTEL_EXPORTER_OTLP_ENDPOINT" in os.environ:
+    print(f"[OK] OTLP configured: {os.environ['OTEL_EXPORTER_OTLP_ENDPOINT']}")
+else:
+    print("[INFO] OTLP not configured (optional)")
+
+# 3. Check SQLite
+from dcc_mcp_core.admin_sqlite_lane import resolve_admin_db_path
+db = resolve_admin_db_path()
+if db.exists():
+    print(f"[OK] Admin SQLite database exists: {db}")
+else:
+    print(f"[WARN] Admin SQLite database not found at {db}")
+
+# 4. Check gateway admin UI
+try:
+    resp = urllib.request.urlopen(f"http://localhost:{port}/admin/api/calls")
+    print(f"[OK] Gateway admin API reachable")
+except Exception as e:
+    print(f"[WARN] Gateway admin API: {e}")
+```

--- a/docs/guide/observability-usage.md
+++ b/docs/guide/observability-usage.md
@@ -1,0 +1,324 @@
+# Observability Usage Guide
+
+How to consume observability data from each interface: AI agents, the CLI, and
+the Admin UI.
+
+---
+
+## 1. AI Agent Usage
+
+Agents can query observability data programmatically through the
+`ObservabilityQuery` Python API.
+
+### Prerequisites
+
+The gateway admin SQLite database must exist on the machine. It is created
+automatically when the gateway runs for the first time. The default path is:
+
+```
+<tempdir>/dcc-mcp-registry/gateway_admin.sqlite
+```
+
+Override with `DCC_MCP_GATEWAY_ADMIN_DB` environment variable.
+
+### Basic queries
+
+```python
+from dcc_mcp_core import ObservabilityQuery
+
+query = ObservabilityQuery(db_path="/path/to/gateway_admin.sqlite")
+
+# Session statistics
+stats = query.get_session_stats(
+    dcc_type="maya",
+    since_ms=1700000000000,
+)
+
+print(stats["data"])
+# {
+#   "total_sessions": 42,
+#   "active_sessions": 3,
+#   "ended_normally": 35,
+#   "ended_abnormally": 4,
+#   "avg_duration_ms": 312000.0,
+#   "total_tool_calls": 1280,
+#   "total_errors": 15,
+# }
+
+# Tool-call statistics
+tool_stats = query.get_tool_call_stats(
+    tool_name="maya__poly_sphere",
+    since_ms=1700000000000,
+    limit=50,
+)
+
+print(tool_stats["data"]["stats"])
+# {
+#   "total_calls": 200,
+#   "success_count": 195,
+#   "failure_count": 5,
+#   "success_rate": 0.975,
+#   "avg_duration_ms": 45.2,
+# }
+
+print(tool_stats["data"]["events"])  # list of individual call records
+```
+
+### Session tree
+
+```python
+# All root sessions
+tree = query.get_session_tree(dcc_type="maya")
+
+# Drill into one session
+children = query.get_session_tree(root_session_id="sess-abc123")
+```
+
+### Coverage and crash stats
+
+```python
+# Gateway coverage ratio
+cov = query.get_coverage_stats(since_ms=1700000000000)
+
+# Crash analysis
+crashes = query.get_crash_stats(dcc_type="houdini", since_ms=1700000000000)
+```
+
+### Diagnostic checks
+
+```python
+# Does the database exist?
+from pathlib import Path
+db = Path("/path/to/gateway_admin.sqlite")
+if not db.exists():
+    print("Gateway has never run on this machine — no observability data.")
+
+# Are there recent sessions?
+stats = query.get_session_stats()
+if stats["data"]["total_sessions"] == 0:
+    print("No sessions recorded yet.")
+```
+
+### Agent context for call attribution
+
+When making MCP or REST calls through the gateway, attach agent context for
+observability correlation:
+
+```python
+# MCP: attach context to params._meta
+params = {
+    "name": "maya__poly_sphere",
+    "arguments": {"radius": 2.0},
+    "_meta": {
+        "agent_context": {
+            "agent_id": "my-agent",
+            "agent_name": "SceneBuilder",
+            "turn_id": "turn-42",
+            "model": "claude-sonnet-4-20250514",
+        }
+    }
+}
+```
+
+```json
+// REST: attach context to meta.agent_context
+POST /v1/call
+{
+  "tool": "maya__poly_sphere",
+  "args": {"radius": 2.0},
+  "meta": {
+    "agent_context": {
+      "agent_id": "my-agent",
+      "turn_id": "turn-42"
+    }
+  }
+}
+```
+
+---
+
+## 2. CLI Usage
+
+The `dcc-mcp-cli stats` command queries the gateway admin SQLite database.
+
+### Quick start
+
+```bash
+# Show summary statistics
+dcc-mcp-cli stats
+
+# Filter by time range
+dcc-mcp-cli stats --since 1h
+dcc-mcp-cli stats --since 24h
+dcc-mcp-cli stats --since 7d
+
+# Filter by DCC type
+dcc-mcp-cli stats --dcc maya
+dcc-mcp-cli stats --dcc blender
+
+# Show top tools
+dcc-mcp-cli stats --top-tools 10
+
+# Show session breakdown
+dcc-mcp-cli stats --sessions
+```
+
+### Output format
+
+```
+=== Session Statistics (last 24h) ===
+Total sessions:    42
+Active:             3
+Ended normally:    35
+Ended abnormally:   4
+Avg duration:     5.2m
+Total tool calls: 1,280
+Total errors:       15
+
+=== Tool Call Performance ===
+Tool                  Calls  Success  P95(ms)  P99(ms)
+maya__poly_sphere      200   97.5%     120      340
+blender__bevel_edge     50   94.0%      85      210
+houdini__vdb_fog        30   96.7%     450     1200
+
+=== Coverage ===
+Observed:   1,250
+Unobserved:   30
+Coverage:   97.7%
+```
+
+---
+
+## 3. Admin UI Usage
+
+The gateway serves a read-only HTML dashboard at `GET /admin` when the gateway
+process is running.
+
+### Dashboard sections
+
+| Tab | Endpoint | What you see |
+|-----|----------|-------------|
+| **Calls** | `GET /admin/api/calls` | Recent audit records: request_id, tool, DCC, duration, success/failure. |
+| **Traces** | `GET /admin/api/traces?limit=200` | Dispatch waterfalls with bounded input/output payloads. |
+| **Stats** | `GET /admin/api/stats?range=1h` | Aggregated success rate, latency percentiles, top tools/instances, hourly distribution. |
+| **Workflows** | `GET /admin/api/workflows?limit=200` | Session/workflow chains with agent metadata and step links. |
+| **Workers** | `GET /admin/api/workers` | Per-instance registry cards (live DCC backends). |
+| **Traffic** | `GET /admin/api/traffic?limit=300` | Capture status and retained metadata-only frames. |
+| **Governance** | `GET /admin/api/governance?limit=300` | Policy decisions, redaction paths, quota state. |
+| **Skills** | Admin UI page | Skill paths, load states, health. |
+| **Marketplace** | Admin UI page | Marketplace extension browsing. |
+| **Instances** | Admin UI page | DCC instances and their connection status. |
+
+### Enabling audit persistence
+
+By default audit data lives in an in-memory ring buffer. For persistence across
+gateway restarts, set:
+
+```bash
+DCC_MCP_GATEWAY_AUDIT_DIR=/var/log/dcc-mcp/audit  # enables JSONL files
+DCC_MCP_GATEWAY_AUDIT_MAX_ROWS=5000                # default, rows per file
+```
+
+When set, the gateway writes `audit.jsonl` and `traces.jsonl` to that directory
+and seeds the in-memory buffers from these files on restart.
+
+### Enabling SQLite persistence
+
+Build the gateway with the `admin-persist-sqlite` Cargo feature:
+
+```toml
+dcc-mcp-gateway = { features = ["admin-persist-sqlite"] }
+```
+
+The gateway then persists every trace, audit, skill path change, and
+deregistered instance to `gateway_admin.sqlite`. The SQLite lane runs on a
+background writer thread and never blocks the hot path.
+
+### Prometheus integration
+
+```bash
+# Scrape a DCC server's metrics
+curl -u scraper:change-me http://localhost:8765/metrics
+
+# Add to prometheus.yml
+scrape_configs:
+  - job_name: dcc-mcp
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["host:8765", "host:8766"]
+    metrics_path: /metrics
+    basic_auth:
+      username: scraper
+      password_file: /etc/prometheus/dcc-mcp.pass
+```
+
+---
+
+## 4. OTLP Trace Correlation
+
+### Jaeger
+
+```bash
+docker run -d --name jaeger \
+  -p 4317:4317 \
+  -p 16686:16686 \
+  jaegertracing/all-in-one:latest
+
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_SERVICE_NAME=dcc-mcp-gateway \
+  dcc-mcp-server
+```
+
+### Grafana Tempo
+
+```yaml
+# docker-compose.yml
+services:
+  tempo:
+    image: grafana/tempo:latest
+    ports: ["4317:4317", "3200:3200"]
+```
+
+### Phoenix
+
+Route through an OpenTelemetry Collector (the Rust exporter uses OTLP/gRPC;
+Phoenix accepts OTLP/HTTP):
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+exporters:
+  otlphttp/phoenix:
+    traces_endpoint: http://phoenix:6006/v1/traces
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/phoenix]
+```
+
+---
+
+## 5. Python ToolRecorder (In-Process Metrics)
+
+For lightweight per-tool telemetry without a database:
+
+```python
+from dcc_mcp_core import ToolRecorder
+
+recorder = ToolRecorder("maya")
+
+# Context manager (recommended)
+with recorder.start("create_sphere", "maya") as guard:
+    result = cmds.polySphere(r=2.0)
+
+# Query results
+metrics = recorder.metrics("create_sphere")
+if metrics:
+    print(f"Calls: {metrics.invocation_count}")
+    print(f"Success: {metrics.success_rate():.1%}")
+    print(f"P95: {metrics.p95_duration_ms:.1f} ms")
+```

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -403,6 +403,10 @@ rate(dcc_mcp_gateway_probes_total{outcome="ready"}[5m])
 
 ## See also
 
+- [metric-dictionary.md](metric-dictionary.md) — canonical reference for every metric, dimension, unit, sampling window, and null semantics
+- [observability-schema.md](observability-schema.md) — SQLite schema versions, query API versioning, and migration procedures
+- [observability-usage.md](observability-usage.md) — how to consume observability from agents, CLI, and Admin UI
+- [observability-troubleshooting.md](observability-troubleshooting.md) — operational runbook for diagnosing observability issues
 - [telemetry.md](telemetry.md) — `ToolMetrics`, `ToolRecorder`, legacy Python telemetry
 - [adapter-runtime-contracts.md](adapter-runtime-contracts.md) — session events, artefacts, debug descriptors, UI automation contracts
 - [gateway-diagnostics.md](gateway-diagnostics.md) — log templates for election/eviction events

--- a/docs/zh/guide/INDEX.md
+++ b/docs/zh/guide/INDEX.md
@@ -71,6 +71,10 @@
 | [artefacts.md](artefacts.md) | FileRef + ArtefactStore — 跨工具文件交接 |
 | [telemetry.md](telemetry.md) | ToolMetrics、ToolRecorder、RecordingGuard |
 | [observability.md](observability.md) | OTLP exporter、agent workflow spans、网关事件日志（`resources://gateway/events`）、Prometheus 计数器 |
+| [metric-dictionary.md](../../guide/metric-dictionary.md) | 指标字典：单位、采样窗口、空值语义、存储层清单 |
+| [observability-schema.md](../../guide/observability-schema.md) | 版本化 schema、迁移路径、查询 API 版本策略 |
+| [observability-usage.md](../../guide/observability-usage.md) | Agent、CLI、Admin UI 可观测性使用说明 |
+| [observability-troubleshooting.md](../../guide/observability-troubleshooting.md) | 可观测性运维排障手册 |
 | [scheduler.md](scheduler.md) | ScheduleSpec、TriggerSpec、cron/webhook 调度 |
 | [workflows.md](workflows.md) | WorkflowSpec 引擎：步骤类型、策略、持久化 |
 | [job-persistence.md](job-persistence.md) | SQLite 支持的作业/工作流持久化与恢复 |

--- a/docs/zh/guide/observability.md
+++ b/docs/zh/guide/observability.md
@@ -290,6 +290,10 @@ rate(dcc_mcp_gateway_probes_total{outcome="ready"}[5m])
 
 ## 参见
 
+- [metric-dictionary.md](../../guide/metric-dictionary.md) — 指标字典：单位、采样窗口、空值语义、存储层
+- [observability-schema.md](../../guide/observability-schema.md) — 版本化 schema、迁移路径、查询 API 版本策略
+- [observability-usage.md](../../guide/observability-usage.md) — Agent、CLI、Admin UI 使用说明
+- [observability-troubleshooting.md](../../guide/observability-troubleshooting.md) — 运维排障手册
 - [telemetry.md](telemetry.md) — `ToolMetrics`、`ToolRecorder`、旧版 Python 遥测
 - [gateway-diagnostics.md](gateway-diagnostics.md) — 选举/驱逐事件的日志模板
 - [production-deployment.md](production-deployment.md) — 生产环境监控检查清单


### PR DESCRIPTION
## Summary

Add four new documentation pages for the observability data model introduced in the merged observability data model (session lifecycle, tool-call attribution, metrics):

- **metric-dictionary.md** — canonical reference for every metric across all
  storage layers (SQLite, Prometheus, OTLP, Query API, ToolRecorder, Admin
  API), with units, sampling windows, and null/missing-value semantics
- **observability-schema.md** — SQLite schema version history (v1 → v2),
  query API version policy (API_VERSION = "v1"), and migration procedures for
  adding tables, columns, changing types, and deprecating fields
- **observability-usage.md** — how to consume observability from AI agents
  (ObservabilityQuery Python API), CLI (dcc-mcp-cli stats), and Admin UI
  dashboard tabs, plus OTLP trace correlation setup
- **observability-troubleshooting.md** — operational runbook: missing metrics,
  OTLP traces not appearing, empty admin tables, ToolRecorder edge cases,
  SQLite schema issues, and a quick diagnostic script

All English and Chinese index pages updated to reference the new pages.

## Test plan

- [ ] Review rendering of all four .md files in GitHub
- [ ] Verify links in INDEX.md and observability.md "See also" sections
- [ ] Confirm CLI examples match current dcc-mcp-cli stats flags
- [ ] English-only; zh index pages cross-reference English source pages