### PR TITLE
fix: decouple ClawHub Skill releases

### DIFF
--- a/.github/actions/npm-ci-with-retry/action.yml
+++ b/.github/actions/npm-ci-with-retry/action.yml
@@ -1,0 +1,33 @@
+name: npm ci with retry
+description: Install locked npm dependencies with bounded retries.
+
+inputs:
+  working-directory:
+    description: Directory containing package-lock.json.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install locked dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        NPM_CONFIG_FETCH_RETRIES: "3"
+        NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "20000"
+        NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "120000"
+      run: |
+        for attempt in 1 2 3; do
+          if npm ci --prefer-offline --no-audit; then
+            exit 0
+          fi
+
+          if [[ "$attempt" -eq 3 ]]; then
+            echo "::error::npm ci failed after ${attempt} attempts"
+            exit 1
+          fi
+
+          delay=$((attempt * 15))
+          echo "::warning::npm ci attempt ${attempt} failed; retrying in ${delay}s"
+          sleep "$delay"
+        done

--- a/.github/clawhub-skills.json
+++ b/.github/clawhub-skills.json
@@ -2,16 +2,19 @@
   {
     "path": "skills/dcc-mcp",
     "slug": "dcc-mcp",
-    "owner": "loonghao"
+    "owner": "loonghao",
+    "version": "0.19.64"
   },
   {
     "path": "skills/dcc-mcp-skills-creator",
     "slug": "dcc-mcp-skills-creator",
-    "owner": "loonghao"
+    "owner": "loonghao",
+    "version": "0.19.64"
   },
   {
     "path": "skills/dcc-mcp-creator",
     "slug": "dcc-mcp-creator",
-    "owner": "loonghao"
+    "owner": "loonghao",
+    "version": "0.19.64"
   }
 ]

--- a/.github/workflows/clawhub.yml
+++ b/.github/workflows/clawhub.yml
@@ -15,7 +15,7 @@ on:
         default: false
     secrets:
       CLAWHUB_TOKEN:
-        required: true
+        required: false
   pull_request:
     branches:
       - main
@@ -52,7 +52,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CLAWHUB_CLI_PACKAGE: clawhub@0.17.0
+  CLAWHUB_CLI_PACKAGE: clawhub@0.23.1
   CLAWHUB_CONFIG_PATH: .clawhub/config.json
   CLAWHUB_DISABLE_TELEMETRY: "1"
 
@@ -71,28 +71,17 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Remove pre-installed Rust component shims
+        run: rm -f ~/.cargo/bin/cargo-clippy ~/.cargo/bin/cargo-fmt || true
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Install dcc-mcp-core (for validate_skill / parse_skill_md)
         run: pip install -e .
 
       - name: Package ClawHub skill archives
-        env:
-          CLAWHUB_SKILLS_MANIFEST: .github/clawhub-skills.json
-        run: |
-          mkdir -p dist/skills
-          python - <<'PY'
-          import json
-          import os
-          import subprocess
-          import sys
-          from pathlib import Path
-
-          manifest = json.loads(Path(os.environ["CLAWHUB_SKILLS_MANIFEST"]).read_text(encoding="utf-8"))
-          for entry in manifest:
-              subprocess.run(
-                  [sys.executable, "scripts/package_openclaw_skill.py", entry["path"], "dist/skills"],
-                  check=True,
-              )
-          PY
+        run: python scripts/package_openclaw_skill.py .github/clawhub-skills.json dist/skills --manifest
 
       - name: Upload packaged skill artifacts
         uses: actions/upload-artifact@v4
@@ -125,7 +114,7 @@ jobs:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
           mkdir -p "$(dirname "$CLAWHUB_CONFIG_PATH")"
-          npx "$CLAWHUB_CLI_PACKAGE" login --token "$CLAWHUB_TOKEN" --no-browser --no-input
+          npx "$CLAWHUB_CLI_PACKAGE" --no-input login --token "$CLAWHUB_TOKEN" --no-browser
 
       - name: Dry-run ClawHub publish
         if: >-

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,8 +31,9 @@ jobs:
           cache-dependency-path: docs/package-lock.json
 
       - name: Install dependencies
-        working-directory: docs
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          working-directory: docs
 
       - name: Build with VitePress
         working-directory: docs

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -4,12 +4,18 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".github/actions/npm-ci-with-retry/**"
+      - ".github/workflows/deploy-docs.yml"
+      - ".github/workflows/docs-ci.yml"
       - "docs/**"
       - "README.md"
       - "README_zh.md"
   push:
     branches: [main]
     paths:
+      - ".github/actions/npm-ci-with-retry/**"
+      - ".github/workflows/deploy-docs.yml"
+      - ".github/workflows/docs-ci.yml"
       - "docs/**"
       - "README.md"
       - "README_zh.md"
@@ -38,8 +44,9 @@ jobs:
           cache-dependency-path: docs/package-lock.json
 
       - name: Install dependencies
-        working-directory: docs
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          working-directory: docs
 
       - name: Build with VitePress
         working-directory: docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -591,15 +591,6 @@ jobs:
       checkout-ref: ${{ needs.release-please.outputs.tag_name }}
       release-tag-name: ${{ needs.release-please.outputs.tag_name }}
 
-  publish-clawhub-skills:
-    needs: [release-please]
-    if: needs.release-please.outputs.release_created == 'true'
-    uses: ./.github/workflows/clawhub.yml
-    with:
-      checkout-ref: ${{ needs.release-please.outputs.tag_name }}
-      publish: true
-    secrets: inherit
-
   # ── Validate release metadata once before publishing artefacts ──
   validate-release-version:
     needs: [release-please]

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Add `--global` to each command when every local OpenClaw agent should see the
 suite. Other ClawHub-compatible workspaces can use the registry CLI directly:
 
 ~~~bash
-npx --yes clawhub@0.17.0 install dcc-mcp
-npx --yes clawhub@0.17.0 install dcc-mcp-skills-creator
-npx --yes clawhub@0.17.0 install dcc-mcp-creator
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-skills-creator
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-creator
 ~~~
 
 | Skill | Agent role |
@@ -98,9 +98,13 @@ npx --yes clawhub@0.17.0 install dcc-mcp-creator
 | [`dcc-mcp-creator`](skills/dcc-mcp-creator/) | Create or modernize a complete DCC adapter and its runtime wiring |
 
 All three packages carry Codex `agents/openai.yaml` metadata while preserving
-their DCC-MCP and ClawHub contracts. They are versioned with the core release,
-listed in [`.github/clawhub-skills.json`](.github/clawhub-skills.json), and
-published to ClawHub by the release workflow.
+their DCC-MCP and ClawHub contracts. Their immutable ClawHub releases are
+versioned independently in
+[`.github/clawhub-skills.json`](.github/clawhub-skills.json), so Skill updates
+do not collide with an already-published core version. The sync workflow
+publishes the manifest versions and verifies their packaged files. Bump both
+the manifest entry and the matching `SKILL.md` metadata version for every new
+immutable Skill release.
 
 Keep an official build current through the release manifest:
 

--- a/justfile
+++ b/justfile
@@ -329,7 +329,7 @@ ci: check-python-support preflight install test lint-py
 
 # Package skills from .github/clawhub-skills.json (zip under dist/skills/).
 package-clawhub-skills:
-    python scripts/package_openclaw_skill.py skills/dcc-mcp dist/skills
+    python scripts/package_openclaw_skill.py .github/clawhub-skills.json dist/skills --manifest
 
 # Validate publish commands without uploading (PR / local).
 clawhub-sync-dry-run:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -50,18 +50,6 @@
         },
         {
           "type": "generic",
-          "path": "skills/dcc-mcp/SKILL.md"
-        },
-        {
-          "type": "generic",
-          "path": "skills/dcc-mcp-skills-creator/SKILL.md"
-        },
-        {
-          "type": "generic",
-          "path": "skills/dcc-mcp-creator/SKILL.md"
-        },
-        {
-          "type": "generic",
           "path": "docs/.vitepress/config.mts"
         },
         {

--- a/scripts/clawhub_sync.py
+++ b/scripts/clawhub_sync.py
@@ -7,7 +7,9 @@ import hashlib
 import json
 import os
 from pathlib import Path
+from pathlib import PurePosixPath
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -22,7 +24,7 @@ import dcc_mcp_core
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
-DEFAULT_CLI = os.environ.get("CLAWHUB_CLI_PACKAGE", "clawhub@0.17.0")
+DEFAULT_CLI = os.environ.get("CLAWHUB_CLI_PACKAGE", "clawhub@0.23.1")
 CLAWHUB_API_BASE = "https://clawhub.ai/api/v1"
 CLAWHUB_LICENSE = "MIT-0"
 MAX_RETRIES = 3
@@ -33,6 +35,21 @@ RETRYABLE_RE = re.compile(
 )
 RESET_IN_RE = re.compile(r"\breset in (\d+)s\b", re.IGNORECASE)
 REQUIRED_PUBLIC_FILES = ("SKILL.md", "agents/openai.yaml")
+# ClawHub creates this asynchronously and excludes it from the source bundle fingerprint.
+GENERATED_PUBLIC_FILES = {"skill-card.md"}
+STABLE_SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+# Mirrors clawhub@0.23.1 packages/clawhub/src/skills.ts::buildSkillFingerprint.
+NODE_FINGERPRINT_SCRIPT = r"""
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const files = JSON.parse(fs.readFileSync(0, "utf8"));
+const normalized = files
+  .filter((file) => Boolean(file.path) && Boolean(file.sha256))
+  .map((file) => ({ path: file.path, sha256: file.sha256 }))
+  .sort((a, b) => a.path.localeCompare(b.path));
+const payload = normalized.map((file) => `${file.path}:${file.sha256}`).join("\n");
+process.stdout.write(crypto.createHash("sha256").update(payload).digest("hex"));
+"""
 
 
 def parse_args() -> argparse.Namespace:
@@ -42,7 +59,7 @@ def parse_args() -> argparse.Namespace:
         "--manifest",
         type=Path,
         default=MANIFEST,
-        help="JSON manifest: [{path, slug, owner}]",
+        help="JSON manifest: [{path, slug, owner, version}]",
     )
     parser.add_argument(
         "--dry-run",
@@ -52,13 +69,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--cli",
         default=DEFAULT_CLI,
-        help="npm package for clawhub CLI (default: clawhub@0.17.0)",
+        help="npm package for clawhub CLI (default: clawhub@0.23.1)",
     )
     return parser.parse_args()
 
 
 def load_manifest(path: Path) -> list[dict[str, Any]]:
-    """Load [{path, slug, owner}, ...] entries from the JSON manifest."""
+    """Load [{path, slug, owner, version}, ...] entries from the JSON manifest."""
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, list):
         raise ValueError(f"manifest must be a JSON array: {path}")
@@ -93,7 +110,8 @@ def skill_license(skill_dir: Path) -> str:
 
 def npx_cmd(cli: str, *args: str) -> list[str]:
     """Build an npx invocation argv list."""
-    npx = os.environ.get("NPX", "npx")
+    requested = os.environ.get("NPX", "npx")
+    npx = shutil.which(requested) or requested
     return [npx, cli, *args]
 
 
@@ -144,9 +162,34 @@ def file_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def clawhub_file_fingerprint(file_hashes: dict[str, str]) -> str:
+    """Reproduce ClawHub 0.23.1's locale-aware buildSkillFingerprint."""
+    requested = os.environ.get("NODE", "node").strip() or "node"
+    node = shutil.which(requested) or requested
+    files = [{"path": path, "sha256": digest} for path, digest in file_hashes.items()]
+    try:
+        proc = subprocess.run(
+            [node, "-e", NODE_FINGERPRINT_SCRIPT],
+            input=json.dumps(files, separators=(",", ":")),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(f"could not run Node.js fingerprint helper: {exc}") from exc
+    fingerprint = proc.stdout.strip().lower()
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or f"Node.js exited with code {proc.returncode}"
+        raise ValueError(f"ClawHub fingerprint helper failed: {detail}")
+    if re.fullmatch(r"[0-9a-f]{64}", fingerprint) is None:
+        raise ValueError(f"ClawHub fingerprint helper returned invalid output: {fingerprint!r}")
+    return fingerprint
+
+
 def published_skill_release(slug: str, owner: str, version: str) -> dict[str, Any]:
     """Read one owner-qualified public version record from ClawHub."""
-    query = urlencode({"owner": owner})
+    query = urlencode({"ownerHandle": owner})
     url = f"{CLAWHUB_API_BASE}/skills/{quote(slug, safe='')}/versions/{quote(version, safe='')}?{query}"
     request = Request(
         url,
@@ -172,27 +215,279 @@ def published_skill_version(slug: str, owner: str, version: str) -> str:
     return published_version.strip()
 
 
-def public_file_mismatches(published: dict[str, Any], skill_dir: Path) -> list[str]:
-    """Return missing or hash-mismatched required public Skill artifacts."""
+def published_file_mismatches(
+    published: dict[str, Any],
+    skill_dir: Path,
+    *,
+    location: str,
+    expected_file_count: int | None = None,
+    expected_fingerprint: str | None = None,
+) -> list[str]:
+    """Compare ClawHub's authoritative published file set with local bytes."""
     raw_files = published.get("files")
     files = raw_files if isinstance(raw_files, list) else []
-    remote_hashes = {
-        item["path"]: item["sha256"].lower()
+    source_files = [
+        item
         for item in files
-        if isinstance(item, dict) and isinstance(item.get("path"), str) and isinstance(item.get("sha256"), str)
-    }
+        if not (
+            isinstance(item, dict)
+            and isinstance(item.get("path"), str)
+            and item["path"].strip().lower() in GENERATED_PUBLIC_FILES
+        )
+    ]
     mismatches: list[str] = []
+    if expected_file_count is not None and len(source_files) != expected_file_count:
+        mismatches.append(f"{location} file count {len(source_files)}, expected {expected_file_count}")
+    remote_hashes: dict[str, str] = {}
+    for item in source_files:
+        if (
+            not isinstance(item, dict)
+            or not isinstance(item.get("path"), str)
+            or not isinstance(item.get("sha256"), str)
+        ):
+            mismatches.append(f"{location} contains malformed file metadata")
+            continue
+        relative = item["path"]
+        if relative in remote_hashes:
+            mismatches.append(f"{location} contains duplicate file: {relative}")
+            continue
+        remote_hash = item["sha256"].lower()
+        if re.fullmatch(r"[0-9a-f]{64}", remote_hash) is None:
+            mismatches.append(f"{location} contains invalid sha256 for: {relative}")
+            continue
+        remote_hashes[relative] = remote_hash
+
+    if expected_fingerprint is not None:
+        try:
+            actual_fingerprint = clawhub_file_fingerprint(remote_hashes)
+        except ValueError as exc:
+            mismatches.append(f"{location} fingerprint validation failed: {exc}")
+        else:
+            if actual_fingerprint != expected_fingerprint:
+                mismatches.append(f"{location} fingerprint {actual_fingerprint}, expected {expected_fingerprint}")
+
     for relative in REQUIRED_PUBLIC_FILES:
-        local_path = skill_dir / relative
+        if relative not in remote_hashes:
+            mismatches.append(f"{location} file missing: {relative}")
+    for relative, remote_hash in remote_hashes.items():
+        posix_path = PurePosixPath(relative)
+        parts = posix_path.parts
+        if "\\" in relative or posix_path.is_absolute() or not parts or any(part in {"", ".", ".."} for part in parts):
+            mismatches.append(f"{location} file has unsafe path: {relative}")
+            continue
+        local_path = skill_dir.joinpath(*parts)
+        current = skill_dir
+        has_symlink = False
+        for part in parts:
+            current = current / part
+            if current.is_symlink():
+                has_symlink = True
+                break
+        if has_symlink:
+            mismatches.append(f"local file is a symbolic link: {relative}")
+            continue
+        try:
+            local_path.resolve().relative_to(skill_dir.resolve())
+        except ValueError:
+            mismatches.append(f"local file escapes Skill root: {relative}")
+            continue
         if not local_path.is_file():
             mismatches.append(f"local file missing: {relative}")
-            continue
-        remote_hash = remote_hashes.get(relative)
-        if remote_hash is None:
-            mismatches.append(f"public file missing: {relative}")
         elif remote_hash != file_sha256(local_path):
-            mismatches.append(f"public file hash mismatch: {relative}")
+            mismatches.append(f"{location} file hash mismatch: {relative}")
     return mismatches
+
+
+def public_file_mismatches(
+    published: dict[str, Any],
+    skill_dir: Path,
+    expected_file_count: int | None = None,
+    expected_fingerprint: str | None = None,
+) -> list[str]:
+    """Return mismatches between the public release and local Skill tree."""
+    return published_file_mismatches(
+        published,
+        skill_dir,
+        location="public",
+        expected_file_count=expected_file_count,
+        expected_fingerprint=expected_fingerprint,
+    )
+
+
+def publish_command(cli: str, skill_dir: Path, slug: str, owner: str, version: str) -> list[str]:
+    """Build the pinned, non-interactive ClawHub Skill publish command."""
+    return npx_cmd(
+        cli,
+        "--no-input",
+        "skill",
+        "publish",
+        str(skill_dir),
+        "--slug",
+        slug,
+        "--version",
+        version,
+        "--owner",
+        owner,
+        "--json",
+    )
+
+
+def preview_publish_metadata(
+    cmd: list[str],
+    *,
+    slug: str,
+    version: str,
+    announce: bool = False,
+) -> tuple[int, str] | None:
+    """Return ClawHub's authoritative file count and content fingerprint."""
+    preview_cmd = [*cmd, "--dry-run"]
+    if announce:
+        print("DRY-RUN:", " ".join(preview_cmd), flush=True)
+    proc = subprocess.run(preview_cmd, check=False, capture_output=True, text=True)
+    if announce or proc.returncode != 0:
+        print_completed_process_output(proc)
+    if proc.returncode != 0:
+        return None
+    try:
+        payload = json.loads(proc.stdout)
+        if not isinstance(payload, dict) or payload.get("ok") is not True:
+            raise ValueError("preview response is not a successful JSON object")
+        if payload.get("status") not in {"would-publish", "unchanged"}:
+            raise ValueError(f"preview has unexpected status: {payload.get('status')!r}")
+        if payload.get("slug") != slug or payload.get("version") != version:
+            raise ValueError(
+                f"preview identity mismatch: slug={payload.get('slug')!r}, version={payload.get('version')!r}"
+            )
+        file_count = payload.get("fileCount")
+        fingerprint = payload.get("fingerprint")
+        if not isinstance(file_count, int) or file_count < len(REQUIRED_PUBLIC_FILES):
+            raise ValueError(f"preview has invalid fileCount: {file_count!r}")
+        if not isinstance(fingerprint, str) or re.fullmatch(r"[0-9a-f]{64}", fingerprint) is None:
+            raise ValueError(f"preview has invalid fingerprint: {fingerprint!r}")
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"ClawHub publish preview validation failed for {slug}@{version}: {exc}", file=sys.stderr)
+        return None
+    print(f"ClawHub publish preview selected {file_count} file(s) for {slug}@{version}.")
+    return file_count, fingerprint
+
+
+def owner_inspect_command(cli: str, slug: str, owner: str, version: str) -> list[str]:
+    """Build the authenticated, owner-qualified release inspection command."""
+    return npx_cmd(
+        cli,
+        "--no-input",
+        "inspect",
+        f"@{owner}/{slug}",
+        "--version",
+        version,
+        "--files",
+        "--json",
+    )
+
+
+def parse_owner_release(
+    raw: str,
+    *,
+    slug: str,
+    owner: str,
+    version: str,
+) -> tuple[dict[str, Any], str]:
+    """Parse and identity-check one authenticated ClawHub inspect response."""
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("ClawHub inspect response is not a JSON object")
+    moderation = payload.get("moderation")
+    moderation_label = "not reported"
+    if isinstance(moderation, dict):
+        raw_verdict = moderation.get("verdict")
+        verdict = str(raw_verdict).strip().lower() if raw_verdict is not None else ""
+        is_malware_blocked = moderation.get("isMalwareBlocked") is True
+        if is_malware_blocked or verdict == "malicious":
+            reasons = moderation.get("reasonCodes")
+            raise ValueError(f"owner inspect reports a malware-blocked release: {reasons!r}")
+        if verdict in {"clean", "suspicious"}:
+            moderation_label = str(verdict)
+        elif moderation.get("isSuspicious") is True:
+            moderation_label = "suspicious"
+    skill = payload.get("skill")
+    publisher = payload.get("owner")
+    published = payload.get("version")
+    actual_slug = skill.get("slug") if isinstance(skill, dict) else None
+    actual_owner = publisher.get("handle") if isinstance(publisher, dict) else None
+    actual_version = published.get("version") if isinstance(published, dict) else None
+    security = published.get("security") if isinstance(published, dict) else None
+    if isinstance(security, dict):
+        raw_security_status = security.get("status")
+        security_status = str(raw_security_status).strip().lower() if raw_security_status is not None else ""
+        if security_status in {"malicious", "blocked"}:
+            raise ValueError(f"owner inspect reports security status {security_status!r}")
+        if moderation_label == "not reported" and security_status:
+            moderation_label = f"security:{security_status}"
+    if actual_slug != slug:
+        raise ValueError(f"owner inspect returned slug {actual_slug!r}, expected {slug!r}")
+    if actual_owner != owner:
+        raise ValueError(f"owner inspect returned owner {actual_owner!r}, expected {owner!r}")
+    if actual_version != version:
+        raise ValueError(f"owner inspect returned version {actual_version!r}, expected {version!r}")
+    return published, moderation_label
+
+
+def verify_owner_version(
+    cli: str,
+    slug: str,
+    owner: str,
+    expected_version: str,
+    skill_dir: Path,
+    expected_file_count: int,
+    expected_fingerprint: str,
+) -> bool:
+    """Require the authenticated owner view to match every local Skill file."""
+    cmd = owner_inspect_command(cli, slug, owner, expected_version)
+    last_error = "owner-visible version was not checked"
+    for attempt in range(1, MAX_RETRIES + 1):
+        proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        if proc.returncode == 0:
+            try:
+                published, moderation_label = parse_owner_release(
+                    proc.stdout,
+                    slug=slug,
+                    owner=owner,
+                    version=expected_version,
+                )
+                mismatches = published_file_mismatches(
+                    published,
+                    skill_dir,
+                    location="owner-visible",
+                    expected_file_count=expected_file_count,
+                    expected_fingerprint=expected_fingerprint,
+                )
+                if not mismatches:
+                    print(
+                        f"Verified @{owner}/{slug}@{expected_version} in the authenticated owner view "
+                        f"(moderation: {moderation_label})."
+                    )
+                    return True
+                last_error = "; ".join(mismatches)
+            except (json.JSONDecodeError, ValueError) as exc:
+                last_error = str(exc)
+        else:
+            output = "\n".join(part.strip() for part in (proc.stdout, proc.stderr) if part.strip())
+            last_error = output or f"inspect exited with code {proc.returncode}"
+
+        if attempt < MAX_RETRIES:
+            wait = retry_delay(proc, attempt) if is_retryable(proc) else 2**attempt
+            print(
+                f"ClawHub owner verification pending for @{owner}/{slug}@{expected_version}; "
+                f"retrying in {wait}s (attempt {attempt}/{MAX_RETRIES}) ...",
+                flush=True,
+            )
+            time.sleep(wait)
+
+    print(
+        f"ClawHub owner verification failed for @{owner}/{slug}@{expected_version}: {last_error}",
+        file=sys.stderr,
+    )
+    return False
 
 
 def verify_published_version(
@@ -200,17 +495,31 @@ def verify_published_version(
     owner: str,
     expected_version: str,
     skill_dir: Path | None = None,
-) -> bool:
-    """Require the expected version and key artifacts on the public API."""
+    expected_file_count: int | None = None,
+    expected_fingerprint: str | None = None,
+) -> bool | None:
+    """Verify the public release, returning None while moderation hides it."""
     last_error = "public version was not checked"
+    saw_public_record = False
+    only_not_found = True
     for attempt in range(1, MAX_RETRIES + 1):
         retry_wait: int | None = None
         try:
             published = published_skill_release(slug, owner, expected_version)
+            saw_public_record = True
             raw_version = published.get("version")
             actual_version = raw_version.strip() if isinstance(raw_version, str) else ""
             if actual_version == expected_version:
-                mismatches = public_file_mismatches(published, skill_dir) if skill_dir is not None else []
+                mismatches = (
+                    public_file_mismatches(
+                        published,
+                        skill_dir,
+                        expected_file_count,
+                        expected_fingerprint,
+                    )
+                    if skill_dir is not None
+                    else []
+                )
                 if not mismatches:
                     print(f"Verified @{owner}/{slug}@{expected_version} on the public ClawHub API.")
                     return True
@@ -220,7 +529,13 @@ def verify_published_version(
         except HTTPError as exc:
             last_error = str(exc)
             retry_wait = http_retry_delay(exc, attempt)
-        except (OSError, ValueError) as exc:
+            if exc.code != 404:
+                only_not_found = False
+        except OSError as exc:
+            only_not_found = False
+            last_error = str(exc)
+        except ValueError as exc:
+            only_not_found = False
             last_error = str(exc)
 
         if attempt < MAX_RETRIES:
@@ -232,11 +547,51 @@ def verify_published_version(
             )
             time.sleep(wait)
 
+    if not saw_public_record and only_not_found:
+        print(
+            f"Owner-verified @{owner}/{slug}@{expected_version} is not publicly visible; "
+            f"ClawHub review or moderation may still be pending ({last_error})."
+        )
+        return None
     print(
         f"ClawHub public verification failed for @{owner}/{slug}@{expected_version}: {last_error}",
         file=sys.stderr,
     )
     return False
+
+
+def verify_uploaded_version(
+    cli: str,
+    slug: str,
+    owner: str,
+    expected_version: str,
+    skill_dir: Path,
+) -> bool:
+    """Verify owner-visible bytes, then report public or pending-review state."""
+    cmd = publish_command(cli, skill_dir, slug, owner, expected_version)
+    preview = preview_publish_metadata(cmd, slug=slug, version=expected_version)
+    if preview is None:
+        return False
+    expected_file_count, expected_fingerprint = preview
+    if not verify_owner_version(
+        cli,
+        slug,
+        owner,
+        expected_version,
+        skill_dir,
+        expected_file_count,
+        expected_fingerprint,
+    ):
+        return False
+    public_status = verify_published_version(
+        slug,
+        owner,
+        expected_version,
+        skill_dir,
+        expected_file_count,
+        expected_fingerprint,
+    )
+    return public_status is not False
 
 
 def publish_one(
@@ -249,16 +604,35 @@ def publish_one(
     rel = entry.get("path")
     slug = entry.get("slug")
     owner = entry.get("owner")
-    if not rel or not slug or not owner:
-        print(f"invalid manifest entry (need path + slug + owner): {entry}", file=sys.stderr)
+    declared_version = entry.get("version")
+    if not rel or not slug or not owner or not declared_version:
+        print(
+            f"invalid manifest entry (need path + slug + owner + version): {entry}",
+            file=sys.stderr,
+        )
+        return 1
+    version = str(declared_version).strip()
+    if STABLE_SEMVER_RE.fullmatch(version) is None:
+        print(f"invalid manifest version for {slug}: {declared_version!r}", file=sys.stderr)
         return 1
 
     skill_dir = (REPO_ROOT / str(rel)).resolve()
+    try:
+        skill_dir.relative_to(REPO_ROOT)
+    except ValueError:
+        print(f"skill directory escapes repository root: {skill_dir}", file=sys.stderr)
+        return 1
     if not skill_dir.is_dir():
         print(f"skill directory not found: {skill_dir}", file=sys.stderr)
         return 1
 
-    version = skill_version(skill_dir)
+    metadata_version = skill_version(skill_dir)
+    if metadata_version != version:
+        print(
+            f"manifest version {version!r} does not match SKILL.md version {metadata_version!r}: {skill_dir}",
+            file=sys.stderr,
+        )
+        return 1
     license_id = skill_license(skill_dir)
     if license_id != CLAWHUB_LICENSE:
         print(
@@ -276,31 +650,20 @@ def publish_one(
             print(f"  - {issue}", file=sys.stderr)
         return 1
 
-    cmd = npx_cmd(
-        cli,
-        "publish",
-        str(skill_dir),
-        "--slug",
-        str(slug),
-        "--version",
-        version,
-        "--owner",
-        str(owner),
-        "--no-input",
-    )
+    cmd = publish_command(cli, skill_dir, str(slug), str(owner), version)
     if dry_run:
-        print("DRY-RUN:", " ".join(cmd))
-        return 0
+        preview = preview_publish_metadata(cmd, slug=str(slug), version=version, announce=True)
+        return 0 if preview is not None else 1
 
     print(f"Publishing {slug}@{version} from {skill_dir} ...", flush=True)
     for attempt in range(1, MAX_RETRIES + 1):
         proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
         print_completed_process_output(proc)
         if proc.returncode == 0:
-            return 0 if verify_published_version(str(slug), str(owner), version, skill_dir) else 1
+            return 0 if verify_uploaded_version(cli, str(slug), str(owner), version, skill_dir) else 1
         if version_already_exists(proc):
             print(f"{slug}@{version} already exists on ClawHub; skipping.")
-            return 0 if verify_published_version(str(slug), str(owner), version, skill_dir) else 1
+            return 0 if verify_uploaded_version(cli, str(slug), str(owner), version, skill_dir) else 1
         if attempt < MAX_RETRIES and is_retryable(proc):
             wait = retry_delay(proc, attempt)
             print(

--- a/scripts/package_openclaw_skill.py
+++ b/scripts/package_openclaw_skill.py
@@ -3,19 +3,35 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
+import re
 import sys
 from zipfile import ZIP_DEFLATED
 from zipfile import ZipFile
-
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - exercised on Python < 3.11
-    import tomli as tomllib
+from zipfile import ZipInfo
 
 IGNORED_NAMES = {".DS_Store", "Thumbs.db"}
 IGNORED_DIRECTORY_NAMES = {"__pycache__", ".mypy_cache", ".pytest_cache", ".ruff_cache"}
 IGNORED_SUFFIXES = {".pyc", ".pyo"}
+STABLE_SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+ZIP_FILE_MODE = 0o100644
+
+
+def workspace_version_from_text(raw: str) -> str:
+    """Extract workspace.package.version with a Python 3.7-safe TOML subset."""
+    in_workspace_package = False
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_workspace_package = stripped == "[workspace.package]"
+            continue
+        if in_workspace_package:
+            match = re.fullmatch(r"version\s*=\s*['\"]([^'\"]+)['\"]\s*(?:#.*)?", stripped)
+            if match is not None:
+                return match.group(1)
+    raise ValueError("missing [workspace.package] version")
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,6 +53,11 @@ def parse_args() -> argparse.Namespace:
         help="Package every immediate child directory that contains SKILL.md",
     )
     parser.add_argument(
+        "--manifest",
+        action="store_true",
+        help="Treat source as a ClawHub manifest and use each entry's independent version",
+    )
+    parser.add_argument(
         "--version",
         help="Override version in output filename (default: workspace Cargo.toml version)",
     )
@@ -45,6 +66,15 @@ def parse_args() -> argparse.Namespace:
 
 def workspace_version(repo_root: Path) -> str:
     """Read workspace version from the root Cargo.toml."""
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover - exercised on Python < 3.11
+        cargo_toml = repo_root / "Cargo.toml"
+        try:
+            return workspace_version_from_text(cargo_toml.read_text(encoding="utf-8"))
+        except ValueError as error:
+            raise ValueError(f"{error}: {cargo_toml}") from error
+
     cargo_toml = repo_root / "Cargo.toml"
     data = tomllib.loads(cargo_toml.read_text(encoding="utf-8"))
     return str(data["workspace"]["package"]["version"])
@@ -52,9 +82,19 @@ def workspace_version(repo_root: Path) -> str:
 
 def iter_skill_files(skill_dir: Path):
     """Yield packable files under a skill directory."""
+    if skill_dir.is_symlink():
+        raise ValueError(f"refusing to package symbolic-link Skill directory: {skill_dir}")
+    resolved_root = skill_dir.resolve()
     for path in sorted(skill_dir.rglob("*")):
+        if path.is_symlink():
+            raise ValueError(f"refusing to package symbolic link: {path}")
         if not path.is_file():
             continue
+        resolved = path.resolve()
+        try:
+            resolved.relative_to(resolved_root)
+        except ValueError as error:
+            raise ValueError(f"Skill file escapes package root: {path}") from error
         relative_parts = path.relative_to(skill_dir).parts
         if any(part in IGNORED_DIRECTORY_NAMES for part in relative_parts[:-1]):
             continue
@@ -67,10 +107,22 @@ def iter_skill_files(skill_dir: Path):
 
 def resolve_skill_dirs(source: Path, package_all: bool) -> list[Path]:
     """Resolve one or many skill directories from CLI source path."""
+    if source.is_symlink():
+        raise ValueError(f"refusing symbolic-link Skill source: {source}")
     if package_all:
         if not source.is_dir():
             raise ValueError(f"skills root does not exist: {source}")
-        skill_dirs = [path for path in sorted(source.iterdir()) if path.is_dir() and (path / "SKILL.md").is_file()]
+        resolved_source = source.resolve()
+        skill_dirs = []
+        for path in sorted(source.iterdir()):
+            if path.is_symlink() and (path / "SKILL.md").is_file():
+                raise ValueError(f"refusing symbolic-link Skill directory: {path}")
+            if path.is_dir() and (path / "SKILL.md").is_file():
+                try:
+                    path.resolve().relative_to(resolved_source)
+                except ValueError as error:
+                    raise ValueError(f"Skill directory escapes skills root: {path}") from error
+                skill_dirs.append(path)
         if not skill_dirs:
             raise ValueError(f"no skill directories with SKILL.md under: {source}")
         return skill_dirs
@@ -82,13 +134,59 @@ def resolve_skill_dirs(source: Path, package_all: bool) -> list[Path]:
     return [source]
 
 
+def resolve_manifest_skills(manifest: Path, repo_root: Path) -> list[tuple[Path, str]]:
+    """Resolve Skill directories and immutable versions from a ClawHub manifest."""
+    if not manifest.is_file():
+        raise ValueError(f"ClawHub manifest does not exist: {manifest}")
+    entries = json.loads(manifest.read_text(encoding="utf-8"))
+    if not isinstance(entries, list) or not entries:
+        raise ValueError(f"ClawHub manifest must be a non-empty JSON array: {manifest}")
+    resolved: list[tuple[Path, str]] = []
+    for entry in entries:
+        if not isinstance(entry, dict) or not entry.get("path") or not entry.get("version"):
+            raise ValueError(f"ClawHub manifest entry needs path and version: {entry!r}")
+        unresolved_skill_dir = repo_root / str(entry["path"])
+        if unresolved_skill_dir.is_symlink():
+            raise ValueError(f"refusing symbolic-link Skill directory: {unresolved_skill_dir}")
+        skill_dir = unresolved_skill_dir.resolve()
+        try:
+            skill_dir.relative_to(repo_root)
+        except ValueError as error:
+            raise ValueError(f"Skill path escapes repository root: {skill_dir}") from error
+        if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").is_file():
+            raise ValueError(f"invalid Skill directory in ClawHub manifest: {skill_dir}")
+        version = str(entry["version"]).strip()
+        if STABLE_SEMVER_RE.fullmatch(version) is None:
+            raise ValueError(f"invalid ClawHub manifest version: {entry['version']!r}")
+        resolved.append((skill_dir, version))
+    return resolved
+
+
 def package_skill(skill_dir: Path, output_dir: Path, version: str) -> Path:
-    """Zip one skill tree and return the archive path."""
+    """Create one reproducible Skill archive and return its path."""
+    if STABLE_SEMVER_RE.fullmatch(version) is None:
+        raise ValueError(f"invalid stable Skill archive version: {version!r}")
+    if skill_dir.is_symlink():
+        raise ValueError(f"refusing symbolic-link Skill directory: {skill_dir}")
+    resolved_skill_dir = skill_dir.resolve()
+    resolved_output_dir = output_dir.resolve()
+    try:
+        resolved_output_dir.relative_to(resolved_skill_dir)
+    except ValueError:
+        pass
+    else:
+        raise ValueError(f"output directory cannot be inside Skill directory: {output_dir}")
     archive_path = output_dir / f"{skill_dir.name}-{version}.zip"
+    if archive_path.is_symlink():
+        raise ValueError(f"refusing to overwrite symbolic-link archive: {archive_path}")
     with ZipFile(archive_path, "w", compression=ZIP_DEFLATED) as archive:
         for path in iter_skill_files(skill_dir):
             relative_path = path.relative_to(skill_dir.parent)
-            archive.write(path, arcname=relative_path.as_posix())
+            info = ZipInfo(relative_path.as_posix(), date_time=ZIP_TIMESTAMP)
+            info.create_system = 3
+            info.compress_type = ZIP_DEFLATED
+            info.external_attr = ZIP_FILE_MODE << 16
+            archive.writestr(info, path.read_bytes())
     return archive_path
 
 
@@ -96,20 +194,29 @@ def main() -> int:
     """Package skill directories into dist/skills archives."""
     args = parse_args()
     repo_root = Path(__file__).resolve().parent.parent
-    source = Path(args.source).resolve()
+    source = Path(args.source).absolute()
     output_dir = Path(args.output_dir).resolve()
 
     try:
-        skill_dirs = resolve_skill_dirs(source, args.all)
+        if args.manifest:
+            if args.all or args.version:
+                raise ValueError("--manifest cannot be combined with --all or --version")
+            skill_releases = resolve_manifest_skills(source, repo_root)
+        else:
+            skill_dirs = resolve_skill_dirs(source, args.all)
+            version = args.version or workspace_version(repo_root)
+            skill_releases = [(skill_dir, version) for skill_dir in skill_dirs]
     except ValueError as error:
         print(error, file=sys.stderr)
         return 1
-
-    version = args.version or workspace_version(repo_root)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    for archive_path in (package_skill(skill_dir, output_dir, version) for skill_dir in skill_dirs):
-        print(archive_path)
+    try:
+        for archive_path in (package_skill(skill_dir, output_dir, version) for skill_dir, version in skill_releases):
+            print(archive_path)
+    except (OSError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 1
     return 0
 
 

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -13,7 +13,7 @@ metadata:
     dcc: python
     layer: infrastructure
     compatibility: "dcc-mcp-core 0.17+, Python 3.7+"
-    version: "0.19.63"  # x-release-please-version
+    version: "0.19.64"
     search-hint: >-
       create DCC MCP adapter, Nuke MCP, DccServerBase, HostExecutionBridge,
       dispatcher, readiness, resources, gateway, Blender, 3ds Max, Unreal,

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:
     dcc: python
-    version: "0.19.63"  # x-release-please-version
+    version: "0.19.64"
     layer: infrastructure
     compatibility: "Python 3.7+, dcc-mcp-core 0.17+"
     search-hint: "create dcc mcp skill, validate skill, scaffold skill, SKILL.md, tools.yaml, scripts, groups, prompts, skill taxonomy"

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -20,7 +20,7 @@ metadata:
     dcc: python
     layer: infrastructure
     compatibility: Cross-platform Windows/macOS/Linux. Prefers dcc-mcp-cli on PATH; can download release asset from GitHub; local profile needs no gateway env. DCC_MCP_BASE_URL is optional for remote/legacy gateway REST fallback.
-    version: "0.19.63"  # x-release-please-version
+    version: "0.19.64"
     search-hint: "dcc control operate UI control menu dialog window button click keyboard Maya Blender Houdini Photoshop 3ds Max Nuke Unreal Godot RenderDoc Substance connect create edit render automate cli gateway stats marketplace skill catalog recommend install update 商城 技能 操作 控制 界面 菜单 弹窗 窗口 按钮 点击 键盘"
     tags: "dcc, dcc-ui-control, ui-control, maya, blender, houdini, photoshop, nuke, unreal, godot, renderdoc, cli, gateway, marketplace, skill-catalog, clawhub, openclaw"
   openclaw:

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import io
 import json
 from pathlib import Path
+import re
+import shutil
 import subprocess
-import sys
+
+import pytest
 
 from conftest import REPO_ROOT
 from dcc_mcp_core import parse_skill_md
@@ -15,7 +19,7 @@ from dcc_mcp_core import yaml_loads
 
 MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
 RELEASE_PLEASE_CONFIG = REPO_ROOT / "release-please-config.json"
-RELEASE_MANIFEST = REPO_ROOT / ".release-please-manifest.json"
+CLAWHUB_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "clawhub.yml"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
 SYNC_SCRIPT = REPO_ROOT / "scripts" / "clawhub_sync.py"
 README = REPO_ROOT / "README.md"
@@ -39,6 +43,7 @@ class TestClawhubSync:
         assert "dcc-mcp-skills-creator" in slugs
         assert "dcc-mcp-creator" in slugs
         assert {entry["owner"] for entry in entries} == {"loonghao"}
+        assert all(re.fullmatch(r"\d+\.\d+\.\d+", entry["version"]) for entry in entries)
 
     def test_published_skills_include_codex_interface_metadata(self) -> None:
         entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
@@ -54,27 +59,44 @@ class TestClawhubSync:
         for slug in ("dcc-mcp", "dcc-mcp-skills-creator", "dcc-mcp-creator"):
             qualified = f"@loonghao/{slug}"
             assert f"openclaw skills install {qualified}" in readme
-            assert f"clawhub@0.17.0 install {slug}" in readme
+            assert f"clawhub@0.23.1 install {qualified}" in readme
         assert ".github/clawhub-skills.json" in readme
+        assert "versioned independently" in readme
 
-    def test_dry_run_exits_zero(self) -> None:
-        proc = subprocess.run(
-            [sys.executable, str(SYNC_SCRIPT), "--dry-run"],
-            capture_output=True,
-            text=True,
-            timeout=60,
-            cwd=str(REPO_ROOT),
-            check=False,
-        )
-        assert proc.returncode == 0, proc.stderr
-        assert "DRY-RUN" in proc.stdout
-        assert "clawhub@0.17.0" in proc.stdout
-        assert "dcc-mcp" in proc.stdout
-        assert "dcc-mcp-skills-creator" in proc.stdout
-        assert "dcc-mcp-creator" in proc.stdout
-        assert proc.stdout.count("--owner loonghao") == 3
+    def test_dry_run_uses_current_cli_and_real_publish_preview(self, monkeypatch) -> None:
+        sync = load_sync_module()
+        calls: list[list[str]] = []
 
-    def test_dry_run_does_not_publish_or_verify(self, tmp_path, monkeypatch) -> None:
+        def fake_run(cmd, *, check, capture_output, text):
+            assert check is False
+            assert capture_output is True
+            assert text is True
+            calls.append(cmd)
+            payload = {
+                "ok": True,
+                "status": "would-publish",
+                "slug": cmd[cmd.index("--slug") + 1],
+                "version": cmd[cmd.index("--version") + 1],
+                "fileCount": 2,
+                "fingerprint": "a" * 64,
+            }
+            return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(payload), stderr="")
+
+        monkeypatch.setattr(sync.subprocess, "run", fake_run)
+        entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        for entry in entries:
+            assert sync.publish_one(entry, dry_run=True, cli=sync.DEFAULT_CLI) == 0
+
+        assert sync.DEFAULT_CLI == "clawhub@0.23.1"
+        assert len(calls) == 3
+        for cmd in calls:
+            assert Path(cmd[0]).name.lower() in {"npx", "npx.cmd", "npx.exe"}
+            assert cmd[1:5] == ["clawhub@0.23.1", "--no-input", "skill", "publish"]
+            assert cmd[-2:] == ["--json", "--dry-run"]
+            assert "--owner" in cmd
+            assert cmd[cmd.index("--owner") + 1] == "loonghao"
+
+    def test_dry_run_does_not_verify_uploaded_state(self, tmp_path, monkeypatch) -> None:
         sync = load_sync_module()
         skill_dir = tmp_path / "skills" / "example"
         skill_dir.mkdir(parents=True)
@@ -83,23 +105,38 @@ class TestClawhubSync:
             is_clean = True
             issues: tuple[str, ...] = ()
 
+        calls = []
+
+        def fake_run(cmd, *, check, capture_output, text):
+            calls.append(cmd)
+            payload = {
+                "ok": True,
+                "status": "would-publish",
+                "slug": "example",
+                "version": "1.2.3",
+                "fileCount": 2,
+                "fingerprint": "a" * 64,
+            }
+            return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(payload), stderr="")
+
         def fail(*_args, **_kwargs):
-            raise AssertionError("dry-run must not publish or access the public API")
+            raise AssertionError("dry-run must not inspect uploaded or public state")
 
         monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
         monkeypatch.setattr(sync, "skill_version", lambda _skill_dir: "1.2.3")
         monkeypatch.setattr(sync, "skill_license", lambda _skill_dir: sync.CLAWHUB_LICENSE)
         monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
-        monkeypatch.setattr(sync.subprocess, "run", fail)
-        monkeypatch.setattr(sync, "verify_published_version", fail)
+        monkeypatch.setattr(sync.subprocess, "run", fake_run)
+        monkeypatch.setattr(sync, "verify_uploaded_version", fail)
 
         rc = sync.publish_one(
-            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
+            {"path": "skills/example", "slug": "example", "owner": "loonghao", "version": "1.2.3"},
             dry_run=True,
             cli="clawhub@test",
         )
 
         assert rc == 0
+        assert calls[0][-1] == "--dry-run"
 
     def test_public_version_request_is_owner_qualified(self, monkeypatch) -> None:
         sync = load_sync_module()
@@ -115,7 +152,7 @@ class TestClawhubSync:
 
         assert version == "1.2.3"
         assert requests[0][0].full_url == (
-            "https://clawhub.ai/api/v1/skills/example-skill/versions/1.2.3?owner=loonghao"
+            "https://clawhub.ai/api/v1/skills/example-skill/versions/1.2.3?ownerHandle=loonghao"
         )
         assert requests[0][1] == 20
 
@@ -215,7 +252,355 @@ class TestClawhubSync:
         assert sync.verify_published_version("example", "loonghao", "1.2.3", skill_dir) is False
         assert "public file hash mismatch: agents/openai.yaml" in capsys.readouterr().err
 
-    def test_existing_version_fails_when_not_publicly_visible(self, tmp_path, monkeypatch, capsys) -> None:
+    def test_public_version_gate_reports_pending_review_for_hidden_release(self, monkeypatch, capsys) -> None:
+        sync = load_sync_module()
+
+        def hidden_release(*_args):
+            raise sync.HTTPError("https://clawhub.ai", 404, "not found", {}, None)
+
+        monkeypatch.setattr(sync, "published_skill_release", hidden_release)
+        monkeypatch.setattr(sync, "MAX_RETRIES", 1)
+
+        assert sync.verify_published_version("example", "loonghao", "1.2.3") is None
+        assert "review or moderation may still be pending" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("failure", ["rate-limit", "service", "network", "schema"])
+    def test_public_version_gate_does_not_mislabel_service_errors_as_review(self, failure, monkeypatch, capsys) -> None:
+        sync = load_sync_module()
+
+        def unavailable_release(*_args):
+            if failure == "rate-limit":
+                raise sync.HTTPError("https://clawhub.ai", 429, "rate limited", {}, None)
+            if failure == "service":
+                raise sync.HTTPError("https://clawhub.ai", 503, "unavailable", {}, None)
+            if failure == "network":
+                raise OSError("network unavailable")
+            raise ValueError("unexpected public schema")
+
+        monkeypatch.setattr(sync, "published_skill_release", unavailable_release)
+        monkeypatch.setattr(sync, "MAX_RETRIES", 1)
+
+        assert sync.verify_published_version("example", "loonghao", "1.2.3") is False
+        captured = capsys.readouterr()
+        assert "public verification failed" in captured.err
+        assert "pending ClawHub review" not in captured.out
+
+    def test_owner_inspect_gate_checks_identity_and_all_file_hashes(self, tmp_path, monkeypatch) -> None:
+        sync = load_sync_module()
+        skill_dir = tmp_path / "example"
+        (skill_dir / "agents").mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: example\n---\n", encoding="utf-8")
+        (skill_dir / "agents" / "openai.yaml").write_text(
+            "interface:\n  short_description: Example\n",
+            encoding="utf-8",
+        )
+        (skill_dir / "notes.md").write_text("release notes\n", encoding="utf-8")
+        published = {
+            "version": "1.2.3",
+            "files": [
+                {
+                    "path": path.relative_to(skill_dir).as_posix(),
+                    "sha256": sync.file_sha256(path),
+                }
+                for path in sorted(skill_dir.rglob("*"))
+                if path.is_file()
+            ],
+        }
+        payload = {
+            "skill": {"slug": "example"},
+            "owner": {"handle": "loonghao"},
+            "version": published,
+        }
+        calls = []
+
+        def fake_run(cmd, *, check, capture_output, text):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(payload), stderr="")
+
+        monkeypatch.setattr(sync.subprocess, "run", fake_run)
+        expected_fingerprint = "a" * 64
+        monkeypatch.setattr(sync, "clawhub_file_fingerprint", lambda _hashes: expected_fingerprint)
+        monkeypatch.setattr(sync, "MAX_RETRIES", 1)
+
+        assert (
+            sync.verify_owner_version(
+                "clawhub@test",
+                "example",
+                "loonghao",
+                "1.2.3",
+                skill_dir,
+                3,
+                expected_fingerprint,
+            )
+            is True
+        )
+        assert len(calls) == 1
+        assert Path(calls[0][0]).name.lower() in {"npx", "npx.cmd", "npx.exe"}
+        assert calls[0][1:] == [
+            "clawhub@test",
+            "--no-input",
+            "inspect",
+            "@loonghao/example",
+            "--version",
+            "1.2.3",
+            "--files",
+            "--json",
+        ]
+
+        published["files"][0]["sha256"] = "0" * 64
+        assert (
+            sync.verify_owner_version(
+                "clawhub@test",
+                "example",
+                "loonghao",
+                "1.2.3",
+                skill_dir,
+                3,
+                expected_fingerprint,
+            )
+            is False
+        )
+
+    def test_owner_inspect_rejects_malware_blocked_release(self) -> None:
+        sync = load_sync_module()
+        payload = {
+            "skill": {"slug": "example"},
+            "owner": {"handle": "loonghao"},
+            "version": {"version": "1.2.3", "files": []},
+            "moderation": {
+                "isMalwareBlocked": True,
+                "verdict": "malicious",
+                "reasonCodes": ["malware-detected"],
+            },
+        }
+
+        with pytest.raises(ValueError, match="malware-blocked"):
+            sync.parse_owner_release(
+                json.dumps(payload),
+                slug="example",
+                owner="loonghao",
+                version="1.2.3",
+            )
+
+    def test_owner_inspect_rejects_malicious_version_security(self) -> None:
+        sync = load_sync_module()
+        payload = {
+            "skill": {"slug": "example"},
+            "owner": {"handle": "loonghao"},
+            "version": {
+                "version": "1.2.3",
+                "files": [],
+                "security": {"status": "malicious"},
+            },
+            "moderation": None,
+        }
+
+        with pytest.raises(ValueError, match="security status 'malicious'"):
+            sync.parse_owner_release(
+                json.dumps(payload),
+                slug="example",
+                owner="loonghao",
+                version="1.2.3",
+            )
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "not-json",
+            json.dumps(
+                {
+                    "ok": True,
+                    "status": "would-publish",
+                    "slug": "wrong",
+                    "version": "1.2.3",
+                    "fileCount": 2,
+                    "fingerprint": "a" * 64,
+                }
+            ),
+        ],
+    )
+    def test_publish_preview_rejects_untrusted_output(self, payload, monkeypatch) -> None:
+        sync = load_sync_module()
+        monkeypatch.setattr(
+            sync.subprocess,
+            "run",
+            lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, stdout=payload, stderr=""),
+        )
+
+        assert sync.preview_publish_metadata([], slug="example", version="1.2.3") is None
+
+    @pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required by ClawHub")
+    def test_fingerprint_matches_clawhub_reference_order(self) -> None:
+        sync = load_sync_module()
+        file_hashes = {
+            "SKILL.md": "1" * 64,
+            "agents/openai.yaml": "2" * 64,
+        }
+        payload = f"agents/openai.yaml:{'2' * 64}\nSKILL.md:{'1' * 64}"
+        expected = hashlib.sha256(payload.encode()).hexdigest()
+
+        assert sync.clawhub_file_fingerprint(file_hashes) == expected
+
+    def test_same_count_selection_drift_fails_fingerprint_gate(self, tmp_path, monkeypatch) -> None:
+        sync = load_sync_module()
+        skill_dir = tmp_path / "example"
+        (skill_dir / "agents").mkdir(parents=True)
+        for relative, content in {
+            "SKILL.md": "skill\n",
+            "agents/openai.yaml": "interface: {}\n",
+            "old-selection.md": "old\n",
+            "new-selection.md": "new\n",
+        }.items():
+            (skill_dir / relative).write_text(content, encoding="utf-8")
+        published = {
+            "files": [
+                {"path": relative, "sha256": sync.file_sha256(skill_dir / relative)}
+                for relative in ("SKILL.md", "agents/openai.yaml", "old-selection.md")
+            ]
+        }
+        monkeypatch.setattr(sync, "clawhub_file_fingerprint", lambda _hashes: "b" * 64)
+
+        mismatches = sync.published_file_mismatches(
+            published,
+            skill_dir,
+            location="owner-visible",
+            expected_file_count=3,
+            expected_fingerprint="a" * 64,
+        )
+
+        assert mismatches == [f"owner-visible fingerprint {'b' * 64}, expected {'a' * 64}"]
+
+    def test_generated_skill_card_is_excluded_from_source_fingerprint(self, tmp_path, monkeypatch) -> None:
+        sync = load_sync_module()
+        skill_dir = tmp_path / "example"
+        (skill_dir / "agents").mkdir(parents=True)
+        for relative, content in {
+            "SKILL.md": "skill\n",
+            "agents/openai.yaml": "interface: {}\n",
+        }.items():
+            (skill_dir / relative).write_text(content, encoding="utf-8")
+        published = {
+            "files": [
+                {"path": relative, "sha256": sync.file_sha256(skill_dir / relative)}
+                for relative in ("SKILL.md", "agents/openai.yaml")
+            ]
+            + [{"path": "skill-card.md", "sha256": "c" * 64}]
+        }
+        monkeypatch.setattr(sync, "clawhub_file_fingerprint", lambda _hashes: "a" * 64)
+
+        assert (
+            sync.published_file_mismatches(
+                published,
+                skill_dir,
+                location="owner-visible",
+                expected_file_count=2,
+                expected_fingerprint="a" * 64,
+            )
+            == []
+        )
+
+    def test_uploaded_version_accepts_owner_match_while_public_review_is_pending(self, monkeypatch) -> None:
+        sync = load_sync_module()
+        monkeypatch.setattr(sync, "preview_publish_metadata", lambda *_args, **_kwargs: (3, "a" * 64))
+        monkeypatch.setattr(sync, "verify_owner_version", lambda *_args: True)
+        monkeypatch.setattr(sync, "verify_published_version", lambda *_args: None)
+
+        assert (
+            sync.verify_uploaded_version(
+                "clawhub@test",
+                "example",
+                "loonghao",
+                "1.2.3",
+                Path("example"),
+            )
+            is True
+        )
+
+    def test_uploaded_version_rejects_public_hash_mismatch(self, monkeypatch) -> None:
+        sync = load_sync_module()
+        monkeypatch.setattr(sync, "preview_publish_metadata", lambda *_args, **_kwargs: (3, "a" * 64))
+        monkeypatch.setattr(sync, "verify_owner_version", lambda *_args: True)
+        monkeypatch.setattr(sync, "verify_published_version", lambda *_args: False)
+
+        assert (
+            sync.verify_uploaded_version(
+                "clawhub@test",
+                "example",
+                "loonghao",
+                "1.2.3",
+                Path("example"),
+            )
+            is False
+        )
+
+    def test_manifest_version_must_match_skill_metadata(self, tmp_path, monkeypatch) -> None:
+        sync = load_sync_module()
+        skill_dir = tmp_path / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+
+        def fail(*_args, **_kwargs):
+            raise AssertionError("version mismatch must fail before validation or CLI execution")
+
+        monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(sync, "skill_version", lambda _skill_dir: "1.2.2")
+        monkeypatch.setattr(sync, "skill_license", fail)
+        monkeypatch.setattr(sync.subprocess, "run", fail)
+
+        assert (
+            sync.publish_one(
+                {"path": "skills/example", "slug": "example", "owner": "loonghao", "version": "1.2.3"},
+                dry_run=True,
+                cli="clawhub@test",
+            )
+            == 1
+        )
+
+    def test_manifest_rejects_prerelease_version_before_cli_execution(self, tmp_path, monkeypatch) -> None:
+        sync = load_sync_module()
+
+        def fail(*_args, **_kwargs):
+            raise AssertionError("invalid stable version must fail before filesystem or CLI access")
+
+        monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(sync.subprocess, "run", fail)
+
+        assert (
+            sync.publish_one(
+                {
+                    "path": "skills/example",
+                    "slug": "example",
+                    "owner": "loonghao",
+                    "version": "1.2.3-01",
+                },
+                dry_run=True,
+                cli="clawhub@test",
+            )
+            == 1
+        )
+
+    def test_manifest_skill_path_cannot_escape_repository(self, tmp_path, monkeypatch) -> None:
+        sync = load_sync_module()
+        repo_root = tmp_path / "repo"
+        outside = tmp_path / "outside"
+        repo_root.mkdir()
+        outside.mkdir()
+
+        def fail(*_args, **_kwargs):
+            raise AssertionError("escaping paths must fail before Skill parsing")
+
+        monkeypatch.setattr(sync, "REPO_ROOT", repo_root)
+        monkeypatch.setattr(sync, "skill_version", fail)
+
+        assert (
+            sync.publish_one(
+                {"path": "../outside", "slug": "example", "owner": "loonghao", "version": "1.2.3"},
+                dry_run=True,
+                cli="clawhub@test",
+            )
+            == 1
+        )
+
+    def test_existing_version_requires_owner_visible_hash_match(self, tmp_path, monkeypatch, capsys) -> None:
         sync = load_sync_module()
         skill_dir = tmp_path / "skills" / "example"
         skill_dir.mkdir(parents=True)
@@ -240,10 +625,10 @@ class TestClawhubSync:
         monkeypatch.setattr(sync, "skill_license", lambda _skill_dir: sync.CLAWHUB_LICENSE)
         monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
         monkeypatch.setattr(sync.subprocess, "run", fake_run)
-        monkeypatch.setattr(sync, "verify_published_version", lambda *_args: False)
+        monkeypatch.setattr(sync, "verify_uploaded_version", lambda *_args: False)
 
         rc = sync.publish_one(
-            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
+            {"path": "skills/example", "slug": "example", "owner": "loonghao", "version": "1.2.3"},
             dry_run=False,
             cli="clawhub@test",
         )
@@ -289,10 +674,10 @@ class TestClawhubSync:
         monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
         monkeypatch.setattr(sync.subprocess, "run", fake_run)
         monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
-        monkeypatch.setattr(sync, "verify_published_version", lambda *_args: True)
+        monkeypatch.setattr(sync, "verify_uploaded_version", lambda *_args: True)
 
         rc = sync.publish_one(
-            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
+            {"path": "skills/example", "slug": "example", "owner": "loonghao", "version": "1.2.3"},
             dry_run=False,
             cli="clawhub@test",
         )
@@ -342,10 +727,10 @@ class TestClawhubSync:
         monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
         monkeypatch.setattr(sync.subprocess, "run", fake_run)
         monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
-        monkeypatch.setattr(sync, "verify_published_version", lambda *_args: True)
+        monkeypatch.setattr(sync, "verify_uploaded_version", lambda *_args: True)
 
         rc = sync.publish_one(
-            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
+            {"path": "skills/example", "slug": "example", "owner": "loonghao", "version": "1.2.3"},
             dry_run=False,
             cli="clawhub@test",
         )
@@ -386,7 +771,7 @@ class TestClawhubSync:
         monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
 
         rc = sync.publish_one(
-            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
+            {"path": "skills/example", "slug": "example", "owner": "loonghao", "version": "1.2.3"},
             dry_run=False,
             cli="clawhub@test",
         )
@@ -427,7 +812,7 @@ class TestClawhubSync:
         monkeypatch.setattr(sync.time, "sleep", lambda _s: None)
 
         rc = sync.publish_one(
-            {"path": "skills/example", "slug": "example", "owner": "loonghao"},
+            {"path": "skills/example", "slug": "example", "owner": "loonghao", "version": "1.2.3"},
             dry_run=False,
             cli="clawhub@test",
         )
@@ -435,27 +820,36 @@ class TestClawhubSync:
         assert rc == 1
         assert len(calls) == 1
 
-    def test_clawhub_skill_versions_follow_release_please(self) -> None:
+    def test_clawhub_skill_versions_follow_independent_manifest(self) -> None:
         entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
-        release_version = json.loads(RELEASE_MANIFEST.read_text(encoding="utf-8"))["."]
         for entry in entries:
             meta = parse_skill_md(str(REPO_ROOT / entry["path"]))
             assert meta is not None
-            assert meta.version == release_version
+            assert meta.version == entry["version"]
 
-    def test_release_please_updates_published_skill_versions(self) -> None:
+    def test_release_please_does_not_mutate_independent_skill_versions(self) -> None:
         entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
         config = json.loads(RELEASE_PLEASE_CONFIG.read_text(encoding="utf-8"))
         extra_files = {item["path"] for item in config["packages"]["."]["extra-files"] if item.get("type") == "generic"}
         for entry in entries:
-            assert f"{entry['path']}/SKILL.md" in extra_files
+            assert f"{entry['path']}/SKILL.md" not in extra_files
 
-    def test_release_workflow_publishes_clawhub_skills_on_release(self) -> None:
-        workflow = yaml_loads(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
-        job = workflow["jobs"]["publish-clawhub-skills"]
-        assert job["needs"] == ["release-please"]
-        assert job["if"] == "needs.release-please.outputs.release_created == 'true'"
-        assert job["uses"] == "./.github/workflows/clawhub.yml"
-        assert job["with"]["checkout-ref"] == "${{ needs.release-please.outputs.tag_name }}"
-        assert job["with"]["publish"] is True
-        assert job["secrets"] == "inherit"
+    def test_clawhub_workflow_is_the_independent_publish_stream(self) -> None:
+        workflow = yaml_loads(CLAWHUB_WORKFLOW.read_text(encoding="utf-8"))
+        release_workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        assert workflow["env"]["CLAWHUB_CLI_PACKAGE"] == "clawhub@0.23.1"
+        assert workflow["on"]["workflow_call"]["secrets"]["CLAWHUB_TOKEN"]["required"] is False
+        for event in ("pull_request", "push"):
+            assert workflow["on"][event]["branches"] == ["main"]
+            assert ".github/clawhub-skills.json" in workflow["on"][event]["paths"]
+            assert "skills/**" in workflow["on"][event]["paths"]
+        steps = {step["name"]: step for step in workflow["jobs"]["sync-skills"]["steps"] if "name" in step}
+        dry_run = steps["Dry-run ClawHub publish"]
+        publish = steps["Publish skills to ClawHub"]
+        assert steps["Set up Rust"]["uses"] == "dtolnay/rust-toolchain@stable"
+        assert "cargo-clippy" in steps["Remove pre-installed Rust component shims"]["run"]
+        assert dry_run["run"] == "python scripts/clawhub_sync.py --dry-run"
+        assert "github.event_name == 'pull_request'" in dry_run["if"]
+        assert publish["run"] == "python scripts/clawhub_sync.py"
+        assert "github.event_name == 'push' && github.ref == 'refs/heads/main'" in publish["if"]
+        assert "publish-clawhub-skills:" not in release_workflow

--- a/tests/test_dcc_mcp_skill.py
+++ b/tests/test_dcc_mcp_skill.py
@@ -13,7 +13,7 @@ import dcc_mcp_core
 
 DCC_MCP_SKILL_DIR = str(REPO_ROOT / "skills" / "dcc-mcp")
 CHECK_SCRIPT = Path(DCC_MCP_SKILL_DIR) / "scripts" / "check_cli.py"
-RELEASE_MANIFEST = REPO_ROOT / ".release-please-manifest.json"
+CLAWHUB_MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
 
 sys.path.insert(0, str(CHECK_SCRIPT.parent))
 import check_cli as check_cli_mod  # noqa: E402
@@ -30,8 +30,9 @@ class TestDccMcpSkill:
         meta = dcc_mcp_core.parse_skill_md(DCC_MCP_SKILL_DIR)
         assert meta is not None
         assert meta.name == "dcc-mcp"
-        release_version = json.loads(RELEASE_MANIFEST.read_text(encoding="utf-8"))["."]
-        assert meta.version == release_version
+        entries = json.loads(CLAWHUB_MANIFEST.read_text(encoding="utf-8"))
+        manifest_version = next(entry["version"] for entry in entries if entry["slug"] == "dcc-mcp")
+        assert meta.version == manifest_version
 
     def test_validate_skill_clean(self) -> None:
         report = dcc_mcp_core.validate_skill(DCC_MCP_SKILL_DIR)

--- a/tests/test_docs_workflows.py
+++ b/tests/test_docs_workflows.py
@@ -1,0 +1,61 @@
+"""Documentation workflow resilience tests."""
+
+from __future__ import annotations
+
+from conftest import REPO_ROOT
+from dcc_mcp_core import yaml_loads
+
+DOCS_CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs-ci.yml"
+DEPLOY_DOCS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-docs.yml"
+NPM_CI_ACTION = REPO_ROOT / ".github" / "actions" / "npm-ci-with-retry" / "action.yml"
+NPM_CI_ACTION_REF = "./.github/actions/npm-ci-with-retry"
+
+
+def _load_yaml(path):
+    return yaml_loads(path.read_text(encoding="utf-8"))
+
+
+def _install_step(workflow_path):
+    workflow = _load_yaml(workflow_path)
+    return next(step for step in workflow["jobs"]["build"]["steps"] if step["name"] == "Install dependencies")
+
+
+def test_docs_workflows_share_bounded_npm_ci_retry_action() -> None:
+    expected_step = {
+        "name": "Install dependencies",
+        "uses": NPM_CI_ACTION_REF,
+        "with": {"working-directory": "docs"},
+    }
+
+    assert _install_step(DOCS_CI_WORKFLOW) == expected_step
+    assert _install_step(DEPLOY_DOCS_WORKFLOW) == expected_step
+
+
+def test_npm_ci_retry_action_is_bounded_and_fail_closed() -> None:
+    action = _load_yaml(NPM_CI_ACTION)
+    step = action["runs"]["steps"][0]
+    script = step["run"]
+
+    assert action["runs"]["using"] == "composite"
+    assert step["working-directory"] == "${{ inputs.working-directory }}"
+    assert step["env"] == {
+        "NPM_CONFIG_FETCH_RETRIES": "3",
+        "NPM_CONFIG_FETCH_RETRY_MINTIMEOUT": "20000",
+        "NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT": "120000",
+    }
+    assert "for attempt in 1 2 3" in script
+    assert "npm ci --prefer-offline --no-audit" in script
+    assert 'if [[ "$attempt" -eq 3 ]]' in script
+    assert "exit 1" in script
+
+
+def test_docs_ci_runs_when_retry_or_docs_workflow_changes() -> None:
+    workflow = _load_yaml(DOCS_CI_WORKFLOW)
+    expected_paths = {
+        ".github/actions/npm-ci-with-retry/**",
+        ".github/workflows/deploy-docs.yml",
+        ".github/workflows/docs-ci.yml",
+    }
+
+    assert expected_paths <= set(workflow["on"]["pull_request"]["paths"])
+    assert expected_paths <= set(workflow["on"]["push"]["paths"])

--- a/tests/test_package_openclaw_skill.py
+++ b/tests/test_package_openclaw_skill.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 from zipfile import ZipFile
+
+import pytest
 
 from conftest import REPO_ROOT
 
 SCRIPT = REPO_ROOT / "scripts" / "package_openclaw_skill.py"
+MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
 
 
 def load_packager():
@@ -46,3 +53,177 @@ def test_package_excludes_python_cache_and_bytecode(tmp_path: Path) -> None:
         "dcc-mcp/agents/openai.yaml",
         "dcc-mcp/scripts/helper.py",
     }
+
+
+def test_manifest_packages_each_skill_with_its_independent_version(tmp_path: Path) -> None:
+    packager = load_packager()
+    repo_root = tmp_path / "repo"
+    first = repo_root / "skills" / "first"
+    second = repo_root / "skills" / "second"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "SKILL.md").write_text("---\nname: first\n---\n", encoding="utf-8")
+    (second / "SKILL.md").write_text("---\nname: second\n---\n", encoding="utf-8")
+    manifest = repo_root / "clawhub-skills.json"
+    manifest.write_text(
+        json.dumps(
+            [
+                {"path": "skills/first", "version": "1.2.3"},
+                {"path": "skills/second", "version": "2.0.0"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    releases = packager.resolve_manifest_skills(manifest, repo_root)
+    output_dir = tmp_path / "dist"
+    output_dir.mkdir()
+    archives = [packager.package_skill(skill_dir, output_dir, version) for skill_dir, version in releases]
+
+    assert [archive.name for archive in archives] == ["first-1.2.3.zip", "second-2.0.0.zip"]
+
+
+def test_manifest_cli_packages_the_repository_suite(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), str(MANIFEST), str(tmp_path), "--manifest"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    expected = {f"{Path(entry['path']).name}-{entry['version']}.zip" for entry in entries}
+    assert {path.name for path in tmp_path.glob("*.zip")} == expected
+
+
+def test_package_rejects_symbolic_links(tmp_path: Path) -> None:
+    packager = load_packager()
+    skill_dir = tmp_path / "skills" / "example"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: example\n---\n", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret\n", encoding="utf-8")
+    link = skill_dir / "outside.txt"
+    try:
+        link.symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"symbolic links are unavailable: {error}")
+
+    with pytest.raises(ValueError, match="symbolic link"):
+        list(packager.iter_skill_files(skill_dir))
+
+
+def test_package_all_rejects_symbolic_link_skill_directory(tmp_path: Path) -> None:
+    packager = load_packager()
+    skills_root = tmp_path / "skills"
+    real_skill = tmp_path / "real-skill"
+    skills_root.mkdir()
+    real_skill.mkdir()
+    (real_skill / "SKILL.md").write_text("---\nname: linked\n---\n", encoding="utf-8")
+    linked_skill = skills_root / "linked"
+    try:
+        linked_skill.symlink_to(real_skill, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"symbolic links are unavailable: {error}")
+
+    with pytest.raises(ValueError, match="symbolic-link Skill directory"):
+        packager.resolve_skill_dirs(skills_root, package_all=True)
+
+
+def test_package_all_containment_catches_unreported_directory_link(tmp_path: Path, monkeypatch) -> None:
+    packager = load_packager()
+    skills_root = tmp_path / "skills"
+    real_skill = tmp_path / "real-skill"
+    skills_root.mkdir()
+    real_skill.mkdir()
+    (real_skill / "SKILL.md").write_text("---\nname: linked\n---\n", encoding="utf-8")
+    linked_skill = skills_root / "linked"
+    try:
+        linked_skill.symlink_to(real_skill, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"directory links are unavailable: {error}")
+    original_is_symlink = Path.is_symlink
+
+    def hide_link_from_pathlib(path: Path) -> bool:
+        if path == linked_skill:
+            return False
+        return original_is_symlink(path)
+
+    monkeypatch.setattr(Path, "is_symlink", hide_link_from_pathlib)
+    with pytest.raises(ValueError, match="Skill directory escapes skills root"):
+        packager.resolve_skill_dirs(skills_root, package_all=True)
+
+
+def test_package_rejects_unsafe_direct_version(tmp_path: Path) -> None:
+    packager = load_packager()
+    skill_dir = tmp_path / "skills" / "example"
+    output_dir = tmp_path / "dist"
+    skill_dir.mkdir(parents=True)
+    output_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("---\nname: example\n---\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid stable Skill archive version"):
+        packager.package_skill(skill_dir, output_dir, "../../victim")
+
+
+def test_package_rejects_output_inside_skill_directory(tmp_path: Path) -> None:
+    packager = load_packager()
+    skill_dir = tmp_path / "skills" / "example"
+    output_dir = skill_dir / "dist"
+    output_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: example\n---\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="output directory cannot be inside Skill directory"):
+        packager.package_skill(skill_dir, output_dir, "1.2.3")
+
+
+def test_python37_workspace_version_fallback_parser() -> None:
+    packager = load_packager()
+    raw = """
+[workspace]
+members = []
+
+[workspace.package]
+version = "1.2.3" # release
+edition = "2021"
+"""
+
+    assert packager.workspace_version_from_text(raw) == "1.2.3"
+
+
+def test_package_is_reproducible_across_source_mtime_changes(tmp_path: Path) -> None:
+    packager = load_packager()
+    skill_dir = tmp_path / "skills" / "example"
+    skill_dir.mkdir(parents=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text("---\nname: example\n---\n", encoding="utf-8")
+    first_output = tmp_path / "first"
+    second_output = tmp_path / "second"
+    first_output.mkdir()
+    second_output.mkdir()
+
+    first_bytes = packager.package_skill(skill_dir, first_output, "1.2.3").read_bytes()
+    stat = skill_md.stat()
+    os.utime(skill_md, (stat.st_atime + 60, stat.st_mtime + 60))
+    second_bytes = packager.package_skill(skill_dir, second_output, "1.2.3").read_bytes()
+
+    assert first_bytes == second_bytes
+
+
+@pytest.mark.parametrize("version", ["", "next", "../1.2.3", "1.2.3-01", "1.2.3-rc.1"])
+def test_manifest_rejects_unsafe_versions(tmp_path: Path, version: str) -> None:
+    packager = load_packager()
+    repo_root = tmp_path / "repo"
+    skill_dir = repo_root / "skills" / "example"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: example\n---\n", encoding="utf-8")
+    manifest = repo_root / "clawhub-skills.json"
+    manifest.write_text(
+        json.dumps([{"path": "skills/example", "version": version}]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        packager.resolve_manifest_skills(manifest, repo_root)


### PR DESCRIPTION
## Summary
- decouple the three public Skill versions from core releases and publish 0.19.64 from the manifest
- pin ClawHub 0.23.1 and verify owner-visible source files, fingerprints, and security status after upload
- harden deterministic Skill packaging against path, symlink, junction, and version escapes
- share a bounded, fail-closed npm dependency retry across docs checks and deployment

## Validation
- 70 focused ClawHub/package/Skill/docs workflow tests
- 54 bundled Skill/scaffold/E2E tests
- actionlint and ruff
- real ClawHub 0.19.64 dry-run for all three Skills
- Python 3.7 direct packaging smoke test