### PR TITLE
fix(computer-use): resolve clippy type_complexity and too_many_arguments for #1998

### DIFF
--- a/crates/dcc-mcp-computer-use/src/lib.rs
+++ b/crates/dcc-mcp-computer-use/src/lib.rs
@@ -357,7 +357,7 @@ struct SessionState {
     target_available: Arc<AtomicBool>,
     cleanup_pending: Arc<AtomicBool>,
     overlay_thread: Option<JoinHandle<()>>,
-    last_action_point: Arc<std::sync::Mutex<Option<(i32, i32, std::time::Instant)>>>,
+    last_action_point: platform::LastActionPoint,
 }
 
 impl Default for SessionState {
@@ -639,9 +639,11 @@ impl ComputerUseSession {
             target.handle,
             &observation,
             request,
-            &self.stop_requested,
-            &state.desktop_state,
-            &state.desktop_barrier,
+            &platform::ActionSessionState {
+                stop_requested: self.stop_requested.clone(),
+                desktop_state: state.desktop_state.clone(),
+                desktop_barrier: state.desktop_barrier.clone(),
+            },
             pre_input_fence,
             &state.last_action_point,
         );

--- a/crates/dcc-mcp-computer-use/src/platform.rs
+++ b/crates/dcc-mcp-computer-use/src/platform.rs
@@ -13,6 +13,10 @@ use crate::{
     PreInputFence,
 };
 
+/// Type alias for the last pointer-action coordinate + timestamp,
+/// shared between the session owner and the control-banner thread.
+pub(crate) type LastActionPoint = Arc<std::sync::Mutex<Option<(i32, i32, std::time::Instant)>>>;
+
 #[cfg(windows)]
 mod windows;
 
@@ -32,7 +36,7 @@ pub(crate) struct ControlBannerSignals {
     pub(crate) target_available: Arc<AtomicBool>,
     pub(crate) cleanup_pending: Arc<AtomicBool>,
     pub(crate) session_id: Option<String>,
-    pub(crate) last_action_point: Arc<std::sync::Mutex<Option<(i32, i32, std::time::Instant)>>>,
+    pub(crate) last_action_point: LastActionPoint,
 }
 
 /// Non-Windows stub: `ControlBannerSignals` is a ZST that satisfies the type
@@ -107,6 +111,14 @@ impl From<ComputerUseError> for ControlBannerStartError {
 }
 
 pub(crate) type ControlBannerStartResult = Result<JoinHandle<()>, ControlBannerStartError>;
+
+/// Session-level signals that `perform_action` reads during execution.
+/// Grouped to stay under clippy's `too_many_arguments` limit.
+pub(crate) struct ActionSessionState {
+    pub(crate) stop_requested: Arc<AtomicBool>,
+    pub(crate) desktop_state: Arc<AtomicU64>,
+    pub(crate) desktop_barrier: Arc<DesktopEventBarrier>,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg(windows)]
@@ -230,11 +242,9 @@ pub(crate) fn perform_action(
     _window_handle: u64,
     _observation: &ComputerUseObservation,
     _request: &ComputerUseAction,
-    _interrupted: &Arc<AtomicBool>,
-    _desktop_state: &Arc<AtomicU64>,
-    _desktop_barrier: &Arc<DesktopEventBarrier>,
+    _session: &ActionSessionState,
     _pre_input_fence: Option<&mut PreInputFence<'_>>,
-    _last_action_point: &Arc<std::sync::Mutex<Option<(i32, i32, std::time::Instant)>>>,
+    _last_action_point: &LastActionPoint,
 ) -> ComputerUseResult<()> {
     Err(ComputerUseError::new(
         ComputerUseErrorCode::BackendUnavailable,

--- a/crates/dcc-mcp-computer-use/src/platform/windows.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows.rs
@@ -61,7 +61,7 @@ use crate::{
 
 use super::{
     ControlBannerSignals, ControlBannerStartError, ControlBannerStartResult, DesktopEventBarrier,
-    ScopedWindowOperation, ScopedWindowState,
+    LastActionPoint, ScopedWindowOperation, ScopedWindowState,
 };
 use overlay::ControlOverlay;
 
@@ -989,7 +989,7 @@ fn run_banner(
     signals: &BannerRuntimeSignals,
     ready: &std::sync::mpsc::SyncSender<ComputerUseResult<()>>,
     session_id: Option<&str>,
-    last_action_point: &Arc<std::sync::Mutex<Option<(i32, i32, std::time::Instant)>>>,
+    last_action_point: &LastActionPoint,
 ) -> ComputerUseResult<()> {
     ensure_interactive_desktop()?;
     let target = HWND(window_handle as *mut core::ffi::c_void);

--- a/crates/dcc-mcp-computer-use/src/platform/windows/input.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/input.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::platform::{ActionSessionState, LastActionPoint};
 
 mod send_input;
 
@@ -57,11 +58,9 @@ pub(crate) fn perform_action(
     window_handle: u64,
     observation: &ComputerUseObservation,
     request: &ComputerUseAction,
-    stop_requested: &Arc<AtomicBool>,
-    desktop_state: &Arc<AtomicU64>,
-    desktop_barrier: &Arc<DesktopEventBarrier>,
+    session: &ActionSessionState,
     mut pre_input_fence: Option<&mut PreInputFence<'_>>,
-    last_action_point: &Arc<std::sync::Mutex<Option<(i32, i32, std::time::Instant)>>>,
+    last_action_point: &LastActionPoint,
 ) -> ComputerUseResult<()> {
     if matches!(
         request.action.as_str(),
@@ -78,9 +77,9 @@ pub(crate) fn perform_action(
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     flush_pending_input_releases_locked()?;
     let guard = ActionGuard::new(
-        stop_requested,
-        desktop_state,
-        desktop_barrier,
+        &session.stop_requested,
+        &session.desktop_state,
+        &session.desktop_barrier,
         observation.desktop_generation,
     );
     guard.synchronize()?;


### PR DESCRIPTION
## Root Cause

`cargo fmt` fix (7ecc5ac) unblocked clippy on CI, revealing two pre-existing clippy errors in `platform.rs`:
- `clippy::type_complexity` — `Arc<Mutex<Option<(i32, i32, Instant)>>>` needed a type alias
- `clippy::too_many_arguments` — `perform_action` had 8 parameters (limit 7)

## Fix

1. **Type alias** `LastActionPoint` for the complex `Arc<Mutex<...>>` type, used consistently across `lib.rs`, `platform.rs`, `windows.rs`, and `input.rs`.
2. **Struct grouping** `ActionSessionState` holds the three session-level signals (`stop_requested`, `desktop_state`, `desktop_barrier`), reducing `perform_action` from 8 params to 6.

## Test Plan

- `cargo fmt --check` passes
- `cargo check --package dcc-mcp-computer-use` passes
- No `type_complexity` or `too_many_arguments` warnings from clippy