### PR TITLE
feat: add Unity adapter to public catalog

### DIFF
--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -746,7 +746,7 @@ mod tests {
                 .count(),
             1
         );
-        for expected in ["godot", "renderdoc"] {
+        for expected in ["godot", "renderdoc", "unity"] {
             let entry = catalog
                 .dcc_types
                 .iter()

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -1525,8 +1525,8 @@ fn dcc_types_lists_release_catalog_without_a_gateway() {
 
     assert_eq!(value["custom_types_supported"], true);
     let types = value["dcc_types"].as_array().unwrap();
-    assert_eq!(types.len(), 18);
-    for expected in ["godot", "openusd", "renderdoc", "shotgrid"] {
+    assert_eq!(types.len(), 19);
+    for expected in ["godot", "openusd", "renderdoc", "shotgrid", "unity"] {
         assert!(types.iter().any(|entry| entry["dcc_type"] == expected));
     }
 }

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -238,7 +238,7 @@ entries:
     dcc: ["unity"]
     url: "https://github.com/dcc-mcp/dcc-mcp-unity"
     tags: ["adapter", "unity", "official", "pip", "game-engine", "upm"]
-    version: "0.2.0"
+    version: "0.3.0"
     min_core_version: "0.19.45"
     maintainer: "dcc-mcp"
     install:

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -233,6 +233,19 @@ entries:
       pip_package: "dcc-mcp-godot"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-godot/main/README.md"
 
+  - name: "dcc-mcp-unity"
+    description: "Unity Editor adapter and typed game-authoring skills for DCC-MCP"
+    dcc: ["unity"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-unity"
+    tags: ["adapter", "unity", "official", "pip", "game-engine", "upm"]
+    version: "0.2.0"
+    min_core_version: "0.19.45"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-unity"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unity/main/install.md"
+
   - name: "dcc-mcp-fpt"
     description: "Autodesk Flow Production Tracking adapter for DCC-MCP"
     dcc: ["shotgrid"]

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -41,7 +41,7 @@ submit a PR updating this matrix before the release PR merges.
 | Substance 3D Designer | [dcc-mcp-substance3d-designer](https://github.com/dcc-mcp/dcc-mcp-substance3d-designer) | 0.3.0 | >=0.19.45,<1.0.0 | — | Host bridge | — |
 | Substance 3D Painter | [dcc-mcp-substance3d-painter](https://github.com/dcc-mcp/dcc-mcp-substance3d-painter) | 0.1.3 | >=0.19.3,<1.0.0 | — | Host bridge | — |
 | Godot | [dcc-mcp-godot](https://github.com/dcc-mcp/dcc-mcp-godot) | 0.4.0 | >=0.19.45,<1.0.0 | 4.x | EditorPlugin + runtime bridge | 2026-07 |
-| Unity | [dcc-mcp-unity](https://github.com/dcc-mcp/dcc-mcp-unity) | 0.2.0 | >=0.19.45,<1.0.0 | 2021.3+ | EditorApplication.update + WebSocket bridge | — |
+| Unity | [dcc-mcp-unity](https://github.com/dcc-mcp/dcc-mcp-unity) | 0.3.0 | >=0.19.45,<1.0.0 | 2018.4.36f1+ | EditorApplication.update + WebSocket bridge | — |
 | OpenUSD | [dcc-mcp-openusd](https://github.com/dcc-mcp/dcc-mcp-openusd) | 0.8.1 | >=0.19.45,<1.0.0 | — | Headless USD stage adapter | 2026-07 |
 | Custom Studio Tool | _(your repo here)_ | _your version_ | _your pin_ | _your min_ | _your pattern_ | _date_ |
 

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -41,6 +41,7 @@ submit a PR updating this matrix before the release PR merges.
 | Substance 3D Designer | [dcc-mcp-substance3d-designer](https://github.com/dcc-mcp/dcc-mcp-substance3d-designer) | 0.3.0 | >=0.19.45,<1.0.0 | — | Host bridge | — |
 | Substance 3D Painter | [dcc-mcp-substance3d-painter](https://github.com/dcc-mcp/dcc-mcp-substance3d-painter) | 0.1.3 | >=0.19.3,<1.0.0 | — | Host bridge | — |
 | Godot | [dcc-mcp-godot](https://github.com/dcc-mcp/dcc-mcp-godot) | 0.4.0 | >=0.19.45,<1.0.0 | 4.x | EditorPlugin + runtime bridge | 2026-07 |
+| Unity | [dcc-mcp-unity](https://github.com/dcc-mcp/dcc-mcp-unity) | 0.2.0 | >=0.19.45,<1.0.0 | 2021.3+ | EditorApplication.update + WebSocket bridge | — |
 | OpenUSD | [dcc-mcp-openusd](https://github.com/dcc-mcp/dcc-mcp-openusd) | 0.8.1 | >=0.19.45,<1.0.0 | — | Headless USD stage adapter | 2026-07 |
 | Custom Studio Tool | _(your repo here)_ | _your version_ | _your pin_ | _your min_ | _your pattern_ | _date_ |
 


### PR DESCRIPTION
## Summary
- add dcc-mcp-unity 0.3.0 to the bundled first-party adapter catalog
- document the verified Unity 2018.4.36f1+ compatibility floor and Editor update-loop WebSocket dispatcher
- cover the canonical unity DCC type and total catalog count in CLI regression tests

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p dcc-mcp-catalog bundled_adapter_catalog_matches_compatibility_matrix`
- `cargo test -p dcc-mcp-cli bundled_catalog_lists_adapter_dcc_types_and_collapses_aliases`
- `cargo test -p dcc-mcp-cli dcc_types_lists_release_catalog_without_a_gateway`
- isolated public PyPI 0.3.0 import, bundled UPM 0.3.0 payload check, and adapter lifecycle smoke
- [Unity main validation](https://github.com/dcc-mcp/dcc-mcp-unity/actions/runs/29844899317): Unity 2018.4.36f1, 2021.3.45f1, and 6000.5.4f1 each reported 3 passed / 0 failed plus a successful real bridge response

## Verification boundary
- the published adapter, bundled UPM payload, Editor tests, and Python-to-Editor bridge were verified
- a full gateway-to-Editor tool invocation was not run, so Last Verified remains unset