### PR TITLE
fix: suppress dead_code clippy warnings in dcc-mcp-computer-use

### DIFF
--- a/crates/dcc-mcp-computer-use/src/keyboard_policy.rs
+++ b/crates/dcc-mcp-computer-use/src/keyboard_policy.rs
@@ -14,6 +14,7 @@ pub(crate) enum CommonKey {
 }
 
 impl CommonKey {
+    #[allow(dead_code)]
     pub(crate) const fn virtual_key(self) -> Option<u16> {
         match self {
             Self::Control(value) | Self::Shift(value) | Self::Alt(value) => Some(value),

--- a/crates/dcc-mcp-computer-use/src/lib.rs
+++ b/crates/dcc-mcp-computer-use/src/lib.rs
@@ -602,6 +602,7 @@ impl ComputerUseSession {
         self.perform_inner(request, None)
     }
 
+    #[allow(dead_code)]
     fn perform_with_pre_input_fence(
         &self,
         request: &ComputerUseAction,

--- a/crates/dcc-mcp-computer-use/src/ui_control_host.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host.rs
@@ -24,6 +24,7 @@ mod system_operations;
 #[cfg(windows)]
 mod windows;
 
+#[allow(unused_imports)]
 use policy::{
     ActionControlFence, classify_action, stale_accessibility_state, verify_action_fence,
     verify_expected_action_fence,
@@ -60,6 +61,7 @@ struct RuntimeSnapshot {
 }
 
 #[derive(Clone)]
+#[allow(dead_code)]
 struct RuntimeAccessibilityState {
     root: Value,
     focus_runtime_id: Option<String>,
@@ -129,6 +131,7 @@ struct HostSession {
     runtime: Box<dyn HostRuntimeSession>,
 }
 
+#[allow(dead_code)]
 struct ActionFenceExpectation {
     controls: Vec<ActionControlFence>,
     observation: Option<Value>,
@@ -291,6 +294,7 @@ fn request_session(request: &UiControlHostRequest) -> Option<(&str, bool, bool)>
 }
 
 impl UiControlHost {
+    #[allow(dead_code)]
     fn from_operator_config() -> Result<Self, String> {
         Ok(Self {
             system_grants: load_system_grants()?,

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/policy.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/policy.rs
@@ -205,6 +205,7 @@ pub(super) fn verify_action_fence(
     ))
 }
 
+#[allow(dead_code)]
 pub(super) fn verify_expected_action_fence(
     action: &UiControlAction,
     expected: &ActionFenceExpectation,

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/system_operations.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/system_operations.rs
@@ -9,9 +9,12 @@ use dcc_mcp_ui_control::host_protocol::{
 use super::runtime_windows;
 use super::{HostFailure, valid_wire_label};
 
+#[allow(dead_code)]
 const SYSTEM_GRANTS_FILE_ENV: &str = "DCC_MCP_UI_CONTROL_SYSTEM_GRANTS_FILE";
+#[allow(dead_code)]
 const MAX_SYSTEM_GRANTS_FILE_BYTES: u64 = 1024 * 1024;
 
+#[allow(dead_code)]
 pub(super) fn load_system_grants() -> Result<HashMap<String, UiControlSystemGrant>, String> {
     let Some(path) = std::env::var_os(SYSTEM_GRANTS_FILE_ENV) else {
         return Ok(HashMap::new());
@@ -30,6 +33,7 @@ pub(super) fn load_system_grants() -> Result<HashMap<String, UiControlSystemGran
     parse_system_grants(&bytes)
 }
 
+#[allow(dead_code)]
 pub(super) fn parse_system_grants(
     bytes: &[u8],
 ) -> Result<HashMap<String, UiControlSystemGrant>, String> {


### PR DESCRIPTION
## Summary

Fix 11 clippy `dead_code` errors on ubuntu-latest from [CI run 29762393934](https://github.com/dcc-mcp/dcc-mcp-core/actions/runs/29762393934).

## Changes

Add `#[allow(dead_code)]` to items that are platform-gated (`#[cfg(windows)]` consumers) or planned for future wiring:

| File | Item |
|------|------|
| `ui_control_host.rs` | `ActionFenceExpectation` struct, `RuntimeAccessibilityState` struct, `from_operator_config` fn |
| `lib.rs` | `perform_with_pre_input_fence` fn |
| `keyboard_policy.rs` | `CommonKey::virtual_key` method |
| `policy.rs` | `verify_expected_action_fence` fn |
| `system_operations.rs` | `SYSTEM_GRANTS_FILE_ENV`, `MAX_SYSTEM_GRANTS_FILE_BYTES`, `load_system_grants`, `parse_system_grants` |

## Validation

- `cargo check` — passes
- `cargo clippy -- -D warnings` — clean
- `cargo test --no-run` — compiles

Refs: PIP-2776, PR #1995