### PR TITLE
fix(cli): extract lint module to pass file size gate (1534→1424 lines)

### DIFF
--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::io::Read;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -7,8 +6,6 @@ use anyhow::Context;
 #[cfg(test)]
 use base64::Engine;
 use clap::{Parser, Subcommand, ValueEnum};
-use dcc_mcp_skills::validator::IssueSeverity;
-use dcc_mcp_skills::{SkillValidationReport, validate_skill_dir};
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -28,6 +25,7 @@ use crate::domain::rest::{
 use crate::infra::http::HttpGateway;
 
 mod image_artifacts;
+mod lint;
 mod ui_control_output;
 
 #[cfg(test)]
@@ -912,7 +910,7 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
             }
         }
         Command::Lint(lint_args) => {
-            let result = run_lint_cmd(&lint_args)?;
+            let result = lint::run_lint_cmd(&lint_args)?;
             failed = result.failed;
             result.value
         }
@@ -963,114 +961,6 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
         std::process::exit(1);
     }
     Ok(())
-}
-
-struct LintCommandResult {
-    value: Value,
-    failed: bool,
-}
-
-fn collect_skill_dirs(
-    root: &std::path::Path,
-    out: &mut BTreeSet<PathBuf>,
-    max_depth: usize,
-) -> anyhow::Result<()> {
-    collect_skill_dirs_at(root, out, max_depth, 0)
-}
-
-fn collect_skill_dirs_at(
-    root: &std::path::Path,
-    out: &mut BTreeSet<PathBuf>,
-    max_depth: usize,
-    depth: usize,
-) -> anyhow::Result<()> {
-    if root.join("SKILL.md").is_file() {
-        out.insert(root.to_path_buf());
-        return Ok(());
-    }
-
-    if !root.is_dir() {
-        anyhow::bail!(
-            "skill lint path does not exist or is not a directory: {}",
-            root.display()
-        );
-    }
-    if depth >= max_depth {
-        return Ok(());
-    }
-
-    let entries = std::fs::read_dir(root).map_err(|err| {
-        anyhow::anyhow!("cannot read skill lint path '{}': {err}", root.display())
-    })?;
-    for entry in entries {
-        let entry = entry?;
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        if name.starts_with('.') || name == "node_modules" || name == "target" {
-            continue;
-        }
-        collect_skill_dirs_at(&path, out, max_depth, depth + 1)?;
-    }
-    Ok(())
-}
-
-fn issue_severity_label(severity: IssueSeverity) -> &'static str {
-    match severity {
-        IssueSeverity::Error => "error",
-        IssueSeverity::Warning => "warning",
-    }
-}
-
-fn lint_report_to_json(report: &SkillValidationReport) -> Value {
-    let (errors, warnings) = report.counts();
-    let issues: Vec<_> = report
-        .issues
-        .iter()
-        .map(|issue| {
-            serde_json::json!({
-                "severity": issue_severity_label(issue.severity),
-                "category": format!("{:?}", issue.category),
-                "message": issue.message,
-            })
-        })
-        .collect();
-    serde_json::json!({
-        "skill_dir": report.skill_dir.display().to_string(),
-        "errors": errors,
-        "warnings": warnings,
-        "issues": issues,
-    })
-}
-
-fn run_lint_cmd(args: &LintArgs) -> anyhow::Result<LintCommandResult> {
-    let mut skill_dirs = BTreeSet::new();
-    for root in &args.paths {
-        collect_skill_dirs(root, &mut skill_dirs, args.max_depth)?;
-    }
-
-    let reports: Vec<_> = skill_dirs
-        .iter()
-        .map(|skill_dir| validate_skill_dir(skill_dir))
-        .collect();
-    let (errors, warnings) = reports.iter().fold((0, 0), |(e_acc, w_acc), report| {
-        let (errors, warnings) = report.counts();
-        (e_acc + errors, w_acc + warnings)
-    });
-    let failed = errors > 0 || (args.warnings_as_errors && warnings > 0);
-    let reports_json: Vec<_> = reports.iter().map(lint_report_to_json).collect();
-    let value = serde_json::json!({
-        "checked": reports.len(),
-        "errors": errors,
-        "warnings": warnings,
-        "failed": failed,
-        "reports": reports_json,
-    });
-
-    Ok(LintCommandResult { value, failed })
 }
 
 async fn ensure_gateway_for_command(

--- a/crates/dcc-mcp-cli/src/presentation/cli/lint.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/lint.rs
@@ -1,0 +1,116 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use dcc_mcp_skills::validator::IssueSeverity;
+use dcc_mcp_skills::{SkillValidationReport, validate_skill_dir};
+use serde_json::Value;
+
+use super::LintArgs;
+
+pub(crate) struct LintCommandResult {
+    pub(crate) value: Value,
+    pub(crate) failed: bool,
+}
+
+pub(crate) fn collect_skill_dirs(
+    root: &std::path::Path,
+    out: &mut BTreeSet<PathBuf>,
+    max_depth: usize,
+) -> anyhow::Result<()> {
+    collect_skill_dirs_at(root, out, max_depth, 0)
+}
+
+fn collect_skill_dirs_at(
+    root: &std::path::Path,
+    out: &mut BTreeSet<PathBuf>,
+    max_depth: usize,
+    depth: usize,
+) -> anyhow::Result<()> {
+    if root.join("SKILL.md").is_file() {
+        out.insert(root.to_path_buf());
+        return Ok(());
+    }
+
+    if !root.is_dir() {
+        anyhow::bail!(
+            "skill lint path does not exist or is not a directory: {}",
+            root.display()
+        );
+    }
+    if depth >= max_depth {
+        return Ok(());
+    }
+
+    let entries = std::fs::read_dir(root).map_err(|err| {
+        anyhow::anyhow!("cannot read skill lint path '{}': {err}", root.display())
+    })?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with('.') || name == "node_modules" || name == "target" {
+            continue;
+        }
+        collect_skill_dirs_at(&path, out, max_depth, depth + 1)?;
+    }
+    Ok(())
+}
+
+fn issue_severity_label(severity: IssueSeverity) -> &'static str {
+    match severity {
+        IssueSeverity::Error => "error",
+        IssueSeverity::Warning => "warning",
+    }
+}
+
+fn lint_report_to_json(report: &SkillValidationReport) -> Value {
+    let (errors, warnings) = report.counts();
+    let issues: Vec<_> = report
+        .issues
+        .iter()
+        .map(|issue| {
+            serde_json::json!({
+                "severity": issue_severity_label(issue.severity),
+                "category": format!("{:?}", issue.category),
+                "message": issue.message,
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "skill_dir": report.skill_dir.display().to_string(),
+        "errors": errors,
+        "warnings": warnings,
+        "issues": issues,
+    })
+}
+
+pub(crate) fn run_lint_cmd(args: &LintArgs) -> anyhow::Result<LintCommandResult> {
+    let mut skill_dirs = BTreeSet::new();
+    for root in &args.paths {
+        collect_skill_dirs(root, &mut skill_dirs, args.max_depth)?;
+    }
+
+    let reports: Vec<_> = skill_dirs
+        .iter()
+        .map(|skill_dir| validate_skill_dir(skill_dir))
+        .collect();
+    let (errors, warnings) = reports.iter().fold((0, 0), |(e_acc, w_acc), report| {
+        let (errors, warnings) = report.counts();
+        (e_acc + errors, w_acc + warnings)
+    });
+    let failed = errors > 0 || (args.warnings_as_errors && warnings > 0);
+    let reports_json: Vec<_> = reports.iter().map(lint_report_to_json).collect();
+    let value = serde_json::json!({
+        "checked": reports.len(),
+        "errors": errors,
+        "warnings": warnings,
+        "failed": failed,
+        "reports": reports_json,
+    });
+
+    Ok(LintCommandResult { value, failed })
+}


### PR DESCRIPTION
## Problem

PR #1992 fails the file size gate: `crates/dcc-mcp-cli/src/presentation/cli.rs` at 1534 lines (max 1500, +34 over).

## Fix

Extract the self-contained lint functions into `cli/lint.rs`:
- `run_lint_cmd`, `collect_skill_dirs`, `lint_report_to_json`, `issue_severity_label`, `LintCommandResult`
- Removes unused imports (`BTreeSet`, `IssueSeverity`, `dcc_mcp_skills` types) from cli.rs

## Result

- `cli.rs`: 1534 → **1424 lines** (well under 1500 limit)
- All 141 tests pass (88 unit + 53 integration/e2e)
- No functional changes — pure module extraction

## Validation

```
cargo check -p dcc-mcp-cli  # PASS
cargo test -p dcc-mcp-cli   # 141 passed, 0 failed
```