### PR TITLE
fix: keep Skill search compatible with released CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ Then discover a live capability before calling it:
 ~~~bash
 dcc-mcp-cli dcc-types
 dcc-mcp-cli list
-dcc-mcp-cli search create sphere --dcc-type maya --limit 20
+dcc-mcp-cli search --query "create sphere" --dcc-type maya --limit 20
 dcc-mcp-cli describe <tool-slug>
 dcc-mcp-cli call <tool-slug> --json '{"radius": 2.0}' \
   --meta-json '{"agent_context":{"session_id":"task-42"}}'
 ~~~
 
-Search accepts unquoted positional words; `--query "create sphere"` remains
-available for existing scripts.
+`--query "create sphere"` is compatible with released CLI builds. Builds that
+contain the unified search parser also accept unquoted positional words.
 
 `dcc-types` is an offline, catalog-backed capability query. It reports
 canonical adapter identifiers and install-plan availability; `list` remains

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -119,7 +119,7 @@ dcc-mcp-cli gateway register https://workstation.example:19293 --name pcA
 dcc-mcp-cli gateway list
 dcc-mcp-cli gateway set pcA
 dcc-mcp-cli gateway set local
-dcc-mcp-cli search create sphere --dcc-type maya --instance-id abc12345
+dcc-mcp-cli search --query "create sphere" --dcc-type maya --instance-id abc12345
 dcc-mcp-cli describe maya.abc12345.create_sphere
 dcc-mcp-cli load-skill workflow --dcc-type 3dsmax --instance-id 80321760
 dcc-mcp-cli call maya.abc12345.create_sphere --json '{"radius":2}'
@@ -130,7 +130,7 @@ dcc-mcp-cli install --dcc-type maya --version 2026
 dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe"
 dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe" --execute
 dcc-mcp-cli marketplace add dcc-mcp/marketplace
-dcc-mcp-cli marketplace search maya rigging --limit 20
+dcc-mcp-cli marketplace search --query "maya rigging" --limit 20
 dcc-mcp-cli marketplace inspect dcc-asset-hunyuan-download
 dcc-mcp-cli marketplace install dcc-asset-hunyuan-download --dcc maya
 dcc-mcp-cli reload-skills --dcc-type maya
@@ -160,7 +160,7 @@ dcc-mcp-cli lint path/to/skills
 | `stats [--range 1h\|24h\|7d\|all] [--dcc-type <dcc>] [--skill <name>] [--tool <name>] [--status success\|failure] [--instance-id <id>] [--session-id <id>]` | `GET /v1/debug/stats` | Query persisted tool-call counts, success/failure, latency, tokens, and top dimensions after applying all supplied filters. JSON is the default output for agent use. |
 | `doctor [--registry-dir <path>] [--gateway-port <port>]` | local filesystem + gateway probe | Report profile config/current selection, local registry path/inventory, direct-control readiness counts and not-ready diagnostics, gateway daemon status, and server binary diagnostics without auto-starting or downloading services. |
 | `list [--gateway <profile>]` | local FileRegistry or `GET /v1/instances` | List live DCC instances. Defaults to local FileRegistry after ensuring the loopback gateway; remote profiles use the selected gateway. |
-| `search [QUERY...] [-q\|--query <q>] [--instance-id <id>]` | local MCP `search_tools` or remote `POST /v1/search` | Search callable capabilities with positional natural-language words or the backward-compatible query flag, optionally scoped to a full UUID or unique prefix. |
+| `search [-q\|--query <q>] [--instance-id <id>]` | local MCP `search_tools` or remote `POST /v1/search` | Search callable capabilities with the release-compatible query flag; current builds also accept positional natural-language words as an alternative. Optionally scope to a full UUID or unique prefix. |
 | `describe <tool-slug>` | local MCP `tools/list` or remote `POST /v1/describe` | Inspect a capability before calling it. |
 | `load-skill <skill-name> [--dcc-type <dcc>] [--instance-id <id>]` | local MCP `tools/call load_skill` or remote `POST /v1/load_skill` | Activate a progressive skill and print its registered tools. |
 | `call <tool-slug> --json <object>` | local MCP `tools/call` or remote `POST /v1/call` | Invoke one capability. |
@@ -171,7 +171,7 @@ dcc-mcp-cli lint path/to/skills
 | `install --dcc-type <dcc> [--version <v>] [--python <path>] [--execute]` | catalog-backed local plan / executor | Resolve the matching adapter and emit an auditable install plan; with `--execute`, run package-install steps with consent, rollback, and package/path verification. Live DCC checks stay in the emitted `next_steps`. |
 | `marketplace add <source>` | local source registry | Register a marketplace source (`dcc-mcp/marketplace`, a GitHub `owner/repo`, raw JSON URL, or local catalog file). |
 | `marketplace list` | local source registry | List the built-in, configured, and environment-provided marketplace sources. |
-| `marketplace search [QUERY...] [-q\|--query <q>] [--dcc <dcc>] [--source <source>]` | marketplace catalog JSON/YAML | Fuzzy-rank Skill packages across configured or explicit sources using the shared search engine; deduplicate by package name before applying `--limit`. `--dcc-type` is an alias for `--dcc`. |
+| `marketplace search [-q\|--query <q>] [--dcc <dcc>] [--source <source>]` | marketplace catalog JSON/YAML | Fuzzy-rank Skill packages across configured or explicit sources using the shared search engine; the query flag works with released builds, while current builds also accept positional words as an alternative. Deduplicate by package name before applying `--limit`; `--dcc-type` is an alias for `--dcc`. |
 | `marketplace inspect <name> [--source <source>]` | marketplace catalog JSON/YAML | Print exact entry metadata including version and install fields. |
 | `marketplace install <name> [--dcc <dcc>] [--source <source>] [--force]` | marketplace catalog + local filesystem/git | Install a skill package to `~/.dcc-mcp/marketplace/<dcc>/<name>/`. |
 | `marketplace list-installed [--dcc <dcc>]` | local installed-state file | List locally installed marketplace packages and their versions/paths. |

--- a/docs/guide/marketplace.md
+++ b/docs/guide/marketplace.md
@@ -72,7 +72,7 @@ Set `DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES=1` to disable the built-in source.
 |-------------------------------------------|------------------------------------------------|
 | `marketplace add <source>`                | Register a marketplace source                  |
 | `marketplace list`                        | List configured sources                        |
-| `marketplace search [QUERY...]`           | Fuzzy-rank entries across all sources; `--query <q>` remains supported |
+| `marketplace search --query <q>`           | Fuzzy-rank entries across all sources; current builds also accept positional query words |
 | `marketplace inspect <name>`              | Show full entry metadata                       |
 | `marketplace install <name> --dcc <dcc>`  | Install a skill package                        |
 | `marketplace list-installed --dcc <dcc>`  | List installed packages                        |
@@ -364,7 +364,7 @@ future phase.
 
 | Aspect | CLI | Admin UI |
 |--------|-----|----------|
-| Catalog search | `marketplace search [QUERY...]` | Browse tab with search + DCC filter |
+| Catalog search | `marketplace search --query <q>` | Browse tab with search + DCC filter |
 | Install | `marketplace install <name> --dcc <dcc>` | Install button on card or detail modal |
 | Uninstall | `marketplace uninstall <name> --dcc <dcc>` | Uninstall button in Installed tab |
 | List installed | `marketplace list-installed --dcc <dcc>` | Installed tab |

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -52,7 +52,7 @@ marketplace Skill must start with the official CLI catalog, even when the user
 says “Skill store”, “marketplace”, or “商城” without naming DCC-MCP:
 
 ```bash
-dcc-mcp-cli marketplace search maya rigging --limit 20
+dcc-mcp-cli marketplace search --query "maya rigging" --limit 20
 dcc-mcp-cli marketplace inspect <exact-name-from-search>
 ```
 
@@ -316,7 +316,7 @@ Only run this when inventory shows at least one non-stale target:
 
 ```bash
 # CLI (primary)
-dcc-mcp-cli search create sphere --dcc-type maya --limit 20
+dcc-mcp-cli search --query "create sphere" --dcc-type maya --limit 20
 
 # Python fallback
 python scripts/dcc_gateway.py search --query sphere --dcc-type maya --limit 20
@@ -436,7 +436,7 @@ dcc-mcp-cli update apply
 For marketplace Skills, preserve the mandatory search-first sequence:
 
 ```bash
-dcc-mcp-cli marketplace search maya rigging --limit 20
+dcc-mcp-cli marketplace search --query "maya rigging" --limit 20
 dcc-mcp-cli marketplace inspect <package_name>
 dcc-mcp-cli marketplace install <package_name> --dcc maya
 dcc-mcp-cli reload-skills --dcc-type maya

--- a/skills/dcc-mcp/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-mcp/references/CLI_CHEATSHEET.md
@@ -44,7 +44,7 @@ vx python scripts/dcc_gateway.py --ensure-cli list
 | `dcc-mcp-cli dcc-types --catalog path/to/catalog.yml` | Inspect a studio or test catalog through the same typed contract |
 | `dcc-mcp-cli list` | Ensure the local loopback gateway, then list local DCC instances from the FileRegistry |
 | `dcc-mcp-cli doctor` | Report profile, registry, local inventory, direct-control readiness counts, gateway daemon status, and server binary diagnostics without launching services |
-| `dcc-mcp-cli search create sphere --dcc-type maya --limit 20` | Search local instances directly through MCP in the `local` profile; `--query "create sphere"` remains supported |
+| `dcc-mcp-cli search --query "create sphere" --dcc-type maya --limit 20` | Search local instances directly through MCP in the `local` profile; this form remains compatible with released CLI builds |
 | `dcc-mcp-cli list --gateway pcA` | List DCC instances through a named remote gateway profile |
 | `dcc-mcp-cli health` (or `python scripts/dcc_gateway.py health`) | Check gateway liveness; CLI auto-starts loopback gateway targets |
 | `dcc-mcp-cli gateway register https://host:19293 --name pcA` | Persist a named remote gateway profile |
@@ -60,7 +60,7 @@ vx python scripts/dcc_gateway.py --ensure-cli list
 
 | Command | Purpose |
 |---------|---------|
-| `dcc-mcp-cli search create sphere --dcc-type maya --limit 20` | Find tools with positional natural-language words |
+| `dcc-mcp-cli search --query "create sphere" --dcc-type maya --limit 20` | Find tools with a natural-language phrase |
 | `dcc-mcp-cli describe <slug>` | Inspect schema |
 | `dcc-mcp-cli call <slug> --json '{"radius":2}' --meta-json '{"agent_context":{"session_id":"task-42"}}'` | Invoke one tool with a stable task-scoped stats identifier |
 | `dcc-mcp-cli call <slug> --json '{"radius":2}' --meta-json '{"lease_owner":"workflow-42","agent_context":{"session_id":"task-42"}}'` | Invoke a tool on an instance leased by this workflow |
@@ -90,7 +90,7 @@ paths, or full tool payloads.
 |---------|---------|
 | `dcc-mcp-cli install --dcc-type maya --version 2026` | Build an auditable adapter install plan with machine-readable `next_steps`, without changing local state |
 | `dcc-mcp-cli install --dcc-type maya --version 2026 --python "<mayapy>" --execute` | Execute package install after consent; rolls back on failure and verifies pip/path outputs |
-| `dcc-mcp-cli marketplace search maya rigging --limit 20` | Find installable Skill packages; `--query "maya rigging"` remains supported |
+| `dcc-mcp-cli marketplace search --query "maya rigging" --limit 20` | Find installable Skill packages with released and current CLI builds |
 | `dcc-mcp-cli marketplace inspect <package_name>` | Inspect the selected skill package metadata before installing |
 | `dcc-mcp-cli marketplace install <package_name> --dcc maya` | Install a skill package into the local marketplace root |
 | `dcc-mcp-cli reload-skills --dcc-type maya` | Ask running Maya adapters to re-scan installed skill paths |
@@ -132,7 +132,7 @@ python scripts/dcc_gateway.py list
 
 ```bash
 # CLI (primary)
-dcc-mcp-cli search create sphere --dcc-type maya --limit 10
+dcc-mcp-cli search --query "create sphere" --dcc-type maya --limit 10
 
 # Python fallback
 python scripts/dcc_gateway.py search --query sphere --dcc-type maya --limit 10

--- a/tests/test_dcc_mcp_skill.py
+++ b/tests/test_dcc_mcp_skill.py
@@ -69,9 +69,25 @@ class TestDccMcpSkill:
         body = " ".join((Path(DCC_MCP_SKILL_DIR) / "SKILL.md").read_text(encoding="utf-8").lower().split())
         assert "marketplace intent" in body
         assert "dcc-mcp-cli marketplace search" in body
+        assert 'dcc-mcp-cli marketplace search --query "maya rigging"' in body
         assert "does not require a live dcc instance" in body
         assert "never invent a package name" in body
         assert "dcc-mcp-cli marketplace inspect" in body
+
+        release_compatible_examples = {
+            REPO_ROOT / "README.md": 'dcc-mcp-cli search --query "create sphere"',
+            REPO_ROOT / "docs" / "guide" / "cli-reference.md": (
+                'dcc-mcp-cli marketplace search --query "maya rigging"'
+            ),
+            REPO_ROOT / "docs" / "guide" / "marketplace.md": "marketplace search --query <q>",
+            Path(DCC_MCP_SKILL_DIR) / "references" / "CLI_CHEATSHEET.md": (
+                'dcc-mcp-cli marketplace search --query "maya rigging"'
+            ),
+        }
+        for path, example in release_compatible_examples.items():
+            assert example in path.read_text(encoding="utf-8"), path
+        cli_reference = (REPO_ROOT / "docs" / "guide" / "cli-reference.md").read_text(encoding="utf-8")
+        assert "marketplace search [-q\\|--query <q>] [--dcc <dcc>]" in cli_reference
 
     def test_body_prioritizes_structured_dcc_mcp_tools_for_user_intent(self) -> None:
         body = (Path(DCC_MCP_SKILL_DIR) / "SKILL.md").read_text(encoding="utf-8").lower()


### PR DESCRIPTION
## Summary

- keep documented Skill searches compatible with the released CLI by using `--query`
- retain the friendlier positional query support in current CLI code
- add a regression assertion for the marketplace search-first example

## Validation

- `15 passed` in `tests/test_dcc_mcp_skill.py`
- standard Skill validation passed
- released `dcc-mcp-cli 0.19.63 marketplace search --query "maya rigging"` succeeded
- ClawHub sync dry-run passed