### PR TITLE
chore: remove stale marketplace/service.rs file-size exemption

### DIFF
--- a/.github/file-size-exemptions.txt
+++ b/.github/file-size-exemptions.txt
@@ -17,5 +17,3 @@ crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
 crates/dcc-mcp-skill-rest/src/service.rs
 # PIP-1799 — capability_service.rs 1507L, exceeds 1500 limit by 7 lines
 crates/dcc-mcp-gateway/src/gateway/capability_service.rs
-# PIP-2701 — service.rs 1523L, exceeds 1500 limit by 23 lines
-crates/dcc-mcp-marketplace/src/service.rs


### PR DESCRIPTION
## Summary

Remove the stale file-size exemption for `crates/dcc-mcp-marketplace/src/service.rs` from `.github/file-size-exemptions.txt`.

## Evidence

- `service.rs` is currently **991 lines**, well below the 1500-line Rust limit
- The refactor is complete, so the exemption is no longer needed

## Validation

- File-size gate: `service.rs` at 991 lines passes the \<1500 limit without any exemption
- Remaining exemptions are all still above their respective limits