### PR TITLE
style: cargo fmt for #1998

### DIFF
--- a/crates/dcc-mcp-computer-use/src/platform/windows.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows.rs
@@ -5,14 +5,12 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use windows::Win32::Foundation::{
-    COLORREF, CloseHandle, HANDLE, HWND, LPARAM, POINT, RECT, WAIT_ABANDONED,
-    WAIT_OBJECT_0, WAIT_TIMEOUT, WPARAM,
+    COLORREF, CloseHandle, HANDLE, HWND, LPARAM, POINT, RECT, WAIT_ABANDONED, WAIT_OBJECT_0,
+    WAIT_TIMEOUT, WPARAM,
 };
 use windows::Win32::Graphics::Gdi::{
-    CreateEllipticRgn,
-    EnumDisplayMonitors, GetMonitorInfoW, HDC,
-    HMONITOR, MONITOR_DEFAULTTONULL, MONITORINFO, MonitorFromPoint, MonitorFromRect,
-    SetWindowRgn,
+    CreateEllipticRgn, EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR, MONITOR_DEFAULTTONULL,
+    MONITORINFO, MonitorFromPoint, MonitorFromRect, SetWindowRgn,
 };
 use windows::Win32::System::RemoteDesktop::{
     NOTIFY_FOR_THIS_SESSION, WTS_CONNECTSTATE_CLASS, WTS_CURRENT_SESSION, WTSActive,
@@ -40,17 +38,15 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     MOUSEINPUT, RegisterHotKey, SendInput, UnregisterHotKey, VIRTUAL_KEY, VK_ESCAPE,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
-    BringWindowToTop, DestroyWindow, DispatchMessageW, GA_ROOT,
-    GW_HWNDPREV, GWL_EXSTYLE, GetAncestor, GetClassNameW, GetCursorPos, GetForegroundWindow, GetSystemMetrics, GetWindow,
+    BringWindowToTop, DestroyWindow, DispatchMessageW, GA_ROOT, GW_HWNDPREV, GWL_EXSTYLE,
+    GetAncestor, GetClassNameW, GetCursorPos, GetForegroundWindow, GetSystemMetrics, GetWindow,
     GetWindowLongPtrW, GetWindowRect, GetWindowTextLengthW, GetWindowTextW,
-    GetWindowThreadProcessId, HWND_NOTOPMOST, HWND_TOPMOST, IsIconic, IsWindow, IsWindowVisible, MSG, PM_NOREMOVE, PM_REMOVE, PeekMessageW, PostMessageW,
-    SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
-    SW_RESTORE, SW_SHOWNOACTIVATE, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW,
-    SetForegroundWindow,
-    SetWindowPos, ShowWindow, TranslateMessage, WM_APP, WM_DISPLAYCHANGE, WM_DPICHANGED, WM_HOTKEY,
-    WM_WTSSESSION_CHANGE,
-    WS_EX_TOPMOST, WS_EX_TRANSPARENT,
-    WindowFromPoint,
+    GetWindowThreadProcessId, HWND_NOTOPMOST, HWND_TOPMOST, IsIconic, IsWindow, IsWindowVisible,
+    MSG, PM_NOREMOVE, PM_REMOVE, PeekMessageW, PostMessageW, SM_CXVIRTUALSCREEN,
+    SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SW_RESTORE, SW_SHOWNOACTIVATE,
+    SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW, SetForegroundWindow, SetWindowPos,
+    ShowWindow, TranslateMessage, WM_APP, WM_DISPLAYCHANGE, WM_DPICHANGED, WM_HOTKEY,
+    WM_WTSSESSION_CHANGE, WS_EX_TOPMOST, WS_EX_TRANSPARENT, WindowFromPoint,
 };
 use windows::core::{BOOL, PCWSTR, PWSTR, w};
 
@@ -1209,5 +1205,5 @@ mod overlay;
 mod overlay_render;
 
 use geometry::*;
-pub(super) use overlay_render::*;
 pub(crate) use input::{flush_pending_input_releases, perform_action, window_dpi};
+pub(super) use overlay_render::*;

--- a/crates/dcc-mcp-computer-use/src/platform/windows/input_tests.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/input_tests.rs
@@ -805,7 +805,8 @@ fn persistent_overlay_layers_stay_hidden_until_their_geometry_is_ready() {
     use windows::Win32::UI::WindowsAndMessaging::IsWindowVisible;
 
     let _dpi_awareness = ThreadDpiAwareness::enter().unwrap();
-    let hwnd = create_color_overlay("", (80, 90, 160, 24), 42, false, OverlayTone::Glow, None).unwrap();
+    let hwnd =
+        create_color_overlay("", (80, 90, 160, 24), 42, false, OverlayTone::Glow, None).unwrap();
     assert!(!unsafe { IsWindowVisible(hwnd) }.as_bool());
 
     set_overlay_visible(hwnd, true).unwrap();
@@ -821,7 +822,8 @@ fn overlay_classes_are_revalidated_for_each_window_creation() {
 
     unsafe { GetClassInfoW(Some(instance.into()), CONTROL_OVERLAY_CLASS, &raw mut class) }.unwrap();
 
-    let hwnd = create_color_overlay("", (80, 90, 160, 24), 42, false, OverlayTone::Accent, None).unwrap();
+    let hwnd =
+        create_color_overlay("", (80, 90, 160, 24), 42, false, OverlayTone::Accent, None).unwrap();
     assert!(unsafe { IsWindow(Some(hwnd)) }.as_bool());
     unsafe { DestroyWindow(hwnd) }.unwrap();
 }
@@ -1266,11 +1268,8 @@ fn glow_from_accent_is_lighter() {
     let accent = CONTROL_ACCENT_COLOR;
     let glow = glow_from_accent(accent);
     // Glow should have higher RGB values (lighter)
-    let accent_sum = (accent.0 & 0xFF)
-        + ((accent.0 >> 8) & 0xFF)
-        + ((accent.0 >> 16) & 0xFF);
-    let glow_sum =
-        (glow.0 & 0xFF) + ((glow.0 >> 8) & 0xFF) + ((glow.0 >> 16) & 0xFF);
+    let accent_sum = (accent.0 & 0xFF) + ((accent.0 >> 8) & 0xFF) + ((accent.0 >> 16) & 0xFF);
+    let glow_sum = (glow.0 & 0xFF) + ((glow.0 >> 8) & 0xFF) + ((glow.0 >> 16) & 0xFF);
     assert!(glow_sum > accent_sum);
 }
 
@@ -1290,5 +1289,8 @@ fn all_palette_colors_are_reachable() {
     let mut colors: Vec<u32> = ids.iter().map(|id| session_color(id).0).collect();
     colors.sort_unstable();
     colors.dedup();
-    assert!(colors.len() >= 2, "expected at least 2 distinct colors from palette");
+    assert!(
+        colors.len() >= 2,
+        "expected at least 2 distinct colors from palette"
+    );
 }

--- a/crates/dcc-mcp-computer-use/src/platform/windows/overlay.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/overlay.rs
@@ -281,15 +281,29 @@ impl ControlOverlay {
 
         let elapsed_ms = self.pulse_started.elapsed().as_millis() as u64;
         for layer in &self.capsule_glows {
-            layer.apply_pulse_with_boost(CONTROL_BORDER_PULSE_FLOOR_PERCENT, elapsed_ms, scope_boost)?;
+            layer.apply_pulse_with_boost(
+                CONTROL_BORDER_PULSE_FLOOR_PERCENT,
+                elapsed_ms,
+                scope_boost,
+            )?;
         }
-        self.capsule
-            .apply_pulse_with_boost(CONTROL_CAPSULE_PULSE_FLOOR_PERCENT, elapsed_ms, scope_boost)?;
+        self.capsule.apply_pulse_with_boost(
+            CONTROL_CAPSULE_PULSE_FLOOR_PERCENT,
+            elapsed_ms,
+            scope_boost,
+        )?;
         for layer in &self.corners {
-            layer.apply_pulse_with_boost(CONTROL_BORDER_PULSE_FLOOR_PERCENT, elapsed_ms, scope_boost)?;
+            layer.apply_pulse_with_boost(
+                CONTROL_BORDER_PULSE_FLOOR_PERCENT,
+                elapsed_ms,
+                scope_boost,
+            )?;
         }
-        self.cursor_ring
-            .apply_pulse_with_boost(CONTROL_CURSOR_PULSE_FLOOR_PERCENT, elapsed_ms, scope_boost)?;
+        self.cursor_ring.apply_pulse_with_boost(
+            CONTROL_CURSOR_PULSE_FLOOR_PERCENT,
+            elapsed_ms,
+            scope_boost,
+        )?;
 
         // Update the last-action fading dot
         self.update_last_action_dot();

--- a/crates/dcc-mcp-computer-use/src/platform/windows/overlay_render.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/overlay_render.rs
@@ -1,35 +1,33 @@
-use windows::Win32::Foundation::{
-    COLORREF, HWND, LPARAM, LRESULT, RECT, WPARAM,
-};
+use windows::Win32::Foundation::{COLORREF, HWND, LPARAM, LRESULT, RECT, WPARAM};
 use windows::Win32::Graphics::Gdi::{
     BeginPaint, CLEARTYPE_QUALITY, CLIP_DEFAULT_PRECIS, CombineRgn, CreateEllipticRgn, CreateFontW,
     CreateRoundRectRgn, CreateSolidBrush, DEFAULT_CHARSET, DEFAULT_PITCH, DT_CENTER,
     DT_END_ELLIPSIS, DT_SINGLELINE, DT_VCENTER, DeleteObject, DrawTextW, EndPaint, FW_SEMIBOLD,
-    GetStockObject, HBRUSH, HGDIOBJ, NULL_BRUSH, OUT_DEFAULT_PRECIS, PAINTSTRUCT, RGN_DIFF, RGN_ERROR,
-    SelectObject, SetBkMode, SetTextColor, SetWindowRgn, TRANSPARENT,
+    GetStockObject, HBRUSH, HGDIOBJ, NULL_BRUSH, OUT_DEFAULT_PRECIS, PAINTSTRUCT, RGN_DIFF,
+    RGN_ERROR, SelectObject, SetBkMode, SetTextColor, SetWindowRgn, TRANSPARENT,
 };
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows::Win32::UI::HiDpi::GetDpiForWindow;
 use windows::Win32::UI::WindowsAndMessaging::{
-    CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetClassInfoW, GetClassNameW,
-    GetClientRect, GetWindowLongPtrW, GetWindowRect, GetWindowTextLengthW, GetWindowTextW,
-    GWL_USERDATA, HWND_TOPMOST, IsWindowVisible, LWA_ALPHA, MSG, PM_REMOVE,
-    PeekMessageW, RegisterClassW, SW_HIDE, SW_SHOWNOACTIVATE, SWP_NOACTIVATE, SWP_SHOWWINDOW,
+    CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GWL_USERDATA, GetClassInfoW,
+    GetClassNameW, GetClientRect, GetWindowLongPtrW, GetWindowRect, GetWindowTextLengthW,
+    GetWindowTextW, HWND_TOPMOST, IsWindowVisible, LWA_ALPHA, MSG, PM_REMOVE, PeekMessageW,
+    RegisterClassW, SW_HIDE, SW_SHOWNOACTIVATE, SWP_NOACTIVATE, SWP_SHOWWINDOW,
     SetLayeredWindowAttributes, SetWindowDisplayAffinity, SetWindowLongPtrW, SetWindowPos,
     ShowWindow, TranslateMessage, WDA_EXCLUDEFROMCAPTURE, WINDOW_EX_STYLE, WINDOW_STYLE, WM_PAINT,
-    WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST,
-    WS_EX_TRANSPARENT, WS_POPUP, WTS_CONSOLE_CONNECT, WTS_CONSOLE_DISCONNECT, WTS_REMOTE_CONNECT,
+    WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_TRANSPARENT,
+    WS_POPUP, WTS_CONSOLE_CONNECT, WTS_CONSOLE_DISCONNECT, WTS_REMOTE_CONNECT,
     WTS_REMOTE_DISCONNECT, WTS_SESSION_LOCK, WTS_SESSION_UNLOCK,
 };
 use windows::core::{PCWSTR, w};
 
-use crate::{ComputerUseError, ComputerUseErrorCode, ComputerUseResult};
 use super::geometry::scaled_pixels;
 use super::{
-    CONTROL_ACCENT_COLOR, CONTROL_CAPSULE_FONT_SIZE, CONTROL_CURSOR_COLOR, CONTROL_GLOW_COLOR,
-    CONTROL_OVERLAY_CLASS, CONTROL_GLOW_CLASS, CONTROL_CURSOR_CLASS, LAST_ACTION_DOT_CLASS,
+    CONTROL_ACCENT_COLOR, CONTROL_CAPSULE_FONT_SIZE, CONTROL_CURSOR_CLASS, CONTROL_CURSOR_COLOR,
+    CONTROL_GLOW_CLASS, CONTROL_GLOW_COLOR, CONTROL_OVERLAY_CLASS, LAST_ACTION_DOT_CLASS,
     OverlayGeometry,
 };
+use crate::{ComputerUseError, ComputerUseErrorCode, ComputerUseResult};
 
 #[derive(Clone, Copy)]
 pub(super) enum OverlayTone {
@@ -96,8 +94,7 @@ unsafe extern "system" fn overlay_window_proc(
                 COLORREF(stored_color)
             } else {
                 let mut class_name = [0_u16; 64];
-                let class_length =
-                    unsafe { GetClassNameW(hwnd, &mut class_name) }.max(0) as usize;
+                let class_length = unsafe { GetClassNameW(hwnd, &mut class_name) }.max(0) as usize;
                 match String::from_utf16_lossy(&class_name[..class_length]).as_ref() {
                     "DccMcpComputerUseGlowOverlay" => CONTROL_GLOW_COLOR,
                     "DccMcpComputerUseCursorOverlay" => CONTROL_CURSOR_COLOR,
@@ -229,7 +226,14 @@ pub(super) fn create_cursor_ring_overlay(
     alpha: u8,
     session_color: Option<COLORREF>,
 ) -> ComputerUseResult<HWND> {
-    let hwnd = create_color_overlay("", geometry, alpha, false, OverlayTone::Cursor, session_color)?;
+    let hwnd = create_color_overlay(
+        "",
+        geometry,
+        alpha,
+        false,
+        OverlayTone::Cursor,
+        session_color,
+    )?;
     if let Err(error) = set_pointer_ring_region(hwnd, geometry.2, geometry.3) {
         let _ = unsafe { DestroyWindow(hwnd) };
         return Err(error);
@@ -237,7 +241,11 @@ pub(super) fn create_cursor_ring_overlay(
     Ok(hwnd)
 }
 
-pub(super) fn set_pointer_ring_region(hwnd: HWND, width: i32, height: i32) -> ComputerUseResult<()> {
+pub(super) fn set_pointer_ring_region(
+    hwnd: HWND,
+    width: i32,
+    height: i32,
+) -> ComputerUseResult<()> {
     let thickness = (width.min(height) / 12).max(3);
     let outer = unsafe { CreateEllipticRgn(0, 0, width, height) };
     let inner =


### PR DESCRIPTION
Fix `cargo fmt --check` CI failure on #1998.

Ran `cargo fmt` across the computer-use crate to fix formatting in:
- `crates/dcc-mcp-computer-use/src/platform/windows.rs`
- `crates/dcc-mcp-computer-use/src/platform/windows/input_tests.rs`
- `crates/dcc-mcp-computer-use/src/platform/windows/overlay.rs`
- `crates/dcc-mcp-computer-use/src/platform/windows/overlay_render.rs`