### PR TITLE
feat: unify skill discovery and instance lifecycle

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.githooks/* text eol=lf

--- a/.github/clawhub-skills.json
+++ b/.github/clawhub-skills.json
@@ -1,14 +1,17 @@
 [
   {
     "path": "skills/dcc-mcp",
-    "slug": "dcc-mcp"
+    "slug": "dcc-mcp",
+    "owner": "loonghao"
   },
   {
     "path": "skills/dcc-mcp-skills-creator",
-    "slug": "dcc-mcp-skills-creator"
+    "slug": "dcc-mcp-skills-creator",
+    "owner": "loonghao"
   },
   {
     "path": "skills/dcc-mcp-creator",
-    "slug": "dcc-mcp-creator"
+    "slug": "dcc-mcp-creator",
+    "owner": "loonghao"
   }
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,12 +1122,14 @@ dependencies = [
 name = "dcc-mcp-catalog"
 version = "0.19.63"
 dependencies = [
+ "dcc-mcp-gateway-search",
  "jsonschema",
  "serde",
  "serde_json",
  "serde_yaml_ng",
  "tempfile",
  "thiserror",
+ "uuid",
  "workspace-hack",
 ]
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,37 @@ curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/i
 powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
 ~~~
 
+### Install the agent Skill suite
+
+Install the three public Skills directly from ClawHub; cloning this repository
+is not required:
+
+~~~bash
+openclaw skills install @loonghao/dcc-mcp
+openclaw skills install @loonghao/dcc-mcp-skills-creator
+openclaw skills install @loonghao/dcc-mcp-creator
+~~~
+
+Add `--global` to each command when every local OpenClaw agent should see the
+suite. Other ClawHub-compatible workspaces can use the registry CLI directly:
+
+~~~bash
+npx --yes clawhub@0.17.0 install dcc-mcp
+npx --yes clawhub@0.17.0 install dcc-mcp-skills-creator
+npx --yes clawhub@0.17.0 install dcc-mcp-creator
+~~~
+
+| Skill | Agent role |
+|---|---|
+| [`dcc-mcp`](skills/dcc-mcp/) | Default live DCC control and marketplace discovery; Skill-store requests begin with `dcc-mcp-cli marketplace search` |
+| [`dcc-mcp-skills-creator`](skills/dcc-mcp-skills-creator/) | Create, validate, package, and review DCC-MCP Skill packages |
+| [`dcc-mcp-creator`](skills/dcc-mcp-creator/) | Create or modernize a complete DCC adapter and its runtime wiring |
+
+All three packages carry Codex `agents/openai.yaml` metadata while preserving
+their DCC-MCP and ClawHub contracts. They are versioned with the core release,
+listed in [`.github/clawhub-skills.json`](.github/clawhub-skills.json), and
+published to ClawHub by the release workflow.
+
 Keep an official build current through the release manifest:
 
 ~~~bash
@@ -86,11 +117,14 @@ Then discover a live capability before calling it:
 ~~~bash
 dcc-mcp-cli dcc-types
 dcc-mcp-cli list
-dcc-mcp-cli search --query "create sphere" --dcc-type maya --limit 20
+dcc-mcp-cli search create sphere --dcc-type maya --limit 20
 dcc-mcp-cli describe <tool-slug>
 dcc-mcp-cli call <tool-slug> --json '{"radius": 2.0}' \
   --meta-json '{"agent_context":{"session_id":"task-42"}}'
 ~~~
+
+Search accepts unquoted positional words; `--query "create sphere"` remains
+available for existing scripts.
 
 `dcc-types` is an offline, catalog-backed capability query. It reports
 canonical adapter identifiers and install-plan availability; `list` remains

--- a/crates/dcc-mcp-catalog/Cargo.toml
+++ b/crates/dcc-mcp-catalog/Cargo.toml
@@ -8,11 +8,13 @@ license.workspace = true
 description = "Public DCC-MCP catalog for ecosystem discovery — adapters, skill packs, and plugins"
 
 [dependencies]
+dcc-mcp-gateway-search = { workspace = true }
 jsonschema = "0.28"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
+uuid = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -18,7 +18,9 @@
 
 use std::path::Path;
 
+use dcc_mcp_gateway_search::{SearchQuery, SearchRecord, rank_all};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 mod error;
 pub use error::{CatalogError, CatalogValidationError};
@@ -201,78 +203,126 @@ pub struct SearchHit {
     /// Index into the source `&[CatalogEntry]` slice.
     pub index: usize,
     /// Match quality score (higher = better match).
-    ///
-    /// Currently a simple 1-point per matched field; callers that need richer
-    /// ranking can sort by this score before paginating.
     pub score: u32,
+}
+
+#[derive(Clone, Copy)]
+struct CatalogSearchRecord<'a> {
+    index: usize,
+    entry: &'a CatalogEntry,
+    search_tokens: &'a [String],
+}
+
+impl SearchRecord for CatalogSearchRecord<'_> {
+    fn tool_slug(&self) -> &str {
+        &self.entry.name
+    }
+
+    fn backend_tool(&self) -> &str {
+        &self.entry.name
+    }
+
+    fn summary(&self) -> &str {
+        &self.entry.description
+    }
+
+    fn skill_name(&self) -> Option<&str> {
+        None
+    }
+
+    fn tags(&self) -> &[String] {
+        &self.entry.tags
+    }
+
+    fn search_tokens(&self) -> &[String] {
+        self.search_tokens
+    }
+
+    fn dcc_type(&self) -> &str {
+        self.entry.dcc.first().map_or("", String::as_str)
+    }
+
+    fn instance_id(&self) -> Uuid {
+        Uuid::nil()
+    }
+
+    fn loaded(&self) -> bool {
+        true
+    }
+}
+
+fn catalog_search_tokens(entry: &CatalogEntry) -> Vec<String> {
+    let mut tokens = entry.dcc.clone();
+    tokens.extend(entry.url.iter().cloned());
+    tokens.extend(entry.version.iter().cloned());
+    tokens.extend(entry.min_core_version.iter().cloned());
+    tokens.extend(entry.maintainer.iter().cloned());
+    tokens.extend(entry.category.iter().cloned());
+    if let Some(policy) = &entry.policy {
+        tokens.push(policy.installation.clone());
+    }
+    if let Some(requires) = &entry.requires {
+        tokens.extend(requires.env.iter().cloned());
+        tokens.extend(requires.bins.iter().cloned());
+        tokens.extend(requires.python.iter().cloned());
+        tokens.extend(requires.skills.iter().cloned());
+    }
+
+    if let Some(install) = &entry.install {
+        tokens.push(install.install_type.clone());
+        tokens.extend(install.url.iter().cloned());
+        tokens.extend(install.instructions_url.iter().cloned());
+        tokens.extend(install.pip_package.iter().cloned());
+        if let Some(extras) = &install.pip_extras {
+            tokens.extend(extras.iter().cloned());
+        }
+    }
+
+    tokens
 }
 
 /// Score every matching entry and return lightweight index references.
 ///
-/// `query` is matched case-insensitively against `name`, `description`,
-/// `dcc`, `tags`, version/maintainer metadata, and install URL.  An empty query
-/// returns all entries with a score of 1.
+/// `query` is matched case-insensitively with fuzzy, token-aware ranking across
+/// `name`, `description`, `dcc`, `tags`, version/maintainer/category metadata,
+/// runtime requirements, and package URLs. An empty or whitespace-only query
+/// returns all entries in source order with a score of 1.
 ///
-/// Callers should sort the returned hits by their chosen criteria (e.g.
-/// alphabetically by name, or by score), then materialise only the needed page
-/// via [`materialise_page`].
+/// Non-empty results are already ordered by descending relevance. Callers can
+/// paginate the lightweight hits before cloning entries via [`materialise_page`].
 pub fn search_hits(entries: &[CatalogEntry], query: &str) -> Vec<SearchHit> {
-    if query.is_empty() {
+    if query.trim().is_empty() {
         return entries
             .iter()
             .enumerate()
             .map(|(i, _)| SearchHit { index: i, score: 1 })
             .collect();
     }
-    let q = query.to_lowercase();
-    entries
+
+    let search_tokens: Vec<Vec<String>> = entries.iter().map(catalog_search_tokens).collect();
+    let records: Vec<CatalogSearchRecord<'_>> = entries
         .iter()
         .enumerate()
-        .filter_map(|(i, e)| {
-            let mut score: u32 = 0;
-            if e.name.to_lowercase().contains(&q) {
-                score += 1;
-            }
-            if e.description.to_lowercase().contains(&q) {
-                score += 1;
-            }
-            if e.dcc.iter().any(|d| d.to_lowercase().contains(&q)) {
-                score += 1;
-            }
-            if e.tags.iter().any(|t| t.to_lowercase().contains(&q)) {
-                score += 1;
-            }
-            if e.version
-                .as_deref()
-                .is_some_and(|version| version.to_lowercase().contains(&q))
-            {
-                score += 1;
-            }
-            if e.maintainer
-                .as_deref()
-                .is_some_and(|maintainer| maintainer.to_lowercase().contains(&q))
-            {
-                score += 1;
-            }
-            if e.install
-                .as_ref()
-                .and_then(|install| install.url.as_deref())
-                .is_some_and(|url| url.to_lowercase().contains(&q))
-            {
-                score += 1;
-            }
-            if e.install
-                .as_ref()
-                .and_then(|install| install.instructions_url.as_deref())
-                .is_some_and(|url| url.to_lowercase().contains(&q))
-            {
-                score += 1;
-            }
-            if score > 0 {
-                Some(SearchHit { index: i, score })
-            } else {
-                None
-            }
+        .zip(&search_tokens)
+        .map(|((index, entry), tokens)| CatalogSearchRecord {
+            index,
+            entry,
+            search_tokens: tokens,
+        })
+        .collect();
+    let ranked = rank_all(
+        &records,
+        &SearchQuery {
+            query: query.to_owned(),
+            ..Default::default()
+        },
+    );
+
+    ranked
+        .into_iter()
+        .map(|hit| SearchHit {
+            index: hit.record.index,
+            score: hit.score,
         })
         .collect()
 }
@@ -512,9 +562,7 @@ entries:
         let hits = search_hits(&entries, "maya");
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].index, 0);
-        // "maya" matches: name (dcc-mcp-**maya**-skills), description (**Maya**),
-        // dcc (["maya"]), tags (["maya"]) = score 4
-        assert_eq!(hits[0].score, 4);
+        assert!(hits[0].score > 0);
     }
 
     #[test]
@@ -523,6 +571,14 @@ entries:
         let hits = search_hits(&entries, "");
         assert_eq!(hits.len(), 3);
         assert!(hits.iter().all(|h| h.score == 1));
+        assert_eq!(
+            hits.iter().map(|hit| hit.index).collect::<Vec<_>>(),
+            [0, 1, 2]
+        );
+
+        let whitespace_hits = search_hits(&entries, "   ");
+        assert_eq!(whitespace_hits.len(), 3);
+        assert!(whitespace_hits.iter().all(|hit| hit.score == 1));
     }
 
     #[test]
@@ -580,8 +636,33 @@ entries:
         }];
         let hits = search_hits(&entries, "maya");
         assert_eq!(hits.len(), 1);
-        // name + description + dcc + tags = 4
-        assert_eq!(hits[0].score, 4);
+        assert!(hits[0].score > 0);
+    }
+
+    #[test]
+    fn test_search_hits_matches_natural_multiword_query_across_fields() {
+        let mut entry = make_entry(
+            "skin-weight-painter",
+            "Paint smooth character deformation weights",
+        );
+        entry.dcc = vec!["maya".into()];
+        entry.tags = vec!["rigging".into()];
+
+        let hits = search_hits(&[entry], "maya rigging");
+
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].score > 0);
+    }
+
+    #[test]
+    fn test_search_hits_tolerates_spelling_error() {
+        let mut entry = make_entry("character-rigging", "Build production character rigs");
+        entry.tags = vec!["rigging".into()];
+
+        let hits = search_hits(&[entry], "riggng");
+
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].score > 0);
     }
 
     #[test]

--- a/crates/dcc-mcp-cli/src/application/local_instance.rs
+++ b/crates/dcc-mcp-cli/src/application/local_instance.rs
@@ -178,6 +178,7 @@ pub(crate) fn instance_summary(entry: &ServiceEntry) -> Value {
         "display_id": entry.display_id(),
         "display_name": entry.display_name,
         "pid": entry.pid,
+        "host_pid": entry.host_pid,
         "mcp_url": mcp_url(entry),
         "status": entry.status.to_string(),
     })

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -131,8 +131,12 @@ enum Command {
     },
     /// Search callable tools through local MCP or the selected gateway profile.
     Search {
-        #[arg(long)]
+        /// Query text. Positional words are also accepted, for example `search create sphere`.
+        #[arg(short, long, conflicts_with = "query_terms")]
         query: Option<String>,
+        /// Unquoted positional query words joined with spaces.
+        #[arg(value_name = "QUERY", num_args = 1.., conflicts_with = "query")]
+        query_terms: Vec<String>,
         #[arg(long)]
         dcc_type: Option<String>,
         /// Filter to a full instance UUID or unique >=4-character prefix.
@@ -338,9 +342,13 @@ enum MarketplaceAction {
     List,
     /// Search marketplace entries across configured sources.
     Search {
-        #[arg(long)]
+        /// Query text. Positional words are also accepted, for example `search maya rigging`.
+        #[arg(short, long, conflicts_with = "query_terms")]
         query: Option<String>,
-        #[arg(long)]
+        /// Unquoted positional query words joined with spaces.
+        #[arg(value_name = "QUERY", num_args = 1.., conflicts_with = "query")]
+        query_terms: Vec<String>,
+        #[arg(long, visible_alias = "dcc-type")]
         dcc: Option<String>,
         /// Use this source for the query instead of configured sources.
         #[arg(long = "source")]
@@ -673,12 +681,13 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
         }
         Command::Search {
             query,
+            query_terms,
             dcc_type,
             instance_id,
             limit,
         } => {
             let request = SearchRequest {
-                query,
+                query: resolve_query(query, query_terms),
                 dcc_type,
                 instance_id,
                 limit,
@@ -859,13 +868,20 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                 MarketplaceAction::List => to_json(service.list_sources()?)?,
                 MarketplaceAction::Search {
                     query,
+                    query_terms,
                     dcc,
                     sources,
                     limit,
                     skip_validation,
                 } => to_json(
                     service
-                        .search(query, dcc, sources, limit, skip_validation)
+                        .search(
+                            resolve_query(query, query_terms),
+                            dcc,
+                            sources,
+                            limit,
+                            skip_validation,
+                        )
                         .await?,
                 )?,
                 MarketplaceAction::Inspect {
@@ -1132,6 +1148,13 @@ impl From<GatewayStatusArgs> for gateway_ctrl::GatewayDaemonStatusRequest {
             registry_dir: args.registry_dir,
         }
     }
+}
+
+fn resolve_query(query: Option<String>, query_terms: Vec<String>) -> Option<String> {
+    query.or_else(|| {
+        let joined = query_terms.join(" ");
+        (!joined.is_empty()).then_some(joined)
+    })
 }
 
 fn parse_json_object(raw: &str, flag_name: &str) -> anyhow::Result<Value> {

--- a/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
@@ -17,6 +17,67 @@ fn dcc_types_contract_accepts_a_custom_catalog() {
 }
 
 #[test]
+fn search_contract_accepts_unquoted_positional_query_words() {
+    let args = Args::try_parse_from([
+        "dcc-mcp-cli",
+        "search",
+        "create",
+        "sphere",
+        "--dcc-type",
+        "maya",
+    ])
+    .expect("parse positional search query");
+
+    let Command::Search {
+        query,
+        query_terms,
+        dcc_type,
+        ..
+    } = args.command
+    else {
+        panic!("expected search command");
+    };
+    assert!(query.is_none());
+    assert_eq!(
+        resolve_query(query, query_terms).as_deref(),
+        Some("create sphere")
+    );
+    assert_eq!(dcc_type.as_deref(), Some("maya"));
+}
+
+#[test]
+fn marketplace_search_contract_accepts_positional_query_and_dcc_type_alias() {
+    let args = Args::try_parse_from([
+        "dcc-mcp-cli",
+        "marketplace",
+        "search",
+        "maya",
+        "rigging",
+        "--dcc-type",
+        "maya",
+    ])
+    .expect("parse positional marketplace query");
+
+    let Command::Marketplace {
+        action:
+            MarketplaceAction::Search {
+                query,
+                query_terms,
+                dcc,
+                ..
+            },
+    } = args.command
+    else {
+        panic!("expected marketplace search command");
+    };
+    assert_eq!(
+        resolve_query(query, query_terms).as_deref(),
+        Some("maya rigging")
+    );
+    assert_eq!(dcc.as_deref(), Some("maya"));
+}
+
+#[test]
 fn stats_contract_parses_composable_runtime_filters() {
     let args = Args::try_parse_from([
         "dcc-mcp-cli",
@@ -496,6 +557,7 @@ fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
             DEFAULT_BASE_URL,
             &Command::Search {
                 query: Some("sphere".to_string()),
+                query_terms: Vec::new(),
                 dcc_type: None,
                 instance_id: None,
                 limit: None,
@@ -590,6 +652,7 @@ fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
             DEFAULT_BASE_URL,
             &Command::Search {
                 query: Some("sphere".to_string()),
+                query_terms: Vec::new(),
                 dcc_type: None,
                 instance_id: None,
                 limit: None,

--- a/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
@@ -97,6 +97,122 @@ fn marketplace_add_list_search_and_inspect_local_source() {
 }
 
 #[test]
+fn marketplace_search_accepts_natural_language_and_ranks_the_best_skill() {
+    let tmp = TempDir::new().unwrap();
+    let catalog_path = tmp.path().join("marketplace.json");
+    std::fs::write(
+        &catalog_path,
+        json!({
+            "version": "1",
+            "entries": [
+                {
+                    "name": "maya-asset-browser",
+                    "description": "Browse reusable assets in Maya",
+                    "dcc": ["maya"],
+                    "tags": ["assets", "skills"]
+                },
+                {
+                    "name": "maya-rigging-tools",
+                    "description": "Rigging workflows for Maya character animation",
+                    "dcc": ["maya"],
+                    "tags": ["rigging", "skills"],
+                    "category": "character"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let source = catalog_path.to_string_lossy().to_string();
+    let search = run_json(&[
+        "marketplace",
+        "search",
+        "I",
+        "need",
+        "a",
+        "Maya",
+        "rigging",
+        "skill",
+        "--source",
+        &source,
+    ]);
+
+    assert_eq!(search["query"], "I need a Maya rigging skill");
+    assert_eq!(search["hits"][0]["entry"]["name"], "maya-rigging-tools");
+}
+
+#[test]
+fn marketplace_limit_is_applied_after_cross_source_ranking() {
+    let tmp = TempDir::new().unwrap();
+    let generic_catalog = tmp.path().join("generic.json");
+    let rigging_catalog = tmp.path().join("rigging.json");
+    std::fs::write(
+        &generic_catalog,
+        json!({
+            "version": "1",
+            "entries": [{
+                "name": "maya-skill-collection",
+                "description": "General Skills for Maya",
+                "dcc": ["maya"],
+                "tags": ["skills"]
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        &rigging_catalog,
+        json!({
+            "version": "1",
+            "entries": [{
+                "name": "maya-rigging-tools",
+                "description": "Character rigging workflows for Maya",
+                "dcc": ["maya"],
+                "tags": ["rigging", "skills"]
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let config_path = tmp.path().join("sources.json");
+    std::fs::write(
+        &config_path,
+        json!({"sources": [
+            {"name": "generic", "url": generic_catalog.to_string_lossy()},
+            {"name": "rigging", "url": rigging_catalog.to_string_lossy()}
+        ]})
+        .to_string(),
+    )
+    .unwrap();
+    let config = config_path.to_string_lossy().to_string();
+    let envs = [
+        ("DCC_MCP_MARKETPLACE_SOURCES_FILE", config.as_str()),
+        ("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES", "1"),
+    ];
+
+    let search = run_json_with_env(
+        &[
+            "marketplace",
+            "search",
+            "I",
+            "need",
+            "a",
+            "Maya",
+            "rigging",
+            "skill",
+            "--limit",
+            "1",
+        ],
+        &envs,
+    );
+
+    assert_eq!(search["count"], 1);
+    assert_eq!(search["hits"][0]["entry"]["name"], "maya-rigging-tools");
+}
+
+#[test]
 fn marketplace_v1_catalog_preserves_curation_and_runtime_metadata() {
     let tmp = TempDir::new().unwrap();
     let catalog_path = tmp.path().join("marketplace.json");
@@ -1446,11 +1562,14 @@ fn marketplace_search_dedupes_same_entry_from_multiple_sources() {
         .join("sources.json")
         .to_string_lossy()
         .to_string();
-    // Register catalog1 (lower priority — registered first in config)
-    // and pass catalog2 as explicit (higher priority).
+    // Register both sources. Source order defines which duplicate wins.
     std::fs::write(
         &config_path,
-        json!({"sources": [{"name": "catalog1", "url": source1}]}).to_string(),
+        json!({"sources": [
+            {"name": "catalog1", "url": source1},
+            {"name": "catalog2", "url": source2}
+        ]})
+        .to_string(),
     )
     .unwrap();
 
@@ -1459,12 +1578,8 @@ fn marketplace_search_dedupes_same_entry_from_multiple_sources() {
         ("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES", "1"),
     ];
 
-    // Search with explicit source for catalog2 — only catalog2 is searched
-    // because explicit sources are exclusive (replace configured sources).
-    let search = run_json_with_env(&["marketplace", "search", "--source", &source2], &envs);
-    // Should have exactly 2 unique entries (skill-b, skill-c) from catalog2.
-    // catalog1 is not searched because --source is exclusive.
-    assert_eq!(search["count"], 2);
+    let search = run_json_with_env(&["marketplace", "search"], &envs);
+    assert_eq!(search["count"], 3);
     let skill_b = search["hits"]
         .as_array()
         .unwrap()
@@ -1473,17 +1588,15 @@ fn marketplace_search_dedupes_same_entry_from_multiple_sources() {
         .unwrap();
     assert_eq!(
         skill_b["entry"]["description"],
-        "Shared skill from catalog 2"
+        "Shared skill from catalog 1"
     );
-    assert_eq!(skill_b["source"]["origin"], "explicit");
-    // skill-a from catalog1 must not appear.
+    assert_eq!(skill_b["source"]["origin"], "config");
     assert!(
-        !search["hits"]
+        search["hits"]
             .as_array()
             .unwrap()
             .iter()
-            .any(|h| h["entry"]["name"] == "skill-a"),
-        "configured-source entries must not appear when explicit --source is given"
+            .any(|h| h["entry"]["name"] == "skill-a")
     );
 }
 

--- a/crates/dcc-mcp-gateway-search/Cargo.toml
+++ b/crates/dcc-mcp-gateway-search/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Pure gateway capability search: query wire types, fuzzy/substring ranking, pagination — no gateway runtime deps."
+description = "Pure reusable DCC-MCP search: query types, fuzzy ranking, and pagination with no gateway runtime dependencies"
 keywords = ["mcp", "gateway", "search", "fuzzy"]
 categories = ["text-processing"]
 

--- a/crates/dcc-mcp-gateway-search/src/engine.rs
+++ b/crates/dcc-mcp-gateway-search/src/engine.rs
@@ -13,8 +13,39 @@ pub fn search<R: SearchRecord + Clone>(records: &[R], query: &SearchQuery) -> Ve
 /// Paginated variant of [`search`].
 #[must_use]
 pub fn search_page<R: SearchRecord + Clone>(records: &[R], query: &SearchQuery) -> SearchPage<R> {
+    let hits = rank_all(records, query);
+    let total = hits.len() as u32;
+    let effective_limit = effective_limit(query.limit);
+    let offset = query.offset.unwrap_or(0).min(total);
+    let end = offset.saturating_add(effective_limit).min(total);
+    let page = if offset < total {
+        hits[offset as usize..end as usize].to_vec()
+    } else {
+        Vec::new()
+    };
+
+    SearchPage {
+        hits: page,
+        total,
+        offset,
+        limit: effective_limit,
+    }
+}
+
+/// Rank every matching record without applying pagination limits or offsets.
+///
+/// Filtering, scoring, and ordering are identical to [`search_page`]. This is
+/// useful for callers that own their own pagination contract, such as package
+/// catalogs that must not inherit the gateway's [`MAX_LIMIT`] page cap.
+#[must_use]
+pub fn rank_all<R: SearchRecord + Clone>(records: &[R], query: &SearchQuery) -> Vec<SearchHit<R>> {
     let qnorm = query.query.trim().to_ascii_lowercase();
-    let dcc_filter = query.dcc_type.as_deref();
+    let dcc_filter = query
+        .dcc_type
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_lowercase);
     let dcc_types: Vec<String> = query
         .dcc_types
         .iter()
@@ -59,8 +90,12 @@ pub fn search_page<R: SearchRecord + Clone>(records: &[R], query: &SearchQuery) 
         .iter()
         .filter(|r| {
             dcc_filter.is_none() && dcc_types.is_empty()
-                || dcc_filter.is_some_and(|f| r.dcc_type() == f)
-                || dcc_types.iter().any(|d| r.dcc_type() == d)
+                || dcc_filter
+                    .as_deref()
+                    .is_some_and(|f| r.dcc_type().eq_ignore_ascii_case(f))
+                || dcc_types
+                    .iter()
+                    .any(|d| r.dcc_type().eq_ignore_ascii_case(d))
         })
         .filter(|r| instance_filter.is_none_or(|iid| r.instance_id() == iid))
         .filter(|r| loaded_filter != Some(true) || r.loaded())
@@ -121,25 +156,11 @@ pub fn search_page<R: SearchRecord + Clone>(records: &[R], query: &SearchQuery) 
             .then_with(|| a.record.tool_slug().cmp(b.record.tool_slug()))
     });
 
-    let total = hits.len() as u32;
-    let effective_limit = effective_limit(query.limit);
-    let offset = query.offset.unwrap_or(0).min(total);
-    let end = offset.saturating_add(effective_limit).min(total);
-    let mut page = if offset < total {
-        hits[offset as usize..end as usize].to_vec()
-    } else {
-        Vec::new()
-    };
-    for (idx, hit) in page.iter_mut().enumerate() {
-        hit.rank = offset + idx as u32 + 1;
+    for (idx, hit) in hits.iter_mut().enumerate() {
+        hit.rank = idx as u32 + 1;
     }
 
-    SearchPage {
-        hits: page,
-        total,
-        offset,
-        limit: effective_limit,
-    }
+    hits
 }
 
 fn apply_skill_hint_boost<R: SearchRecord>(hit: &mut SearchHit<R>, hint: Option<&str>) {
@@ -513,6 +534,35 @@ mod tests {
     }
 
     #[test]
+    fn rank_all_is_not_capped_by_page_limit() {
+        let records: Vec<Row> = (0..125)
+            .map(|index| {
+                mk(
+                    &format!("m.1.tool-{index:03}"),
+                    &format!("maya_tools__tool_{index:03}"),
+                    "A matching catalog tool.",
+                    &[],
+                    true,
+                )
+            })
+            .collect();
+        let query = SearchQuery {
+            query: "tool".into(),
+            limit: Some(125),
+            ..Default::default()
+        };
+
+        let ranked = rank_all(&records, &query);
+        let page = search_page(&records, &query);
+
+        assert_eq!(ranked.len(), 125);
+        assert_eq!(ranked.last().map(|hit| hit.rank), Some(125));
+        assert_eq!(page.total, 125);
+        assert_eq!(page.limit, MAX_LIMIT);
+        assert_eq!(page.hits.len(), MAX_LIMIT as usize);
+    }
+
+    #[test]
     fn hybrid_mode_acts_like_fuzzy() {
         let records = vec![
             mk(
@@ -630,6 +680,29 @@ mod tests {
         assert!(tools.contains(&"maya_primitives__create_sphere"));
         assert!(tools.contains(&"blender_mesh__create_cube"));
         assert!(!tools.contains(&"houdini_sop__grid"));
+    }
+
+    #[test]
+    fn single_dcc_type_filter_is_trimmed_and_case_insensitive() {
+        let records = vec![mk(
+            "m.1.sphere",
+            "create_sphere",
+            "Create a sphere.",
+            &[],
+            true,
+        )];
+
+        let hits = search(
+            &records,
+            &SearchQuery {
+                query: "sphere".into(),
+                dcc_type: Some("  MAYA  ".into()),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].record.backend_tool(), "create_sphere");
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway-search/src/lib.rs
+++ b/crates/dcc-mcp-gateway-search/src/lib.rs
@@ -1,14 +1,14 @@
-//! Pure gateway capability search: wire types, ranking, and pagination.
+//! Pure reusable DCC-MCP search: wire types, ranking, and pagination.
 //!
 //! This crate has **no** dependency on `dcc-mcp-gateway` or HTTP stacks — only
 //! `serde`, `uuid`, and `nucleo-matcher`.  Implement [`SearchRecord`] on your
-//! compact index row type (for example in `dcc-mcp-gateway-core`) and call
-//! [`search_page`].
+//! compact capability or catalog row type and call [`search_page`] or
+//! [`rank_all`].
 //!
 //! Dependency direction:
 //!
 //! ```text
-//! dcc-mcp-gateway / dcc-mcp-gateway-core  →  dcc-mcp-gateway-search
+//! dcc-mcp-gateway-core / dcc-mcp-catalog  →  dcc-mcp-gateway-search
 //! ```
 
 #![forbid(unsafe_code)]
@@ -18,7 +18,7 @@ mod query;
 mod ranking;
 mod record;
 
-pub use engine::{search, search_page};
+pub use engine::{rank_all, search, search_page};
 pub use query::{
     DEFAULT_LIMIT, MAX_LIMIT, RANKER_VERSION, SearchHit, SearchMode, SearchPage, SearchQuery,
 };

--- a/crates/dcc-mcp-gateway/src/gateway/admin/instance_update_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/instance_update_tests.rs
@@ -281,6 +281,7 @@ fn make_service_entry(
         scene: None,
         documents: vec![],
         pid,
+        host_pid: None,
         sentinel_path: None,
         display_name: Some(format!("{dcc_type}-test")),
         status: ServiceStatus::Available,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/raw_proxy_lease_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/raw_proxy_lease_tests.rs
@@ -91,6 +91,7 @@ fn make_service_entry(port: u16) -> ServiceEntry {
         scene: None,
         documents: vec![],
         pid: None,
+        host_pid: None,
         sentinel_path: None,
         display_name: Some("maya-test".into()),
         status: ServiceStatus::Available,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -1748,6 +1748,7 @@ filters:
             scene: None,
             documents: vec![],
             pid,
+            host_pid: None,
             sentinel_path: None,
             display_name: Some(format!("{dcc_type}-test")),
             status: ServiceStatus::Available,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/workers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/workers.rs
@@ -135,6 +135,7 @@ fn entry_to_worker_json(e: &ServiceEntry, gs: &GatewayState) -> Value {
         "dcc_type":             e.dcc_type,
         "display_name":         e.display_name,
         "pid":                  e.pid,
+        "host_pid":             e.host_pid,
         "mcp_url":              entry_mcp_url(e),
         "host":                 e.host,
         "port":                 e.port,

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/catalog.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/catalog.rs
@@ -213,8 +213,10 @@ pub async fn build_payload(query: &Query) -> Result<Value, String> {
             offset,
         } => {
             let mut hits = dcc_mcp_catalog::search_hits(&entries, query);
-            // Sort alphabetically by name (stable behaviour).
-            hits.sort_by(|a, b| entries[a.index].name.cmp(&entries[b.index].name));
+            if query.trim().is_empty() {
+                // Browse mode remains alphabetical; searches preserve relevance order.
+                hits.sort_by(|a, b| entries[a.index].name.cmp(&entries[b.index].name));
+            }
             let total = hits.len();
             let start = (*offset).min(total);
             let end = limit.map_or(total, |lim| total.min(start + lim));

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
@@ -38,7 +38,7 @@ pub fn pointer() -> Value {
     json!({
         "uri":         ROOT_URI,
         "name":        "DCC instance registry",
-        "description": "List of DCC instances registered with the gateway. Supports filtering: ?dcc_type=maya, ?query=<substring>, ?status=available, ?limit=N, ?offset=N, ?verbose=true. Default response is compact (~500B/hit); verbose returns full instance objects. Honesty fields (list_ok, index_health) separate listing success from dispatch readiness (PIP-2725).",
+        "description": "List live, routable DCC instances registered with the gateway. Supports filtering: ?dcc_type=maya, ?query=<substring>, ?status=available, ?limit=N, ?offset=N, ?verbose=true. Historical/non-routable rows require an explicit diagnostic view via ?include_stale=true, ?include_dead=true, or ?view=all (stale + dead). Default response is compact (~500B/hit); verbose returns full instance objects. Honesty fields (list_ok, index_health) separate listing success from dispatch readiness (PIP-2725).",
         "mimeType":    "application/json"
     })
 }
@@ -48,9 +48,9 @@ pub fn pointer() -> Value {
 pub enum Query {
     /// Full list with optional filters from the URI query string.
     List {
-        /// Include stale (no-heartbeat) entries (default: true).
+        /// Include stale and other owner-alive non-routable entries (default: false).
         include_stale: bool,
-        /// Include dead-PID entries via `read_alive_instances` (default: false).
+        /// Include owner/host-dead rows from the operator all-instances view (default: false).
         include_dead: bool,
         /// Exact DCC type filter (e.g. "blender", "maya").
         dcc_type: Option<String>,
@@ -70,10 +70,10 @@ pub enum Query {
 }
 
 impl Query {
-    /// Default list query with backward-compatible defaults.
+    /// Default agent-facing list query: live and routable instances only.
     fn default_list() -> Self {
         Query::List {
-            include_stale: true,
+            include_stale: false,
             include_dead: false,
             dcc_type: None,
             query: None,
@@ -132,6 +132,13 @@ pub fn parse(uri: &str) -> Option<Query> {
             {
                 *include_dead = b;
             }
+            if params
+                .get("view")
+                .is_some_and(|value| value.eq_ignore_ascii_case("all"))
+            {
+                *include_stale = true;
+                *include_dead = true;
+            }
             if let Some(v) = params.get("dcc_type") {
                 *dcc_type = Some(v.to_string());
             }
@@ -186,8 +193,13 @@ pub async fn build_payload(gs: &GatewayState, query: &Query) -> Result<Value, St
             // ── Fetch raw entries ──────────────────────────────────────
             let (raw, evicted_dead) = if *include_dead {
                 (gs.all_instances(&reg), 0usize)
-            } else {
+            } else if *include_stale {
                 gs.read_alive_instances(&reg).map_err(|e| e.to_string())?
+            } else {
+                // Prune owner/host-dead file rows before projecting the same
+                // live+routable view used by REST routing and dispatch.
+                let (_, evicted) = gs.read_alive_instances(&reg).map_err(|e| e.to_string())?;
+                (gs.live_instances(&reg), evicted)
             };
 
             // ── Compute index health before filtering ──────────────────
@@ -341,6 +353,7 @@ pub fn compact_instance_json(e: &ServiceEntry, stale_timeout: std::time::Duratio
         "version":        e.version,
         "host":           e.host,
         "port":           e.port,
+        "host_pid":       e.host_pid,
         "mcp_url":        super::super::http_registration::entry_mcp_url(e),
         "source":         super::super::http_registration::entry_registry_source(e),
         "status":         status_str,
@@ -398,7 +411,7 @@ pub fn compute_index_health(
 mod tests {
     use super::*;
 
-    // ── Parse tests (backward-compatible) ────────────────────────────────
+    // ── Parse tests ──────────────────────────────────────────────────────
 
     #[test]
     fn parse_root_defaults() {
@@ -436,6 +449,26 @@ mod tests {
     }
 
     #[test]
+    fn parse_explicit_diagnostic_views() {
+        assert!(matches!(
+            parse("gateway://instances?include_stale=true"),
+            Some(Query::List {
+                include_stale: true,
+                include_dead: false,
+                ..
+            })
+        ));
+        assert!(matches!(
+            parse("gateway://instances?view=all"),
+            Some(Query::List {
+                include_stale: true,
+                include_dead: true,
+                ..
+            })
+        ));
+    }
+
+    #[test]
     fn parse_unknown_query_keys_are_ignored() {
         assert_eq!(
             parse("gateway://instances?future=1&include_stale=false"),
@@ -459,7 +492,7 @@ mod tests {
         assert_eq!(
             parse("gateway://instances?dcc_type=blender"),
             Some(Query::List {
-                include_stale: true,
+                include_stale: false,
                 include_dead: false,
                 dcc_type: Some("blender".to_string()),
                 query: None,
@@ -476,7 +509,7 @@ mod tests {
         assert_eq!(
             parse("gateway://instances?query=4.2"),
             Some(Query::List {
-                include_stale: true,
+                include_stale: false,
                 include_dead: false,
                 dcc_type: None,
                 query: Some("4.2".to_string()),
@@ -493,7 +526,7 @@ mod tests {
         assert_eq!(
             parse("gateway://instances?status=available"),
             Some(Query::List {
-                include_stale: true,
+                include_stale: false,
                 include_dead: false,
                 dcc_type: None,
                 query: None,
@@ -510,7 +543,7 @@ mod tests {
         assert_eq!(
             parse("gateway://instances?limit=10&offset=5"),
             Some(Query::List {
-                include_stale: true,
+                include_stale: false,
                 include_dead: false,
                 dcc_type: None,
                 query: None,
@@ -547,7 +580,7 @@ mod tests {
         assert_eq!(
             parse("gateway://instances?verbose=true"),
             Some(Query::List {
-                include_stale: true,
+                include_stale: false,
                 include_dead: false,
                 dcc_type: None,
                 query: None,
@@ -567,7 +600,7 @@ mod tests {
         assert_eq!(
             q,
             Some(Query::List {
-                include_stale: true,
+                include_stale: false,
                 include_dead: false,
                 dcc_type: Some("maya".to_string()),
                 query: Some("2024".to_string()),

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -489,26 +489,27 @@ impl GatewayState {
         }
     }
 
-    /// Return operator-facing registry rows with dead-PID entries pruned.
+    /// Return operator-facing registry rows with dead owner/host entries pruned.
     ///
     /// Issue #719: before this method existed, `list_dcc_instances` could
-    /// return rows whose owning DCC process had already exited — for up to
+    /// return rows whose owning service or bound DCC host had already exited — for up to
     /// `stale_timeout_secs` (default 30 s) after the process died, or
     /// indefinitely if no gateway process was running the periodic sweep.
     /// Agents then routed `call_tool` / `acquire_dcc_instance` to a dead
     /// backend and hit connection-refused.
     ///
     /// This is a self-healing read path: every call consults
-    /// [`FileRegistry::read_alive`] which probes each row's `pid` field via
-    /// `sysinfo` and evicts dead-PID rows from both the in-memory view and
-    /// the on-disk `services.json` before returning. The same
+    /// [`FileRegistry::read_alive`] which checks the service sentinel (or
+    /// legacy `pid` fallback) plus any explicit `host_pid`, and evicts dead
+    /// rows from both the in-memory view and on-disk `services.json` before
+    /// returning. The same
     /// sentinel / self-row filters that [`Self::all_instances`] uses are
     /// applied after the prune so the caller sees the identical view
     /// minus the zombies.
     ///
-    /// Fail-open contract (#227): rows with no `pid` are considered alive
-    /// and survive the prune. `FileRegistry::read_alive` enforces this
-    /// internally; we do not re-check it here.
+    /// Fail-open contract (#227): legacy rows with neither a sentinel nor PID
+    /// are considered alive and survive the prune. `FileRegistry::read_alive`
+    /// enforces this internally; we do not re-check it here.
     ///
     /// Returns `(alive_entries, evicted_count)`. `evicted_count` is the
     /// total number of dead-PID rows the registry dropped — callers can
@@ -628,11 +629,18 @@ fn lifecycle_json(e: &ServiceEntry) -> Value {
             "root_path",
         ],
     );
+    let instance_type = first_metadata_value(&e.metadata, &["dcc_mcp_instance_type"]);
 
     json!({
         "role": role,
         "owner": owner,
         "session": session,
+        "pid": e.pid,
+        "service_pid": e.pid,
+        "host_pid": e.host_pid,
+        "dcc_pid": e.host_pid,
+        "host_bound": e.host_pid.is_some(),
+        "instance_type": instance_type,
         "sidecar_pid": sidecar_pid,
         "supports_safe_stop": sidecar_pid.is_some() || safe_stop_url.is_some(),
         "safe_stop_url": safe_stop_url,
@@ -804,6 +812,7 @@ pub fn entry_to_json(
         // Both fields are null when not set; agents should skip null values
         // when building the disambiguation prompt for users.
         "pid":             e.pid,
+        "host_pid":        e.host_pid,
         "display_name":    e.display_name,
         // ── misc ───────────────────────────────────────────────────────────
         "version":         e.version,

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -460,7 +460,9 @@ async fn test_live_instances_prefers_sidecar_for_same_dcc_pid() {
         in_process.version = Some("2026".into());
         r.register(in_process).unwrap();
 
-        let mut sidecar = ServiceEntry::new("maya", "127.0.0.1", 28812).with_pid(4242);
+        let mut sidecar = ServiceEntry::new("maya", "127.0.0.1", 28812)
+            .with_pid(31337)
+            .with_host_pid(4242);
         sidecar.adapter_version = Some("0.3.3".into());
         sidecar
             .metadata
@@ -481,7 +483,9 @@ async fn test_live_instances_prefers_sidecar_for_same_dcc_pid() {
 
 #[test]
 fn test_entry_json_exposes_lifecycle_metadata_for_admin() {
-    let mut entry = ServiceEntry::new("maya", "127.0.0.1", 28812).with_pid(4242);
+    let mut entry = ServiceEntry::new("maya", "127.0.0.1", 28812)
+        .with_pid(31337)
+        .with_host_pid(4242);
     entry
         .metadata
         .insert("dcc_mcp_role".into(), "per-dcc-sidecar".into());
@@ -498,6 +502,9 @@ fn test_entry_json_exposes_lifecycle_metadata_for_admin() {
         .metadata
         .insert("owner".into(), "release-smoke-test".into());
     entry.metadata.insert("session".into(), "test".into());
+    entry
+        .metadata
+        .insert("dcc_mcp_instance_type".into(), "gui".into());
     entry.metadata.insert(
         "safe_stop_url".into(),
         "http://127.0.0.1:19000/safe-stop".into(),
@@ -508,6 +515,11 @@ fn test_entry_json_exposes_lifecycle_metadata_for_admin() {
     assert_eq!(row["lifecycle"]["role"], "per-dcc-sidecar");
     assert_eq!(row["lifecycle"]["owner"], "release-smoke-test");
     assert_eq!(row["lifecycle"]["session"], "test");
+    assert_eq!(row["lifecycle"]["service_pid"], 31337);
+    assert_eq!(row["lifecycle"]["host_pid"], 4242);
+    assert_eq!(row["lifecycle"]["dcc_pid"], 4242);
+    assert_eq!(row["lifecycle"]["host_bound"], true);
+    assert_eq!(row["lifecycle"]["instance_type"], "gui");
     assert_eq!(row["lifecycle"]["sidecar_pid"], 31337);
     assert_eq!(row["lifecycle"]["supports_safe_stop"], true);
     assert_eq!(
@@ -1242,6 +1254,56 @@ async fn gateway_instances_resource_lists_many_dcc_rows_without_gateway_sentinel
         rows.iter()
             .all(|row| row["dcc_type"] != serde_json::json!(GATEWAY_SENTINEL_DCC_TYPE)),
         "gateway://instances must expose only addressable DCC services"
+    );
+}
+
+#[tokio::test]
+async fn gateway_instances_resource_defaults_to_live_routable_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+    {
+        let r = registry.read().await;
+        r.register(ServiceEntry::new("maya", "127.0.0.1", 18812))
+            .unwrap();
+
+        let mut unreal = ServiceEntry::new("unreal", "127.0.0.1", 18813);
+        unreal.status = ServiceStatus::Unreachable;
+        r.register(unreal).unwrap();
+
+        let mut blender = ServiceEntry::new("blender", "127.0.0.1", 18814);
+        blender.status = ServiceStatus::Booting;
+        r.register(blender).unwrap();
+
+        let mut houdini = ServiceEntry::new("houdini", "127.0.0.1", 18815);
+        houdini.status = ServiceStatus::ShuttingDown;
+        r.register(houdini).unwrap();
+    }
+
+    let gs = test_gateway_state(registry.clone());
+    let default_query = crate::gateway::native_resources::instances::parse(
+        crate::gateway::native_resources::instances::ROOT_URI,
+    )
+    .expect("default gateway://instances query");
+    let payload = crate::gateway::native_resources::instances::build_payload(&gs, &default_query)
+        .await
+        .expect("default gateway://instances payload");
+
+    assert_eq!(payload["total"], 1);
+    assert_eq!(payload["instances"][0]["dcc_type"], "maya");
+
+    let diagnostics_query = crate::gateway::native_resources::instances::parse(
+        "gateway://instances?include_stale=true",
+    )
+    .expect("diagnostic gateway://instances query");
+    let diagnostics =
+        crate::gateway::native_resources::instances::build_payload(&gs, &diagnostics_query)
+            .await
+            .expect("diagnostic gateway://instances payload");
+
+    assert_eq!(
+        diagnostics["total"], 4,
+        "non-routable owner-alive rows remain available only through an explicit diagnostic view"
     );
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/state/views.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/views.rs
@@ -341,7 +341,8 @@ fn is_per_dcc_sidecar(entry: &ServiceEntry) -> bool {
 
 fn sidecar_owner_key(entry: &ServiceEntry) -> Option<(String, u32)> {
     entry
-        .pid
+        .host_pid
+        .or(entry.pid)
         .map(|pid| (entry.dcc_type.to_ascii_lowercase(), pid))
 }
 

--- a/crates/dcc-mcp-http-py/src/config.rs
+++ b/crates/dcc-mcp-http-py/src/config.rs
@@ -667,6 +667,18 @@ impl PyMcpHttpConfig {
 
     // ── InstanceConfig getters/setters ───────────────────────────────
 
+    /// Optional external DCC host PID that bounds this service lifetime.
+    #[getter]
+    fn host_pid(&self) -> Option<u32> {
+        self.inner.instance.host_pid
+    }
+
+    /// Optional external DCC host PID that bounds this service lifetime.
+    #[setter]
+    fn set_host_pid(&mut self, v: Option<u32>) {
+        self.inner.instance.host_pid = v;
+    }
+
     /// DCC application type (e.g. ``"maya"``).
     #[getter]
     fn dcc_type(&self) -> Option<String> {

--- a/crates/dcc-mcp-http-py/src/config/tests.rs
+++ b/crates/dcc-mcp-http-py/src/config/tests.rs
@@ -88,6 +88,7 @@ fn all_mcp_http_config_fields_have_py_getters() {
     let _ = cfg.queue_send_timeout_ms();
 
     // ── InstanceConfig ──────────────────────────────────────────
+    let _ = cfg.host_pid();
     let _ = cfg.dcc_type();
     let _ = cfg.dcc_version();
     let _ = cfg.scene();

--- a/crates/dcc-mcp-http-types/src/config/aggregate.rs
+++ b/crates/dcc-mcp-http-types/src/config/aggregate.rs
@@ -366,6 +366,12 @@ impl McpHttpConfig {
     pub fn set_dcc_type(&mut self, v: Option<String>) {
         self.instance.dcc_type = v;
     }
+    pub fn host_pid(&self) -> Option<u32> {
+        self.instance.host_pid
+    }
+    pub fn set_host_pid(&mut self, v: Option<u32>) {
+        self.instance.host_pid = v;
+    }
     pub fn dcc_version(&self) -> Option<String> {
         self.instance.dcc_version.clone()
     }
@@ -470,6 +476,12 @@ impl McpHttpConfig {
             .into_iter()
             .map(|(key, value)| (key.into(), value.into()))
             .collect();
+        self
+    }
+
+    /// Builder: bind this service to an external DCC host process.
+    pub fn with_host_pid(mut self, host_pid: u32) -> Self {
+        self.instance.host_pid = Some(host_pid);
         self
     }
 
@@ -717,6 +729,15 @@ mod tests {
         let cfg = McpHttpConfig::default().with_job_recovery(JobRecoveryPolicy::Requeue);
         assert_eq!(cfg.job.job_recovery, JobRecoveryPolicy::Requeue);
         assert_eq!(cfg.job.job_recovery.as_str(), "requeue");
+    }
+
+    #[test]
+    fn mcp_http_config_external_host_pid_round_trips() {
+        let cfg = McpHttpConfig::default().with_host_pid(4242);
+        let serialized = serde_json::to_string(&cfg).unwrap();
+        let back: McpHttpConfig = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(back.host_pid(), Some(4242));
     }
 
     #[test]

--- a/crates/dcc-mcp-http-types/src/config/instance.rs
+++ b/crates/dcc-mcp-http-types/src/config/instance.rs
@@ -13,6 +13,15 @@ use serde::{Deserialize, Serialize};
 /// nothing carries runtime state.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct InstanceConfig {
+    /// Optional PID of an external DCC host whose lifetime bounds this server.
+    ///
+    /// Embedded and standalone servers leave this unset because the registry
+    /// owner sentinel already represents their lifetime. Sidecars and other
+    /// out-of-process adapters set it so a surviving service cannot keep a
+    /// closed DCC instance discoverable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_pid: Option<u32>,
+
     /// DCC application type (e.g. `"maya"`, `"blender"`). Reported in
     /// the shared `FileRegistry` so the gateway can route by DCC
     /// type.

--- a/crates/dcc-mcp-http-types/src/config/tests.rs
+++ b/crates/dcc-mcp-http-types/src/config/tests.rs
@@ -335,6 +335,7 @@ fn instance_config_round_trips() {
     metadata.insert("task".to_owned(), "lighting".to_owned());
 
     let cfg = InstanceConfig {
+        host_pid: Some(4242),
         dcc_type: Some("maya".into()),
         dcc_version: Some("2025.1".into()),
         scene: Some("/tmp/scene.ma".into()),
@@ -343,6 +344,7 @@ fn instance_config_round_trips() {
     };
     let s = serde_json::to_string(&cfg).unwrap();
     let back: InstanceConfig = serde_json::from_str(&s).unwrap();
+    assert_eq!(back.host_pid, cfg.host_pid);
     assert_eq!(back.dcc_type, cfg.dcc_type);
     assert_eq!(back.dcc_version, cfg.dcc_version);
     assert_eq!(back.scene, cfg.scene);

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -85,6 +85,7 @@ pub(crate) async fn start_gateway_runner(
         port,
     );
     entry.version = config.instance.dcc_version.clone();
+    entry.host_pid = config.instance.host_pid;
     entry.scene = config.instance.scene.clone();
     entry.adapter_version = config.gateway.adapter_version.clone();
     entry.adapter_dcc = config

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -1,7 +1,7 @@
 //! Shared [`MarketplaceService`] — catalog fetch, install/uninstall, source
 //! management, installed state persistence, and integrity verification.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -160,28 +160,36 @@ impl MarketplaceService {
     ) -> Result<MarketplaceSearchResult, MarketplaceError> {
         let sources = self.sources_for_query(explicit_sources)?;
         let mut hits = Vec::new();
+        let mut seen = HashSet::new();
         for source in sources {
             let entries = self
                 .load_source_entries_validated(&source, !skip_validation)
                 .await?;
-            let matched = dcc_mcp_catalog::search(&entries, query.as_deref().unwrap_or(""));
-            for entry in matched {
+            for entry in entries {
                 if let Some(dcc) = dcc.as_deref()
                     && !entry_targets_dcc(&entry, dcc)
                 {
                     continue;
                 }
-                hits.push(MarketplaceHit {
-                    source: source.clone(),
-                    entry,
-                });
-                if limit.is_some_and(|limit| hits.len() >= limit) {
-                    break;
+                if seen.insert(entry.name.clone()) {
+                    hits.push(MarketplaceHit {
+                        source: source.clone(),
+                        entry,
+                    });
                 }
             }
-            if limit.is_some_and(|limit| hits.len() >= limit) {
-                break;
-            }
+        }
+
+        if let Some(query) = query.as_deref().filter(|query| !query.trim().is_empty()) {
+            let entries = hits.iter().map(|hit| hit.entry.clone()).collect::<Vec<_>>();
+            let ranked = dcc_mcp_catalog::search_hits(&entries, query);
+            hits = ranked
+                .into_iter()
+                .map(|ranked_hit| hits[ranked_hit.index].clone())
+                .collect();
+        }
+        if let Some(limit) = limit {
+            hits.truncate(limit);
         }
         Ok(MarketplaceSearchResult {
             query,

--- a/crates/dcc-mcp-sidecar/src/sidecar/registry.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar/registry.rs
@@ -219,7 +219,11 @@ pub(crate) fn build_service_entry(args: &SidecarArgs, registry_dir: &Path) -> Se
     // the HostRpc connection fails, the row still gets a diagnostic MCP URL but
     // stays Booting/unavailable so operators can diagnose it in Admin without
     // making it routable.
-    let mut entry = ServiceEntry::new(&args.dcc, "127.0.0.1", 0).with_pid(args.watch_pid);
+    let mut entry = ServiceEntry::new(&args.dcc, "127.0.0.1", 0)
+        // The sentinel/PID belong to this sidecar service. The watched DCC is a
+        // separate required lifetime so a surviving sidecar cannot become a
+        // ghost instance after its host exits.
+        .with_host_pid(args.watch_pid);
     entry.status = ServiceStatus::Booting;
 
     if let Some(uuid) = args.instance_id {

--- a/crates/dcc-mcp-sidecar/src/sidecar_tests.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_tests.rs
@@ -100,6 +100,12 @@ fn sidecar_service_entry_preserves_discovery_endpoint_metadata() {
     let entry = build_service_entry(&args, &registry_dir);
 
     assert_eq!(
+        entry.host_pid,
+        Some(args.watch_pid),
+        "the sidecar owner sentinel and watched DCC host must have separate liveness signals"
+    );
+
+    assert_eq!(
         entry
             .metadata
             .get(DISCOVERY_MCP_URL_METADATA_KEY)

--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -42,8 +42,32 @@ const REGISTRY_LOCK_BACKOFF_ENV: &str = "DCC_MCP_REGISTRY_LOCK_BACKOFF_MS";
 const DEFAULT_REGISTRY_LOCK_TIMEOUT_MS: u64 = 2_000;
 const DEFAULT_REGISTRY_LOCK_BACKOFF_MS: u64 = 10;
 const REGISTRY_LOCK_SLOW_WARN_MS: u64 = 250;
+const ROLE_METADATA_KEY: &str = "dcc_mcp_role";
+const ROLE_PER_DCC_SIDECAR: &str = "per-dcc-sidecar";
+const SIDECAR_PID_METADATA_KEY: &str = "sidecar_pid";
 
 type EntryMap = HashMap<ServiceKey, ServiceEntry>;
+
+/// Recover the bound DCC PID from pre-`host_pid` sidecar rows.
+///
+/// Those rows stored the watched DCC in `pid`, while the actual registry owner
+/// appeared in `metadata.sidecar_pid` and held the sentinel lock. Restrict the
+/// inference to the explicit sidecar role and unequal, valid PIDs so ordinary
+/// legacy services keep their sentinel-first owner semantics.
+fn legacy_sidecar_host_pid(entry: &ServiceEntry) -> Option<u32> {
+    if entry.host_pid.is_some()
+        || entry.metadata.get(ROLE_METADATA_KEY).map(String::as_str) != Some(ROLE_PER_DCC_SIDECAR)
+    {
+        return None;
+    }
+    let watched_pid = entry.pid?;
+    let sidecar_pid = entry
+        .metadata
+        .get(SIDECAR_PID_METADATA_KEY)?
+        .parse::<u32>()
+        .ok()?;
+    (watched_pid != sidecar_pid).then_some(watched_pid)
+}
 
 fn env_duration_ms(name: &str, default_ms: u64) -> Duration {
     let ms = std::env::var(name)
@@ -908,11 +932,12 @@ impl FileRegistry {
         )
     }
 
-    /// Set the OS process ID for a registered service.
+    /// Set the registered service owner's OS process ID.
     ///
     /// Normally called once at registration time; exposed separately so that
-    /// bridge plugins can set it after the initial [`register`] call if the PID
-    /// was not known at startup.
+    /// service launchers can set it after the initial [`register`] call if the
+    /// owner PID was not known at startup. External DCC hosts use `host_pid`
+    /// on the entry instead.
     pub fn set_pid(&self, key: &ServiceKey, pid: u32) -> TransportResult<bool> {
         self.with_write_transaction(|| {
             let found = if let Some(mut entry) = self.services.get_mut(key) {
@@ -958,12 +983,17 @@ impl FileRegistry {
         })
     }
 
-    /// Remove entries whose owning OS process is no longer running.
+    /// Remove entries whose service owner or explicitly-bound DCC host is no
+    /// longer running.
     ///
-    /// Sentinel locks are checked before PID liveness: if another process can
-    /// acquire the sentinel lock, the owner is gone even if the PID has already
-    /// been reused. Rows from older versions without a sentinel fall back to the
-    /// PID probe. Includes the gateway sentinel.
+    /// Sentinel locks are checked before owner-PID liveness: if another process
+    /// can acquire the sentinel lock, the service owner is gone even if the PID
+    /// has already been reused. Rows from older versions without a sentinel fall
+    /// back to the PID probe. When `host_pid` is present it is an independent
+    /// required lifetime: an alive sidecar must not keep a dead DCC host visible.
+    /// Pre-`host_pid` sidecar rows are recognised from their role and
+    /// `sidecar_pid` metadata so rolling upgrades reap the same ghosts.
+    /// Standalone services omit `host_pid`. Includes the gateway sentinel.
     ///
     /// Issue #719 follow-up: reload the on-disk registry before pruning
     /// so rows written by a separate (now-crashed) process become
@@ -978,11 +1008,14 @@ impl FileRegistry {
                 .iter()
                 .filter(|r| {
                     let entry = r.value();
-                    if let Some(path) = entry.sentinel_path.as_deref() {
+                    let owner_dead = if let Some(path) = entry.sentinel_path.as_deref() {
                         self.sentinel_is_dead(r.key(), path)
                     } else {
                         entry.pid.is_some_and(|p| !is_pid_alive(p))
-                    }
+                    };
+                    let bound_host_pid = entry.host_pid.or_else(|| legacy_sidecar_host_pid(entry));
+                    let host_dead = bound_host_pid.is_some_and(|p| !is_pid_alive(p));
+                    owner_dead || host_dead
                 })
                 .map(|r| r.key().clone())
                 .collect();
@@ -999,7 +1032,7 @@ impl FileRegistry {
                 tracing::info!(
                     dcc_type = %key.dcc_type,
                     instance_id = %key.instance_id,
-                    "removed ghost entry (owner sentinel/PID is dead)"
+                    "removed ghost entry (service owner or bound DCC host is dead)"
                 );
             }
 
@@ -1012,7 +1045,7 @@ impl FileRegistry {
         self.prune_dead_entries()
     }
 
-    /// Read all live entries, evicting any whose owning OS process is dead.
+    /// Read all live entries, evicting any whose owner or bound host is dead.
     ///
     /// Combines the reload-if-stale + [`Self::prune_dead_pids`] + [`Self::list_all`]
     /// dance into a single call so external readers (gateway aggregator,

--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -12,26 +12,14 @@ use std::time::{Duration, Instant, SystemTime};
 
 use dashmap::DashMap;
 use fs4::{FileExt, TryLockError};
-use sysinfo::{Pid, ProcessesToUpdate, System};
 use tracing;
 use uuid::Uuid;
 
+use super::liveness::{is_pid_alive, legacy_sidecar_host_pid};
 use super::types::{
     GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceKey, ServiceSnapshot, ServiceStatus,
 };
 use crate::error::{TransportError, TransportResult};
-
-/// Return `true` when `pid` refers to a currently running OS process.
-///
-/// Used by [`FileRegistry::prune_dead_pids`] to detect ghost entries left behind
-/// when a DCC plugin crashes after registering but before the heartbeat loop
-/// starts. See issue #227.
-fn is_pid_alive(pid: u32) -> bool {
-    let sp = Pid::from_u32(pid);
-    let mut sys = System::new();
-    sys.refresh_processes(ProcessesToUpdate::Some(&[sp]), true);
-    sys.process(sp).is_some()
-}
 
 /// File name for the registry JSON.
 const REGISTRY_FILE: &str = "services.json";
@@ -42,32 +30,8 @@ const REGISTRY_LOCK_BACKOFF_ENV: &str = "DCC_MCP_REGISTRY_LOCK_BACKOFF_MS";
 const DEFAULT_REGISTRY_LOCK_TIMEOUT_MS: u64 = 2_000;
 const DEFAULT_REGISTRY_LOCK_BACKOFF_MS: u64 = 10;
 const REGISTRY_LOCK_SLOW_WARN_MS: u64 = 250;
-const ROLE_METADATA_KEY: &str = "dcc_mcp_role";
-const ROLE_PER_DCC_SIDECAR: &str = "per-dcc-sidecar";
-const SIDECAR_PID_METADATA_KEY: &str = "sidecar_pid";
 
 type EntryMap = HashMap<ServiceKey, ServiceEntry>;
-
-/// Recover the bound DCC PID from pre-`host_pid` sidecar rows.
-///
-/// Those rows stored the watched DCC in `pid`, while the actual registry owner
-/// appeared in `metadata.sidecar_pid` and held the sentinel lock. Restrict the
-/// inference to the explicit sidecar role and unequal, valid PIDs so ordinary
-/// legacy services keep their sentinel-first owner semantics.
-fn legacy_sidecar_host_pid(entry: &ServiceEntry) -> Option<u32> {
-    if entry.host_pid.is_some()
-        || entry.metadata.get(ROLE_METADATA_KEY).map(String::as_str) != Some(ROLE_PER_DCC_SIDECAR)
-    {
-        return None;
-    }
-    let watched_pid = entry.pid?;
-    let sidecar_pid = entry
-        .metadata
-        .get(SIDECAR_PID_METADATA_KEY)?
-        .parse::<u32>()
-        .ok()?;
-    (watched_pid != sidecar_pid).then_some(watched_pid)
-}
 
 fn env_duration_ms(name: &str, default_ms: u64) -> Duration {
     let ms = std::env::var(name)

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -236,7 +236,7 @@ fn test_file_registry_prune_dead_pids() {
 }
 
 #[test]
-fn test_file_registry_sentinel_survives_dead_pid_while_lock_held() {
+fn test_file_registry_legacy_pid_does_not_override_live_owner_sentinel() {
     let dir = tempfile::tempdir().unwrap();
     let registry = FileRegistry::new(dir.path()).unwrap();
 
@@ -246,6 +246,61 @@ fn test_file_registry_sentinel_survives_dead_pid_while_lock_held() {
 
     assert_eq!(registry.prune_dead_entries().unwrap(), 0);
     assert!(registry.get(&key).is_some());
+}
+
+#[test]
+fn test_file_registry_prunes_legacy_sidecar_dead_watched_host() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    let mut entry = ServiceEntry::new("unreal", "127.0.0.1", 18812).with_pid(u32::MAX);
+    entry
+        .metadata
+        .insert("dcc_mcp_role".into(), "per-dcc-sidecar".into());
+    entry
+        .metadata
+        .insert("sidecar_pid".into(), std::process::id().to_string());
+    let key = entry.key();
+    registry.register(entry).unwrap();
+
+    assert_eq!(
+        registry.prune_dead_entries().unwrap(),
+        1,
+        "a live legacy sidecar sentinel must not hide its dead watched DCC"
+    );
+    assert!(registry.get(&key).is_none());
+}
+
+#[test]
+fn test_file_registry_prunes_dead_bound_hosts_while_owner_sentinels_are_locked() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    let mut unreal = ServiceEntry::new("unreal", "127.0.0.1", 18812);
+    unreal.host_pid = Some(u32::MAX);
+    let unreal_key = unreal.key();
+    registry.register(unreal).unwrap();
+
+    let mut photoshop = ServiceEntry::new("photoshop", "127.0.0.1", 18813);
+    photoshop.host_pid = Some(u32::MAX - 1);
+    let photoshop_key = photoshop.key();
+    registry.register(photoshop).unwrap();
+
+    let standalone = ServiceEntry::new("renderdoc", "127.0.0.1", 18814);
+    let standalone_key = standalone.key();
+    registry.register(standalone).unwrap();
+
+    assert_eq!(
+        registry.prune_dead_entries().unwrap(),
+        2,
+        "host-bound rows must be evicted even while their service owner is alive"
+    );
+    assert!(registry.get(&unreal_key).is_none());
+    assert!(registry.get(&photoshop_key).is_none());
+    assert!(
+        registry.get(&standalone_key).is_some(),
+        "a standalone service has no external host lifetime to validate"
+    );
 }
 
 #[test]

--- a/crates/dcc-mcp-transport/src/discovery/liveness.rs
+++ b/crates/dcc-mcp-transport/src/discovery/liveness.rs
@@ -1,0 +1,38 @@
+//! Process-lifetime helpers shared by file-based discovery reads.
+
+use sysinfo::{Pid, ProcessesToUpdate, System};
+
+use super::types::ServiceEntry;
+
+const ROLE_METADATA_KEY: &str = "dcc_mcp_role";
+const ROLE_PER_DCC_SIDECAR: &str = "per-dcc-sidecar";
+const SIDECAR_PID_METADATA_KEY: &str = "sidecar_pid";
+
+/// Return `true` when `pid` refers to a currently running OS process.
+pub(super) fn is_pid_alive(pid: u32) -> bool {
+    let process_id = Pid::from_u32(pid);
+    let mut system = System::new();
+    system.refresh_processes(ProcessesToUpdate::Some(&[process_id]), true);
+    system.process(process_id).is_some()
+}
+
+/// Recover the bound DCC PID from pre-`host_pid` sidecar rows.
+///
+/// Those rows stored the watched DCC in `pid`, while the actual registry owner
+/// appeared in `metadata.sidecar_pid` and held the sentinel lock. Restrict the
+/// inference to the explicit sidecar role and unequal, valid PIDs so ordinary
+/// legacy services keep their sentinel-first owner semantics.
+pub(super) fn legacy_sidecar_host_pid(entry: &ServiceEntry) -> Option<u32> {
+    if entry.host_pid.is_some()
+        || entry.metadata.get(ROLE_METADATA_KEY).map(String::as_str) != Some(ROLE_PER_DCC_SIDECAR)
+    {
+        return None;
+    }
+    let watched_pid = entry.pid?;
+    let sidecar_pid = entry
+        .metadata
+        .get(SIDECAR_PID_METADATA_KEY)?
+        .parse::<u32>()
+        .ok()?;
+    (watched_pid != sidecar_pid).then_some(watched_pid)
+}

--- a/crates/dcc-mcp-transport/src/discovery/mod.rs
+++ b/crates/dcc-mcp-transport/src/discovery/mod.rs
@@ -1,6 +1,7 @@
 //! Service discovery — unified registry supporting file-based and future mDNS strategies.
 
 pub mod file_registry;
+mod liveness;
 #[cfg(feature = "mdns")]
 pub mod mdns;
 pub mod types;

--- a/crates/dcc-mcp-transport/src/discovery/mod.rs
+++ b/crates/dcc-mcp-transport/src/discovery/mod.rs
@@ -53,7 +53,7 @@ pub trait ServiceDiscovery: Send + Sync {
     /// Remove stale services.
     fn cleanup_stale(&self, timeout: Duration) -> TransportResult<usize>;
 
-    /// Remove entries whose owning OS process is no longer running.
+    /// Remove entries whose service owner or explicitly-bound host is no longer running.
     ///
     /// Default implementation is a no-op so strategies without PID awareness
     /// (e.g. future mDNS) compile unchanged.
@@ -211,7 +211,7 @@ impl ServiceRegistry {
         self.strategy.cleanup_stale(timeout)
     }
 
-    /// Remove entries whose owning OS process is no longer running (ghost-entry reaping).
+    /// Remove entries whose service owner or explicitly-bound host is no longer running.
     ///
     /// See [`file_registry::FileRegistry::prune_dead_pids`] for the full contract.
     pub fn prune_dead_pids(&self) -> TransportResult<usize> {

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -249,12 +249,21 @@ pub struct ServiceEntry {
     /// The active document is also reflected in `scene`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub documents: Vec<String>,
-    /// OS process ID of the DCC process.
+    /// OS process ID of the registered service owner.
     ///
-    /// Used to disambiguate two instances of the same DCC type that have the
-    /// same scene open (e.g. two Maya sessions reviewing the same asset).
+    /// For embedded adapters this is also the DCC process. For sidecars it is
+    /// the sidecar process; use `host_pid` for the separately watched DCC host.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
+    /// Optional OS process ID of an external DCC host this service is bound to.
+    ///
+    /// `pid` and the sentinel identify the registered service owner. A sidecar
+    /// or out-of-process adapter sets `host_pid` when its row must disappear as
+    /// soon as the DCC host exits, even if the service process is still alive.
+    /// Standalone services leave this unset and are governed only by their own
+    /// sentinel/PID and heartbeat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_pid: Option<u32>,
     /// OS-held sentinel lock file for crash-resilient liveness checks.
     ///
     /// The owning process holds an exclusive lock while registered. Readers can
@@ -318,8 +327,8 @@ impl ServiceEntry {
     /// `pid` is auto-populated with [`std::process::id()`] so the registry can
     /// reap ghost entries when the owning process crashes (see
     /// [`FileRegistry::prune_dead_pids`](super::file_registry::FileRegistry::prune_dead_pids)).
-    /// Override via [`ServiceEntry::with_pid`] when registering on behalf of
-    /// another process (bridge scenarios).
+    /// Override via [`ServiceEntry::with_pid`] only when the registry owner PID
+    /// cannot be inferred from the current process.
     pub fn new(dcc_type: impl Into<String>, host: impl Into<String>, port: u16) -> Self {
         let now = SystemTime::now();
         Self {
@@ -334,6 +343,7 @@ impl ServiceEntry {
             scene: None,
             documents: Vec::new(),
             pid: Some(std::process::id()),
+            host_pid: None,
             sentinel_path: None,
             display_name: None,
             metadata: HashMap::new(),
@@ -371,6 +381,7 @@ impl ServiceEntry {
             scene: None,
             documents: Vec::new(),
             pid: Some(std::process::id()),
+            host_pid: None,
             sentinel_path: None,
             display_name: None,
             metadata: HashMap::new(),
@@ -385,9 +396,18 @@ impl ServiceEntry {
         }
     }
 
-    /// Override the owning process PID (useful when registering on behalf of a bridge).
+    /// Override the registered service owner's PID.
     pub fn with_pid(mut self, pid: u32) -> Self {
         self.pid = Some(pid);
+        self
+    }
+
+    /// Bind this service row to an external DCC host process.
+    ///
+    /// The registry requires both the service owner and this host process to
+    /// remain alive. Do not set this for standalone/headless services.
+    pub fn with_host_pid(mut self, host_pid: u32) -> Self {
+        self.host_pid = Some(host_pid);
         self
     }
 
@@ -597,6 +617,13 @@ mod tests {
     fn test_service_entry_with_pid_override() {
         let entry = ServiceEntry::new("maya", "127.0.0.1", 18812).with_pid(42);
         assert_eq!(entry.pid, Some(42));
+    }
+
+    #[test]
+    fn test_service_entry_with_external_host_pid() {
+        let entry = ServiceEntry::new("unreal", "127.0.0.1", 18812).with_host_pid(42);
+        assert_eq!(entry.pid, Some(std::process::id()));
+        assert_eq!(entry.host_pid, Some(42));
     }
 
     // Issue maya#137: adapter_version and adapter_dcc must round-trip

--- a/crates/dcc-mcp-transport/src/python/types.rs
+++ b/crates/dcc-mcp-transport/src/python/types.rs
@@ -407,12 +407,14 @@ pub struct PyServiceEntry {
     /// For multi-document apps each element is a file path.
     #[pyo3(get)]
     pub documents: Vec<String>,
-    /// OS process ID of the DCC process.
+    /// OS process ID of the registered service owner.
     ///
-    /// Useful for disambiguating two instances of the same DCC type
-    /// that have the same scene open.
+    /// For sidecars this differs from `host_pid`, which identifies the DCC.
     #[pyo3(get)]
     pub pid: Option<u32>,
+    /// Optional PID of an external DCC host that bounds this service lifetime.
+    #[pyo3(get)]
+    pub host_pid: Option<u32>,
     /// Human-readable label for this instance (e.g. `"Maya-Rigging"`).
     ///
     /// Set by the bridge plugin at registration time.  Displayed by the
@@ -486,6 +488,7 @@ impl PyServiceEntry {
         dict.set_item("scene", &self.scene)?;
         dict.set_item("documents", &self.documents)?;
         dict.set_item("pid", self.pid)?;
+        dict.set_item("host_pid", self.host_pid)?;
         dict.set_item("display_name", &self.display_name)?;
         dict.set_item("metadata", &self.metadata)?;
         dict.set_item("status", self.status.__str__())?;
@@ -529,6 +532,7 @@ impl From<&ServiceEntry> for PyServiceEntry {
             scene: entry.scene.clone(),
             documents: entry.documents.clone(),
             pid: entry.pid,
+            host_pid: entry.host_pid,
             display_name: entry.display_name.clone(),
             metadata: entry.metadata.clone(),
             status: entry.status.into(),

--- a/docs/guide/adapter-install-lifecycle.md
+++ b/docs/guide/adapter-install-lifecycle.md
@@ -203,6 +203,19 @@ ready = result.get("readiness", {})
 Leaving `wait_ready_timeout_secs` unset preserves the non-blocking startup
 contract. External supervisors that are not running inside the DCC process must
 pass `watch_pid=current_dcc_pid`; in-process hooks should keep the default.
+The sidecar records its own service PID/sentinel separately from this watched
+host PID. Registry reads require both lifetimes, so the row is evicted even if
+the sidecar briefly survives after Unreal, 3ds Max, Maya, or another host exits.
+During rolling upgrades, readers also recognise older `per-dcc-sidecar` rows
+whose watched DCC PID predates the explicit `host_pid` field.
+Out-of-process `DccServerBase` adapters that do not use the standard sidecar
+must pass `dcc_pid=current_dcc_pid` to `DccServerOptions.from_env(...)` for the
+same host-bound contract. Standalone/headless services must leave `dcc_pid`
+unset and pass `instance_type="standalone"`; their own sentinel, endpoint, and
+heartbeat are the complete lifetime. `instance_type` describes the process
+lifetime and is independent from `standalone_main_thread`, which only selects
+the execution/threading contract. It can also be supplied with
+`DCC_MCP_<DCC>_INSTANCE_TYPE` (or the process-wide `DCC_MCP_INSTANCE_TYPE`).
 The Python API keeps `liveness_check_secs=0.0` by default for DCC UI startup
 hooks, but the module CLI defaults `launch-sidecar` to a 1-second process check
 because it is normally used from installers and supervisors.

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -119,7 +119,7 @@ dcc-mcp-cli gateway register https://workstation.example:19293 --name pcA
 dcc-mcp-cli gateway list
 dcc-mcp-cli gateway set pcA
 dcc-mcp-cli gateway set local
-dcc-mcp-cli search --query sphere --dcc-type maya --instance-id abc12345
+dcc-mcp-cli search create sphere --dcc-type maya --instance-id abc12345
 dcc-mcp-cli describe maya.abc12345.create_sphere
 dcc-mcp-cli load-skill workflow --dcc-type 3dsmax --instance-id 80321760
 dcc-mcp-cli call maya.abc12345.create_sphere --json '{"radius":2}'
@@ -130,7 +130,7 @@ dcc-mcp-cli install --dcc-type maya --version 2026
 dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe"
 dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe" --execute
 dcc-mcp-cli marketplace add dcc-mcp/marketplace
-dcc-mcp-cli marketplace search --query hunyuan --dcc maya
+dcc-mcp-cli marketplace search maya rigging --limit 20
 dcc-mcp-cli marketplace inspect dcc-asset-hunyuan-download
 dcc-mcp-cli marketplace install dcc-asset-hunyuan-download --dcc maya
 dcc-mcp-cli reload-skills --dcc-type maya
@@ -160,7 +160,7 @@ dcc-mcp-cli lint path/to/skills
 | `stats [--range 1h\|24h\|7d\|all] [--dcc-type <dcc>] [--skill <name>] [--tool <name>] [--status success\|failure] [--instance-id <id>] [--session-id <id>]` | `GET /v1/debug/stats` | Query persisted tool-call counts, success/failure, latency, tokens, and top dimensions after applying all supplied filters. JSON is the default output for agent use. |
 | `doctor [--registry-dir <path>] [--gateway-port <port>]` | local filesystem + gateway probe | Report profile config/current selection, local registry path/inventory, direct-control readiness counts and not-ready diagnostics, gateway daemon status, and server binary diagnostics without auto-starting or downloading services. |
 | `list [--gateway <profile>]` | local FileRegistry or `GET /v1/instances` | List live DCC instances. Defaults to local FileRegistry after ensuring the loopback gateway; remote profiles use the selected gateway. |
-| `search [--instance-id <id>]` | local MCP `search_tools` or remote `POST /v1/search` | Search callable capabilities, optionally scoped to a full UUID or unique prefix. |
+| `search [QUERY...] [-q\|--query <q>] [--instance-id <id>]` | local MCP `search_tools` or remote `POST /v1/search` | Search callable capabilities with positional natural-language words or the backward-compatible query flag, optionally scoped to a full UUID or unique prefix. |
 | `describe <tool-slug>` | local MCP `tools/list` or remote `POST /v1/describe` | Inspect a capability before calling it. |
 | `load-skill <skill-name> [--dcc-type <dcc>] [--instance-id <id>]` | local MCP `tools/call load_skill` or remote `POST /v1/load_skill` | Activate a progressive skill and print its registered tools. |
 | `call <tool-slug> --json <object>` | local MCP `tools/call` or remote `POST /v1/call` | Invoke one capability. |
@@ -171,7 +171,7 @@ dcc-mcp-cli lint path/to/skills
 | `install --dcc-type <dcc> [--version <v>] [--python <path>] [--execute]` | catalog-backed local plan / executor | Resolve the matching adapter and emit an auditable install plan; with `--execute`, run package-install steps with consent, rollback, and package/path verification. Live DCC checks stay in the emitted `next_steps`. |
 | `marketplace add <source>` | local source registry | Register a marketplace source (`dcc-mcp/marketplace`, a GitHub `owner/repo`, raw JSON URL, or local catalog file). |
 | `marketplace list` | local source registry | List the built-in, configured, and environment-provided marketplace sources. |
-| `marketplace search [--query <q>] [--dcc <dcc>] [--source <source>]` | marketplace catalog JSON/YAML | Search skill package entries across configured or explicit sources. |
+| `marketplace search [QUERY...] [-q\|--query <q>] [--dcc <dcc>] [--source <source>]` | marketplace catalog JSON/YAML | Fuzzy-rank Skill packages across configured or explicit sources using the shared search engine; deduplicate by package name before applying `--limit`. `--dcc-type` is an alias for `--dcc`. |
 | `marketplace inspect <name> [--source <source>]` | marketplace catalog JSON/YAML | Print exact entry metadata including version and install fields. |
 | `marketplace install <name> [--dcc <dcc>] [--source <source>] [--force]` | marketplace catalog + local filesystem/git | Install a skill package to `~/.dcc-mcp/marketplace/<dcc>/<name>/`. |
 | `marketplace list-installed [--dcc <dcc>]` | local installed-state file | List locally installed marketplace packages and their versions/paths. |

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -551,12 +551,16 @@ The gateway exposes the live DCC registry as a gateway-native MCP resource
  "params":{"uri":"gateway://instances"}}
 ```
 
-The payload includes live, stale, and unhealthy rows so clients can decide
-whether to route, reconnect, or ask the user to restart a DCC instance.
-Each entry already carries `mcp_url`, so clients that have read this
-resource can connect directly. Optional URI query parameters
-(`?include_stale=false`, `?include_dead=true`) match the legacy tool
-flags. `resources/list` advertises only root pointers for gateway-native
+The default payload includes only live, routable rows, matching the gateway's
+`live_instances` REST/routing contract. It excludes stale, booting,
+shutting-down, and unreachable rows so an agent cannot mistake an operator
+diagnostic record for a usable DCC instance. Each entry already carries
+`mcp_url`, so clients that have read this resource can connect directly.
+Use `?include_stale=true` for owner-alive diagnostic rows,
+`?include_dead=true` for owner/host-dead rows, or `?view=all` for the full
+stale-and-dead operator registry;
+these expanded views are for diagnosis, not routing. `resources/list`
+advertises only root pointers for gateway-native
 families; it does not enumerate every instance-specific URI. Backend
 capability indexes refresh on demand before gateway `search` / `describe`,
 so instances registered after gateway startup are picked up without a restart.
@@ -617,12 +621,21 @@ ready yet — wait and re-probe, don't route calls to it.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `pid` | `int \| null` | OS process ID of the DCC or sidecar |
-| `dcc_pid` | `int \| null` | OS process ID of the DCC host (when different from sidecar) |
+| `pid` / `service_pid` | `int \| null` | OS process ID of the registered service owner; for a sidecar this is the sidecar process |
+| `host_pid` / `dcc_pid` | `int \| null` | Explicitly bound DCC host PID; `null` for standalone services and embedded adapters whose owner sentinel already follows the DCC |
+| `host_bound` | `bool` | Whether the row has a separate required DCC host lifetime |
+| `instance_type` | `string \| null` | Adapter-declared `gui` or `standalone` runtime shape |
 | `session` | `string \| null` | DCC session identifier (e.g. `"untitled"`) |
 | `sidecar_pid` | `int \| null` | OS process ID of the sidecar process |
 | `supports_safe_stop` | `bool` | Whether the instance advertises a safe-stop endpoint |
 | `restartable` | `bool` | Whether the instance can be restarted (has sidecar_pid or restart/launch command) |
+
+File-registry liveness has two independent gates. The sentinel (with legacy
+`pid` fallback) proves that the registered service owner is alive. When
+`host_pid` is set, the DCC host must also be alive; a surviving sidecar cannot
+keep an exited Unreal, Maya, Photoshop, or custom host discoverable. A true
+standalone/headless service leaves `host_pid` unset and remains valid while its
+own service endpoint and heartbeat remain healthy.
 
 ### Remote HTTP Instance Registration (#1361)
 

--- a/docs/guide/host-adapter.md
+++ b/docs/guide/host-adapter.md
@@ -112,6 +112,7 @@ from dcc_mcp_core import DccServerBase, DccServerOptions
 opts = DccServerOptions.from_env(
     "maya",
     skills_dir,
+    instance_type="standalone",  # this process owns the full runtime lifetime
     standalone_main_thread=True,  # mayapy/batch only, never GUI sessions
 )
 server = DccServerBase(opts)
@@ -123,6 +124,8 @@ GUI dispatcher and that its in-process execution lane is safe for tools that
 declare `thread_affinity: main`. Core then installs the inline in-process skill
 executor before discovery and lets MCP `tools/call` plus REST `/v1/call` satisfy
 enforced main-affinity tools without adapter-local metadata mutation.
+`instance_type="standalone"` separately tells discovery that no external GUI
+host bounds this service lifetime. Do not infer one contract from the other.
 
 Keep using a real `QueueDispatcher` / `BlockingDispatcher` for GUI hosts. Use
 `set_skill_load_transform(...)` only for runtime policy that does not lie about

--- a/docs/guide/marketplace.md
+++ b/docs/guide/marketplace.md
@@ -72,7 +72,7 @@ Set `DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES=1` to disable the built-in source.
 |-------------------------------------------|------------------------------------------------|
 | `marketplace add <source>`                | Register a marketplace source                  |
 | `marketplace list`                        | List configured sources                        |
-| `marketplace search --query <q>`          | Search entries across all sources              |
+| `marketplace search [QUERY...]`           | Fuzzy-rank entries across all sources; `--query <q>` remains supported |
 | `marketplace inspect <name>`              | Show full entry metadata                       |
 | `marketplace install <name> --dcc <dcc>`  | Install a skill package                        |
 | `marketplace list-installed --dcc <dcc>`  | List installed packages                        |
@@ -364,7 +364,7 @@ future phase.
 
 | Aspect | CLI | Admin UI |
 |--------|-----|----------|
-| Catalog search | `marketplace search --query <q>` | Browse tab with search + DCC filter |
+| Catalog search | `marketplace search [QUERY...]` | Browse tab with search + DCC filter |
 | Install | `marketplace install <name> --dcc <dcc>` | Install button on card or detail modal |
 | Uninstall | `marketplace uninstall <name> --dcc <dcc>` | Uninstall button in Installed tab |
 | List installed | `marketplace list-installed --dcc <dcc>` | Installed tab |

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -2232,10 +2232,14 @@ class ServiceEntry:
     @property
     def pid(self) -> typing.Optional[builtins.int]:
         r"""
-        OS process ID of the DCC process.
+        OS process ID of the registered service owner.
 
-        Useful for disambiguating two instances of the same DCC type
-        that have the same scene open.
+        For sidecars this differs from `host_pid`, which identifies the DCC.
+        """
+    @property
+    def host_pid(self) -> typing.Optional[builtins.int]:
+        r"""
+        Optional PID of an external DCC host that bounds this service lifetime.
         """
     @property
     def display_name(self) -> typing.Optional[builtins.str]:

--- a/python/dcc_mcp_core/_runtime/mcp_http_config.py
+++ b/python/dcc_mcp_core/_runtime/mcp_http_config.py
@@ -40,6 +40,7 @@ class McpHttpConfig:
     dcc_version: str = ""
     scene: str = ""
     dcc_type: str = ""
+    host_pid: int | None = None
     instance_metadata: dict[str, str] = field(default_factory=dict)
     standalone_main_thread_execution: bool = False
     exclude_skill_stubs_from_tools_list: bool = False
@@ -69,6 +70,8 @@ class McpHttpConfig:
         self.dcc_version = str(kwargs.pop("dcc_version", ""))
         self.scene = str(kwargs.pop("scene", ""))
         self.dcc_type = str(kwargs.pop("dcc_type", ""))
+        raw_host_pid = kwargs.pop("host_pid", None)
+        self.host_pid = int(raw_host_pid) if raw_host_pid is not None else None
         metadata = kwargs.pop("instance_metadata", None)
         self.instance_metadata = dict(metadata) if isinstance(metadata, dict) else {}
         self.standalone_main_thread_execution = bool(kwargs.pop("standalone_main_thread_execution", False))

--- a/python/dcc_mcp_core/_server/config.py
+++ b/python/dcc_mcp_core/_server/config.py
@@ -55,6 +55,7 @@ except ImportError:
         dcc_version: str | None = None
         scene: str | None = None
         dcc_type: str = ""
+        host_pid: int | None = None
         instance_metadata: dict[str, str] = field(default_factory=dict)
         standalone_main_thread_execution: bool = False
         sandbox_policy: Any = None
@@ -216,10 +217,17 @@ def build_mcp_http_config(
         config.scene = gateway.scene
 
     config.dcc_type = options.dcc_name
+    # Only an explicitly supplied DCC PID creates a second lifetime. When the
+    # adapter is embedded, the owner sentinel already follows the DCC process;
+    # standalone/headless services intentionally remain unbound.
+    config.host_pid = options.diagnostics.dcc_pid
     execution = resolve_execution_binding(options.execution.mode)
     instance_metadata = collect_context_metadata_from_env(options.dcc_name)
     instance_metadata["dcc_mcp_server_version"] = str(config.server_version)
-    instance_metadata["dcc_mcp_instance_type"] = "standalone" if execution.standalone_main_thread else "gui"
+    # Runtime lifetime and execution/threading are separate contracts. Keep the
+    # legacy inference only when an adapter has not declared its runtime shape.
+    legacy_instance_type = "standalone" if execution.standalone_main_thread else "gui"
+    instance_metadata["dcc_mcp_instance_type"] = options.instance_type or legacy_instance_type
     config.instance_metadata = instance_metadata
     config.standalone_main_thread_execution = execution.standalone_main_thread
     apply_tools_list_stub_policy(config, options.dcc_name)

--- a/python/dcc_mcp_core/_server/options.py
+++ b/python/dcc_mcp_core/_server/options.py
@@ -7,7 +7,7 @@ dataclasses so every cross-cutting concern lives in one place:
 - :class:`ObservabilityOptions` — file logging, job persistence, telemetry
 - :class:`DiagnosticsOptions`  — window PID/title/handle, snapshot provider
 - :class:`ExecutionOptions`    — dispatcher vs execution bridge (tagged union)
-- :class:`DccServerOptions`    — root object passed to ``DccServerBase.__init__``
+- :class:`DccServerOptions`    — runtime identity plus the root server options
 
 Usage::
 
@@ -286,6 +286,10 @@ class DccServerOptions:
         server_name: Name reported in the MCP ``initialize`` response.
         server_version: Version reported in the MCP ``initialize`` response.
             ``None`` defaults to the installed ``dcc_mcp_core`` version.
+        instance_type: Runtime lifetime shape reported to discovery. Use
+            ``"gui"`` for a DCC-bound adapter and ``"standalone"`` for a
+            headless service whose own process is the complete lifetime. This
+            is independent from the tool execution/threading mode.
         gateway: :class:`GatewayOptions` instance.
         observability: :class:`ObservabilityOptions` instance.
         diagnostics: :class:`DiagnosticsOptions` instance.
@@ -303,6 +307,16 @@ class DccServerOptions:
     diagnostics: DiagnosticsOptions = field(default_factory=DiagnosticsOptions)
     execution: ExecutionOptions = field(default_factory=ExecutionOptions)
     sidecar: SidecarOptions = field(default_factory=SidecarOptions)
+    # Appended to preserve the public dataclass's historical positional order.
+    instance_type: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.instance_type is None:
+            return
+        normalized = self.instance_type.strip().lower()
+        if normalized not in {"gui", "standalone"}:
+            raise ValueError("instance_type must be 'gui' or 'standalone'")
+        object.__setattr__(self, "instance_type", normalized)
 
     @classmethod
     def from_env(
@@ -313,6 +327,7 @@ class DccServerOptions:
         port: int | None = None,
         server_name: str | None = None,
         server_version: str | None = None,
+        instance_type: str | None = None,
         # gateway kwargs
         gateway_port: int | None = None,
         registry_dir: str | None = None,
@@ -346,7 +361,8 @@ class DccServerOptions:
         directory happens here once, producing a fully-resolved frozen object.
 
         Raises:
-            ValueError: If more than one execution mode is provided.
+            ValueError: If more than one execution mode is provided or the
+                runtime instance type is invalid.
 
         """
         if dispatcher is not None and execution_bridge is not None:
@@ -364,6 +380,13 @@ class DccServerOptions:
             raise ValueError(f"{port_env} must be an integer between 0 and 65535") from exc
         if not 0 <= resolved_port <= 65535:
             raise ValueError(f"{port_env} must be an integer between 0 and 65535")
+
+        instance_type_env = "DCC_MCP_{}_INSTANCE_TYPE".format(
+            "".join(character if character.isalnum() else "_" for character in dcc_name.upper())
+        )
+        resolved_instance_type = instance_type
+        if resolved_instance_type is None:
+            resolved_instance_type = os.environ.get(instance_type_env, os.environ.get("DCC_MCP_INSTANCE_TYPE"))
 
         gateway = GatewayOptions.from_env(
             port=gateway_port,
@@ -408,6 +431,7 @@ class DccServerOptions:
             port=resolved_port,
             server_name=server_name,
             server_version=server_version,
+            instance_type=resolved_instance_type,
             gateway=gateway,
             observability=observability,
             diagnostics=diagnostics,

--- a/scripts/clawhub_sync.py
+++ b/scripts/clawhub_sync.py
@@ -3,6 +3,7 @@ r"""Publish listed skills to ClawHub (https://clawhub.ai/)."""
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -11,12 +12,18 @@ import subprocess
 import sys
 import time
 from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.parse import urlencode
+from urllib.request import Request
+from urllib.request import urlopen
 
 import dcc_mcp_core
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
 DEFAULT_CLI = os.environ.get("CLAWHUB_CLI_PACKAGE", "clawhub@0.17.0")
+CLAWHUB_API_BASE = "https://clawhub.ai/api/v1"
 CLAWHUB_LICENSE = "MIT-0"
 MAX_RETRIES = 3
 VERSION_EXISTS_RE = re.compile(r"\bVersion(?:\s+\S+)?\s+already exists\b")
@@ -24,6 +31,8 @@ RETRYABLE_RE = re.compile(
     r"\b(?:Embedding failed|Please try again|reset in \d+s)\b",
     re.IGNORECASE,
 )
+RESET_IN_RE = re.compile(r"\breset in (\d+)s\b", re.IGNORECASE)
+REQUIRED_PUBLIC_FILES = ("SKILL.md", "agents/openai.yaml")
 
 
 def parse_args() -> argparse.Namespace:
@@ -33,7 +42,7 @@ def parse_args() -> argparse.Namespace:
         "--manifest",
         type=Path,
         default=MANIFEST,
-        help="JSON manifest: [{path, slug}]",
+        help="JSON manifest: [{path, slug, owner}]",
     )
     parser.add_argument(
         "--dry-run",
@@ -49,7 +58,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def load_manifest(path: Path) -> list[dict[str, Any]]:
-    """Load [{path, slug}, ...] entries from the JSON manifest."""
+    """Load [{path, slug, owner}, ...] entries from the JSON manifest."""
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, list):
         raise ValueError(f"manifest must be a JSON array: {path}")
@@ -108,6 +117,128 @@ def is_retryable(proc: subprocess.CompletedProcess[str]) -> bool:
     return RETRYABLE_RE.search(output) is not None
 
 
+def retry_delay(proc: subprocess.CompletedProcess[str], attempt: int) -> int:
+    """Return a bounded retry delay, honoring a server-provided reset window."""
+    output = "\n".join(part for part in (proc.stdout, proc.stderr) if part)
+    match = RESET_IN_RE.search(output)
+    if match is not None:
+        return min(int(match.group(1)) + 1, 120)
+    return 2**attempt
+
+
+def http_retry_delay(error: HTTPError, attempt: int) -> int:
+    """Honor numeric HTTP Retry-After while keeping waits bounded."""
+    raw = error.headers.get("Retry-After") if error.headers is not None else None
+    try:
+        return min(max(int(raw), 1), 120)
+    except (TypeError, ValueError):
+        return 2**attempt
+
+
+def file_sha256(path: Path) -> str:
+    """Hash one local publish artifact without loading it fully into memory."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def published_skill_release(slug: str, owner: str, version: str) -> dict[str, Any]:
+    """Read one owner-qualified public version record from ClawHub."""
+    query = urlencode({"owner": owner})
+    url = f"{CLAWHUB_API_BASE}/skills/{quote(slug, safe='')}/versions/{quote(version, safe='')}?{query}"
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "dcc-mcp-core-clawhub-sync",
+        },
+    )
+    with urlopen(request, timeout=20) as response:
+        payload = json.load(response)
+    published = payload.get("version") if isinstance(payload, dict) else None
+    if not isinstance(published, dict):
+        raise ValueError(f"ClawHub response has no version record: {url}")
+    return published
+
+
+def published_skill_version(slug: str, owner: str, version: str) -> str:
+    """Read one owner-qualified public version number from ClawHub."""
+    published = published_skill_release(slug, owner, version)
+    published_version = published.get("version") if isinstance(published, dict) else None
+    if not isinstance(published_version, str) or not published_version.strip():
+        raise ValueError(f"ClawHub response has no version.version for @{owner}/{slug}@{version}")
+    return published_version.strip()
+
+
+def public_file_mismatches(published: dict[str, Any], skill_dir: Path) -> list[str]:
+    """Return missing or hash-mismatched required public Skill artifacts."""
+    raw_files = published.get("files")
+    files = raw_files if isinstance(raw_files, list) else []
+    remote_hashes = {
+        item["path"]: item["sha256"].lower()
+        for item in files
+        if isinstance(item, dict) and isinstance(item.get("path"), str) and isinstance(item.get("sha256"), str)
+    }
+    mismatches: list[str] = []
+    for relative in REQUIRED_PUBLIC_FILES:
+        local_path = skill_dir / relative
+        if not local_path.is_file():
+            mismatches.append(f"local file missing: {relative}")
+            continue
+        remote_hash = remote_hashes.get(relative)
+        if remote_hash is None:
+            mismatches.append(f"public file missing: {relative}")
+        elif remote_hash != file_sha256(local_path):
+            mismatches.append(f"public file hash mismatch: {relative}")
+    return mismatches
+
+
+def verify_published_version(
+    slug: str,
+    owner: str,
+    expected_version: str,
+    skill_dir: Path | None = None,
+) -> bool:
+    """Require the expected version and key artifacts on the public API."""
+    last_error = "public version was not checked"
+    for attempt in range(1, MAX_RETRIES + 1):
+        retry_wait: int | None = None
+        try:
+            published = published_skill_release(slug, owner, expected_version)
+            raw_version = published.get("version")
+            actual_version = raw_version.strip() if isinstance(raw_version, str) else ""
+            if actual_version == expected_version:
+                mismatches = public_file_mismatches(published, skill_dir) if skill_dir is not None else []
+                if not mismatches:
+                    print(f"Verified @{owner}/{slug}@{expected_version} on the public ClawHub API.")
+                    return True
+                last_error = "; ".join(mismatches)
+            else:
+                last_error = f"public endpoint returned {actual_version or '<missing>'}, expected {expected_version}"
+        except HTTPError as exc:
+            last_error = str(exc)
+            retry_wait = http_retry_delay(exc, attempt)
+        except (OSError, ValueError) as exc:
+            last_error = str(exc)
+
+        if attempt < MAX_RETRIES:
+            wait = retry_wait if retry_wait is not None else 2**attempt
+            print(
+                f"ClawHub public verification pending for @{owner}/{slug}@{expected_version}; "
+                f"retrying in {wait}s (attempt {attempt}/{MAX_RETRIES}) ...",
+                flush=True,
+            )
+            time.sleep(wait)
+
+    print(
+        f"ClawHub public verification failed for @{owner}/{slug}@{expected_version}: {last_error}",
+        file=sys.stderr,
+    )
+    return False
+
+
 def publish_one(
     entry: dict[str, Any],
     *,
@@ -117,8 +248,9 @@ def publish_one(
     """Validate and publish one manifest entry; return process exit code."""
     rel = entry.get("path")
     slug = entry.get("slug")
-    if not rel or not slug:
-        print(f"invalid manifest entry (need path + slug): {entry}", file=sys.stderr)
+    owner = entry.get("owner")
+    if not rel or not slug or not owner:
+        print(f"invalid manifest entry (need path + slug + owner): {entry}", file=sys.stderr)
         return 1
 
     skill_dir = (REPO_ROOT / str(rel)).resolve()
@@ -152,6 +284,8 @@ def publish_one(
         str(slug),
         "--version",
         version,
+        "--owner",
+        str(owner),
         "--no-input",
     )
     if dry_run:
@@ -163,12 +297,12 @@ def publish_one(
         proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
         print_completed_process_output(proc)
         if proc.returncode == 0:
-            return 0
+            return 0 if verify_published_version(str(slug), str(owner), version, skill_dir) else 1
         if version_already_exists(proc):
             print(f"{slug}@{version} already exists on ClawHub; skipping.")
-            return 0
+            return 0 if verify_published_version(str(slug), str(owner), version, skill_dir) else 1
         if attempt < MAX_RETRIES and is_retryable(proc):
-            wait = 2**attempt
+            wait = retry_delay(proc, attempt)
             print(
                 f"Transient ClawHub error for {slug}@{version}; "
                 f"retrying in {wait}s (attempt {attempt}/{MAX_RETRIES}) ...",

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -52,6 +52,8 @@ does not replace a running server binary.
 - Gateway daemon: the one machine-wide `dcc-mcp-server gateway` process that owns routing, dynamic capability search/describe/call, and Gateway Admin.
 - Guardian: a lightweight loop inside daemon-backed services that probes gateway `/health` and re-ensures the daemon through `gateway-launch.lock`; it is not a separate process.
 - Service heartbeat: registry freshness for the service row only. Do not describe heartbeat as the gateway restart trigger.
+- Service owner: the process that owns the registry sentinel and MCP endpoint; its `pid`/sentinel prove the service itself is alive.
+- Bound DCC host: optional external process identified by `host_pid`; both owner and host must stay alive. Standalone/headless services intentionally have no bound host.
 
 ## Fast Workflow
 
@@ -75,6 +77,11 @@ does not replace a running server binary.
     - [docs/guide/new-adapter-onboarding.md](../../docs/guide/new-adapter-onboarding.md) for new adapter scaffolding.
     - [docs/guide/adapter-compatibility-matrix.md](../../docs/guide/adapter-compatibility-matrix.md) for the per-DCC compatibility table.
 4. Start from `DccServerBase` + `DccServerOptions.from_env(...)`.
+   Classify the runtime lifetime explicitly:
+   - Embedded adapter: the service owner is the DCC process; no separate host PID is needed.
+   - Standard sidecar: pass `watch_pid=current_dcc_pid`; core publishes the sidecar owner and bound host as separate liveness signals.
+   - Other out-of-process adapter: pass `dcc_pid=current_dcc_pid` so `McpHttpConfig.host_pid` binds discovery to the DCC lifetime.
+   - Standalone/headless service: pass `instance_type="standalone"`, leave `dcc_pid` unset, and do not bind it to an optional GUI process. Runtime identity is independent from `standalone_main_thread`, which controls tool execution only.
 5. Route host API calls through `HostExecutionBridge`; do not hand-roll a second script executor.
 6. Keep DCC identity data-driven: `dcc_name`, `server_name`, env-var prefix, skill names, and gateway metadata.
    Leave the instance port unset so core resolves `DCC_MCP_<DCC>_PORT` or asks the OS for a free port.
@@ -128,6 +135,10 @@ does not replace a running server binary.
      idempotent, confirmation-gated, and free of credentials. Do not treat
      `elevation_required` as permission to automate UAC or another shell path.
 8. Use CLI profiles (`dcc-mcp-cli gateway ...`, `list/search/describe/call`) as the user UX; treat `dcc-mcp-server` modes as runtime plumbing. Read `docs/guide/gateway.md` before changing daemon, guardian, sentinel, registry, or idle-timeout behavior.
+   `gateway://instances` is agent-safe by default and returns only live,
+   routable rows. Use `?include_stale=true`, `?include_dead=true`, or
+   `?view=all` only for explicit diagnosis; never route a call from those
+   expanded operator views without re-validating live readiness.
 9. Use `dcc_mcp_core.install_lifecycle.build_sidecar_command(...)` / `launch_sidecar(...)` for sidecar startup and readiness. Read `docs/guide/adapter-install-lifecycle.md` before changing host RPC, dispatch readiness, launch stdio, `watch_pid`, or `instance_id` handling.
    - The sidecar MCP listener is dispatch-only. A py37-lite factory can expose local skill metadata, but it cannot advertise or activate declarative skills through the gateway. Require a native py37 wheel for that path, or provide a separate discovery MCP URL; never report lite `load_skill` success without an executable catalog.
 10. Pass `instance_id` to sidecar launch helpers only when it is a real UUID for the DCC service. During early startup, omit it or pass `None`; `build_sidecar_command()` rejects cosmetic values such as `"unknown"` with `success=false` and `reason="invalid_instance_id"` so adapters do not spawn a child that can only fail with a CLI argument error.

--- a/skills/dcc-mcp-creator/agents/openai.yaml
+++ b/skills/dcc-mcp-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DCC-MCP Creator"
+  short_description: "Create and modernize DCC-MCP adapters"
+  default_prompt: "Use $dcc-mcp-creator to create or modernize a DCC-MCP adapter with the shared core contracts."

--- a/skills/dcc-mcp-skills-creator/agents/openai.yaml
+++ b/skills/dcc-mcp-skills-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DCC-MCP Skills Creator"
+  short_description: "Create and validate DCC-MCP Skill packages"
+  default_prompt: "Use $dcc-mcp-skills-creator to create, validate, or improve a DCC-MCP Skill package."

--- a/skills/dcc-mcp-skills-creator/scripts/create_skill.py
+++ b/skills/dcc-mcp-skills-creator/scripts/create_skill.py
@@ -98,6 +98,7 @@ def create_skill(
         raise FileExistsError(f"Skill directory already exists: {skill_dir}")
 
     skill_dir.mkdir(parents=True)
+    (skill_dir / "agents").mkdir()
     (skill_dir / "scripts").mkdir()
     (skill_dir / "references").mkdir()
 
@@ -139,6 +140,16 @@ Runtime scripts should import dependency-light helpers from
 file/path helpers, validation, cancellation checks, and result helpers without
 adding small Python dependencies to DCC hosts.
 """,
+        encoding="utf-8",
+    )
+
+    openai_yaml = skill_dir / "agents" / "openai.yaml"
+    openai_yaml.write_text(
+        f'''interface:
+  display_name: "{title}"
+  short_description: "Run a structured DCC-MCP workflow"
+  default_prompt: "Use ${name} to complete this DCC-MCP workflow."
+''',
         encoding="utf-8",
     )
 

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -8,10 +8,11 @@ description: >-
   to operate or control something in a DCC app, even when they do not mention
   DCC-MCP. Interface-specific intent such as clicking a menu, dismissing a
   dialog, or controlling a window routes to DCC UI Control after structured
-  tools are checked. OpenClaw
-  and other shell agents use dcc-mcp-cli inventory/search/describe/call;
-  MCP-native IDEs use the gateway MCP surface. Not for tasks unrelated to DCC
-  software.
+  tools are checked. Also use this skill first for DCC-MCP Skill marketplace,
+  catalog, recommendation, install, or update requests: query the marketplace
+  through dcc-mcp-cli before recommending a package. OpenClaw and other shell
+  agents use dcc-mcp-cli; MCP-native IDEs use the gateway MCP surface. Not for
+  tasks unrelated to DCC software.
 license: MIT-0
 allowed-tools: Bash Read
 metadata:
@@ -20,8 +21,8 @@ metadata:
     layer: infrastructure
     compatibility: Cross-platform Windows/macOS/Linux. Prefers dcc-mcp-cli on PATH; can download release asset from GitHub; local profile needs no gateway env. DCC_MCP_BASE_URL is optional for remote/legacy gateway REST fallback.
     version: "0.19.63"  # x-release-please-version
-    search-hint: "dcc control operate UI control menu dialog window button click keyboard Maya Blender Houdini Photoshop 3ds Max Nuke Unreal Godot RenderDoc Substance connect create edit render automate cli gateway stats 操作 控制 界面 菜单 弹窗 窗口 按钮 点击 键盘"
-    tags: "dcc, dcc-ui-control, ui-control, maya, blender, houdini, photoshop, nuke, unreal, godot, renderdoc, cli, gateway, clawhub, openclaw"
+    search-hint: "dcc control operate UI control menu dialog window button click keyboard Maya Blender Houdini Photoshop 3ds Max Nuke Unreal Godot RenderDoc Substance connect create edit render automate cli gateway stats marketplace skill catalog recommend install update 商城 技能 操作 控制 界面 菜单 弹窗 窗口 按钮 点击 键盘"
+    tags: "dcc, dcc-ui-control, ui-control, maya, blender, houdini, photoshop, nuke, unreal, godot, renderdoc, cli, gateway, marketplace, skill-catalog, clawhub, openclaw"
   openclaw:
     emoji: "🖥️"
     homepage: https://github.com/dcc-mcp/dcc-mcp-core/blob/main/skills/dcc-mcp/SKILL.md
@@ -43,6 +44,29 @@ REST (`/v1/search`, `/v1/describe`, `/v1/call`) for named remote profiles.
 The CLI returns JSON by default. The bundled Python fallback is gateway-REST
 only and sends `Accept: application/json` because the gateway REST API itself
 now defaults to compact TOON for agent-facing routes.
+
+## Marketplace Intent — Search Before Recommending
+
+Any request to find, compare, recommend, install, or update a DCC-MCP
+marketplace Skill must start with the official CLI catalog, even when the user
+says “Skill store”, “marketplace”, or “商城” without naming DCC-MCP:
+
+```bash
+dcc-mcp-cli marketplace search maya rigging --limit 20
+dcc-mcp-cli marketplace inspect <exact-name-from-search>
+```
+
+Marketplace discovery does not require a live DCC instance. Do not apply
+the live-inventory `total == 0` stop rule to `marketplace search` or `inspect`.
+Use the user's capability words first. If there are no results, retry once with
+a shorter capability query or without the DCC filter; never invent a package
+name or substitute a web recommendation for the CLI result.
+
+Installing or updating changes local state. Inspect the exact returned package
+and obtain user consent before `marketplace install` or `update`; then run
+`reload-skills` and, only when needed, `load-skill`. The Python REST fallback
+does not implement marketplace commands, so a missing CLI follows the
+consent-gated official CLI installation path below.
 
 ## DCC Intent Routing — Use This Skill First
 
@@ -123,100 +147,31 @@ or when the user explicitly chooses that integration.
 ### CLI installation
 
 If `dcc-mcp-cli` is missing, obtain the user's consent before installing the
-latest official release:
-
-```bash
-# Linux/macOS
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
-
-# Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
-```
-
-After installation, use `dcc-mcp-cli update check` and
-`dcc-mcp-cli update apply` to keep the CLI current. The apply step stages the
-new CLI for the next launch; it does not update a running `dcc-mcp-server`.
+latest official release. Exact Linux/macOS and Windows commands, update
+semantics, and development fallbacks live in
+[`references/CLI_CHEATSHEET.md`](references/CLI_CHEATSHEET.md).
 
 ### DCC UI Control fallback
 
-**DCC UI Control** is the public capability name and `ui-control` is its stable
-CLI command. The `ui_control__*` names below are canonical runtime tool identifiers;
-do not call the feature “Computer Use” in agent-facing text.
-
-Do not choose UI Control first. Search, describe, and call the structured DCC
-skill, host API, or adapter script that owns the operation. If the operation is
-reported as unsupported, no suitable tool exists, or semantic UI Automation
-cannot reach the required control, make an agent-directed transition to DCC UI
-Control:
+**DCC UI Control** is the public capability name. Its dedicated runtime Skill
+is loaded with `dcc-mcp-cli load-skill ui-control`; it is not one of the three
+installable agent Skills in this suite. Use it only after the structured DCC
+capability is unsupported or cannot reach the required semantic UI:
 
 1. `ui_control__snapshot` with an exact `process_id`, `window_handle`, or
    `window_title`.
-2. `ui_control__find` and a semantic `ui_control__act` when possible; otherwise one
-   screenshot-coordinate `ui_control__act` using that snapshot.
+2. `ui_control__find` and one semantic `ui_control__act` when possible.
 3. `ui_control__snapshot` after every action before choosing the next action.
 4. `ui_control__stop_computer_use` when the fallback completes, fails, or is
-   abandoned so the visible effects and input owner are released.
-
-Shell agents should use the stable CLI wrapper instead of hand-building legacy
-tool slugs:
-
-```bash
-dcc-mcp-cli ui-control snapshot --instance-id <id> \
-  --json '{"session_id":"menu","process_id":1234}'
-dcc-mcp-cli ui-control find --instance-id <id> \
-  --json '{"session_id":"menu","label":"Settings","role":"menu_item"}'
-dcc-mcp-cli ui-control act --instance-id <id> \
-  --json '{"session_id":"menu","control_id":"settings","action":"click","snapshot_id":"<snapshot_id>"}'
-dcc-mcp-cli ui-control snapshot --instance-id <id> \
-  --json '{"session_id":"menu","process_id":1234}'
-dcc-mcp-cli ui-control stop --instance-id <id> \
-  --json '{"session_id":"menu"}'
-```
-
-For an operator-preapproved Windows plug-in setup, use the separate typed
-system-operation route. It does not use a window or snapshot. The request sends
-only a non-sensitive operation id; the native host resolves it from the catalog
-selected by `DCC_MCP_UI_CONTROL_SYSTEM_GRANT_ID`:
-
-```bash
-dcc-mcp-cli ui-control system-operation --instance-id <id> \
-  --json '{"operation_id":"enable-remote-control"}'
-```
-
-The host always confirms the exact target. Never use this route for passwords,
-tokens, shell commands, HKLM, deletion/replacement, UAC, or security settings.
-If it returns `elevation_required`, `approval_required`, or
-`system_operation_not_granted`, stop and hand the operation to the user or the
-approved installer.
-
-Use `ui-control wait` for condition-based waits. Every subcommand accepts
-`--dcc-type`, `--json-file`, `--meta-json`, and `--timeout-secs` with the same
-meaning as `call`. Output is compact JSON by default so agents receive ids,
-matches, errors, and screenshot artifact paths without the repeated MCP
-envelope or full UIA tree. Add `--full-output` only for targeted diagnostics.
+   abandoned.
 
 Do not transition or retry through another UI/input path after a policy,
 authorization, authentication, security, confirmation, `desktop_unavailable`,
 or `user_interrupted` result. Those outcomes require the user or environment to
-resolve the boundary first.
-
-Never widen the scope to the desktop or reuse coordinates across snapshots.
-Native pointer or keyboard fallback requires one exact `process_id` or
-`window_handle` already bound by the adapter/operator through
-`DCC_MCP_UI_CONTROL_UIA_PROCESS_ID` or `DCC_MCP_UI_CONTROL_UIA_WINDOW_HANDLE`; request
-scope can only narrow that trusted target. Title-only and process-name scopes
-are observation-only.
-If the user presses Esc and the tool returns `user_interrupted`, stop without
-retrying, changing `session_id`, or starting a new session. Only call
-`ui_control__snapshot(resume_computer_use=true)` after the user explicitly asks to
-resume DCC UI Control.
-
-For an exact PID/HWND, `ui_control__snapshot` automatically uses native window
-capture if Windows UIA enumeration fails or times out; treat the returned tree
-as image-only and continue with one bounded native action.
-On the CLI+REST path, rich images are materialized into a bounded local
-`artifact_path`; use the host agent's local image viewer on that absolute path
-instead of expecting base64 JSON to render in the terminal.
+resolve first. Never widen scope to the desktop, reuse coordinates across
+snapshots, or resume a user-interrupted session without an explicit request.
+Load that runtime Skill for the full target-binding, system-operation,
+native-capture, and image-artifact contract.
 
 Internal studios can fork this skill once and reuse the same CLI+REST workflow across
 agents without maintaining per-host MCP server lists.
@@ -294,6 +249,7 @@ remove the old package to avoid duplicate intent routing.
 
 | Situation | You MUST |
 |-----------|----------|
+| **Marketplace/Skill store intent** | Run `dcc-mcp-cli marketplace search` first, then inspect the exact returned name before any recommendation or consent-gated mutation; live inventory is not required |
 | **Starting any local DCC task** | Run `dcc-mcp-cli list`; it ensures the local gateway, then reads the local FileRegistry |
 | **Startup state is ambiguous** | Run `dcc-mcp-cli doctor`; inspect selected profile, registry dir, local inventory, direct-control readiness counts, daemon status, and server binary diagnostics |
 | **Starting any remote DCC task** | Select or override a profile with `dcc-mcp-cli gateway set <name>` or `dcc-mcp-cli list --gateway <name>` |
@@ -360,7 +316,7 @@ Only run this when inventory shows at least one non-stale target:
 
 ```bash
 # CLI (primary)
-dcc-mcp-cli search --query sphere --dcc-type maya --limit 20
+dcc-mcp-cli search create sphere --dcc-type maya --limit 20
 
 # Python fallback
 python scripts/dcc_gateway.py search --query sphere --dcc-type maya --limit 20
@@ -466,87 +422,41 @@ the task scope.
 
 ## Updates and Marketplace Maintenance
 
-Use the gateway update manifest for binary checks:
-
-Official release builds use the platform-specific manifest from the latest
-GitHub release by default. Set `DCC_MCP_UPDATE_MANIFEST_URL` only to override
-that source for a studio mirror or pinned deployment.
+Use the gateway release manifest for binary checks. `update apply` stages the
+CLI for its next launch; a running server must be updated in its own
+environment. The Admin Instances panel remains check-only because the gateway
+cannot prove an instance's installation root. See the CLI cheatsheet for
+platform manifests and server-side update details.
 
 ```bash
-# Check whether the local CLI has an update.
 dcc-mcp-cli update check
-
-# Check a server/instance version shown in the admin panel.
-dcc-mcp-cli update check --binary dcc-mcp-server --current-version 0.18.16
-
-# Stage a CLI binary update for the next CLI launch.
 dcc-mcp-cli update apply
 ```
 
-`dcc-mcp-cli update apply` only stages the CLI binary. To update a running
-server binary, run the server-side command in that server environment:
+For marketplace Skills, preserve the mandatory search-first sequence:
 
 ```bash
-dcc-mcp-server update check
-dcc-mcp-server update apply
-```
-
-The Admin Instances panel is check-only because a gateway cannot prove the
-selected instance's installation root. On Windows, server-side apply requires
-the same-version `dcc-mcp-ui-control-host` manifest entry and both SHA-256
-digests, then stages the server and host in one installation-bound transaction.
-
-Use marketplace commands for skills:
-
-```bash
-dcc-mcp-cli marketplace search --query rigging --dcc maya --limit 20
+dcc-mcp-cli marketplace search maya rigging --limit 20
 dcc-mcp-cli marketplace inspect <package_name>
 dcc-mcp-cli marketplace install <package_name> --dcc maya
 dcc-mcp-cli reload-skills --dcc-type maya
-dcc-mcp-cli marketplace outdated --dcc maya
-dcc-mcp-cli marketplace update <package_name> --dcc maya
-dcc-mcp-cli reload-skills --dcc-type maya
 ```
 
-Use marketplace release commands for package authors and CI:
+`--query "maya rigging"` remains supported for scripts. Search and inspect are
+read-only; install/update require consent. After either mutation, run
+`reload-skills`, then `load-skill` only if the adapter did not auto-load it.
+Package authors use `marketplace pack` and `marketplace publish`; full commands
+live in the CLI cheatsheet.
 
-```bash
-dcc-mcp-cli marketplace pack ./my-skill --out dist/
-dcc-mcp-cli marketplace publish ./my-skill \
-  --catalog ./marketplace.json \
-  --install-url https://github.com/<owner>/<repo>/releases/download/v0.1.0/my-skill.zip \
-  --sha256 sha256:<digest>
-```
-
-After installing or updating skills, first run
-`dcc-mcp-cli reload-skills --dcc-type <dcc>` so running adapters re-scan the
-marketplace skill path. Then use `dcc-mcp-cli load-skill` for a live instance
-when the adapter has not auto-loaded the skill yet.
-
-Use `install` for adapter plans, not marketplace skills:
+Use `install` for adapter plans, never for marketplace Skills:
 
 ```bash
 dcc-mcp-cli install --dcc-type maya --version 2026
-dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe"
-dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe" --execute
 ```
 
-Agents must ask before using `--execute`. The executor prompts for consent,
-rolls back completed steps if a later step fails, verifies pip packages with
-`pip show`, and verifies git/zip/path installs by checking their target path.
-Package install is not online registration: the DCC plugin or sidecar must
-start and remain alive before `dcc-mcp-cli list` shows an instance. Treat the
-install JSON `next_steps` array as the authoritative machine-readable follow-up
-sequence. If it includes `read-install-instructions`, read that adapter
-repository's raw `install.md` first; it owns host-specific setup. Then
-start/enable the host plugin, run `doctor`, confirm `list`, wait for readiness,
-search/call tools, and use marketplace `search`, `inspect`, `install`, then
-`reload-skills` for optional community skill packages.
-
-If `install_policy.auto_install_enabled` is `false`, do not retry with
-`--execute`. Show the returned `install_policy.prompt` to the user and hand off
-to the named Pipeline TD / studio deployment path. Studios set this through
-`DCC_MCP_INSTALL_DISABLED=1` and `DCC_MCP_INSTALL_DISABLED_PROMPT`.
+Ask before `--execute`, follow the returned `next_steps`, and do not treat
+package installation as live registration. If auto-install is disabled, show
+the returned policy prompt and hand off to the named deployment owner.
 
 ---
 

--- a/skills/dcc-mcp/agents/openai.yaml
+++ b/skills/dcc-mcp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DCC-MCP"
+  short_description: "DCC control and marketplace Skill discovery"
+  default_prompt: "Use $dcc-mcp to discover the right live DCC capability or marketplace Skill through the CLI, inspect it, and act safely."

--- a/skills/dcc-mcp/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-mcp/references/CLI_CHEATSHEET.md
@@ -44,7 +44,7 @@ vx python scripts/dcc_gateway.py --ensure-cli list
 | `dcc-mcp-cli dcc-types --catalog path/to/catalog.yml` | Inspect a studio or test catalog through the same typed contract |
 | `dcc-mcp-cli list` | Ensure the local loopback gateway, then list local DCC instances from the FileRegistry |
 | `dcc-mcp-cli doctor` | Report profile, registry, local inventory, direct-control readiness counts, gateway daemon status, and server binary diagnostics without launching services |
-| `dcc-mcp-cli search --query sphere --dcc-type maya --limit 20` | Search local instances directly through MCP in the `local` profile |
+| `dcc-mcp-cli search create sphere --dcc-type maya --limit 20` | Search local instances directly through MCP in the `local` profile; `--query "create sphere"` remains supported |
 | `dcc-mcp-cli list --gateway pcA` | List DCC instances through a named remote gateway profile |
 | `dcc-mcp-cli health` (or `python scripts/dcc_gateway.py health`) | Check gateway liveness; CLI auto-starts loopback gateway targets |
 | `dcc-mcp-cli gateway register https://host:19293 --name pcA` | Persist a named remote gateway profile |
@@ -60,7 +60,7 @@ vx python scripts/dcc_gateway.py --ensure-cli list
 
 | Command | Purpose |
 |---------|---------|
-| `dcc-mcp-cli search --query sphere --dcc-type maya --limit 20` | Find tools |
+| `dcc-mcp-cli search create sphere --dcc-type maya --limit 20` | Find tools with positional natural-language words |
 | `dcc-mcp-cli describe <slug>` | Inspect schema |
 | `dcc-mcp-cli call <slug> --json '{"radius":2}' --meta-json '{"agent_context":{"session_id":"task-42"}}'` | Invoke one tool with a stable task-scoped stats identifier |
 | `dcc-mcp-cli call <slug> --json '{"radius":2}' --meta-json '{"lease_owner":"workflow-42","agent_context":{"session_id":"task-42"}}'` | Invoke a tool on an instance leased by this workflow |
@@ -90,7 +90,7 @@ paths, or full tool payloads.
 |---------|---------|
 | `dcc-mcp-cli install --dcc-type maya --version 2026` | Build an auditable adapter install plan with machine-readable `next_steps`, without changing local state |
 | `dcc-mcp-cli install --dcc-type maya --version 2026 --python "<mayapy>" --execute` | Execute package install after consent; rolls back on failure and verifies pip/path outputs |
-| `dcc-mcp-cli marketplace search --query rigging --dcc maya --limit 20` | Find installable skill packages |
+| `dcc-mcp-cli marketplace search maya rigging --limit 20` | Find installable Skill packages; `--query "maya rigging"` remains supported |
 | `dcc-mcp-cli marketplace inspect <package_name>` | Inspect the selected skill package metadata before installing |
 | `dcc-mcp-cli marketplace install <package_name> --dcc maya` | Install a skill package into the local marketplace root |
 | `dcc-mcp-cli reload-skills --dcc-type maya` | Ask running Maya adapters to re-scan installed skill paths |
@@ -108,7 +108,11 @@ per-DCC sidecar row is routable once `direct_control.ready=true`; if a row is
 booting or `dispatch_status=unavailable`, inspect
 `direct_control.diagnostics.failure_stage`, `failure_reason`, `host_rpc_*`, and
 any log paths, then run `wait-ready` or `doctor` before calling tools.
-After marketplace skill search, inspect the selected package before installing.
+Marketplace search and inspect do not require a live DCC instance. Always query
+the CLI before recommending a marketplace Skill. If the first query is empty,
+retry once with fewer capability words or without the DCC filter; never invent
+a package name. Inspect the selected package before a consent-gated install or
+update.
 After installing or updating marketplace skills, run `reload-skills`, then use
 `load-skill` if the adapter has not auto-loaded the new skill.
 
@@ -128,7 +132,7 @@ python scripts/dcc_gateway.py list
 
 ```bash
 # CLI (primary)
-dcc-mcp-cli search --query sphere --dcc-type maya --limit 10
+dcc-mcp-cli search create sphere --dcc-type maya --limit 10
 
 # Python fallback
 python scripts/dcc_gateway.py search --query sphere --dcc-type maya --limit 10

--- a/skills/marketplace-create-extension/scripts/create_extension.py
+++ b/skills/marketplace-create-extension/scripts/create_extension.py
@@ -4,6 +4,8 @@ Creates a directory with the standard dcc-mcp skill layout:
   <name>/
   ├── SKILL.md       # MIT-0 licensed frontmatter + body
   ├── tools.yaml     # Tool declarations with schemas and annotations
+  ├── agents/
+  │   └── openai.yaml # Codex interface metadata
   └── scripts/
       └── <action_name>.py
 
@@ -77,6 +79,7 @@ def create_extension(
         raise FileExistsError(f"Extension directory already exists: {skill_dir}")
 
     skill_dir.mkdir(parents=True)
+    (skill_dir / "agents").mkdir()
     (skill_dir / "scripts").mkdir()
 
     primary_dcc = dcc_targets[0] if dcc_targets else "python"
@@ -85,6 +88,10 @@ def create_extension(
     # --- SKILL.md ---
     skill_md = skill_dir / "SKILL.md"
     skill_md.write_text(_make_skill_md(name, description, primary_dcc, version, action_name, author), encoding="utf-8")
+
+    # --- agents/openai.yaml ---
+    openai_yaml = skill_dir / "agents" / "openai.yaml"
+    openai_yaml.write_text(_make_openai_yaml(name), encoding="utf-8")
 
     # --- tools.yaml ---
     tools_yaml = skill_dir / "tools.yaml"
@@ -98,6 +105,16 @@ def create_extension(
 
 
 # ── Templates ───────────────────────────────────────────────────────────────────
+
+
+def _make_openai_yaml(name: str) -> str:
+    """Generate Codex interface metadata for the extension."""
+    title = name.replace("-", " ").title()
+    return f'''interface:
+  display_name: "{title}"
+  short_description: "Run a DCC-MCP marketplace extension"
+  default_prompt: "Use ${name} to complete this DCC-MCP marketplace workflow."
+'''
 
 
 def _make_skill_md(

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 from pathlib import Path
 import subprocess
@@ -17,6 +18,7 @@ RELEASE_PLEASE_CONFIG = REPO_ROOT / "release-please-config.json"
 RELEASE_MANIFEST = REPO_ROOT / ".release-please-manifest.json"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
 SYNC_SCRIPT = REPO_ROOT / "scripts" / "clawhub_sync.py"
+README = REPO_ROOT / "README.md"
 
 
 def load_sync_module():
@@ -36,6 +38,24 @@ class TestClawhubSync:
         assert "dcc-mcp" in slugs
         assert "dcc-mcp-skills-creator" in slugs
         assert "dcc-mcp-creator" in slugs
+        assert {entry["owner"] for entry in entries} == {"loonghao"}
+
+    def test_published_skills_include_codex_interface_metadata(self) -> None:
+        entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        for entry in entries:
+            metadata_path = REPO_ROOT / entry["path"] / "agents" / "openai.yaml"
+            assert metadata_path.is_file(), metadata_path
+            interface = yaml_loads(metadata_path.read_text(encoding="utf-8"))["interface"]
+            assert 25 <= len(interface["short_description"]) <= 64
+            assert f"${entry['slug']}" in interface["default_prompt"]
+
+    def test_readme_installs_the_complete_agent_skill_suite(self) -> None:
+        readme = README.read_text(encoding="utf-8")
+        for slug in ("dcc-mcp", "dcc-mcp-skills-creator", "dcc-mcp-creator"):
+            qualified = f"@loonghao/{slug}"
+            assert f"openclaw skills install {qualified}" in readme
+            assert f"clawhub@0.17.0 install {slug}" in readme
+        assert ".github/clawhub-skills.json" in readme
 
     def test_dry_run_exits_zero(self) -> None:
         proc = subprocess.run(
@@ -52,8 +72,150 @@ class TestClawhubSync:
         assert "dcc-mcp" in proc.stdout
         assert "dcc-mcp-skills-creator" in proc.stdout
         assert "dcc-mcp-creator" in proc.stdout
+        assert proc.stdout.count("--owner loonghao") == 3
 
-    def test_publish_skips_existing_clawhub_version(self, tmp_path, monkeypatch, capsys) -> None:
+    def test_dry_run_does_not_publish_or_verify(self, tmp_path, monkeypatch) -> None:
+        sync = load_sync_module()
+        skill_dir = tmp_path / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+
+        class CleanReport:
+            is_clean = True
+            issues: tuple[str, ...] = ()
+
+        def fail(*_args, **_kwargs):
+            raise AssertionError("dry-run must not publish or access the public API")
+
+        monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(sync, "skill_version", lambda _skill_dir: "1.2.3")
+        monkeypatch.setattr(sync, "skill_license", lambda _skill_dir: sync.CLAWHUB_LICENSE)
+        monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
+        monkeypatch.setattr(sync.subprocess, "run", fail)
+        monkeypatch.setattr(sync, "verify_published_version", fail)
+
+        rc = sync.publish_one(
+            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
+            dry_run=True,
+            cli="clawhub@test",
+        )
+
+        assert rc == 0
+
+    def test_public_version_request_is_owner_qualified(self, monkeypatch) -> None:
+        sync = load_sync_module()
+        requests = []
+
+        def fake_urlopen(request, *, timeout):
+            requests.append((request, timeout))
+            return io.BytesIO(b'{"version":{"version":"1.2.3"}}')
+
+        monkeypatch.setattr(sync, "urlopen", fake_urlopen)
+
+        version = sync.published_skill_version("example-skill", "loonghao", "1.2.3")
+
+        assert version == "1.2.3"
+        assert requests[0][0].full_url == (
+            "https://clawhub.ai/api/v1/skills/example-skill/versions/1.2.3?owner=loonghao"
+        )
+        assert requests[0][1] == 20
+
+    def test_public_version_gate_accepts_existing_version_when_latest_is_newer(self, monkeypatch) -> None:
+        sync = load_sync_module()
+
+        def fake_urlopen(_request, *, timeout):
+            assert timeout == 20
+            return io.BytesIO(b'{"version":{"version":"1.2.3"},"latestVersion":{"version":"2.0.0"}}')
+
+        def fail_sleep(_seconds):
+            raise AssertionError("version is already public")
+
+        monkeypatch.setattr(sync, "urlopen", fake_urlopen)
+        monkeypatch.setattr(sync.time, "sleep", fail_sleep)
+
+        assert sync.verify_published_version("example-skill", "loonghao", "1.2.3") is True
+
+    def test_public_version_gate_retries_until_version_is_visible(self, monkeypatch) -> None:
+        sync = load_sync_module()
+        versions = iter(["1.2.2", "1.2.2", "1.2.3"])
+        calls = []
+        sleeps = []
+
+        def fake_release(slug, owner, version):
+            calls.append((slug, owner, version))
+            return {"version": next(versions), "files": []}
+
+        monkeypatch.setattr(sync, "published_skill_release", fake_release)
+        monkeypatch.setattr(sync.time, "sleep", sleeps.append)
+
+        assert sync.verify_published_version("example", "loonghao", "1.2.3") is True
+        assert calls == [("example", "loonghao", "1.2.3")] * sync.MAX_RETRIES
+        assert sleeps == [2, 4]
+
+    def test_public_version_gate_honors_retry_after(self, monkeypatch) -> None:
+        sync = load_sync_module()
+        responses = iter(
+            [
+                sync.HTTPError("https://clawhub.ai", 429, "rate limited", {"Retry-After": "17"}, None),
+                {"version": "1.2.3", "files": []},
+            ]
+        )
+        sleeps = []
+
+        def fake_release(*_args):
+            response = next(responses)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+        monkeypatch.setattr(sync, "published_skill_release", fake_release)
+        monkeypatch.setattr(sync.time, "sleep", sleeps.append)
+
+        assert sync.verify_published_version("example", "loonghao", "1.2.3") is True
+        assert sleeps == [17]
+
+    def test_public_version_gate_fails_after_bounded_retries(self, monkeypatch, capsys) -> None:
+        sync = load_sync_module()
+        calls = []
+        sleeps = []
+
+        def fake_release(slug, owner, version):
+            calls.append((slug, owner, version))
+            return {"version": "1.2.2", "files": []}
+
+        monkeypatch.setattr(sync, "published_skill_release", fake_release)
+        monkeypatch.setattr(sync.time, "sleep", sleeps.append)
+
+        assert sync.verify_published_version("example", "loonghao", "1.2.3") is False
+        assert calls == [("example", "loonghao", "1.2.3")] * sync.MAX_RETRIES
+        assert sleeps == [2, 4]
+        assert "public endpoint returned 1.2.2, expected 1.2.3" in capsys.readouterr().err
+
+    def test_public_version_gate_checks_required_file_hashes(self, tmp_path, monkeypatch, capsys) -> None:
+        sync = load_sync_module()
+        skill_dir = tmp_path / "example"
+        (skill_dir / "agents").mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: example\n---\n", encoding="utf-8")
+        (skill_dir / "agents" / "openai.yaml").write_text(
+            "interface:\n  short_description: Example\n",
+            encoding="utf-8",
+        )
+        published = {
+            "version": "1.2.3",
+            "files": [
+                {"path": relative, "sha256": sync.file_sha256(skill_dir / relative)}
+                for relative in sync.REQUIRED_PUBLIC_FILES
+            ],
+        }
+        monkeypatch.setattr(sync, "published_skill_release", lambda *_args: published)
+        monkeypatch.setattr(sync, "MAX_RETRIES", 1)
+
+        assert sync.verify_published_version("example", "loonghao", "1.2.3", skill_dir) is True
+
+        published["files"][1]["sha256"] = "0" * 64
+        assert sync.verify_published_version("example", "loonghao", "1.2.3", skill_dir) is False
+        assert "public file hash mismatch: agents/openai.yaml" in capsys.readouterr().err
+
+    def test_existing_version_fails_when_not_publicly_visible(self, tmp_path, monkeypatch, capsys) -> None:
         sync = load_sync_module()
         skill_dir = tmp_path / "skills" / "example"
         skill_dir.mkdir(parents=True)
@@ -78,15 +240,16 @@ class TestClawhubSync:
         monkeypatch.setattr(sync, "skill_license", lambda _skill_dir: sync.CLAWHUB_LICENSE)
         monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
         monkeypatch.setattr(sync.subprocess, "run", fake_run)
+        monkeypatch.setattr(sync, "verify_published_version", lambda *_args: False)
 
         rc = sync.publish_one(
-            {"path": "skills/example", "slug": "example"},
+            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
             dry_run=False,
             cli="clawhub@test",
         )
 
         captured = capsys.readouterr()
-        assert rc == 0
+        assert rc == 1
         assert "Version 1.2.3 already exists" in captured.err
         assert "example@1.2.3 already exists on ClawHub; skipping." in captured.out
 
@@ -126,9 +289,10 @@ class TestClawhubSync:
         monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
         monkeypatch.setattr(sync.subprocess, "run", fake_run)
         monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(sync, "verify_published_version", lambda *_args: True)
 
         rc = sync.publish_one(
-            {"path": "skills/example", "slug": "example"},
+            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
             dry_run=False,
             cli="clawhub@test",
         )
@@ -137,7 +301,7 @@ class TestClawhubSync:
         assert rc == 0
         assert len(calls) == 2
         assert "Embedding failed" in captured.err
-        assert "retrying in 2s" in captured.out
+        assert "retrying in 23s" in captured.out
         assert "Published example@1.2.3" in captured.out
 
     def test_publish_retries_embedding_failure_then_treats_existing_as_success(
@@ -178,9 +342,10 @@ class TestClawhubSync:
         monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
         monkeypatch.setattr(sync.subprocess, "run", fake_run)
         monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(sync, "verify_published_version", lambda *_args: True)
 
         rc = sync.publish_one(
-            {"path": "skills/example", "slug": "example"},
+            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
             dry_run=False,
             cli="clawhub@test",
         )
@@ -221,7 +386,7 @@ class TestClawhubSync:
         monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
 
         rc = sync.publish_one(
-            {"path": "skills/example", "slug": "example"},
+            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
             dry_run=False,
             cli="clawhub@test",
         )
@@ -229,8 +394,7 @@ class TestClawhubSync:
         captured = capsys.readouterr()
         assert rc == 1
         assert len(calls) == sync.MAX_RETRIES
-        assert "retrying in 2s" in captured.out
-        assert "retrying in 4s" in captured.out
+        assert captured.out.count("retrying in 23s") == 2
 
     def test_publish_no_retry_on_permanent_error(self, tmp_path, monkeypatch, capsys) -> None:
         sync = load_sync_module()
@@ -263,7 +427,7 @@ class TestClawhubSync:
         monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
 
         rc = sync.publish_one(
-            {"path": "skills/example", "slug": "example"},
+            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
             dry_run=False,
             cli="clawhub@test",
         )

--- a/tests/test_dcc_mcp_skill.py
+++ b/tests/test_dcc_mcp_skill.py
@@ -59,6 +59,20 @@ class TestDccMcpSkill:
             assert keyword in desc
         assert "use this skill first" in desc
 
+    def test_marketplace_intent_is_cli_search_first(self) -> None:
+        meta = dcc_mcp_core.parse_skill_md(DCC_MCP_SKILL_DIR)
+        assert meta is not None
+        desc = (meta.description or "").lower()
+        assert "marketplace" in desc
+        assert "query the marketplace" in desc
+
+        body = " ".join((Path(DCC_MCP_SKILL_DIR) / "SKILL.md").read_text(encoding="utf-8").lower().split())
+        assert "marketplace intent" in body
+        assert "dcc-mcp-cli marketplace search" in body
+        assert "does not require a live dcc instance" in body
+        assert "never invent a package name" in body
+        assert "dcc-mcp-cli marketplace inspect" in body
+
     def test_body_prioritizes_structured_dcc_mcp_tools_for_user_intent(self) -> None:
         body = (Path(DCC_MCP_SKILL_DIR) / "SKILL.md").read_text(encoding="utf-8").lower()
         assert "dcc intent routing" in body
@@ -83,6 +97,7 @@ class TestDccMcpSkill:
         root = Path(DCC_MCP_SKILL_DIR)
         assert (root / "references" / "CLI_CHEATSHEET.md").is_file()
         assert (root / "references" / "ZERO_INSTANCES_CLI.md").is_file()
+        assert len((root / "SKILL.md").read_text(encoding="utf-8").splitlines()) <= 500
 
     def test_probe_cli_missing(self) -> None:
         with patch.object(check_cli_mod.shutil, "which", return_value=None):

--- a/tests/test_dcc_mcp_skills_creator_scaffold.py
+++ b/tests/test_dcc_mcp_skills_creator_scaffold.py
@@ -1,0 +1,32 @@
+"""Regression tests for the bundled DCC-MCP skill scaffold."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from conftest import REPO_ROOT
+import dcc_mcp_core
+
+
+def _load_creator_scaffold():
+    script = REPO_ROOT / "skills" / "dcc-mcp-skills-creator" / "scripts" / "create_skill.py"
+    spec = importlib.util.spec_from_file_location("creator_create_skill", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_creator_scaffold_includes_codex_interface_metadata(tmp_path: Path) -> None:
+    module = _load_creator_scaffold()
+
+    skill_dir = Path(module.create_skill("maya-rigging-tools", str(tmp_path), dcc="maya"))
+    openai_yaml = skill_dir / "agents" / "openai.yaml"
+    interface = dcc_mcp_core.yaml_loads(openai_yaml.read_text(encoding="utf-8"))["interface"]
+
+    assert interface == {
+        "display_name": "Maya Rigging Tools",
+        "short_description": "Run a structured DCC-MCP workflow",
+        "default_prompt": "Use $maya-rigging-tools to complete this DCC-MCP workflow.",
+    }

--- a/tests/test_dcc_server_options.py
+++ b/tests/test_dcc_server_options.py
@@ -225,6 +225,65 @@ class TestResolvedServerConfig:
         assert config.instance_metadata["dcc_mcp_server_version"] == "9.9.9"
         assert config.instance_metadata["dcc_mcp_instance_type"] == "standalone"
 
+    @pytest.mark.parametrize(
+        ("instance_type", "standalone_main_thread"),
+        [("standalone", False), ("gui", True)],
+    )
+    def test_build_mcp_http_config_keeps_lifetime_independent_from_execution(
+        self,
+        tmp_path,
+        instance_type,
+        standalone_main_thread,
+    ):
+        opts = DccServerOptions.from_env(
+            "renderdoc",
+            tmp_path,
+            port=0,
+            instance_type=instance_type,
+            standalone_main_thread=standalone_main_thread,
+        )
+
+        config = build_mcp_http_config(
+            opts,
+            package_version="9.9.9",
+            version_provider=lambda: "unused",
+        )
+
+        assert config.standalone_main_thread_execution is standalone_main_thread
+        assert config.instance_metadata["dcc_mcp_instance_type"] == instance_type
+
+    def test_build_mcp_http_config_propagates_explicit_host_pid(self, tmp_path):
+        opts = DccServerOptions.from_env(
+            "unreal",
+            tmp_path,
+            port=0,
+            dcc_pid=4242,
+        )
+
+        config = build_mcp_http_config(
+            opts,
+            package_version="9.9.9",
+            version_provider=lambda: "unused",
+        )
+
+        assert config.host_pid == 4242
+
+    def test_build_mcp_http_config_leaves_standalone_host_pid_unbound(self, tmp_path):
+        opts = DccServerOptions.from_env(
+            "renderdoc",
+            tmp_path,
+            port=0,
+            standalone_main_thread=True,
+        )
+
+        config = build_mcp_http_config(
+            opts,
+            package_version="9.9.9",
+            version_provider=lambda: "unused",
+        )
+
+        assert config.host_pid is None
+
 
 # ── DiagnosticsOptions ────────────────────────────────────────────────────────
 
@@ -281,6 +340,14 @@ class TestDccServerOptions:
         assert opts.port == 0
         assert opts.gateway.enable_failover is True
 
+    def test_historical_positional_construction_keeps_gateway_slot(self, tmp_path):
+        gateway = GatewayOptions(port=19765)
+
+        opts = DccServerOptions("maya", tmp_path, 18812, "maya-mcp", "1.2.3", gateway)
+
+        assert opts.gateway is gateway
+        assert opts.instance_type is None
+
     def test_frozen(self, tmp_path):
         opts = DccServerOptions(dcc_name="test", builtin_skills_dir=tmp_path)
         with pytest.raises((AttributeError, TypeError)):
@@ -328,6 +395,24 @@ class TestDccServerOptions:
     def test_from_env_standalone_main_thread(self, tmp_path):
         opts = DccServerOptions.from_env("maya", tmp_path, standalone_main_thread=True)
         assert opts.execution.mode is StandaloneMainThreadExecution
+
+    def test_from_env_reads_dcc_instance_type(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DCC_MCP_RENDERDOC_INSTANCE_TYPE", " STANDALONE ")
+
+        opts = DccServerOptions.from_env("renderdoc", tmp_path)
+
+        assert opts.instance_type == "standalone"
+
+    def test_from_env_explicit_instance_type_wins(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DCC_MCP_RENDERDOC_INSTANCE_TYPE", "standalone")
+
+        opts = DccServerOptions.from_env("renderdoc", tmp_path, instance_type="GUI")
+
+        assert opts.instance_type == "gui"
+
+    def test_rejects_invalid_instance_type(self, tmp_path):
+        with pytest.raises(ValueError, match="instance_type"):
+            DccServerOptions.from_env("renderdoc", tmp_path, instance_type="background")
 
     def test_from_env_mutex_raises(self, tmp_path):
         """Passing both dispatcher and execution_bridge must raise ValueError at build time."""

--- a/tests/test_marketplace_create_extension_scaffold.py
+++ b/tests/test_marketplace_create_extension_scaffold.py
@@ -1,0 +1,39 @@
+"""Regression tests for the bundled marketplace extension scaffold."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from conftest import REPO_ROOT
+import dcc_mcp_core
+
+
+def _load_extension_scaffold():
+    script = REPO_ROOT / "skills" / "marketplace-create-extension" / "scripts" / "create_extension.py"
+    spec = importlib.util.spec_from_file_location("marketplace_create_extension", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extension_scaffold_includes_codex_interface_metadata(tmp_path: Path) -> None:
+    module = _load_extension_scaffold()
+
+    skill_dir = Path(
+        module.create_extension(
+            "maya-pipeline-tools",
+            str(tmp_path),
+            description="Publish Maya pipeline tools.",
+            dcc_targets=["maya"],
+        )
+    )
+    openai_yaml = skill_dir / "agents" / "openai.yaml"
+    interface = dcc_mcp_core.yaml_loads(openai_yaml.read_text(encoding="utf-8"))["interface"]
+
+    assert interface == {
+        "display_name": "Maya Pipeline Tools",
+        "short_description": "Run a DCC-MCP marketplace extension",
+        "default_prompt": "Use $maya-pipeline-tools to complete this DCC-MCP marketplace workflow.",
+    }

--- a/tests/test_package_openclaw_skill.py
+++ b/tests/test_package_openclaw_skill.py
@@ -25,9 +25,12 @@ def test_package_excludes_python_cache_and_bytecode(tmp_path: Path) -> None:
     packager = load_packager()
     skill_dir = tmp_path / "skills" / "dcc-mcp"
     script_dir = skill_dir / "scripts"
+    agents_dir = skill_dir / "agents"
     cache_dir = script_dir / "__pycache__"
     cache_dir.mkdir(parents=True)
+    agents_dir.mkdir()
     (skill_dir / "SKILL.md").write_text("---\nname: dcc-mcp\n---\n", encoding="utf-8")
+    (agents_dir / "openai.yaml").write_text('interface:\n  display_name: "DCC-MCP"\n', encoding="utf-8")
     (script_dir / "helper.py").write_text("VALUE = 1\n", encoding="utf-8")
     (cache_dir / "helper.cpython-312.pyc").write_bytes(b"bytecode")
     (script_dir / "orphan.pyc").write_bytes(b"bytecode")
@@ -38,4 +41,8 @@ def test_package_excludes_python_cache_and_bytecode(tmp_path: Path) -> None:
 
     with ZipFile(archive_path) as archive:
         names = set(archive.namelist())
-    assert names == {"dcc-mcp/SKILL.md", "dcc-mcp/scripts/helper.py"}
+    assert names == {
+        "dcc-mcp/SKILL.md",
+        "dcc-mcp/agents/openai.yaml",
+        "dcc-mcp/scripts/helper.py",
+    }


### PR DESCRIPTION
## Summary
- reuse one ranked search foundation for catalogs, marketplace sources, and natural CLI queries
- ship three conventional agent Skills with CLI-first marketplace discovery and verified ClawHub publishing
- separate service-owner and DCC-host lifetimes so dead host instances are reaped across adapters, including legacy sidecars
- default gateway instance discovery to live, routable rows while retaining explicit diagnostic views

## Validation
- Rust package tests for search, CLI, marketplace, gateway, transport, sidecar, and HTTP configuration
- Clippy with warnings denied across all changed Rust crates
- Python Skill, ClawHub, scaffold, packaging, and server-option tests
- conventional Skill validation and packaged archive inspection for all three published Skills