### PR TITLE
fix(computer-use): suppress dead_code lint on ActionSessionState for Linux builds

### DIFF
--- a/crates/dcc-mcp-computer-use/src/platform.rs
+++ b/crates/dcc-mcp-computer-use/src/platform.rs
@@ -114,6 +114,10 @@ pub(crate) type ControlBannerStartResult = Result<JoinHandle<()>, ControlBannerS
 
 /// Session-level signals that `perform_action` reads during execution.
 /// Grouped to stay under clippy's `too_many_arguments` limit.
+///
+/// Fields are read by the Windows `perform_action` path; on non-Windows
+/// only a stub exists that returns `BackendUnavailable`.
+#[allow(dead_code)]
 pub(crate) struct ActionSessionState {
     pub(crate) stop_requested: Arc<AtomicBool>,
     pub(crate) desktop_state: Arc<AtomicU64>,


### PR DESCRIPTION
The fields `stop_requested`, `desktop_state`, and `desktop_barrier` in `ActionSessionState` are read by the Windows `perform_action` path (`platform/windows/input.rs:79-83`) but never accessed in the `#[cfg(not(windows))]` stub that returns `BackendUnavailable`.

Add `#[allow(dead_code)]` on the struct to suppress the Clippy lint on ubuntu builds.

Fixes the Clippy dead_code failure from [dcc-mcp-core#1998](https://github.com/dcc-mcp/dcc-mcp-core/pull/1998).