### PR TITLE
fix(ui-control): preserve stateful Windows sessions and bound target lifecycle

### DIFF
--- a/crates/dcc-mcp-computer-use/src/keyboard_policy.rs
+++ b/crates/dcc-mcp-computer-use/src/keyboard_policy.rs
@@ -153,6 +153,25 @@ pub(crate) fn is_unmodified_text_entry(keys: &[String]) -> bool {
     false
 }
 
+/// Return true for a genuine application shortcut with Ctrl or Alt plus an
+/// action key. Shift-only and focus-dependent navigation/function keys remain
+/// ordinary keypresses.
+pub(crate) fn is_modified_shortcut(keys: &[String]) -> bool {
+    let mut shortcut_modifier = false;
+    let mut action_key = false;
+    for token in keys.iter().flat_map(|item| item.split('+')).map(str::trim) {
+        if token.is_empty() {
+            continue;
+        }
+        match common_key(token) {
+            Some(CommonKey::Control(_) | CommonKey::Alt(_)) => shortcut_modifier = true,
+            Some(CommonKey::Shift(_)) => {}
+            Some(_) | None => action_key = true,
+        }
+    }
+    shortcut_modifier && action_key
+}
+
 /// Classify chords that can escape the bound DCC or invoke system UI.
 pub(crate) fn shortcut_risk(keys: &[String]) -> ShortcutRisk {
     let mut control = false;
@@ -262,6 +281,17 @@ mod tests {
         }
         for chord in ["LEFT", "ENTER", "F5", "CTRL+A", "ALT+A"] {
             assert!(!is_unmodified_text_entry(&[chord.to_owned()]), "{chord}");
+        }
+    }
+
+    #[test]
+    fn modified_shortcuts_require_ctrl_or_alt_and_an_action_key() {
+        for chord in ["CTRL+P", "CONTROL_L+SHIFT+P", "ALT+F4", "RIGHTALT+ENTER"] {
+            assert!(is_modified_shortcut(&[chord.to_owned()]), "{chord}");
+        }
+        assert!(is_modified_shortcut(&["CTRL".to_owned(), "P".to_owned()]));
+        for keys in ["ENTER", "F5", "SHIFT+P", "CTRL", "ALT+SHIFT"] {
+            assert!(!is_modified_shortcut(&[keys.to_owned()]), "{keys}");
         }
     }
 

--- a/crates/dcc-mcp-computer-use/src/lib.rs
+++ b/crates/dcc-mcp-computer-use/src/lib.rs
@@ -472,7 +472,11 @@ impl ComputerUseSession {
         let target = self.resolve_target()?;
         self.trusted_scope.validate_target(&target)?;
         platform::validate_target_policy(target.handle, target.pid, &target.title)?;
-        platform::prepare_target_window(target.handle)?;
+        // Session ownership and the global Esc watcher must exist before any
+        // capability-bound restore/show/activate transition. A minimized or
+        // hidden exact HWND is therefore allowed to start with its cosmetic
+        // overlay hidden; screenshots still require an available target.
+        platform::prepare_control_session_target(target.handle, target.pid)?;
         let interrupted = Arc::new(AtomicBool::new(false));
         let overlay_visible = Arc::new(AtomicBool::new(false));
         let desktop_state = Arc::new(AtomicU64::new(desktop_state_value(1, true)));

--- a/crates/dcc-mcp-computer-use/src/lib_tests.rs
+++ b/crates/dcc-mcp-computer-use/src/lib_tests.rs
@@ -380,6 +380,72 @@ fn public_perform_restores_a_minimized_observed_window_before_rect_validation() 
     platform::clear_user_interrupt().unwrap();
 }
 
+#[cfg(windows)]
+#[test]
+fn minimized_target_start_owns_input_and_esc_watcher_before_restore() {
+    use windows::Win32::System::Threading::GetCurrentProcessId;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DestroyWindow, IsIconic, SW_MINIMIZE, ShowWindow, WINDOW_EX_STYLE,
+        WINDOW_STYLE, WS_OVERLAPPEDWINDOW, WS_VISIBLE,
+    };
+    use windows::core::PCWSTR;
+
+    struct TestWindow(windows::Win32::Foundation::HWND);
+    impl Drop for TestWindow {
+        fn drop(&mut self) {
+            let _ = unsafe { DestroyWindow(self.0) };
+        }
+    }
+
+    let _interrupt_guard = user_interrupt_test_guard();
+    let _dpi_awareness = platform::ThreadDpiAwareness::enter().unwrap();
+    platform::clear_user_interrupt().unwrap();
+    let class = "STATIC\0".encode_utf16().collect::<Vec<_>>();
+    let title = "DCC MCP minimized pre-snapshot owner target\0"
+        .encode_utf16()
+        .collect::<Vec<_>>();
+    let hwnd = unsafe {
+        CreateWindowExW(
+            WINDOW_EX_STYLE::default(),
+            PCWSTR(class.as_ptr()),
+            PCWSTR(title.as_ptr()),
+            WINDOW_STYLE(WS_OVERLAPPEDWINDOW.0 | WS_VISIBLE.0),
+            200,
+            200,
+            640,
+            480,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+    .unwrap();
+    let _target_window = TestWindow(hwnd);
+    let handle = hwnd.0 as usize as u64;
+    let process_id = unsafe { GetCurrentProcessId() };
+    let _ = unsafe { ShowWindow(hwnd, SW_MINIMIZE) };
+    assert!(unsafe { IsIconic(hwnd) }.as_bool());
+
+    let session = ComputerUseSession::new(
+        ComputerUseTargetScope::new(Some(process_id), Some(handle)).unwrap(),
+        Some(process_id),
+        Some(handle),
+        None,
+        Some("test DCC".to_string()),
+    )
+    .unwrap();
+    let started = session.start().unwrap();
+
+    assert_eq!(started["active"], true);
+    assert_eq!(started["overlay_visible"], false);
+    assert_ne!(session.lock_state().desktop_barrier.window_handle(), 0);
+    assert!(platform::input_owner_is_busy_for_test());
+
+    let _ = session.stop();
+    platform::clear_user_interrupt().unwrap();
+}
+
 #[test]
 fn target_constraints_are_an_intersection() {
     let spec = TargetSpec {

--- a/crates/dcc-mcp-computer-use/src/platform.rs
+++ b/crates/dcc-mcp-computer-use/src/platform.rs
@@ -128,13 +128,15 @@ pub(crate) enum ScopedWindowOperation {
 #[cfg(windows)]
 pub(crate) use windows::{
     ThreadDpiAwareness, clear_user_interrupt, desktop_interactive, flush_pending_input_releases,
-    perform_action, prepare_target_for_input, prepare_target_window, scoped_window_state,
-    start_control_banner, synchronize_desktop_events, transition_scoped_window, user_interrupted,
-    validate_target_policy, window_dpi,
+    perform_action, prepare_control_session_target, prepare_target_for_input,
+    prepare_target_window, scoped_window_state, start_control_banner, synchronize_desktop_events,
+    transition_scoped_window, user_interrupted, validate_target_policy, window_dpi,
 };
 
 #[cfg(all(test, windows))]
-pub(crate) use windows::{TestIsolationGuard, acquire_test_isolation_guard};
+pub(crate) use windows::{
+    TestIsolationGuard, acquire_test_isolation_guard, input_owner_is_busy_for_test,
+};
 
 #[cfg(not(windows))]
 pub(crate) struct ThreadDpiAwareness;
@@ -148,6 +150,17 @@ impl ThreadDpiAwareness {
 
 #[cfg(not(windows))]
 pub(crate) fn prepare_target_window(_window_handle: u64) -> ComputerUseResult<()> {
+    Err(ComputerUseError::new(
+        ComputerUseErrorCode::BackendUnavailable,
+        "native DCC MCP Computer Use is currently available on Windows",
+    ))
+}
+
+#[cfg(not(windows))]
+pub(crate) fn prepare_control_session_target(
+    _window_handle: u64,
+    _expected_process_id: u32,
+) -> ComputerUseResult<()> {
     Err(ComputerUseError::new(
         ComputerUseErrorCode::BackendUnavailable,
         "native DCC MCP Computer Use is currently available on Windows",

--- a/crates/dcc-mcp-computer-use/src/platform/windows.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows.rs
@@ -420,6 +420,17 @@ fn acquire_input_owner() -> ComputerUseResult<NamedMutexOwner> {
     acquire_input_owner_impl(false)
 }
 
+#[cfg(test)]
+pub(crate) fn input_owner_is_busy_for_test() -> bool {
+    matches!(
+        acquire_input_owner(),
+        Err(ComputerUseError {
+            code: ComputerUseErrorCode::PermissionDenied,
+            ..
+        })
+    )
+}
+
 fn acquire_input_owner_after_user_approval() -> ComputerUseResult<NamedMutexOwner> {
     acquire_input_owner_impl(true)
 }
@@ -615,6 +626,15 @@ pub(crate) fn prepare_target_window(window_handle: u64) -> ComputerUseResult<()>
     }
     let _ = available_target_rect(hwnd)?;
     Ok(())
+}
+
+pub(crate) fn prepare_control_session_target(
+    window_handle: u64,
+    expected_process_id: u32,
+) -> ComputerUseResult<()> {
+    ensure_interactive_desktop()?;
+    let hwnd = HWND(window_handle as *mut core::ffi::c_void);
+    validate_target_identity(hwnd, expected_process_id)
 }
 
 pub(crate) fn scoped_window_state(
@@ -1224,8 +1244,29 @@ fn run_banner(
     ensure_interactive_desktop()?;
     let target = HWND(window_handle as *mut core::ffi::c_void);
     let caption = format!("DCC UI Control  ·  {app_name}  ·  {STOP_HOTKEY_LABEL} to stop");
-    let mut rect = available_target_rect_for_process(target, process_id)?;
-    let overlay = ControlOverlay::new(target, &rect, &caption)?;
+    let (mut rect, initially_visible) = match available_target_rect_for_process(target, process_id)
+    {
+        Ok(rect) => (rect, true),
+        Err(error) if error.code == ComputerUseErrorCode::MissingWindow => {
+            // A capability can intentionally bind a minimized or hidden
+            // exact HWND so it can be restored. Revalidate existence and
+            // ownership, then create the control window hidden at benign
+            // placeholder geometry. The input owner, Esc hotkey, desktop
+            // watcher, and generation fences remain fully active.
+            validate_target_identity(target, process_id)?;
+            (
+                RECT {
+                    left: 0,
+                    top: 0,
+                    right: 320,
+                    bottom: 200,
+                },
+                false,
+            )
+        }
+        Err(error) => return Err(error),
+    };
+    let overlay = ControlOverlay::new(target, &rect, &caption, initially_visible)?;
     let overlay_window = overlay.window_handle();
 
     let hotkey_result = unsafe {
@@ -1251,7 +1292,7 @@ fn run_banner(
     let mut display_stamp = display_environment_stamp()?;
 
     record_desktop_transition(&signals.desktop_state, true);
-    signals.visible.store(true, Ordering::Release);
+    signals.visible.store(initially_visible, Ordering::Release);
     let _ = ready.send(Ok(()));
 
     let mut message = MSG::default();
@@ -1345,13 +1386,14 @@ fn run_banner(
             Ok(rect) => rect,
             Err(error) if error.code == ComputerUseErrorCode::MissingWindow => {
                 validate_target_identity(target, process_id)?;
-                if let Err(e) = overlay.set_visible(false) {
+                if signals.visible.swap(false, Ordering::AcqRel)
+                    && let Err(e) = overlay.set_visible(false)
+                {
                     tracing::warn!(
                         "run_banner: overlay.set_visible(false) failed on MissingWindow; \
                          session continues: {e}"
                     );
                 }
-                signals.visible.store(false, Ordering::Release);
                 thread::sleep(Duration::from_millis(50));
                 continue;
             }

--- a/crates/dcc-mcp-computer-use/src/platform/windows/input.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/input.rs
@@ -1031,6 +1031,7 @@ fn keypress(
     let _focus_elevation = focus_target(window_handle, process_id)?;
     guard.check()?;
     run_pre_input_fence(pre_input_fence)?;
+    ensure_target_foreground(window_handle, process_id)?;
     send_inputs(&inputs)?;
     guard.check()
 }

--- a/crates/dcc-mcp-computer-use/src/platform/windows/overlay.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/overlay.rs
@@ -39,7 +39,12 @@ pub(super) struct ControlOverlay {
 }
 
 impl ControlOverlay {
-    pub(super) fn new(target: HWND, target_rect: &RECT, caption: &str) -> ComputerUseResult<Self> {
+    pub(super) fn new(
+        target: HWND,
+        target_rect: &RECT,
+        caption: &str,
+        initially_visible: bool,
+    ) -> ComputerUseResult<Self> {
         let (capsule_geometry, corner_geometries) = overlay_geometries(target, target_rect)?;
         let mut capsule_glows = Vec::with_capacity(CONTROL_CAPSULE_GLOW_ALPHAS.len());
         for (geometry, alpha) in capsule_glow_geometries(capsule_geometry) {
@@ -136,7 +141,9 @@ impl ControlOverlay {
             cursor_visible: Cell::new(cursor_visible),
             pulse_started: Instant::now(),
         };
-        overlay.set_visible(true)?;
+        if initially_visible {
+            overlay.set_visible(true)?;
+        }
         Ok(overlay)
     }
 

--- a/crates/dcc-mcp-computer-use/src/ui_control_host.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host.rs
@@ -1,9 +1,6 @@
 //! Isolated UI Control host state machine and executable entry point.
 
 use std::collections::{HashMap, HashSet};
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::PathBuf;
 
 use dcc_mcp_ui_control::host_protocol::{
     UI_CONTROL_HOST_CAPABILITIES, UI_CONTROL_HOST_PROTOCOL_VERSION, UiControlAction,
@@ -12,11 +9,12 @@ use dcc_mcp_ui_control::host_protocol::{
     UiControlSystemOperation, UiControlTarget, UiControlTaskGrant, UiControlWindowOperation,
     UiControlWindowState,
 };
-use serde_json::{Value, json};
-use time::OffsetDateTime;
-use time::format_description::well_known::Rfc3339;
+use serde_json::Value;
+#[cfg(test)]
+use serde_json::json;
 use uuid::Uuid;
 
+mod audit;
 mod policy;
 #[cfg(windows)]
 mod runtime_windows;
@@ -24,6 +22,7 @@ mod system_operations;
 #[cfg(windows)]
 mod windows;
 
+use audit::{audit_event, audit_system_event};
 #[cfg(any(windows, test))]
 use policy::{ActionControlFence, verify_expected_action_fence};
 use policy::{classify_action, stale_accessibility_state, verify_action_fence};
@@ -70,6 +69,7 @@ struct RuntimeAccessibilityState {
 
 struct RuntimeActionResult {
     message: String,
+    target_closed: bool,
     before_focus_runtime_id: Option<String>,
     after_focus_runtime_id: Option<String>,
 }
@@ -216,6 +216,10 @@ impl UiControlHostConnection {
             }
             _ => None,
         };
+        let completed_window_session = match &request {
+            UiControlHostRequest::ExecuteAction { session_id, .. } => Some(session_id.clone()),
+            _ => None,
+        };
         let response = host.handle(request);
         if let Some(session_id) = consumed_system_session {
             self.owned_system_sessions.remove(&session_id);
@@ -234,6 +238,16 @@ impl UiControlHostConnection {
                 self.owned_system_sessions.remove(session_id);
             }
             _ => {}
+        }
+        if matches!(
+            response,
+            UiControlHostResponse::ActionCompleted {
+                target_closed: true,
+                ..
+            }
+        ) && let Some(session_id) = completed_window_session
+        {
+            self.owned_sessions.remove(&session_id);
         }
         response
     }
@@ -779,14 +793,23 @@ impl UiControlHost {
         {
             Ok(result) => {
                 audit_event(&session.grant, &action.action, true, policy_tier, None);
-                action_response(
+                let target_closed = result.target_closed;
+                if target_closed {
+                    let _ = session.runtime.stop();
+                }
+                let response = completed_action_response(
                     true,
+                    target_closed,
                     policy_tier,
                     result.message,
                     None,
                     result.before_focus_runtime_id,
                     result.after_focus_runtime_id,
-                )
+                );
+                if target_closed {
+                    self.sessions.remove(session_id);
+                }
+                response
             }
             Err(failure) => {
                 audit_event(
@@ -1290,80 +1313,36 @@ fn action_response(
     before_focus_runtime_id: Option<String>,
     after_focus_runtime_id: Option<String>,
 ) -> UiControlHostResponse {
+    completed_action_response(
+        success,
+        false,
+        policy_tier,
+        message,
+        error,
+        before_focus_runtime_id,
+        after_focus_runtime_id,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn completed_action_response(
+    success: bool,
+    target_closed: bool,
+    policy_tier: UiControlPolicyTier,
+    message: impl Into<String>,
+    error: Option<UiControlHostErrorCode>,
+    before_focus_runtime_id: Option<String>,
+    after_focus_runtime_id: Option<String>,
+) -> UiControlHostResponse {
     UiControlHostResponse::ActionCompleted {
         success,
+        target_closed,
         policy_tier,
         message: message.into(),
         error,
         before_focus_runtime_id,
         after_focus_runtime_id,
     }
-}
-
-fn audit_event(
-    grant: &UiControlTaskGrant,
-    action: &str,
-    success: bool,
-    policy_tier: UiControlPolicyTier,
-    error_code: Option<UiControlHostErrorCode>,
-) {
-    audit_event_for_dcc(&grant.dcc_type, action, success, policy_tier, error_code);
-}
-
-fn audit_system_event(
-    grant: &UiControlSystemGrant,
-    action: &str,
-    success: bool,
-    policy_tier: UiControlPolicyTier,
-    error_code: Option<UiControlHostErrorCode>,
-) {
-    audit_event_for_dcc(&grant.dcc_type, action, success, policy_tier, error_code);
-}
-
-fn audit_event_for_dcc(
-    dcc_type: &str,
-    action: &str,
-    success: bool,
-    policy_tier: UiControlPolicyTier,
-    error_code: Option<UiControlHostErrorCode>,
-) {
-    let payload = json!({
-        "event": "ui_control_operation",
-        "tool": "dcc-mcp-ui-control-host",
-        "dcc_type": dcc_type,
-        "action": action,
-        "success": success,
-        "error": error_code,
-        "message": if success { "DCC UI Control host operation succeeded" } else { "DCC UI Control host operation rejected" },
-        "detail": format!("action={action} tier={policy_tier:?}"),
-    });
-    let timestamp = OffsetDateTime::now_utc()
-        .format(&Rfc3339)
-        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
-    let level = if success { "INFO" } else { "WARN" };
-    let line = format!(
-        "{timestamp} {level} dcc_mcp_ui_control_host.audit: {}\n",
-        payload
-    );
-    eprint!("{line}");
-    let path = audit_log_path();
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
-        let _ = file.write_all(line.as_bytes());
-    }
-}
-
-fn audit_log_path() -> PathBuf {
-    let directory = std::env::var_os("DCC_MCP_LOG_DIR")
-        .map(PathBuf::from)
-        .or_else(|| dcc_mcp_paths::get_log_dir().ok().map(PathBuf::from))
-        .unwrap_or_else(std::env::temp_dir);
-    directory.join(format!(
-        "dcc-mcp-ui-control-host.{}.log",
-        std::process::id()
-    ))
 }
 
 #[cfg(windows)]

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/audit.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/audit.rs
@@ -1,0 +1,76 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+
+use dcc_mcp_ui_control::host_protocol::{
+    UiControlHostErrorCode, UiControlPolicyTier, UiControlSystemGrant, UiControlTaskGrant,
+};
+use serde_json::json;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+pub(super) fn audit_event(
+    grant: &UiControlTaskGrant,
+    action: &str,
+    success: bool,
+    policy_tier: UiControlPolicyTier,
+    error_code: Option<UiControlHostErrorCode>,
+) {
+    audit_event_for_dcc(&grant.dcc_type, action, success, policy_tier, error_code);
+}
+
+pub(super) fn audit_system_event(
+    grant: &UiControlSystemGrant,
+    action: &str,
+    success: bool,
+    policy_tier: UiControlPolicyTier,
+    error_code: Option<UiControlHostErrorCode>,
+) {
+    audit_event_for_dcc(&grant.dcc_type, action, success, policy_tier, error_code);
+}
+
+fn audit_event_for_dcc(
+    dcc_type: &str,
+    action: &str,
+    success: bool,
+    policy_tier: UiControlPolicyTier,
+    error_code: Option<UiControlHostErrorCode>,
+) {
+    let payload = json!({
+        "event": "ui_control_operation",
+        "tool": "dcc-mcp-ui-control-host",
+        "dcc_type": dcc_type,
+        "action": action,
+        "success": success,
+        "error": error_code,
+        "message": if success { "DCC UI Control host operation succeeded" } else { "DCC UI Control host operation rejected" },
+        "detail": format!("action={action} tier={policy_tier:?}"),
+    });
+    let timestamp = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+    let level = if success { "INFO" } else { "WARN" };
+    let line = format!(
+        "{timestamp} {level} dcc_mcp_ui_control_host.audit: {}\n",
+        payload
+    );
+    eprint!("{line}");
+    let path = audit_log_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+        let _ = file.write_all(line.as_bytes());
+    }
+}
+
+fn audit_log_path() -> PathBuf {
+    let directory = std::env::var_os("DCC_MCP_LOG_DIR")
+        .map(PathBuf::from)
+        .or_else(|| dcc_mcp_paths::get_log_dir().ok().map(PathBuf::from))
+        .unwrap_or_else(std::env::temp_dir);
+    directory.join(format!(
+        "dcc-mcp-ui-control-host.{}.log",
+        std::process::id()
+    ))
+}

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/policy.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/policy.rs
@@ -120,6 +120,17 @@ fn action_control_fences(
             .as_deref()
             .ok_or_else(stale_accessibility_state)?;
         vec![find_control(root, control_id).ok_or_else(stale_accessibility_state)?]
+    } else if matches!(action.action.as_str(), "keypress" | "keyboard_shortcut")
+        && crate::keyboard_policy::is_modified_shortcut(&action.keys)
+    {
+        // Application shortcuts are scoped by the immutable window capability,
+        // the screen observation, and the native desktop/input fences. They do
+        // not target a child UIA control, so a custom-drawn DCC viewport may
+        // recreate or move focus between ordinary controls without invalidating
+        // them. Keep the stable window root fenced, while the live focus
+        // ancestry is classified on every host and pre-input pass; any root or
+        // policy-tier change fails closed below.
+        vec![root]
     } else if matches!(action.action.as_str(), "keypress" | "keyboard_shortcut") {
         let focus_runtime_id = focus_runtime_id.ok_or_else(stale_accessibility_state)?;
         vec![find_control(root, focus_runtime_id).ok_or_else(stale_accessibility_state)?]

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows.rs
@@ -10,8 +10,8 @@ use dcc_mcp_capture::{CaptureTarget, WindowFinder};
 use dcc_mcp_shm::SharedBuffer;
 use dcc_mcp_ui_control::host_protocol::{
     UiControlAction, UiControlEnsureOutcome, UiControlHostErrorCode, UiControlInputKind,
-    UiControlPolicyTier, UiControlSharedImage, UiControlSystemOperation, UiControlTarget,
-    UiControlTaskGrant, UiControlWindowOperation, UiControlWindowState,
+    UiControlSharedImage, UiControlSystemOperation, UiControlTarget, UiControlTaskGrant,
+    UiControlWindowOperation, UiControlWindowState,
 };
 use serde_json::{Value, json};
 use uuid::Uuid;
@@ -25,8 +25,7 @@ use windows::Win32::System::Registry::{
     RegCloseKey, RegCreateKeyExW, RegQueryValueExW, RegSetValueExW,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
-    GetPropW, GetWindowThreadProcessId, IDYES, IsWindow, MB_DEFBUTTON2, MB_ICONWARNING,
-    MB_SETFOREGROUND, MB_TOPMOST, MB_YESNO, MessageBoxW, RemovePropW, SetPropW,
+    GetPropW, GetWindowThreadProcessId, IsWindow, RemovePropW, SetPropW,
 };
 use windows::core::PCWSTR;
 
@@ -36,10 +35,14 @@ use crate::{
 };
 
 use super::{
-    ActionControlFence, ActionFenceExpectation, ConfirmationKind, ConfirmationSurface, HostFailure,
-    HostRuntime, HostRuntimeSession, RuntimeAccessibilityState, RuntimeActionResult,
-    RuntimeSnapshot, stale_accessibility_state, verify_expected_action_fence,
+    ActionControlFence, ActionFenceExpectation, HostFailure, HostRuntime, HostRuntimeSession,
+    RuntimeAccessibilityState, RuntimeActionResult, RuntimeSnapshot, stale_accessibility_state,
+    verify_expected_action_fence,
 };
+
+mod confirmation;
+
+pub(super) use confirmation::WindowsConfirmationSurface;
 
 const UIA_TIMEOUT: Duration = Duration::from_secs(30);
 const UIA_SCRIPT: &str = include_str!(
@@ -505,6 +508,7 @@ impl HostRuntimeSession for WindowsRuntimeSession {
                     .map_err(map_computer_use_error)?;
                 Ok(RuntimeActionResult {
                     message: format!("completed scoped native action {:?}", action.action),
+                    target_closed: false,
                     before_focus_runtime_id: None,
                     after_focus_runtime_id: None,
                 })
@@ -536,13 +540,23 @@ impl HostRuntimeSession for WindowsRuntimeSession {
                         .and_then(Value::as_str)
                         .unwrap_or("completed scoped Windows UI Automation action")
                         .to_owned(),
+                    target_closed: false,
                     before_focus_runtime_id: optional_string(&raw, "before_focus_runtime_id"),
                     after_focus_runtime_id: optional_string(&raw, "after_focus_runtime_id"),
                 })
             }
         };
-        self.window_generation.verify()?;
-        result
+        let mut result = result?;
+        if self
+            .window_generation
+            .target_closed_after_completed_action()?
+        {
+            result.target_closed = true;
+            result.message.push_str(
+                "; the exact target window closed, so this UI Control session was revoked",
+            );
+        }
+        Ok(result)
     }
 
     fn resume_after_approval(&mut self) -> Result<(), HostFailure> {
@@ -645,6 +659,26 @@ impl WindowGenerationGuard {
         }
         Ok(())
     }
+
+    fn target_closed_after_completed_action(&self) -> Result<bool, HostFailure> {
+        let hwnd = HWND(self.window_handle as usize as *mut core::ffi::c_void);
+        if !unsafe { IsWindow(Some(hwnd)) }.as_bool() {
+            return Ok(true);
+        }
+        let mut process_id = 0;
+        unsafe { GetWindowThreadProcessId(hwnd, Some(&mut process_id)) };
+        let marker = unsafe { GetPropW(hwnd, PCWSTR(self.property_name.as_ptr())) };
+        if process_id != self.process_id || marker.0 as usize != self.marker {
+            if !unsafe { IsWindow(Some(hwnd)) }.as_bool() {
+                return Ok(true);
+            }
+            return Err(HostFailure::new(
+                UiControlHostErrorCode::InvalidTarget,
+                "the exact target HWND generation changed",
+            ));
+        }
+        Ok(false)
+    }
 }
 
 impl Drop for WindowGenerationGuard {
@@ -700,94 +734,6 @@ fn protocol_window_state(state: crate::platform::ScopedWindowState) -> UiControl
         visible: state.visible,
         minimized: state.minimized,
         foreground: state.foreground,
-    }
-}
-
-pub(super) struct WindowsConfirmationSurface;
-
-impl ConfirmationSurface for WindowsConfirmationSurface {
-    fn confirm(
-        &self,
-        kind: ConfirmationKind<'_>,
-        target: Option<&UiControlTarget>,
-        action: Option<&UiControlAction>,
-    ) -> Result<bool, HostFailure> {
-        let (heading, detail) = match kind {
-            ConfirmationKind::ConsequentialAction(UiControlPolicyTier::PreApproval) => (
-                "Approve this DCC UI Control action?",
-                "The action may sign in, upload, move, rename, or transmit identified data.",
-            ),
-            ConfirmationKind::ConsequentialAction(_) => (
-                "Confirm this consequential DCC action?",
-                "The action may delete, overwrite, install, purchase, change access, or submit content.",
-            ),
-            ConfirmationKind::SystemOperation(_) => (
-                "Confirm this Windows configuration change?",
-                "The operation will ensure one exact operator-approved HKCU value or symbolic link.",
-            ),
-            ConfirmationKind::ResumeAfterStop => (
-                "Resume DCC UI Control?",
-                "The global Esc stop latch will be cleared for this Windows session.",
-            ),
-        };
-        let action_name = match kind {
-            ConfirmationKind::SystemOperation(operation) => operation.audit_name(),
-            _ => action
-                .map(|value| value.action.as_str())
-                .unwrap_or("open_session"),
-        };
-        let (scope, privacy) = match kind {
-            ConfirmationKind::SystemOperation(operation) => (
-                system_operation_confirmation_scope(operation),
-                "Registry value data is hidden. The shown key or paths are not written to audit logs.",
-            ),
-            _ => (
-                target.map_or_else(
-                    || "Scope: current Windows user (no DCC window required)".to_owned(),
-                    |target| {
-                        format!(
-                            "Application window: {}\nProcess: {}",
-                            target.window_title, target.process_id
-                        )
-                    },
-                ),
-                "Sensitive text and coordinates are not shown or logged.",
-            ),
-        };
-        let message = format!("{detail}\n\n{scope}\nAction: {action_name}\n\n{privacy}");
-        let message = wide(&message);
-        let heading = wide(heading);
-        let result = unsafe {
-            MessageBoxW(
-                None,
-                PCWSTR(message.as_ptr()),
-                PCWSTR(heading.as_ptr()),
-                MB_YESNO | MB_ICONWARNING | MB_DEFBUTTON2 | MB_SETFOREGROUND | MB_TOPMOST,
-            )
-        };
-        Ok(result == IDYES)
-    }
-}
-
-fn system_operation_confirmation_scope(operation: &UiControlSystemOperation) -> String {
-    match operation {
-        UiControlSystemOperation::EnsureRegistryString {
-            key, value_name, ..
-        }
-        | UiControlSystemOperation::EnsureRegistryDword {
-            key, value_name, ..
-        } => format!(
-            "Scope: current Windows user\nRegistry key: HKEY_CURRENT_USER\\{key}\nValue name: {}",
-            if value_name.is_empty() {
-                "(Default)"
-            } else {
-                value_name
-            }
-        ),
-        UiControlSystemOperation::EnsureFileSymlink { link, target }
-        | UiControlSystemOperation::EnsureDirectorySymlink { link, target } => {
-            format!("Scope: current Windows user\nLink path: {link}\nTarget path: {target}")
-        }
     }
 }
 
@@ -1078,203 +1024,4 @@ fn wide(value: &str) -> Vec<u16> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use windows::Win32::System::Registry::RegDeleteTreeW;
-    use windows::Win32::System::Threading::GetCurrentProcessId;
-    use windows::Win32::UI::WindowsAndMessaging::{
-        CreateWindowExW, DestroyWindow, WINDOW_EX_STYLE, WINDOW_STYLE, WS_OVERLAPPEDWINDOW,
-    };
-
-    struct TestWindow(HWND);
-
-    impl Drop for TestWindow {
-        fn drop(&mut self) {
-            let _ = unsafe { DestroyWindow(self.0) };
-        }
-    }
-
-    struct TestRegistryKey(String);
-
-    impl Drop for TestRegistryKey {
-        fn drop(&mut self) {
-            let key = wide(&self.0);
-            let _ = unsafe { RegDeleteTreeW(HKEY_CURRENT_USER, PCWSTR(key.as_ptr())) };
-        }
-    }
-
-    struct TestSymlinkTree(PathBuf);
-
-    impl Drop for TestSymlinkTree {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_file(self.0.join("file-link"));
-            let _ = std::fs::remove_dir(self.0.join("dir-link"));
-            let _ = std::fs::remove_dir_all(&self.0);
-        }
-    }
-
-    #[test]
-    fn window_generation_marker_detects_capability_replacement() {
-        let class = wide("STATIC");
-        let title = wide("DCC MCP UI Control generation test");
-        let hwnd = unsafe {
-            CreateWindowExW(
-                WINDOW_EX_STYLE::default(),
-                PCWSTR(class.as_ptr()),
-                PCWSTR(title.as_ptr()),
-                WINDOW_STYLE(WS_OVERLAPPEDWINDOW.0),
-                0,
-                0,
-                320,
-                200,
-                None,
-                None,
-                None,
-                None,
-            )
-        }
-        .unwrap();
-        let _window = TestWindow(hwnd);
-        let target = UiControlTarget {
-            process_id: unsafe { GetCurrentProcessId() },
-            window_handle: hwnd.0 as usize as u64,
-            window_title: "DCC generation test".to_owned(),
-        };
-        let guard = WindowGenerationGuard::bind(&target).unwrap();
-        guard.verify().unwrap();
-
-        let _ = unsafe { RemovePropW(hwnd, PCWSTR(guard.property_name.as_ptr())) };
-        let failure = guard.verify().unwrap_err();
-        assert_eq!(failure.code, UiControlHostErrorCode::InvalidTarget);
-    }
-
-    #[test]
-    fn semantic_uia_script_rechecks_the_confirmed_fence_immediately_before_mutation() {
-        let fence_check = UIA_SCRIPT
-            .find("Matches-Expected-Fence $target $payload.expected_fence")
-            .unwrap();
-        let ancestry_check = UIA_SCRIPT[fence_check..]
-            .find("Denied-Action-Target-Reason $root $target")
-            .map(|offset| fence_check + offset)
-            .unwrap();
-        let invoke = UIA_SCRIPT
-            .find("$actionResult = Invoke-Action $target")
-            .unwrap();
-
-        assert!(fence_check < invoke);
-        assert!(fence_check < ancestry_check);
-        assert!(ancestry_check < invoke);
-        assert!(UIA_SCRIPT[fence_check..invoke].contains("stale_observation"));
-        assert!(UIA_SCRIPT.contains("Has-Authentication-Secret-Marker $current"));
-    }
-
-    #[test]
-    fn typed_system_helpers_preserve_registry_and_symlink_contracts() {
-        assert_eq!(registry_string_bytes("ok"), b"o\0k\0\0\0");
-        assert!(path_is_within(
-            Path::new(r"\\?\C:\Program Files\Vendor\plugin"),
-            Path::new(r"C:\Program Files")
-        ));
-
-        let root = std::env::temp_dir().join(format!(
-            "dcc-mcp-system-operation-test-{}",
-            Uuid::new_v4().simple()
-        ));
-        std::fs::create_dir(&root).unwrap();
-        let target = root.join("target.txt");
-        let link = root.join("existing.txt");
-        std::fs::write(&target, b"target").unwrap();
-        std::fs::write(&link, b"keep").unwrap();
-        let failure =
-            ensure_symlink(&link.to_string_lossy(), &target.to_string_lossy(), false).unwrap_err();
-        assert_eq!(failure.code, UiControlHostErrorCode::Conflict);
-        assert_eq!(std::fs::read(&link).unwrap(), b"keep");
-        std::fs::remove_file(link).unwrap();
-        std::fs::remove_file(target).unwrap();
-        std::fs::remove_dir(root).unwrap();
-    }
-
-    #[test]
-    fn registry_ensure_reports_created_updated_and_unchanged() {
-        let key = format!(r"Software\DccMcp\Tests\{}", Uuid::new_v4().simple());
-        let _cleanup = TestRegistryKey(key.clone());
-
-        assert_eq!(
-            ensure_registry_value(&key, "Enabled", REG_SZ, registry_string_bytes("one")).unwrap(),
-            UiControlEnsureOutcome::Created
-        );
-        assert_eq!(
-            ensure_registry_value(&key, "Enabled", REG_SZ, registry_string_bytes("one")).unwrap(),
-            UiControlEnsureOutcome::Unchanged
-        );
-        assert_eq!(
-            ensure_registry_value(&key, "Enabled", REG_SZ, registry_string_bytes("two")).unwrap(),
-            UiControlEnsureOutcome::Updated
-        );
-        assert_eq!(
-            ensure_registry_value(&key, "Enabled", REG_SZ, registry_string_bytes("two")).unwrap(),
-            UiControlEnsureOutcome::Unchanged
-        );
-    }
-
-    #[test]
-    fn file_and_directory_symlinks_report_created_and_unchanged_when_permitted() {
-        let root = std::env::temp_dir().join(format!(
-            "dcc-mcp-symlink-operation-test-{}",
-            Uuid::new_v4().simple()
-        ));
-        std::fs::create_dir(&root).unwrap();
-        let _cleanup = TestSymlinkTree(root.clone());
-        let file_target = root.join("target.txt");
-        let directory_target = root.join("target-dir");
-        std::fs::write(&file_target, b"target").unwrap();
-        std::fs::create_dir(&directory_target).unwrap();
-
-        let file_link = root.join("file-link");
-        let created = ensure_symlink(
-            &file_link.to_string_lossy(),
-            &file_target.to_string_lossy(),
-            false,
-        );
-        if matches!(
-            created,
-            Err(HostFailure {
-                code: UiControlHostErrorCode::ElevationRequired,
-                ..
-            })
-        ) {
-            eprintln!("symlink integration skipped: Windows symlink privilege is unavailable");
-            return;
-        }
-        assert_eq!(created.unwrap(), UiControlEnsureOutcome::Created);
-        assert_eq!(
-            ensure_symlink(
-                &file_link.to_string_lossy(),
-                &file_target.to_string_lossy(),
-                false,
-            )
-            .unwrap(),
-            UiControlEnsureOutcome::Unchanged
-        );
-
-        let directory_link = root.join("dir-link");
-        assert_eq!(
-            ensure_symlink(
-                &directory_link.to_string_lossy(),
-                &directory_target.to_string_lossy(),
-                true,
-            )
-            .unwrap(),
-            UiControlEnsureOutcome::Created
-        );
-        assert_eq!(
-            ensure_symlink(
-                &directory_link.to_string_lossy(),
-                &directory_target.to_string_lossy(),
-                true,
-            )
-            .unwrap(),
-            UiControlEnsureOutcome::Unchanged
-        );
-    }
-}
+mod tests;

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows/confirmation.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows/confirmation.rs
@@ -1,0 +1,652 @@
+use std::cell::RefCell;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use dcc_mcp_ui_control::host_protocol::{
+    UiControlAction, UiControlHostErrorCode, UiControlPolicyTier, UiControlSystemOperation,
+    UiControlTarget,
+};
+use uuid::Uuid;
+use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
+use windows::Win32::System::Threading::{GetCurrentProcessId, GetCurrentThreadId};
+use windows::Win32::UI::WindowsAndMessaging::{
+    CallNextHookEx, DestroyWindow, EndDialog, GetClassNameW, GetWindowTextW,
+    GetWindowThreadProcessId, HCBT_ACTIVATE, HHOOK, IDNO, IDYES, IsWindow, MB_DEFBUTTON2,
+    MB_ICONWARNING, MB_SETFOREGROUND, MB_TOPMOST, MB_YESNO, MessageBoxW, PostMessageW,
+    SetWindowsHookExW, UnhookWindowsHookEx, WH_CBT, WM_CLOSE,
+};
+use windows::core::PCWSTR;
+
+use super::super::{ConfirmationKind, ConfirmationSurface, HostFailure};
+use super::wide;
+
+const CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub(in crate::ui_control_host) struct WindowsConfirmationSurface;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ConfirmationDialogWindow {
+    window_handle: u64,
+    thread_id: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ConfirmationOutcome {
+    approved: bool,
+    dialog: ConfirmationDialogWindow,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ConfirmationWatchdogState {
+    dialog: Option<ConfirmationDialogWindow>,
+    expired: bool,
+    cancelled: bool,
+    capture_error: Option<String>,
+    close_error: Option<String>,
+}
+
+struct ConfirmationWatchdogShared {
+    expected_caption: String,
+    state: Mutex<ConfirmationWatchdogState>,
+    changed: Condvar,
+}
+
+struct ConfirmationHookState {
+    shared: Arc<ConfirmationWatchdogShared>,
+}
+
+thread_local! {
+    static CONFIRMATION_HOOK_STATE: RefCell<Option<ConfirmationHookState>> = const { RefCell::new(None) };
+}
+
+struct ConfirmationHook(HHOOK);
+
+impl Drop for ConfirmationHook {
+    fn drop(&mut self) {
+        let _ = unsafe { UnhookWindowsHookEx(self.0) };
+    }
+}
+
+struct ConfirmationHookStateGuard {
+    active: bool,
+}
+
+impl ConfirmationHookStateGuard {
+    fn take(mut self) -> Option<ConfirmationHookState> {
+        self.active = false;
+        CONFIRMATION_HOOK_STATE.with(|state| state.borrow_mut().take())
+    }
+}
+
+impl Drop for ConfirmationHookStateGuard {
+    fn drop(&mut self) {
+        if self.active {
+            CONFIRMATION_HOOK_STATE.with(|state| {
+                state.borrow_mut().take();
+            });
+        }
+    }
+}
+
+unsafe extern "system" fn confirmation_cbt_hook(
+    code: i32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> windows::Win32::Foundation::LRESULT {
+    if code == HCBT_ACTIVATE as i32 {
+        let dialog = ConfirmationDialogWindow {
+            window_handle: wparam.0 as u64,
+            thread_id: unsafe { GetCurrentThreadId() },
+        };
+        CONFIRMATION_HOOK_STATE.with(|state| {
+            let Ok(state) = state.try_borrow() else {
+                return;
+            };
+            let Some(state) = state.as_ref() else {
+                return;
+            };
+            capture_confirmation_dialog(&state.shared, dialog);
+        });
+    }
+    unsafe { CallNextHookEx(None, code, wparam, lparam) }
+}
+
+fn close_confirmation_dialog_on_owner_thread(hwnd: HWND) -> windows::core::Result<()> {
+    if unsafe { EndDialog(hwnd, IDNO.0 as isize) }.is_ok() {
+        return Ok(());
+    }
+    unsafe { DestroyWindow(hwnd) }
+}
+
+fn watchdog_state(
+    shared: &ConfirmationWatchdogShared,
+) -> std::sync::MutexGuard<'_, ConfirmationWatchdogState> {
+    shared
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn capture_confirmation_dialog(
+    shared: &Arc<ConfirmationWatchdogShared>,
+    dialog: ConfirmationDialogWindow,
+) {
+    let Ok(hwnd) = validate_confirmation_dialog_owner(dialog) else {
+        return;
+    };
+    // This CBT hook is installed only on the current host request thread and
+    // only for the duration of this MessageBoxW call. Capture its first owned
+    // activation even if class/caption inspection fails so an identity error
+    // can close that exact HWND immediately instead of leaving an unbounded
+    // modal surface behind.
+    let identity_error = (confirmation_window_class(hwnd) != "#32770"
+        || confirmation_window_text(hwnd) != shared.expected_caption)
+        .then(|| "the trusted UI Control confirmation HWND identity changed".to_owned());
+    let should_close = {
+        let mut state = watchdog_state(shared);
+        if state.dialog.is_some() {
+            return;
+        }
+        state.dialog = Some(dialog);
+        if let Some(message) = identity_error {
+            state.capture_error = Some(message);
+            state.expired = true;
+        }
+        let should_close = state.expired;
+        shared.changed.notify_all();
+        should_close
+    };
+    if should_close && let Err(error) = close_confirmation_dialog_on_owner_thread(hwnd) {
+        let mut state = watchdog_state(shared);
+        state.close_error = Some(format!(
+            "close the invalid or expired UI Control confirmation surface: {error}"
+        ));
+        shared.changed.notify_all();
+    }
+}
+
+fn confirmation_window_text(hwnd: HWND) -> String {
+    let mut text = vec![0_u16; 512];
+    let copied = unsafe { GetWindowTextW(hwnd, &mut text) }.max(0) as usize;
+    text.truncate(copied);
+    String::from_utf16_lossy(&text)
+}
+
+fn confirmation_window_class(hwnd: HWND) -> String {
+    let mut class_name = [0_u16; 64];
+    let copied = unsafe { GetClassNameW(hwnd, &mut class_name) }.max(0) as usize;
+    String::from_utf16_lossy(&class_name[..copied])
+}
+
+fn validate_confirmation_dialog(
+    dialog: ConfirmationDialogWindow,
+    expected_caption: &str,
+) -> Result<HWND, HostFailure> {
+    let hwnd = validate_confirmation_dialog_owner(dialog)?;
+    if confirmation_window_class(hwnd) != "#32770"
+        || confirmation_window_text(hwnd) != expected_caption
+    {
+        return Err(HostFailure::new(
+            UiControlHostErrorCode::BackendUnavailable,
+            "the trusted UI Control confirmation HWND identity changed",
+        ));
+    }
+    Ok(hwnd)
+}
+
+fn validate_confirmation_dialog_owner(
+    dialog: ConfirmationDialogWindow,
+) -> Result<HWND, HostFailure> {
+    let hwnd = HWND(dialog.window_handle as usize as *mut core::ffi::c_void);
+    if !unsafe { IsWindow(Some(hwnd)) }.as_bool() {
+        return Err(HostFailure::new(
+            UiControlHostErrorCode::BackendUnavailable,
+            "the trusted UI Control confirmation HWND no longer exists",
+        ));
+    }
+    let mut process_id = 0;
+    let thread_id = unsafe { GetWindowThreadProcessId(hwnd, Some(&mut process_id)) };
+    if thread_id != dialog.thread_id || process_id != unsafe { GetCurrentProcessId() } {
+        return Err(HostFailure::new(
+            UiControlHostErrorCode::BackendUnavailable,
+            "the trusted UI Control confirmation HWND changed ownership",
+        ));
+    }
+    Ok(hwnd)
+}
+
+fn confirmation_dialog_still_owned(dialog: ConfirmationDialogWindow) -> bool {
+    let hwnd = HWND(dialog.window_handle as usize as *mut core::ffi::c_void);
+    if !unsafe { IsWindow(Some(hwnd)) }.as_bool() {
+        return false;
+    }
+    let mut process_id = 0;
+    (unsafe { GetWindowThreadProcessId(hwnd, Some(&mut process_id)) }) == dialog.thread_id
+        && process_id == unsafe { GetCurrentProcessId() }
+}
+
+struct ConfirmationWatchdog {
+    shared: Arc<ConfirmationWatchdogShared>,
+    deadline: Instant,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl ConfirmationWatchdog {
+    fn start(expected_caption: String, timeout: Duration) -> Result<Self, HostFailure> {
+        let shared = Arc::new(ConfirmationWatchdogShared {
+            expected_caption,
+            state: Mutex::new(ConfirmationWatchdogState::default()),
+            changed: Condvar::new(),
+        });
+        let deadline = Instant::now() + timeout;
+        let worker_shared = Arc::clone(&shared);
+        let thread = thread::Builder::new()
+            .name("dcc-mcp-ui-control-confirmation-watchdog".to_owned())
+            .spawn(move || run_confirmation_watchdog(&worker_shared, deadline))
+            .map_err(|error| {
+                HostFailure::new(
+                    UiControlHostErrorCode::BackendUnavailable,
+                    format!("start the trusted confirmation expiry watchdog: {error}"),
+                )
+            })?;
+        Ok(Self {
+            shared,
+            deadline,
+            thread: Some(thread),
+        })
+    }
+
+    fn finish(mut self) -> Result<ConfirmationWatchdogState, HostFailure> {
+        {
+            let mut state = watchdog_state(&self.shared);
+            state.cancelled = true;
+            self.shared.changed.notify_all();
+        }
+        let thread = self.thread.take().ok_or_else(|| {
+            HostFailure::new(
+                UiControlHostErrorCode::BackendUnavailable,
+                "the trusted UI Control confirmation watchdog state disappeared",
+            )
+        })?;
+        thread.join().map_err(|_| {
+            HostFailure::new(
+                UiControlHostErrorCode::BackendUnavailable,
+                "the trusted UI Control confirmation watchdog panicked",
+            )
+        })?;
+        Ok(watchdog_state(&self.shared).clone())
+    }
+}
+
+impl Drop for ConfirmationWatchdog {
+    fn drop(&mut self) {
+        {
+            let mut state = watchdog_state(&self.shared);
+            state.cancelled = true;
+            self.shared.changed.notify_all();
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn run_confirmation_watchdog(shared: &Arc<ConfirmationWatchdogShared>, deadline: Instant) {
+    let dialog = {
+        let mut state = watchdog_state(shared);
+        loop {
+            if state.cancelled {
+                return;
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                state.expired = true;
+                let dialog = state.dialog;
+                shared.changed.notify_all();
+                break dialog;
+            }
+            let (next, _) = shared
+                .changed
+                .wait_timeout(state, remaining)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state = next;
+        }
+    };
+    if let Some(dialog) = dialog {
+        expire_confirmation_dialog(shared, dialog);
+    }
+}
+
+fn expire_confirmation_dialog(
+    shared: &Arc<ConfirmationWatchdogShared>,
+    dialog: ConfirmationDialogWindow,
+) {
+    let hwnd = match validate_confirmation_dialog(dialog, &shared.expected_caption) {
+        Ok(hwnd) => hwnd,
+        Err(_) if !confirmation_dialog_still_owned(dialog) => return,
+        Err(failure) => {
+            let mut state = watchdog_state(shared);
+            state.close_error = Some(failure.message);
+            shared.changed.notify_all();
+            return;
+        }
+    };
+    if unsafe { EndDialog(hwnd, IDNO.0 as isize) }.is_ok()
+        || !confirmation_dialog_still_owned(dialog)
+    {
+        return;
+    }
+    if let Err(error) = unsafe { PostMessageW(Some(hwnd), WM_CLOSE, WPARAM(0), LPARAM(0)) } {
+        let mut state = watchdog_state(shared);
+        state.close_error = Some(format!(
+            "close the expired UI Control confirmation surface: {error}"
+        ));
+        shared.changed.notify_all();
+    }
+}
+
+fn run_bounded_confirmation_dialog(
+    caption: String,
+    message: Vec<u16>,
+    operator_timeout: Duration,
+) -> Result<ConfirmationOutcome, HostFailure> {
+    run_bounded_confirmation_dialog_with_identity(
+        caption.clone(),
+        caption,
+        message,
+        operator_timeout,
+    )
+}
+
+fn run_bounded_confirmation_dialog_with_identity(
+    caption: String,
+    expected_caption: String,
+    message: Vec<u16>,
+    operator_timeout: Duration,
+) -> Result<ConfirmationOutcome, HostFailure> {
+    let thread_id = unsafe { GetCurrentThreadId() };
+    let watchdog = ConfirmationWatchdog::start(expected_caption, operator_timeout)?;
+    let deadline = watchdog.deadline;
+    let state_was_installed = CONFIRMATION_HOOK_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        if state.is_some() {
+            return false;
+        }
+        *state = Some(ConfirmationHookState {
+            shared: Arc::clone(&watchdog.shared),
+        });
+        true
+    });
+    if !state_was_installed {
+        return Err(HostFailure::new(
+            UiControlHostErrorCode::BackendUnavailable,
+            "a trusted UI Control confirmation is already active on this thread",
+        ));
+    }
+    let state_guard = ConfirmationHookStateGuard { active: true };
+    let hook = unsafe { SetWindowsHookExW(WH_CBT, Some(confirmation_cbt_hook), None, thread_id) }
+        .map_err(|error| {
+        HostFailure::new(
+            UiControlHostErrorCode::BackendUnavailable,
+            format!("install the trusted confirmation HWND hook: {error}"),
+        )
+    })?;
+    let hook = ConfirmationHook(hook);
+    let wide_caption = wide(&caption);
+    let result = unsafe {
+        MessageBoxW(
+            None,
+            PCWSTR(message.as_ptr()),
+            PCWSTR(wide_caption.as_ptr()),
+            MB_YESNO | MB_ICONWARNING | MB_DEFBUTTON2 | MB_SETFOREGROUND | MB_TOPMOST,
+        )
+    };
+    let message_box_error =
+        (result.0 == 0).then(|| windows::core::Error::from_thread().to_string());
+    let completed_at = Instant::now();
+    drop(hook);
+    state_guard.take().ok_or_else(|| {
+        HostFailure::new(
+            UiControlHostErrorCode::BackendUnavailable,
+            "the trusted UI Control confirmation state disappeared",
+        )
+    })?;
+    let state = watchdog.finish()?;
+    if let Some(dialog) = state.dialog
+        && confirmation_dialog_still_owned(dialog)
+    {
+        return Err(HostFailure::new(
+            UiControlHostErrorCode::BackendUnavailable,
+            "the trusted UI Control confirmation call returned without destroying its HWND",
+        ));
+    }
+    if result.0 == 0 {
+        return Err(HostFailure::new(
+            UiControlHostErrorCode::BackendUnavailable,
+            format!(
+                "show the trusted UI Control confirmation surface: {}",
+                message_box_error
+                    .as_deref()
+                    .unwrap_or("unknown Win32 error")
+            ),
+        ));
+    }
+    let dialog = state.dialog.ok_or_else(|| {
+        HostFailure::new(
+            UiControlHostErrorCode::BackendUnavailable,
+            "the trusted UI Control confirmation HWND was not captured",
+        )
+    })?;
+    if let Some(message) = state.capture_error.as_deref() {
+        return Err(HostFailure::new(
+            UiControlHostErrorCode::BackendUnavailable,
+            message,
+        ));
+    }
+    if let Some(message) = state.close_error.as_deref() {
+        return Err(HostFailure::new(
+            UiControlHostErrorCode::BackendUnavailable,
+            message,
+        ));
+    }
+    Ok(ConfirmationOutcome {
+        approved: confirmation_result_is_approved(
+            result == IDYES,
+            completed_at,
+            deadline,
+            state.expired,
+        ),
+        dialog,
+    })
+}
+
+fn confirmation_result_is_approved(
+    selected_yes: bool,
+    completed_at: Instant,
+    deadline: Instant,
+    expired: bool,
+) -> bool {
+    selected_yes && completed_at < deadline && !expired
+}
+
+impl ConfirmationSurface for WindowsConfirmationSurface {
+    fn confirm(
+        &self,
+        kind: ConfirmationKind<'_>,
+        target: Option<&UiControlTarget>,
+        action: Option<&UiControlAction>,
+    ) -> Result<bool, HostFailure> {
+        let (heading, detail) = match kind {
+            ConfirmationKind::ConsequentialAction(UiControlPolicyTier::PreApproval) => (
+                "Approve this DCC UI Control action?",
+                "The action may sign in, upload, move, rename, or transmit identified data.",
+            ),
+            ConfirmationKind::ConsequentialAction(_) => (
+                "Confirm this consequential DCC action?",
+                "The action may delete, overwrite, install, purchase, change access, or submit content.",
+            ),
+            ConfirmationKind::SystemOperation(_) => (
+                "Confirm this Windows configuration change?",
+                "The operation will ensure one exact operator-approved HKCU value or symbolic link.",
+            ),
+            ConfirmationKind::ResumeAfterStop => (
+                "Resume DCC UI Control?",
+                "The global Esc stop latch will be cleared for this Windows session.",
+            ),
+        };
+        let action_name = match kind {
+            ConfirmationKind::SystemOperation(operation) => operation.audit_name(),
+            _ => action
+                .map(|value| value.action.as_str())
+                .unwrap_or("open_session"),
+        };
+        let (scope, privacy) = match kind {
+            ConfirmationKind::SystemOperation(operation) => (
+                system_operation_confirmation_scope(operation),
+                "Registry value data is hidden. The shown key or paths are not written to audit logs.",
+            ),
+            _ => (
+                target.map_or_else(
+                    || "Scope: current Windows user (no DCC window required)".to_owned(),
+                    |target| {
+                        format!(
+                            "Application window: {}\nProcess: {}",
+                            target.window_title, target.process_id
+                        )
+                    },
+                ),
+                "Sensitive text and coordinates are not shown or logged.",
+            ),
+        };
+        let message = format!(
+            "{detail}\n\n{scope}\nAction: {action_name}\n\n{privacy}\n\nThis confirmation expires after 30 seconds."
+        );
+        let message = wide(&message);
+        let request_marker = Uuid::new_v4().simple().to_string();
+        let caption = format!("{heading} [{}]", &request_marker[..8]);
+        run_bounded_confirmation_dialog(caption, message, CONFIRMATION_TIMEOUT)
+            .map(|outcome| outcome.approved)
+    }
+}
+
+fn system_operation_confirmation_scope(operation: &UiControlSystemOperation) -> String {
+    match operation {
+        UiControlSystemOperation::EnsureRegistryString {
+            key, value_name, ..
+        }
+        | UiControlSystemOperation::EnsureRegistryDword {
+            key, value_name, ..
+        } => format!(
+            "Scope: current Windows user\nRegistry key: HKEY_CURRENT_USER\\{key}\nValue name: {}",
+            if value_name.is_empty() {
+                "(Default)"
+            } else {
+                value_name
+            }
+        ),
+        UiControlSystemOperation::EnsureFileSymlink { link, target }
+        | UiControlSystemOperation::EnsureDirectorySymlink { link, target } => {
+            format!("Scope: current Windows user\nLink path: {link}\nTarget path: {target}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn real_confirmation_timeout_closes_exact_hwnd_on_the_calling_thread() {
+        if !crate::platform::desktop_interactive() {
+            eprintln!("confirmation lifecycle test skipped: Windows desktop is not interactive");
+            return;
+        }
+        let caption = format!(
+            "DCC MCP UI Control lifecycle test [{}]",
+            &Uuid::new_v4().simple().to_string()[..8]
+        );
+        let started = Instant::now();
+
+        let outcome = run_bounded_confirmation_dialog(
+            caption,
+            wide("This test confirmation must close automatically."),
+            Duration::from_millis(100),
+        )
+        .unwrap();
+
+        assert!(!outcome.approved);
+        assert_ne!(outcome.dialog.window_handle, 0);
+        assert_eq!(outcome.dialog.thread_id, unsafe { GetCurrentThreadId() });
+        assert!(!confirmation_dialog_still_owned(outcome.dialog));
+        assert!(started.elapsed() < Duration::from_secs(3));
+    }
+
+    #[test]
+    fn confirmation_identity_failure_closes_the_exact_owned_hwnd_immediately() {
+        if !crate::platform::desktop_interactive() {
+            eprintln!("confirmation lifecycle test skipped: Windows desktop is not interactive");
+            return;
+        }
+        let caption = format!(
+            "DCC MCP UI Control identity failure test [{}]",
+            &Uuid::new_v4().simple().to_string()[..8]
+        );
+        let started = Instant::now();
+
+        let failure = run_bounded_confirmation_dialog_with_identity(
+            caption,
+            "intentionally wrong confirmation caption".to_owned(),
+            wide("This mismatched test confirmation must fail closed immediately."),
+            Duration::from_secs(3),
+        )
+        .unwrap_err();
+
+        assert_eq!(failure.code, UiControlHostErrorCode::BackendUnavailable);
+        assert!(failure.message.contains("HWND identity changed"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn confirmation_watchdog_expires_and_joins_without_an_hwnd() {
+        let watchdog = ConfirmationWatchdog::start(
+            "DCC MCP UI Control missing HWND test".to_owned(),
+            Duration::from_millis(25),
+        )
+        .unwrap();
+        {
+            let state = watchdog_state(&watchdog.shared);
+            let (state, wait_result) = watchdog
+                .shared
+                .changed
+                .wait_timeout_while(state, Duration::from_secs(5), |state| !state.expired)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            assert!(!wait_result.timed_out(), "watchdog did not expire");
+            assert!(state.expired);
+        }
+
+        let state = watchdog.finish().unwrap();
+
+        assert!(state.expired);
+        assert!(state.dialog.is_none());
+    }
+
+    #[test]
+    fn confirmation_yes_at_or_after_deadline_is_never_approved() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_millis(10);
+
+        assert!(confirmation_result_is_approved(true, now, deadline, false));
+        assert!(!confirmation_result_is_approved(
+            true, deadline, deadline, false
+        ));
+        assert!(!confirmation_result_is_approved(
+            true,
+            deadline + Duration::from_millis(1),
+            deadline,
+            false
+        ));
+        assert!(!confirmation_result_is_approved(true, now, deadline, true));
+    }
+}

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows/tests.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows/tests.rs
@@ -1,0 +1,447 @@
+use super::*;
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+
+use dcc_mcp_ui_control::host_protocol::UiControlPolicyTier;
+use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
+use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+use windows::Win32::System::Registry::RegDeleteTreeW;
+use windows::Win32::System::Threading::GetCurrentProcessId;
+use windows::Win32::UI::WindowsAndMessaging::{
+    BS_PUSHBUTTON, CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW,
+    HMENU, MSG, PostMessageW, PostQuitMessage, RegisterClassW, TranslateMessage, WINDOW_EX_STYLE,
+    WINDOW_STYLE, WM_CLOSE, WM_COMMAND, WM_DESTROY, WNDCLASSW, WS_CHILD, WS_OVERLAPPEDWINDOW,
+    WS_VISIBLE,
+};
+use windows::core::w;
+
+struct TestWindow(HWND);
+
+impl Drop for TestWindow {
+    fn drop(&mut self) {
+        let _ = unsafe { DestroyWindow(self.0) };
+    }
+}
+
+const SEMANTIC_CLOSE_BUTTON_ID: usize = 1_001;
+
+unsafe extern "system" fn semantic_close_window_proc(
+    hwnd: HWND,
+    message: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
+    if message == WM_COMMAND && (wparam.0 & 0xffff) == SEMANTIC_CLOSE_BUTTON_ID {
+        let _ = unsafe { DestroyWindow(hwnd) };
+        return LRESULT(0);
+    }
+    if message == WM_DESTROY {
+        unsafe { PostQuitMessage(0) };
+        return LRESULT(0);
+    }
+    unsafe { DefWindowProcW(hwnd, message, wparam, lparam) }
+}
+
+struct SemanticCloseWindow {
+    hwnd: HWND,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl SemanticCloseWindow {
+    fn spawn() -> Self {
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+        let thread = thread::Builder::new()
+            .name("dcc-mcp-semantic-close-test-window".to_owned())
+            .spawn(move || {
+                let instance = unsafe { GetModuleHandleW(None) }.unwrap();
+                let class_name = wide(&format!(
+                    "DccMcpSemanticCloseTestWindow{}",
+                    Uuid::new_v4().simple()
+                ));
+                let window_class = WNDCLASSW {
+                    lpfnWndProc: Some(semantic_close_window_proc),
+                    hInstance: instance.into(),
+                    lpszClassName: PCWSTR(class_name.as_ptr()),
+                    ..Default::default()
+                };
+                assert_ne!(unsafe { RegisterClassW(&window_class) }, 0);
+                let title = wide("DCC MCP semantic Invoke close test");
+                let hwnd = unsafe {
+                    CreateWindowExW(
+                        WINDOW_EX_STYLE::default(),
+                        PCWSTR(class_name.as_ptr()),
+                        PCWSTR(title.as_ptr()),
+                        WINDOW_STYLE(WS_OVERLAPPEDWINDOW.0 | WS_VISIBLE.0),
+                        240,
+                        240,
+                        520,
+                        260,
+                        None,
+                        None,
+                        Some(instance.into()),
+                        None,
+                    )
+                }
+                .unwrap();
+                let button_text = wide("Close test window");
+                unsafe {
+                    CreateWindowExW(
+                        WINDOW_EX_STYLE::default(),
+                        w!("BUTTON"),
+                        PCWSTR(button_text.as_ptr()),
+                        WINDOW_STYLE(WS_CHILD.0 | WS_VISIBLE.0 | BS_PUSHBUTTON as u32),
+                        40,
+                        60,
+                        220,
+                        60,
+                        Some(hwnd),
+                        Some(HMENU(SEMANTIC_CLOSE_BUTTON_ID as *mut core::ffi::c_void)),
+                        Some(instance.into()),
+                        None,
+                    )
+                }
+                .unwrap();
+                ready_tx.send(hwnd.0 as usize as u64).unwrap();
+                let mut message = MSG::default();
+                while unsafe { GetMessageW(&mut message, None, 0, 0) }.as_bool() {
+                    unsafe {
+                        let _ = TranslateMessage(&message);
+                        DispatchMessageW(&message);
+                    }
+                }
+            })
+            .unwrap();
+        let handle = ready_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        Self {
+            hwnd: HWND(handle as usize as *mut core::ffi::c_void),
+            thread: Some(thread),
+        }
+    }
+
+    fn join(mut self) {
+        if let Some(thread) = self.thread.take() {
+            thread.join().unwrap();
+        }
+    }
+}
+
+impl Drop for SemanticCloseWindow {
+    fn drop(&mut self) {
+        if unsafe { IsWindow(Some(self.hwnd)) }.as_bool() {
+            let _ = unsafe { PostMessageW(Some(self.hwnd), WM_CLOSE, WPARAM(0), LPARAM(0)) };
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn find_control_by_name<'a>(node: &'a Value, name: &str) -> Option<&'a Value> {
+    if node.get("name").and_then(Value::as_str) == Some(name) {
+        return Some(node);
+    }
+    node.get("children")
+        .and_then(Value::as_array)
+        .and_then(|children| {
+            children
+                .iter()
+                .find_map(|child| find_control_by_name(child, name))
+        })
+}
+
+struct TestRegistryKey(String);
+
+impl Drop for TestRegistryKey {
+    fn drop(&mut self) {
+        let key = wide(&self.0);
+        let _ = unsafe { RegDeleteTreeW(HKEY_CURRENT_USER, PCWSTR(key.as_ptr())) };
+    }
+}
+
+struct TestSymlinkTree(PathBuf);
+
+impl Drop for TestSymlinkTree {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(self.0.join("file-link"));
+        let _ = std::fs::remove_dir(self.0.join("dir-link"));
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn window_generation_marker_detects_capability_replacement() {
+    let class = wide("STATIC");
+    let title = wide("DCC MCP UI Control generation test");
+    let hwnd = unsafe {
+        CreateWindowExW(
+            WINDOW_EX_STYLE::default(),
+            PCWSTR(class.as_ptr()),
+            PCWSTR(title.as_ptr()),
+            WINDOW_STYLE(WS_OVERLAPPEDWINDOW.0),
+            0,
+            0,
+            320,
+            200,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+    .unwrap();
+    let _window = TestWindow(hwnd);
+    let target = UiControlTarget {
+        process_id: unsafe { GetCurrentProcessId() },
+        window_handle: hwnd.0 as usize as u64,
+        window_title: "DCC generation test".to_owned(),
+    };
+    let guard = WindowGenerationGuard::bind(&target).unwrap();
+    guard.verify().unwrap();
+
+    let _ = unsafe { RemovePropW(hwnd, PCWSTR(guard.property_name.as_ptr())) };
+    let failure = guard.verify().unwrap_err();
+    assert_eq!(failure.code, UiControlHostErrorCode::InvalidTarget);
+    let failure = guard.target_closed_after_completed_action().unwrap_err();
+    assert_eq!(failure.code, UiControlHostErrorCode::InvalidTarget);
+}
+
+#[test]
+fn completed_action_can_report_a_closed_exact_target_without_following_replacement() {
+    let class = wide("STATIC");
+    let title = wide("DCC MCP UI Control close transition test");
+    let hwnd = unsafe {
+        CreateWindowExW(
+            WINDOW_EX_STYLE::default(),
+            PCWSTR(class.as_ptr()),
+            PCWSTR(title.as_ptr()),
+            WINDOW_STYLE(WS_OVERLAPPEDWINDOW.0),
+            0,
+            0,
+            320,
+            200,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+    .unwrap();
+    let _window = TestWindow(hwnd);
+    let target = UiControlTarget {
+        process_id: unsafe { GetCurrentProcessId() },
+        window_handle: hwnd.0 as usize as u64,
+        window_title: "DCC close transition test".to_owned(),
+    };
+    let guard = WindowGenerationGuard::bind(&target).unwrap();
+
+    unsafe { DestroyWindow(hwnd) }.unwrap();
+
+    assert!(guard.target_closed_after_completed_action().unwrap());
+}
+
+#[test]
+fn semantic_uia_script_rechecks_the_confirmed_fence_immediately_before_mutation() {
+    let fence_check = UIA_SCRIPT
+        .find("Matches-Expected-Fence $target $payload.expected_fence")
+        .unwrap();
+    let ancestry_check = UIA_SCRIPT[fence_check..]
+        .find("Denied-Action-Target-Reason $root $target")
+        .map(|offset| fence_check + offset)
+        .unwrap();
+    let invoke = UIA_SCRIPT
+        .find("$actionResult = Invoke-Action $target")
+        .unwrap();
+    let failed_mutation = UIA_SCRIPT[invoke..]
+        .find("if (-not [bool]$actionResult.ok)")
+        .map(|offset| invoke + offset)
+        .unwrap();
+    let optional_post_state = UIA_SCRIPT[failed_mutation..]
+        .find("$afterFocus = $null")
+        .map(|offset| failed_mutation + offset)
+        .unwrap();
+
+    assert!(fence_check < invoke);
+    assert!(fence_check < ancestry_check);
+    assert!(ancestry_check < invoke);
+    assert!(invoke < failed_mutation);
+    assert!(failed_mutation < optional_post_state);
+    assert!(UIA_SCRIPT[optional_post_state..].contains("$control = Element-Raw $target"));
+    assert!(UIA_SCRIPT[optional_post_state..].contains("catch {}"));
+    assert!(UIA_SCRIPT[fence_check..invoke].contains("stale_observation"));
+    assert!(UIA_SCRIPT.contains("Has-Authentication-Secret-Marker $current"));
+}
+
+#[test]
+fn semantic_invoke_that_destroys_the_target_reports_mutation_success() {
+    let window = SemanticCloseWindow::spawn();
+    let target = UiControlTarget {
+        process_id: unsafe { GetCurrentProcessId() },
+        window_handle: window.hwnd.0 as usize as u64,
+        window_title: "DCC MCP semantic Invoke close test".to_owned(),
+    };
+    let accessibility = query_accessibility_state(&target, 5, 100).unwrap();
+    let button = find_control_by_name(&accessibility.root, "Close test window")
+        .expect("standard button must be present in the scoped UIA tree");
+    let runtime_id = button
+        .get("runtime_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty());
+    let fallback_path = button.get("fallback_path").and_then(Value::as_str).unwrap();
+    let identity = runtime_id.unwrap_or(fallback_path).to_owned();
+    let control_id = runtime_id.map_or_else(
+        || format!("uia:path:{fallback_path}"),
+        |value| format!("uia:{value}"),
+    );
+    let text = |key| {
+        button
+            .get(key)
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+    };
+    let expected = ActionControlFence {
+        identity,
+        is_password: button
+            .get("is_password")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        name: text("name"),
+        automation_id: text("automation_id"),
+        class_name: text("class_name"),
+        policy_tier: UiControlPolicyTier::TaskGrant,
+    };
+
+    let raw = run_uia(json!({
+        "mode": "act",
+        "scope": exact_scope(&target),
+        "max_depth": 5,
+        "max_nodes": 100,
+        "expected_fence": control_fence_json(&expected),
+        "action": {
+            "control_id": control_id,
+            "action": "click",
+            "text": "",
+            "checked": false,
+        },
+    }))
+    .unwrap();
+
+    assert_eq!(raw.get("ok").and_then(Value::as_bool), Some(true), "{raw}");
+    assert_eq!(
+        raw.get("message").and_then(Value::as_str),
+        Some("invoked native button"),
+        "{raw}"
+    );
+    assert!(!unsafe { IsWindow(Some(window.hwnd)) }.as_bool());
+    window.join();
+}
+
+#[test]
+fn typed_system_helpers_preserve_registry_and_symlink_contracts() {
+    assert_eq!(registry_string_bytes("ok"), b"o\0k\0\0\0");
+    assert!(path_is_within(
+        Path::new(r"\\?\C:\Program Files\Vendor\plugin"),
+        Path::new(r"C:\Program Files")
+    ));
+
+    let root = std::env::temp_dir().join(format!(
+        "dcc-mcp-system-operation-test-{}",
+        Uuid::new_v4().simple()
+    ));
+    std::fs::create_dir(&root).unwrap();
+    let target = root.join("target.txt");
+    let link = root.join("existing.txt");
+    std::fs::write(&target, b"target").unwrap();
+    std::fs::write(&link, b"keep").unwrap();
+    let failure =
+        ensure_symlink(&link.to_string_lossy(), &target.to_string_lossy(), false).unwrap_err();
+    assert_eq!(failure.code, UiControlHostErrorCode::Conflict);
+    assert_eq!(std::fs::read(&link).unwrap(), b"keep");
+    std::fs::remove_file(link).unwrap();
+    std::fs::remove_file(target).unwrap();
+    std::fs::remove_dir(root).unwrap();
+}
+
+#[test]
+fn registry_ensure_reports_created_updated_and_unchanged() {
+    let key = format!(r"Software\DccMcp\Tests\{}", Uuid::new_v4().simple());
+    let _cleanup = TestRegistryKey(key.clone());
+
+    assert_eq!(
+        ensure_registry_value(&key, "Enabled", REG_SZ, registry_string_bytes("one")).unwrap(),
+        UiControlEnsureOutcome::Created
+    );
+    assert_eq!(
+        ensure_registry_value(&key, "Enabled", REG_SZ, registry_string_bytes("one")).unwrap(),
+        UiControlEnsureOutcome::Unchanged
+    );
+    assert_eq!(
+        ensure_registry_value(&key, "Enabled", REG_SZ, registry_string_bytes("two")).unwrap(),
+        UiControlEnsureOutcome::Updated
+    );
+    assert_eq!(
+        ensure_registry_value(&key, "Enabled", REG_SZ, registry_string_bytes("two")).unwrap(),
+        UiControlEnsureOutcome::Unchanged
+    );
+}
+
+#[test]
+fn file_and_directory_symlinks_report_created_and_unchanged_when_permitted() {
+    let root = std::env::temp_dir().join(format!(
+        "dcc-mcp-symlink-operation-test-{}",
+        Uuid::new_v4().simple()
+    ));
+    std::fs::create_dir(&root).unwrap();
+    let _cleanup = TestSymlinkTree(root.clone());
+    let file_target = root.join("target.txt");
+    let directory_target = root.join("target-dir");
+    std::fs::write(&file_target, b"target").unwrap();
+    std::fs::create_dir(&directory_target).unwrap();
+
+    let file_link = root.join("file-link");
+    let created = ensure_symlink(
+        &file_link.to_string_lossy(),
+        &file_target.to_string_lossy(),
+        false,
+    );
+    if matches!(
+        created,
+        Err(HostFailure {
+            code: UiControlHostErrorCode::ElevationRequired,
+            ..
+        })
+    ) {
+        eprintln!("symlink integration skipped: Windows symlink privilege is unavailable");
+        return;
+    }
+    assert_eq!(created.unwrap(), UiControlEnsureOutcome::Created);
+    assert_eq!(
+        ensure_symlink(
+            &file_link.to_string_lossy(),
+            &file_target.to_string_lossy(),
+            false,
+        )
+        .unwrap(),
+        UiControlEnsureOutcome::Unchanged
+    );
+
+    let directory_link = root.join("dir-link");
+    assert_eq!(
+        ensure_symlink(
+            &directory_link.to_string_lossy(),
+            &directory_target.to_string_lossy(),
+            true,
+        )
+        .unwrap(),
+        UiControlEnsureOutcome::Created
+    );
+    assert_eq!(
+        ensure_symlink(
+            &directory_link.to_string_lossy(),
+            &directory_target.to_string_lossy(),
+            true,
+        )
+        .unwrap(),
+        UiControlEnsureOutcome::Unchanged
+    );
+}

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/tests.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/tests.rs
@@ -11,12 +11,17 @@ use std::sync::Mutex;
 struct FakeRuntime {
     snapshot: RuntimeAccessibilityState,
     live_states: Mutex<VecDeque<RuntimeAccessibilityState>>,
+    minimized: bool,
+    target_closed_after_action: bool,
 }
 
 struct FakeSession {
     target: UiControlTarget,
     snapshot: RuntimeAccessibilityState,
     live_states: VecDeque<RuntimeAccessibilityState>,
+    minimized: bool,
+    target_closed_after_action: bool,
+    notice_started: bool,
 }
 
 impl Default for FakeRuntime {
@@ -24,6 +29,8 @@ impl Default for FakeRuntime {
         Self {
             snapshot: fake_accessibility_state(),
             live_states: Mutex::new(VecDeque::new()),
+            minimized: false,
+            target_closed_after_action: false,
         }
     }
 }
@@ -43,6 +50,9 @@ impl HostRuntime for FakeRuntime {
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner()),
             ),
+            minimized: self.minimized,
+            target_closed_after_action: self.target_closed_after_action,
+            notice_started: false,
         }))
     }
 }
@@ -53,6 +63,7 @@ impl HostRuntimeSession for FakeSession {
     }
 
     fn start_visible_notice(&mut self) -> Result<(), HostFailure> {
+        self.notice_started = true;
         Ok(())
     }
 
@@ -62,15 +73,24 @@ impl HostRuntimeSession for FakeSession {
             window_handle: self.target.window_handle,
             exists: true,
             visible: true,
-            minimized: false,
+            minimized: self.minimized,
             foreground: true,
         })
     }
 
     fn change_window_state(
         &mut self,
-        _operation: UiControlWindowOperation,
+        operation: UiControlWindowOperation,
     ) -> Result<UiControlWindowState, HostFailure> {
+        if !self.notice_started {
+            return Err(HostFailure::new(
+                UiControlHostErrorCode::BackendUnavailable,
+                "the UI Control owner and Esc watcher were not started",
+            ));
+        }
+        if operation == UiControlWindowOperation::Restore {
+            self.minimized = false;
+        }
         self.window_state()
     }
 
@@ -79,6 +99,13 @@ impl HostRuntimeSession for FakeSession {
         _max_depth: u32,
         _max_nodes: u32,
     ) -> Result<RuntimeSnapshot, HostFailure> {
+        self.start_visible_notice()?;
+        if self.minimized {
+            return Err(HostFailure::new(
+                UiControlHostErrorCode::InvalidTarget,
+                "the scoped DCC window is minimized, closed, or unavailable",
+            ));
+        }
         Ok(RuntimeSnapshot {
             observation_id: "obs-1".to_owned(),
             target: self.target.clone(),
@@ -109,11 +136,17 @@ impl HostRuntimeSession for FakeSession {
     fn execute(
         &mut self,
         _observation_id: &str,
-        _action: &UiControlAction,
-        _fence: &ActionFenceExpectation,
+        action: &UiControlAction,
+        fence: &ActionFenceExpectation,
     ) -> Result<RuntimeActionResult, HostFailure> {
+        let live = self
+            .live_states
+            .pop_front()
+            .unwrap_or_else(|| self.snapshot.clone());
+        verify_expected_action_fence(action, fence, &live)?;
         Ok(RuntimeActionResult {
             message: "completed".to_owned(),
+            target_closed: self.target_closed_after_action,
             before_focus_runtime_id: None,
             after_focus_runtime_id: None,
         })
@@ -188,6 +221,8 @@ fn host_with_accessibility_states(
         runtime: Box::new(FakeRuntime {
             snapshot,
             live_states: Mutex::new(live_states.into()),
+            minimized: false,
+            target_closed_after_action: false,
         }),
         confirmation: Box::new(AllowConfirmation),
     }
@@ -302,7 +337,7 @@ fn handshake_is_required_and_exact() {
 }
 
 #[test]
-fn routine_session_is_notice_only() {
+fn opening_a_routine_session_does_not_request_confirmation() {
     let (mut host, mut connection) = negotiated();
     host.confirmation = Box::new(DenyConfirmation);
     assert!(matches!(
@@ -428,6 +463,278 @@ fn window_recovery_does_not_require_an_observation_and_disconnect_revokes_it() {
     ));
     connection.disconnect(&mut host);
     assert!(host.sessions.is_empty());
+}
+
+fn unity_game_view_accessibility_state(
+    game_view_runtime_id: &str,
+    focus_runtime_id: &str,
+) -> RuntimeAccessibilityState {
+    RuntimeAccessibilityState {
+        root: json!({
+            "runtime_id": "42.root",
+            "name": "Unity",
+            "class_name": "UnityContainerWndClass",
+            "children": [
+                {
+                    "runtime_id": "42.toolbar",
+                    "name": "Toolbar",
+                    "children": [
+                        {
+                            "runtime_id": "42.play",
+                            "name": "Play",
+                            "focused": focus_runtime_id == "42.play",
+                            "children": []
+                        },
+                        {
+                            "runtime_id": "42.pause",
+                            "name": "Pause",
+                            "focused": focus_runtime_id == "42.pause",
+                            "children": []
+                        }
+                    ]
+                },
+                {
+                    "runtime_id": "42.dock",
+                    "name": "GameView",
+                    "children": [
+                        {
+                            "runtime_id": game_view_runtime_id,
+                            "name": "Game",
+                            "class_name": "UnityGUIView",
+                            "focused": focus_runtime_id == game_view_runtime_id,
+                            "children": []
+                        },
+                        {
+                            "runtime_id": "42.status",
+                            "name": "Status Bar",
+                            "focused": focus_runtime_id == "42.status",
+                            "children": []
+                        }
+                    ]
+                }
+            ]
+        }),
+        focus_runtime_id: Some(focus_runtime_id.to_owned()),
+        node_count: 7,
+    }
+}
+
+#[test]
+fn minimized_exact_window_can_be_inspected_and_restored_before_interactive_control() {
+    let mut host = host();
+    host.runtime = Box::new(FakeRuntime {
+        minimized: true,
+        ..FakeRuntime::default()
+    });
+    let mut connection = UiControlHostConnection::default();
+    assert!(matches!(
+        connection.handle(
+            &mut host,
+            UiControlHostRequest::Hello(UiControlHostHello {
+                protocol_version: UI_CONTROL_HOST_PROTOCOL_VERSION,
+                client_name: "test".to_owned(),
+            })
+        ),
+        UiControlHostResponse::Hello { .. }
+    ));
+
+    let opened = connection.handle(
+        &mut host,
+        UiControlHostRequest::OpenSession {
+            session_id: "minimized-recovery".to_owned(),
+            grant: grant(false),
+        },
+    );
+    let UiControlHostResponse::SessionOpened {
+        window_capability, ..
+    } = opened
+    else {
+        panic!("minimized exact target could not open a recovery session: {opened:?}");
+    };
+
+    let state = connection.handle(
+        &mut host,
+        UiControlHostRequest::GetWindowState {
+            session_id: "minimized-recovery".to_owned(),
+            task_grant_id: "grant-1".to_owned(),
+            window_capability: window_capability.clone(),
+        },
+    );
+    assert!(matches!(
+        state,
+        UiControlHostResponse::WindowState {
+            state: UiControlWindowState {
+                exists: true,
+                minimized: true,
+                ..
+            },
+            ..
+        }
+    ));
+
+    let snapshot = connection.handle(
+        &mut host,
+        UiControlHostRequest::Snapshot {
+            session_id: "minimized-recovery".to_owned(),
+            task_grant_id: "grant-1".to_owned(),
+            window_capability: window_capability.clone(),
+            max_depth: 5,
+            max_nodes: 250,
+        },
+    );
+    assert!(matches!(
+        snapshot,
+        UiControlHostResponse::Error {
+            code: UiControlHostErrorCode::InvalidTarget,
+            ..
+        }
+    ));
+
+    let action = connection.handle(
+        &mut host,
+        UiControlHostRequest::ExecuteAction {
+            session_id: "minimized-recovery".to_owned(),
+            task_grant_id: "grant-1".to_owned(),
+            window_capability: window_capability.clone(),
+            observation_id: "not-observed".to_owned(),
+            accessibility_state_id: "not-observed".to_owned(),
+            action: Box::new(action(Some("uia:42.1"), UiControlInputKind::Semantic)),
+        },
+    );
+    assert!(matches!(
+        action,
+        UiControlHostResponse::ActionCompleted {
+            success: false,
+            error: Some(UiControlHostErrorCode::StaleObservation),
+            ..
+        }
+    ));
+
+    let restored = connection.handle(
+        &mut host,
+        UiControlHostRequest::ChangeWindowState {
+            session_id: "minimized-recovery".to_owned(),
+            task_grant_id: "grant-1".to_owned(),
+            window_capability: window_capability.clone(),
+            operation: UiControlWindowOperation::Restore,
+        },
+    );
+    assert!(matches!(
+        restored,
+        UiControlHostResponse::WindowStateChanged {
+            state: UiControlWindowState {
+                minimized: false,
+                ..
+            },
+            ..
+        }
+    ));
+
+    assert!(matches!(
+        connection.handle(
+            &mut host,
+            UiControlHostRequest::Snapshot {
+                session_id: "minimized-recovery".to_owned(),
+                task_grant_id: "grant-1".to_owned(),
+                window_capability,
+                max_depth: 5,
+                max_nodes: 250,
+            },
+        ),
+        UiControlHostResponse::Snapshot { .. }
+    ));
+}
+
+#[test]
+fn completed_action_that_closes_exact_target_succeeds_and_revokes_session() {
+    let mut host = host();
+    host.runtime = Box::new(FakeRuntime {
+        snapshot: unity_game_view_accessibility_state("42.game-view", "42.game-view"),
+        target_closed_after_action: true,
+        ..FakeRuntime::default()
+    });
+    let mut connection = UiControlHostConnection::default();
+    assert!(matches!(
+        connection.handle(
+            &mut host,
+            UiControlHostRequest::Hello(UiControlHostHello {
+                protocol_version: UI_CONTROL_HOST_PROTOCOL_VERSION,
+                client_name: "test".to_owned(),
+            })
+        ),
+        UiControlHostResponse::Hello { .. }
+    ));
+    let opened = connection.handle(
+        &mut host,
+        UiControlHostRequest::OpenSession {
+            session_id: "target-transition".to_owned(),
+            grant: grant(false),
+        },
+    );
+    let UiControlHostResponse::SessionOpened {
+        window_capability, ..
+    } = opened
+    else {
+        panic!("session not opened: {opened:?}");
+    };
+    let snapshot = connection.handle(
+        &mut host,
+        UiControlHostRequest::Snapshot {
+            session_id: "target-transition".to_owned(),
+            task_grant_id: "grant-1".to_owned(),
+            window_capability: window_capability.clone(),
+            max_depth: 5,
+            max_nodes: 250,
+        },
+    );
+    let UiControlHostResponse::Snapshot {
+        observation_id,
+        accessibility_state_id,
+        ..
+    } = snapshot
+    else {
+        panic!("snapshot failed: {snapshot:?}");
+    };
+
+    let response = connection.handle(
+        &mut host,
+        UiControlHostRequest::ExecuteAction {
+            session_id: "target-transition".to_owned(),
+            task_grant_id: "grant-1".to_owned(),
+            window_capability: window_capability.clone(),
+            observation_id,
+            accessibility_state_id,
+            action: Box::new(action(
+                Some("uia:42.game-view"),
+                UiControlInputKind::Semantic,
+            )),
+        },
+    );
+    assert!(matches!(
+        response,
+        UiControlHostResponse::ActionCompleted {
+            success: true,
+            target_closed: true,
+            ..
+        }
+    ));
+    assert!(!host.sessions.contains_key("target-transition"));
+    assert!(!connection.owned_sessions.contains("target-transition"));
+
+    assert!(matches!(
+        connection.handle(
+            &mut host,
+            UiControlHostRequest::GetWindowState {
+                session_id: "target-transition".to_owned(),
+                task_grant_id: "grant-1".to_owned(),
+                window_capability,
+            },
+        ),
+        UiControlHostResponse::Error {
+            code: UiControlHostErrorCode::SessionNotFound,
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -841,7 +1148,182 @@ fn execution_fence_rejects_same_identity_with_a_changed_security_signature() {
 }
 
 #[test]
-fn confirmation_round_trip_rechecks_keyboard_focus_before_input() {
+fn unity_shortcut_allows_ordinary_dynamic_focus_drift_before_input() {
+    let snapshot =
+        unity_game_view_accessibility_state("42.game-view.snapshot", "42.game-view.snapshot");
+    let host_refresh =
+        unity_game_view_accessibility_state("42.game-view.live", "42.game-view.live");
+    let pre_input = unity_game_view_accessibility_state("42.game-view.live", "42.play");
+    let mut host = host_with_accessibility_states(snapshot, vec![host_refresh, pre_input]);
+    let mut connection = UiControlHostConnection::default();
+    assert!(matches!(
+        connection.handle(
+            &mut host,
+            UiControlHostRequest::Hello(UiControlHostHello {
+                protocol_version: UI_CONTROL_HOST_PROTOCOL_VERSION,
+                client_name: "test".to_owned(),
+            })
+        ),
+        UiControlHostResponse::Hello { .. }
+    ));
+    let opened = connection.handle(
+        &mut host,
+        UiControlHostRequest::OpenSession {
+            session_id: "unity-game-view".to_owned(),
+            grant: grant(true),
+        },
+    );
+    let UiControlHostResponse::SessionOpened {
+        window_capability, ..
+    } = opened
+    else {
+        panic!("session not opened: {opened:?}");
+    };
+    let snapshot = connection.handle(
+        &mut host,
+        UiControlHostRequest::Snapshot {
+            session_id: "unity-game-view".to_owned(),
+            task_grant_id: "grant-1".to_owned(),
+            window_capability: window_capability.clone(),
+            max_depth: 5,
+            max_nodes: 250,
+        },
+    );
+    let UiControlHostResponse::Snapshot {
+        observation_id,
+        accessibility_state_id,
+        ..
+    } = snapshot
+    else {
+        panic!("snapshot failed: {snapshot:?}");
+    };
+
+    let response = connection.handle(
+        &mut host,
+        UiControlHostRequest::ExecuteAction {
+            session_id: "unity-game-view".to_owned(),
+            task_grant_id: "grant-1".to_owned(),
+            window_capability,
+            observation_id,
+            accessibility_state_id,
+            action: Box::new(UiControlAction {
+                action: "keyboard_shortcut".to_owned(),
+                input_kind: UiControlInputKind::RawInput,
+                keys: vec!["CTRL+P".to_owned()],
+                ..action(None, UiControlInputKind::RawInput)
+            }),
+        },
+    );
+
+    assert!(matches!(
+        response,
+        UiControlHostResponse::ActionCompleted {
+            success: true,
+            policy_tier: UiControlPolicyTier::TaskGrant,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn focus_dependent_keypress_still_rejects_unity_focus_identity_drift() {
+    let snapshot =
+        unity_game_view_accessibility_state("42.game-view.snapshot", "42.game-view.snapshot");
+    let live = unity_game_view_accessibility_state("42.game-view.live", "42.play");
+    for action_name in ["keypress", "keyboard_shortcut"] {
+        let keypress = UiControlAction {
+            action: action_name.to_owned(),
+            input_kind: UiControlInputKind::RawInput,
+            keys: vec!["ENTER".to_owned()],
+            ..action(None, UiControlInputKind::RawInput)
+        };
+
+        let error = verify_action_fence(
+            &keypress,
+            &snapshot.root,
+            snapshot.focus_runtime_id.as_deref(),
+            None,
+            &live,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.code,
+            UiControlHostErrorCode::StaleObservation,
+            "{action_name}"
+        );
+    }
+}
+
+#[test]
+fn both_modified_shortcut_labels_use_the_stable_unity_root_fence() {
+    let snapshot =
+        unity_game_view_accessibility_state("42.game-view.snapshot", "42.game-view.snapshot");
+    let host_refresh =
+        unity_game_view_accessibility_state("42.game-view.live", "42.game-view.live");
+    let pre_input = unity_game_view_accessibility_state("42.game-view.live", "42.play");
+
+    for action_name in ["keypress", "keyboard_shortcut"] {
+        let shortcut = UiControlAction {
+            action: action_name.to_owned(),
+            input_kind: UiControlInputKind::RawInput,
+            keys: vec!["CTRL+P".to_owned()],
+            ..action(None, UiControlInputKind::RawInput)
+        };
+        let (policy_tier, controls) = verify_action_fence(
+            &shortcut,
+            &snapshot.root,
+            snapshot.focus_runtime_id.as_deref(),
+            None,
+            &host_refresh,
+        )
+        .unwrap();
+        assert_eq!(controls.len(), 1, "{action_name}");
+        assert_eq!(controls[0].identity, "42.root", "{action_name}");
+        let expected = ActionFenceExpectation {
+            controls,
+            observation: None,
+            #[cfg(windows)]
+            max_depth: 12,
+            #[cfg(windows)]
+            max_nodes: 2_000,
+            policy_tier,
+        };
+
+        assert_eq!(
+            verify_expected_action_fence(&shortcut, &expected, &pre_input).unwrap(),
+            UiControlPolicyTier::TaskGrant,
+            "{action_name}"
+        );
+    }
+}
+
+#[test]
+fn modified_shortcut_still_rejects_scoped_uia_root_replacement() {
+    let snapshot = unity_game_view_accessibility_state("42.game-view", "42.game-view");
+    let mut live = unity_game_view_accessibility_state("42.game-view", "42.play");
+    live.root["runtime_id"] = json!("42.replacement-root");
+    let shortcut = UiControlAction {
+        action: "keyboard_shortcut".to_owned(),
+        input_kind: UiControlInputKind::RawInput,
+        keys: vec!["CTRL+P".to_owned()],
+        ..action(None, UiControlInputKind::RawInput)
+    };
+
+    let error = verify_action_fence(
+        &shortcut,
+        &snapshot.root,
+        snapshot.focus_runtime_id.as_deref(),
+        None,
+        &live,
+    )
+    .unwrap_err();
+
+    assert_eq!(error.code, UiControlHostErrorCode::StaleObservation);
+}
+
+#[test]
+fn confirmation_round_trip_hard_denies_password_focus_before_input() {
     let snapshot = keyboard_accessibility_state("42.ordinary");
     let before_confirmation = keyboard_accessibility_state("42.ordinary");
     let after_confirmation = keyboard_accessibility_state("42.password");
@@ -910,15 +1392,104 @@ fn confirmation_round_trip_rechecks_keyboard_focus_before_input() {
         response,
         UiControlHostResponse::ActionCompleted {
             success: false,
-            error: Some(UiControlHostErrorCode::StaleObservation),
+            error: Some(UiControlHostErrorCode::HardDenied),
             ..
         }
     ));
+    // The denial happens before a mutation is attempted. Other actions must
+    // still pass their own live fence against this retained observation.
     assert!(
         host.sessions
             .get("keyboard-focus")
-            .is_some_and(|session| session.observation_id.is_none())
+            .is_some_and(|session| session.observation_id.is_some())
     );
+}
+
+#[test]
+fn confirmation_denial_leaves_the_host_available_for_following_requests() {
+    let snapshot = keyboard_accessibility_state("42.ordinary");
+    let live = keyboard_accessibility_state("42.ordinary");
+    let mut host = host_with_accessibility_states(snapshot, vec![live]);
+    host.confirmation = Box::new(DenyConfirmation);
+    let mut connection = UiControlHostConnection::default();
+    assert!(matches!(
+        connection.handle(
+            &mut host,
+            UiControlHostRequest::Hello(UiControlHostHello {
+                protocol_version: UI_CONTROL_HOST_PROTOCOL_VERSION,
+                client_name: "test".to_owned(),
+            })
+        ),
+        UiControlHostResponse::Hello { .. }
+    ));
+    let opened = connection.handle(
+        &mut host,
+        UiControlHostRequest::OpenSession {
+            session_id: "confirmation-timeout".to_owned(),
+            grant: grant(true),
+        },
+    );
+    let UiControlHostResponse::SessionOpened {
+        window_capability, ..
+    } = opened
+    else {
+        panic!("session not opened: {opened:?}");
+    };
+    let snapshot = connection.handle(
+        &mut host,
+        UiControlHostRequest::Snapshot {
+            session_id: "confirmation-timeout".to_owned(),
+            task_grant_id: "grant-1".to_owned(),
+            window_capability: window_capability.clone(),
+            max_depth: 5,
+            max_nodes: 250,
+        },
+    );
+    let UiControlHostResponse::Snapshot {
+        observation_id,
+        accessibility_state_id,
+        ..
+    } = snapshot
+    else {
+        panic!("snapshot failed: {snapshot:?}");
+    };
+
+    let denied = connection.handle(
+        &mut host,
+        UiControlHostRequest::ExecuteAction {
+            session_id: "confirmation-timeout".to_owned(),
+            task_grant_id: "grant-1".to_owned(),
+            window_capability: window_capability.clone(),
+            observation_id,
+            accessibility_state_id,
+            action: Box::new(UiControlAction {
+                action: "keyboard_shortcut".to_owned(),
+                input_kind: UiControlInputKind::RawInput,
+                keys: vec!["ALT+F4".to_owned()],
+                ..action(None, UiControlInputKind::RawInput)
+            }),
+        },
+    );
+    assert!(matches!(
+        denied,
+        UiControlHostResponse::ActionCompleted {
+            success: false,
+            error: Some(UiControlHostErrorCode::ApprovalRequired),
+            ..
+        }
+    ));
+
+    assert!(matches!(
+        connection.handle(
+            &mut host,
+            UiControlHostRequest::GetWindowState {
+                session_id: "confirmation-timeout".to_owned(),
+                task_grant_id: "grant-1".to_owned(),
+                window_capability,
+            },
+        ),
+        UiControlHostResponse::WindowState { .. }
+    ));
 }
 
 #[test]
@@ -1150,59 +1721,66 @@ fn semantic_set_text_rejects_authentication_markers_on_ancestors() {
 
 #[test]
 fn execution_fence_rejects_keyboard_authentication_tier_escalation() {
-    let ordinary = RuntimeAccessibilityState {
-        root: json!({
-            "runtime_id": "42.root",
-            "name": "Tools",
-            "children": [{
-                "runtime_id": "42.input",
-                "name": "Code",
-                "focused": true,
-                "children": []
-            }]
-        }),
-        focus_runtime_id: Some("42.input".to_owned()),
-        node_count: 2,
-    };
-    let keypress = UiControlAction {
-        action: "keypress".to_owned(),
-        keys: vec!["ENTER".to_owned()],
-        ..action(None, UiControlInputKind::RawInput)
-    };
-    let (policy_tier, controls) = verify_action_fence(
-        &keypress,
-        &ordinary.root,
-        ordinary.focus_runtime_id.as_deref(),
-        None,
-        &ordinary,
-    )
-    .unwrap();
-    let expected = ActionFenceExpectation {
-        controls,
-        observation: None,
-        #[cfg(windows)]
-        max_depth: 12,
-        #[cfg(windows)]
-        max_nodes: 2_000,
-        policy_tier,
-    };
-    let authentication = RuntimeAccessibilityState {
-        root: json!({
-            "runtime_id": "42.root",
-            "name": "One-Time Code",
-            "children": [{
-                "runtime_id": "42.input",
-                "name": "Code",
-                "focused": true,
-                "children": []
-            }]
-        }),
-        focus_runtime_id: Some("42.input".to_owned()),
-        node_count: 2,
-    };
+    for action_name in ["keypress", "keyboard_shortcut"] {
+        let ordinary = RuntimeAccessibilityState {
+            root: json!({
+                "runtime_id": "42.root",
+                "name": "Tools",
+                "children": [{
+                    "runtime_id": "42.input",
+                    "name": "Code",
+                    "focused": true,
+                    "children": []
+                }]
+            }),
+            focus_runtime_id: Some("42.input".to_owned()),
+            node_count: 2,
+        };
+        let keyboard_action = UiControlAction {
+            action: action_name.to_owned(),
+            keys: vec!["CTRL+P".to_owned()],
+            ..action(None, UiControlInputKind::RawInput)
+        };
+        let (policy_tier, controls) = verify_action_fence(
+            &keyboard_action,
+            &ordinary.root,
+            ordinary.focus_runtime_id.as_deref(),
+            None,
+            &ordinary,
+        )
+        .unwrap();
+        let expected = ActionFenceExpectation {
+            controls,
+            observation: None,
+            #[cfg(windows)]
+            max_depth: 12,
+            #[cfg(windows)]
+            max_nodes: 2_000,
+            policy_tier,
+        };
+        let authentication = RuntimeAccessibilityState {
+            root: json!({
+                "runtime_id": "42.root",
+                "name": "One-Time Code",
+                "children": [{
+                    "runtime_id": "42.input",
+                    "name": "Code",
+                    "focused": true,
+                    "children": []
+                }]
+            }),
+            focus_runtime_id: Some("42.input".to_owned()),
+            node_count: 2,
+        };
 
-    let error = verify_expected_action_fence(&keypress, &expected, &authentication).unwrap_err();
-    assert_eq!(error.code, UiControlHostErrorCode::StaleObservation);
+        let error =
+            verify_expected_action_fence(&keyboard_action, &expected, &authentication).unwrap_err();
+        assert_eq!(
+            error.code,
+            UiControlHostErrorCode::StaleObservation,
+            "{action_name}"
+        );
+    }
 }
 
 #[test]

--- a/crates/dcc-mcp-ui-control/src/host_protocol.rs
+++ b/crates/dcc-mcp-ui-control/src/host_protocol.rs
@@ -576,6 +576,10 @@ pub enum UiControlHostResponse {
     ActionCompleted {
         /// Whether the requested mutation completed.
         success: bool,
+        /// The exact capability-bound HWND closed after the action completed.
+        /// The host revokes the session and never follows a replacement HWND.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        target_closed: bool,
         /// Host-enforced policy tier.
         policy_tier: UiControlPolicyTier,
         /// Safe result message with sensitive values removed.
@@ -720,6 +724,39 @@ mod tests {
         let response = serde_json::to_value(response).unwrap();
         assert_eq!(response["type"], "snapshot");
         assert_eq!(response["image"]["name"], "shared");
+    }
+
+    #[test]
+    fn target_closed_is_an_additive_action_completion_field() {
+        let legacy = serde_json::json!({
+            "type": "action_completed",
+            "success": true,
+            "policy_tier": "task_grant",
+            "message": "completed",
+            "error": null,
+            "before_focus_runtime_id": null,
+            "after_focus_runtime_id": null
+        });
+        let decoded: UiControlHostResponse = serde_json::from_value(legacy).unwrap();
+        assert!(matches!(
+            decoded,
+            UiControlHostResponse::ActionCompleted {
+                target_closed: false,
+                ..
+            }
+        ));
+
+        let closed = serde_json::to_value(UiControlHostResponse::ActionCompleted {
+            success: true,
+            target_closed: true,
+            policy_tier: UiControlPolicyTier::TaskGrant,
+            message: "completed and closed".to_owned(),
+            error: None,
+            before_focus_runtime_id: None,
+            after_focus_runtime_id: None,
+        })
+        .unwrap();
+        assert_eq!(closed["target_closed"], true);
     }
 
     #[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
     "dcc-mcp-server>=0.18.17,<1.0.0",
 ]
 
+[project.scripts]
+dcc-mcp-ui-control-server = "dcc_mcp_core.ui_control_server:cli"
+
 [project.optional-dependencies]
 test = [
     "pytest>=8.3.0; python_version>='3.8'",  # CVE-2025-71176: fixed line for maintained Python runtimes
@@ -163,6 +166,7 @@ known-first-party = ["dcc_mcp_core"]
 "python/dcc_mcp_core/adapter_contracts.py" = ["UP006", "UP037", "UP045"]
 "python/dcc_mcp_core/asset_import.py" = ["UP006", "UP045"]
 "python/dcc_mcp_core/install_lifecycle.py" = ["UP006", "UP007", "UP045"]
+"python/dcc_mcp_core/ui_control_server.py" = ["UP045"]
 "scripts/check_py37_syntax.py" = ["UP032"]  # intentional: f-strings are syntax errors on 3.7; verified by py37-syntax-check CI job. Enforced in CI via check-py37-syntax job.
 "__init__.py" = ["F401"]
 "tests/test_metadata_registration.py" = ["UP006", "UP007", "UP045"]

--- a/python/dcc_mcp_core/_server/skill_discovery.py
+++ b/python/dcc_mcp_core/_server/skill_discovery.py
@@ -19,7 +19,7 @@ from dcc_mcp_core._server.minimal_mode import MinimalModeConfig
 from dcc_mcp_core._server.minimal_mode import apply_minimal_mode
 from dcc_mcp_core.constants import ENV_DISABLE_DEFAULT_SKILL_PATHS
 from dcc_mcp_core.hotreload import DccSkillHotReloader
-from dcc_mcp_core.skill import get_bundled_skill_paths
+from dcc_mcp_core.skill import _get_bundled_skill_discovery_paths
 from dcc_mcp_core.skills.builtin import register_all_builtin_skills
 
 try:
@@ -127,7 +127,7 @@ class SkillDiscoveryController:
 
         if include_bundled:
             try:
-                paths.extend(get_bundled_skill_paths(include_bundled=True))
+                paths.extend(_get_bundled_skill_discovery_paths())
             except Exception as exc:
                 logger.debug("[%s] Could not load bundled skill paths: %s", owner._dcc_name, exc)
 

--- a/python/dcc_mcp_core/skill.py
+++ b/python/dcc_mcp_core/skill.py
@@ -90,6 +90,17 @@ MAX_TRACE_CALL_LENGTH: int = 500
 # so users do not need to clone the repository.
 _BUNDLED_SKILLS_DIR: Path = Path(__file__).parent / "skills"
 
+# Keep bundled discovery version-owned.  On Windows an in-use wheel can be
+# overlaid during an upgrade, leaving removed package-data directories behind.
+# Those unowned directories must not become executable skills after restart.
+_BUNDLED_SKILL_NAMES: tuple[str, ...] = (
+    "dcc-diagnostics",
+    "media",
+    "qt-ui-inspector",
+    "ui-control",
+    "workflow",
+)
+
 
 def get_bundled_skills_dir() -> str:
     """Return the absolute path to the bundled skills directory.
@@ -141,6 +152,14 @@ def get_bundled_skill_paths(include_bundled: bool = True) -> list[str]:
         return []
     bundled = _BUNDLED_SKILLS_DIR
     return [str(bundled)] if bundled.is_dir() else []
+
+
+def _get_bundled_skill_discovery_paths() -> list[str]:
+    """Return only bundled skill packages owned by this core version."""
+    bundled = _BUNDLED_SKILLS_DIR
+    if not bundled.is_dir():
+        return []
+    return [str(bundled / name) for name in _BUNDLED_SKILL_NAMES if (bundled / name / "SKILL.md").is_file()]
 
 
 # ---------------------------------------------------------------------------

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_entrypoint.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_entrypoint.py
@@ -8,6 +8,7 @@ import importlib
 import json
 import os
 from pathlib import Path
+import sys
 import threading
 from typing import Any
 from typing import Callable
@@ -22,6 +23,23 @@ _AUDIT_LOCK = threading.Lock()
 def emit(result: Dict[str, Any]) -> None:
     """Emit a JSON tool result."""
     print(json.dumps(result, sort_keys=True))
+
+
+def _read_subprocess_params() -> Dict[str, Any]:
+    """Read the authoritative JSON payload written by the skill executor."""
+    try:
+        if sys.stdin.isatty():
+            return {}
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def _import_sibling(name: str) -> Any:
@@ -108,7 +126,11 @@ def _record_operation(name: str, params: Dict[str, Any], result: Dict[str, Any])
 
 
 def _call(name: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    call_params = params or {}
+    # Older standalone servers execute skill scripts as subprocesses and put
+    # the complete tool arguments on stdin.  Read them at the shared boundary
+    # so every backend receives the same contract; backend-specific readers
+    # previously made mock/CDP work while Windows UIA silently received `{}`.
+    call_params = dict(params) if params is not None else _read_subprocess_params()
     backend = _load_backend()
     if backend is None:
         selected = os.environ.get("DCC_MCP_UI_CONTROL_BACKEND", "mock")
@@ -130,7 +152,7 @@ def _call(name: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         return result
     func: Callable[[Optional[Dict[str, Any]]], Dict[str, Any]] = getattr(backend, name)
     try:
-        result = func(params)
+        result = func(call_params)
     except Exception as exc:
         _record_operation(name, call_params, {"success": False, "error": type(exc).__name__})
         raise

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_ui_control_host_client.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_ui_control_host_client.py
@@ -393,7 +393,7 @@ class UiControlHostClient:
         if not self._latest_observation_id or not self._latest_accessibility_state_id:
             raise UiControlHostError("stale_observation", "Take a fresh ui_control snapshot before acting.")
         try:
-            return self._call(
+            response = self._call(
                 {
                     "method": "execute_action",
                     "params": {
@@ -406,6 +406,11 @@ class UiControlHostClient:
                 expected_type="action_completed",
                 allow_unsuccessful=True,
             )
+            if bool(response.get("target_closed")):
+                self._window_capability = None
+                with suppress(OSError):
+                    self._stream.close()
+            return response
         finally:
             self._invalidate_observation()
 

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.ps1
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.ps1
@@ -445,14 +445,29 @@ try {
       exit 0
     }
     $actionResult = Invoke-Action $target
-    $afterFocus = Runtime-Id ([System.Windows.Automation.AutomationElement]::FocusedElement)
+    if (-not [bool]$actionResult.ok) {
+      @{
+        ok = $false
+        error = $actionResult.error
+        message = $actionResult.message
+        before_focus_runtime_id = $beforeFocus
+      } | ConvertTo-Json -Depth 64 -Compress
+      exit 0
+    }
+    $afterFocus = $null
+    try {
+      $afterFocus = Runtime-Id ([System.Windows.Automation.AutomationElement]::FocusedElement)
+    } catch {}
+    $control = $null
+    try {
+      $control = Element-Raw $target 0 "target"
+    } catch {}
     @{
-      ok = [bool]$actionResult.ok
-      error = $actionResult.error
+      ok = $true
       message = $actionResult.message
       before_focus_runtime_id = $beforeFocus
       after_focus_runtime_id = $afterFocus
-      control = Element-Raw $target 0 "target"
+      control = $control
     } | ConvertTo-Json -Depth 64 -Compress
     exit 0
   }

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.py
@@ -177,6 +177,7 @@ def _client_for(session_id: str, params: Dict[str, Any], policy: UiControlPolicy
 
 
 def _host_error(exc: Exception) -> Dict[str, Any]:
+    message = str(exc)
     code = str(getattr(exc, "code", None) or UiErrorCode.BACKEND_UNAVAILABLE)
     mapping = {
         "approval_required": "approval_required",
@@ -189,7 +190,23 @@ def _host_error(exc: Exception) -> Dict[str, Any]:
     }
     mapped_code = mapping.get(code, code)
     recovery: Dict[str, Any] = {}
-    if mapped_code == UiErrorCode.INVALID_TARGET:
+    if mapped_code == UiErrorCode.INVALID_TARGET and "protected system ui" in message.lower():
+        recovery = {
+            "prompt": (
+                "Protected Windows UI is covering the requested point. Call ui_control__stop for this "
+                "session, then ask the operator to close or move that protected system surface manually. "
+                "Do not hide, override, click through, or ignore protected system UI. After the obstruction "
+                "is clear, take a fresh ui_control__snapshot for the same exact authorized PID/HWND before "
+                "retrying the action."
+            ),
+            "possible_solutions": [
+                "Stop this UI Control session so its native overlays are cleaned up.",
+                "Have the operator close or move the protected Windows surface, then take a fresh snapshot.",
+            ],
+            "recovery_actions": ["stop", "snapshot"],
+            "recovery_scope": "same_exact_pid_hwnd",
+        }
+    elif mapped_code == UiErrorCode.INVALID_TARGET:
         recovery = {
             "prompt": (
                 "If this exact PID/HWND is still valid but minimized or hidden, call ui_control__act with "
@@ -204,7 +221,7 @@ def _host_error(exc: Exception) -> Dict[str, Any]:
             "recovery_scope": "same_exact_pid_hwnd",
         }
     return skill_error(
-        str(exc),
+        message,
         mapped_code,
         error_code=mapped_code,
         backend="windows-ui-control-host",
@@ -483,6 +500,12 @@ def act_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         return _host_error(exc)
     entry["snapshot_id"] = None
     success = bool(raw.get("success"))
+    target_closed = bool(raw.get("target_closed"))
+    if target_closed:
+        with _CLIENTS_LOCK:
+            current = _CLIENTS.get(session_id)
+            if current is not None and current.get("client") is client:
+                _CLIENTS.pop(session_id, None)
     error_code = str(raw.get("error")) if raw.get("error") else None
     message = str(raw.get("message") or "DCC UI Control action completed.")
     result = UiActionResult(
@@ -490,15 +513,28 @@ def act_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         control_id=str(params.get("control_id") or ""),
         error_code=error_code,
         message=message,
-        metadata={"requires_new_screenshot": True, "policy_tier": raw.get("policy_tier")},
+        metadata={
+            "requires_new_screenshot": not target_closed,
+            "policy_tier": raw.get("policy_tier"),
+            "target_closed": target_closed,
+        },
     ).to_dict()
     audit = _audit_record(action, success, control, session_id, policy, error_code, message)
+    if target_closed:
+        audit["metadata"]["target_closed"] = True
     if not success:
         return skill_error(message, error_code or UiErrorCode.BACKEND_ERROR, result=result, audit=audit)
     return skill_success(
         f"Completed isolated Windows UI Control action {action!r}.",
-        prompt="Take a new ui_control__snapshot before the next action.",
+        prompt=(
+            "The exact target window closed after the completed action. Explicitly bind the intended new PID/HWND "
+            "before starting another UI Control session; no replacement window was followed."
+            if target_closed
+            else "Take a new ui_control__snapshot before the next action."
+        ),
         session_id=session_id,
+        session_active=not target_closed,
+        target_closed=target_closed,
         result=result,
         audit=audit,
     )

--- a/python/dcc_mcp_core/ui_control_server.py
+++ b/python/dcc_mcp_core/ui_control_server.py
@@ -1,0 +1,196 @@
+"""Run the stateful UI Control skill on a persistent Python MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+import threading
+from typing import Optional
+from typing import Sequence
+
+from dcc_mcp_core import HostExecutionBridge
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import create_skill_server
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run ui-control with a persistent in-process executor.",
+    )
+    parser.add_argument("--process-id", required=True, type=int)
+    parser.add_argument("--window-handle", required=True, type=int)
+    parser.add_argument("--host-exe", required=True, type=Path)
+    parser.add_argument("--skill-root", required=True, type=Path)
+    parser.add_argument("--registry-dir", required=True, type=Path)
+    parser.add_argument("--ready-file", required=True, type=Path)
+    parser.add_argument("--backend-port", type=int, default=0)
+    parser.add_argument("--gateway-port", required=True, type=int)
+    parser.add_argument("--allow-raw-input", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _validate_target(process_id: int, window_handle: int) -> str:
+    if process_id <= 0 or window_handle <= 0:
+        raise ValueError("process-id and window-handle must be positive")
+
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+    hwnd = ctypes.c_void_p(window_handle)
+    if not user32.IsWindow(hwnd):
+        raise RuntimeError("window-handle is not a live native window")
+
+    actual_process_id = ctypes.c_uint32()
+    if not user32.GetWindowThreadProcessId(hwnd, ctypes.byref(actual_process_id)):
+        raise RuntimeError("could not resolve the window owner process")
+    if actual_process_id.value != process_id:
+        raise RuntimeError(
+            f"window target mismatch: expected PID {process_id}, resolved PID {actual_process_id.value}",
+        )
+
+    length = user32.GetWindowTextLengthW(hwnd)
+    title_buffer = ctypes.create_unicode_buffer(length + 1)
+    user32.GetWindowTextW(hwnd, title_buffer, len(title_buffer))
+    return title_buffer.value
+
+
+def _validate_host_executable(path: Path) -> None:
+    if not path.is_file():
+        raise FileNotFoundError(f"UI Control Host not found: {path}")
+    with path.open("rb") as stream:
+        if stream.read(2) != b"MZ":
+            raise ValueError(f"UI Control Host is not a Windows PE executable: {path}")
+
+
+def _write_ready(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _only_ui_control(metadata):
+    if metadata.name != "ui-control":
+        raise RuntimeError("This dedicated server may load only the ui-control skill.")
+    return metadata
+
+
+def _shutdown(bridge, handle) -> None:
+    """Close admission, stop HTTP, then always release owned Host state."""
+    try:
+        bridge.close_script_admission()
+    finally:
+        try:
+            handle.shutdown()
+        finally:
+            bridge.clear_script_packages()
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run until SIGINT or SIGTERM requests an orderly shutdown."""
+    args = _parse_args(argv)
+    host_exe = args.host_exe.resolve()
+    skill_root = args.skill_root.resolve()
+    registry_dir = args.registry_dir.resolve()
+    ready_file = args.ready_file.resolve()
+    _validate_host_executable(host_exe)
+    if not skill_root.is_dir():
+        raise FileNotFoundError(f"Skill root not found: {skill_root}")
+    target_title = _validate_target(args.process_id, args.window_handle)
+
+    os.environ["DCC_MCP_UI_CONTROL_BACKEND"] = "windows-uia"
+    os.environ["DCC_MCP_UI_CONTROL_HOST"] = str(host_exe)
+    os.environ["DCC_MCP_UI_CONTROL_UIA_WINDOW_HANDLE"] = str(args.window_handle)
+    os.environ.pop("DCC_MCP_UI_CONTROL_UIA_PROCESS_ID", None)
+    os.environ["DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS"] = "1"
+    os.environ["DCC_MCP_DISABLE_ACCUMULATED_SKILLS"] = "1"
+    if args.allow_raw_input:
+        os.environ["DCC_MCP_COMPUTER_USE_ALLOW_RAW_INPUT"] = "true"
+    else:
+        os.environ.pop("DCC_MCP_COMPUTER_USE_ALLOW_RAW_INPUT", None)
+
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    config = McpHttpConfig(
+        port=args.backend_port,
+        server_name="ui-control-server",
+        shutdown_on_drop=True,
+    )
+    config.dcc_type = "python"
+    config.adapter_dcc = "ui-control"
+    config.gateway_port = args.gateway_port
+    config.registry_dir = str(registry_dir)
+    config.heartbeat_secs = 1
+    config.stale_timeout_secs = 10
+    config.allowed_skill_names = ["ui-control"]
+
+    bridge = HostExecutionBridge(dispatcher=None)
+    server = create_skill_server(
+        "python",
+        config,
+        extra_paths=[str(skill_root)],
+        accumulated=False,
+    )
+    server.set_skill_load_transform(_only_ui_control)
+    server.set_in_process_executor(bridge.as_inprocess_executor())
+    loaded_actions = server.load_skill("ui-control")
+    handle = server.start()
+
+    try:
+        stop_event = threading.Event()
+
+        def _request_stop(_signum, _frame) -> None:
+            stop_event.set()
+
+        signal.signal(signal.SIGINT, _request_stop)
+        signal.signal(signal.SIGTERM, _request_stop)
+
+        payload = {
+            "status": "ready",
+            "launcher_pid": os.getpid(),
+            "target_process_id": args.process_id,
+            "target_window_handle": args.window_handle,
+            "target_window_title": target_title,
+            "backend_port": handle.port,
+            "backend_mcp_url": handle.mcp_url(),
+            "gateway_port": args.gateway_port,
+            "gateway_mcp_url": f"http://127.0.0.1:{args.gateway_port}/mcp",
+            "is_gateway": handle.is_gateway,
+            "loaded_actions": list(loaded_actions),
+            "host_exe": str(host_exe),
+            "raw_input_enabled": bool(args.allow_raw_input),
+        }
+        _write_ready(ready_file, payload)
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True), flush=True)
+
+        while not stop_event.wait(0.25):
+            pass
+    finally:
+        _shutdown(bridge, handle)
+    return 0
+
+
+def cli() -> int:
+    """Console-script entry point with a machine-readable startup error."""
+    try:
+        return main()
+    except Exception as exc:
+        print(
+            json.dumps(
+                {"status": "error", "error": type(exc).__name__, "message": str(exc)},
+                ensure_ascii=False,
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+            flush=True,
+        )
+        raise
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli())

--- a/python/dcc_mcp_core/ui_control_server.py
+++ b/python/dcc_mcp_core/ui_control_server.py
@@ -35,6 +35,9 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
 
 
 def _validate_target(process_id: int, window_handle: int) -> str:
+    if sys.platform != "win32":
+        raise RuntimeError("UI Control target validation requires Windows")
+
     if process_id <= 0 or window_handle <= 0:
         raise ValueError("process-id and window-handle must be positive")
 

--- a/scripts/ci/check_python_wheel.py
+++ b/scripts/ci/check_python_wheel.py
@@ -62,6 +62,35 @@ def _release_tuple(version: str) -> tuple[int, int, int] | None:
     return tuple(int(part) for part in match.groups())
 
 
+def _core_ui_control_contract_errors(archive: zipfile.ZipFile, names: list[str]) -> list[str]:
+    """Validate the post-0.19.63 Python/skill UI Control naming cutover."""
+    errors: list[str] = []
+    contracts_member = "dcc_mcp_core/adapter_contracts.py"
+    skill_member = "dcc_mcp_core/skills/ui-control/SKILL.md"
+    tools_member = "dcc_mcp_core/skills/ui-control/tools.yaml"
+    for member in (contracts_member, skill_member, tools_member):
+        if member not in names:
+            errors.append(f"wheel is missing required UI Control member {member!r}")
+    legacy_members = sorted(name for name in names if name.startswith("dcc_mcp_core/skills/app-ui/"))
+    if legacy_members:
+        errors.append("wheel contains removed app-ui skill members")
+    if errors:
+        return errors
+
+    contracts = archive.read(contracts_member).decode("utf-8")
+    skill = archive.read(skill_member).decode("utf-8")
+    tools = archive.read(tools_member).decode("utf-8")
+    if "class UiControlPolicy:" not in contracts or "class UiControlAuditRecord:" not in contracts:
+        errors.append("adapter_contracts.py is missing canonical UI Control contracts")
+    if "class AppUiPolicy:" in contracts or "class AppUiAuditRecord:" in contracts:
+        errors.append("adapter_contracts.py contains removed App UI contracts")
+    if "name: ui-control" not in skill or "ui_control__snapshot" not in skill:
+        errors.append("bundled UI Control skill does not expose the canonical ui_control contract")
+    if "app_ui__" in skill or "app_ui__" in tools:
+        errors.append("bundled UI Control skill contains removed app_ui tool names")
+    return errors
+
+
 def validate_wheel(
     path: Path,
     profile: str,
@@ -84,6 +113,14 @@ def validate_wheel(
             has_extension = _contains_extension(names, profile_contract.get("extension_module"))
             metadata = Parser().parsestr(_read_single_member(archive, ".dist-info/METADATA"))
             wheel_metadata = Parser().parsestr(_read_single_member(archive, ".dist-info/WHEEL"))
+            actual_version = str(metadata.get("Version", ""))
+            actual_release = _release_tuple(actual_version)
+            if (
+                profile_contract["distribution"] == "dcc-mcp-core"
+                and actual_release is not None
+                and actual_release >= (0, 19, 63)
+            ):
+                errors.extend(_core_ui_control_contract_errors(archive, names))
     except (OSError, ValueError, zipfile.BadZipFile, UnicodeDecodeError) as exc:
         return [f"cannot inspect wheel: {exc}"]
 
@@ -114,8 +151,6 @@ def validate_wheel(
     for member in required_members:
         if member not in names:
             errors.append(f"wheel is missing required member {member!r}")
-    actual_version = str(metadata.get("Version", ""))
-    actual_release = _release_tuple(actual_version)
     for member, required_from in platform_policy.get("versioned_required_members", {}).items():
         required_release = _release_tuple(str(required_from))
         if actual_release is None:

--- a/tests/test_bundled_skill_metadata.py
+++ b/tests/test_bundled_skill_metadata.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
+
 from conftest import REPO_ROOT
 import dcc_mcp_core
+from dcc_mcp_core import skill as skill_module
+from dcc_mcp_core._server import skill_discovery
 from dcc_mcp_core.skill_reference_docs import _handle_list
 
 SKILL_ROOTS = [
@@ -22,6 +27,30 @@ def test_removed_app_ui_skill_is_not_bundled() -> None:
 
     assert (bundled / "ui-control").is_dir()
     assert not (bundled / "app-ui").exists()
+
+
+def test_bundled_api_keeps_root_contract_while_internal_discovery_ignores_upgrade_leftovers(
+    tmp_path, monkeypatch
+) -> None:
+    bundled = tmp_path / "skills"
+    for name in ("ui-control", "app-ui"):
+        skill_dir = bundled / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\ndescription: test\n---\n", encoding="utf-8")
+    monkeypatch.setattr(skill_module, "_BUNDLED_SKILLS_DIR", bundled)
+    monkeypatch.setattr(skill_discovery, "_default_skill_paths_disabled", lambda: True)
+    monkeypatch.setattr(skill_discovery, "get_app_skill_paths_from_env", lambda _dcc_name: [])
+    monkeypatch.setattr(skill_discovery, "get_skill_paths_from_env", lambda: [])
+
+    public_paths = skill_module.get_bundled_skill_paths()
+    owner = SimpleNamespace(_builtin_skills_dir=tmp_path / "missing", _dcc_name="unity")
+    discovery_paths = skill_discovery.SkillDiscoveryController(owner).collect_skill_search_paths(
+        filter_existing=True,
+        include_admin_custom=False,
+    )
+
+    assert public_paths == [str(bundled)]
+    assert [Path(path).name for path in discovery_paths] == ["ui-control"]
 
 
 def test_official_and_bundled_skills_validate_clean() -> None:

--- a/tests/test_python_wheel_contract.py
+++ b/tests/test_python_wheel_contract.py
@@ -26,6 +26,7 @@ def _write_wheel(
     extension_module: str = "dcc_mcp_core/_core",
     with_removed_capture_helper: bool = False,
     with_ui_control_host: bool | None = None,
+    ui_control_contract: str = "canonical",
 ) -> None:
     root_is_pure = "true" if pure else "false"
     wheel_tags = tags or sorted(_expanded_filename_tags(path))
@@ -44,6 +45,26 @@ def _write_wheel(
         )
         package = extension_module.split("/", 1)[0]
         archive.writestr(f"{package}/__init__.py", "")
+        if distribution == "dcc-mcp-core" and ui_control_contract == "canonical":
+            archive.writestr(
+                "dcc_mcp_core/adapter_contracts.py",
+                "class UiControlPolicy:\n    pass\n\nclass UiControlAuditRecord:\n    pass\n",
+            )
+            archive.writestr(
+                "dcc_mcp_core/skills/ui-control/SKILL.md",
+                "---\nname: ui-control\ndescription: canonical ui_control__snapshot skill\n---\n",
+            )
+            archive.writestr("dcc_mcp_core/skills/ui-control/tools.yaml", "tools: []\n")
+        elif distribution == "dcc-mcp-core" and ui_control_contract == "legacy-skill":
+            archive.writestr(
+                "dcc_mcp_core/adapter_contracts.py",
+                "class UiControlPolicy:\n    pass\n\nclass UiControlAuditRecord:\n    pass\n",
+            )
+            archive.writestr(
+                "dcc_mcp_core/skills/app-ui/SKILL.md",
+                "---\nname: app-ui\ndescription: legacy app_ui__snapshot skill\n---\n",
+            )
+            archive.writestr("dcc_mcp_core/skills/app-ui/tools.yaml", "tools: []\n")
         if with_core:
             archive.writestr(f"{extension_module}.pyd", b"native")
         if with_removed_capture_helper:
@@ -71,6 +92,22 @@ def test_windows_core_wheel_requires_ui_control_host_from_01960(tmp_path: Path) 
     )
     errors = validate_wheel(wheel, "abi3", "windows-x86_64", load_contract(_REPO_ROOT))
     assert any("missing required member" in error and "ui-control-host.exe" in error for error in errors)
+
+
+def test_core_wheel_rejects_legacy_app_ui_skill_with_new_python_contracts(tmp_path: Path) -> None:
+    wheel = tmp_path / "dcc_mcp_core-0.19.63-cp38-abi3-win_amd64.whl"
+    _write_wheel(
+        wheel,
+        pure=False,
+        with_core=True,
+        version="0.19.63",
+        ui_control_contract="legacy-skill",
+    )
+
+    errors = validate_wheel(wheel, "abi3", "windows-x86_64", load_contract(_REPO_ROOT))
+
+    assert any("missing required UI Control member" in error for error in errors)
+    assert any("removed app-ui skill" in error for error in errors)
 
 
 def test_windows_core_wheel_rejects_removed_capture_helper(tmp_path: Path) -> None:

--- a/tests/test_regression_1133_ui_control_gateway.py
+++ b/tests/test_regression_1133_ui_control_gateway.py
@@ -99,7 +99,11 @@ def _load_ui_control(gateway_mcp_url: str) -> None:
     assert body["loaded"] is True, body
 
 
-def _find_ui_control_slug(gateway_rest_url: str, query: str = "ui_control snapshot") -> str:
+def _find_ui_control_slug(
+    gateway_rest_url: str,
+    query: str = "ui_control snapshot",
+    backend_tool: str = "ui_control__snapshot",
+) -> str:
     deadline = time.time() + 8.0
     last = None
     while time.time() < deadline:
@@ -109,10 +113,10 @@ def _find_ui_control_slug(gateway_rest_url: str, query: str = "ui_control snapsh
         )
         last = body
         for hit in body.get("hits", []):
-            if hit.get("backend_tool") == "ui_control__snapshot":
+            if hit.get("backend_tool") == backend_tool:
                 return str(hit["tool_slug"])
         time.sleep(0.25)
-    raise AssertionError(f"ui_control__snapshot not found in gateway search: {last!r}")
+    raise AssertionError(f"{backend_tool} not found in gateway search: {last!r}")
 
 
 def test_ui_control_gateway_rest_and_mcp_discovery_describe_call(ui_control_gateway: dict) -> None:
@@ -142,6 +146,31 @@ def test_ui_control_gateway_rest_and_mcp_discovery_describe_call(ui_control_gate
     )
     assert rest_call["output"]["success"] is True
     assert rest_call["output"]["context"]["snapshot"]["root"]["role"] == "window"
+
+    # Stateful ui-control calls must remain in one Python process. The
+    # snapshot id is private in-process state and cannot survive a per-call
+    # subprocess executor.
+    snapshot_id = rest_call["output"]["context"]["snapshot_id"]
+    act_slug = _find_ui_control_slug(
+        gateway_rest_url,
+        query="ui_control action focus",
+        backend_tool="ui_control__act",
+    )
+    rest_act = _post_json(
+        f"{gateway_rest_url}/v1/call",
+        {
+            "tool_slug": act_slug,
+            "arguments": {
+                "session_id": "core-1133-rest",
+                "control_id": "project-name",
+                "action": "focus",
+                "snapshot_id": snapshot_id,
+            },
+            "response_format": "json",
+        },
+    )
+    assert rest_act["output"]["success"] is True
+    assert rest_act["output"]["context"]["audit"]["action_kind"] == "focus"
 
     mcp_call = _post_mcp(
         gateway_mcp_url,

--- a/tests/test_ui_control_server.py
+++ b/tests/test_ui_control_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -33,6 +34,7 @@ def _required_args(tmp_path: Path) -> list[str]:
     ]
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="_validate_target requires Windows")
 def test_validate_target_requires_live_window_owned_by_exact_process(monkeypatch: pytest.MonkeyPatch) -> None:
     class User32:
         @staticmethod

--- a/tests/test_ui_control_server.py
+++ b/tests/test_ui_control_server.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from dcc_mcp_core import ui_control_server
+
+
+def _required_args(tmp_path: Path) -> list[str]:
+    host = tmp_path / "dcc-mcp-ui-control-host.exe"
+    host.write_bytes(b"MZhost")
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    return [
+        "--process-id",
+        "42",
+        "--window-handle",
+        "84",
+        "--host-exe",
+        str(host),
+        "--skill-root",
+        str(skill_root),
+        "--registry-dir",
+        str(tmp_path / "registry"),
+        "--ready-file",
+        str(tmp_path / "ready.json"),
+        "--gateway-port",
+        "18123",
+    ]
+
+
+def test_validate_target_requires_live_window_owned_by_exact_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    class User32:
+        @staticmethod
+        def IsWindow(_hwnd):
+            return True
+
+        @staticmethod
+        def GetWindowThreadProcessId(_hwnd, process_id):
+            process_id._obj.value = 42
+            return 7
+
+        @staticmethod
+        def GetWindowTextLengthW(_hwnd):
+            return 12
+
+        @staticmethod
+        def GetWindowTextW(_hwnd, buffer, _length):
+            buffer.value = "Unity Player"
+            return 12
+
+    monkeypatch.setattr(
+        ui_control_server.ctypes,
+        "WinDLL",
+        lambda *_args, **_kwargs: User32(),
+        raising=False,
+    )
+
+    assert ui_control_server._validate_target(42, 84) == "Unity Player"
+    with pytest.raises(RuntimeError, match="expected PID 41, resolved PID 42"):
+        ui_control_server._validate_target(41, 84)
+
+
+def test_only_ui_control_transform_rejects_other_skills() -> None:
+    metadata = SimpleNamespace(name="ui-control")
+    assert ui_control_server._only_ui_control(metadata) is metadata
+    with pytest.raises(RuntimeError, match="only the ui-control skill"):
+        ui_control_server._only_ui_control(SimpleNamespace(name="other"))
+
+
+def test_validate_host_executable_requires_windows_pe(tmp_path: Path) -> None:
+    host = tmp_path / "dcc-mcp-ui-control-host.exe"
+    with pytest.raises(FileNotFoundError, match="Host not found"):
+        ui_control_server._validate_host_executable(host)
+
+    host.write_bytes(b"not-a-pe")
+    with pytest.raises(ValueError, match="not a Windows PE executable"):
+        ui_control_server._validate_host_executable(host)
+
+    host.write_bytes(b"MZvalid")
+    ui_control_server._validate_host_executable(host)
+
+
+def test_shutdown_always_clears_owned_host_state() -> None:
+    events: list[str] = []
+
+    class Bridge:
+        @staticmethod
+        def close_script_admission():
+            events.append("close-admission")
+
+        @staticmethod
+        def clear_script_packages():
+            events.append("clear-packages")
+
+    class Handle:
+        @staticmethod
+        def shutdown():
+            events.append("server-shutdown")
+            raise RuntimeError("shutdown failed")
+
+    with pytest.raises(RuntimeError, match="shutdown failed"):
+        ui_control_server._shutdown(Bridge(), Handle())
+    assert events == ["close-admission", "server-shutdown", "clear-packages"]
+
+
+def test_shutdown_stops_server_when_closing_admission_fails() -> None:
+    events: list[str] = []
+
+    class Bridge:
+        @staticmethod
+        def close_script_admission():
+            events.append("close-admission")
+            raise RuntimeError("admission close failed")
+
+        @staticmethod
+        def clear_script_packages():
+            events.append("clear-packages")
+
+    class Handle:
+        @staticmethod
+        def shutdown():
+            events.append("server-shutdown")
+
+    with pytest.raises(RuntimeError, match="admission close failed"):
+        ui_control_server._shutdown(Bridge(), Handle())
+    assert events == ["close-admission", "server-shutdown", "clear-packages"]
+
+
+def test_main_registers_executor_before_load_and_shuts_down_in_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class Config:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class Bridge:
+        def __init__(self, dispatcher):
+            assert dispatcher is None
+
+        def as_inprocess_executor(self):
+            events.append("executor-created")
+            return "executor"
+
+        def close_script_admission(self):
+            events.append("close-admission")
+
+        def clear_script_packages(self):
+            events.append("clear-packages")
+
+    class Handle:
+        port = 19123
+        is_gateway = False
+
+        @staticmethod
+        def mcp_url():
+            return "http://127.0.0.1:19123/mcp"
+
+        @staticmethod
+        def shutdown():
+            events.append("server-shutdown")
+
+    class Server:
+        @staticmethod
+        def set_skill_load_transform(transform):
+            assert transform(SimpleNamespace(name="ui-control")).name == "ui-control"
+            events.append("transform")
+
+        @staticmethod
+        def set_in_process_executor(executor):
+            assert executor == "executor"
+            events.append("executor-registered")
+
+        @staticmethod
+        def load_skill(name):
+            assert name == "ui-control"
+            events.append("load-skill")
+            return ["ui_control__snapshot", "ui_control__act"]
+
+        @staticmethod
+        def start():
+            events.append("start")
+            return Handle()
+
+    class StoppedEvent:
+        @staticmethod
+        def wait(_timeout):
+            return True
+
+        @staticmethod
+        def set():
+            pass
+
+    def create_server(dcc_name, config, extra_paths, accumulated):
+        assert dcc_name == "python"
+        assert config.allowed_skill_names == ["ui-control"]
+        assert extra_paths == [str((tmp_path / "skills").resolve())]
+        assert accumulated is False
+        events.append("create-server")
+        return Server()
+
+    monkeypatch.setattr(ui_control_server, "McpHttpConfig", Config)
+    monkeypatch.setattr(ui_control_server, "HostExecutionBridge", Bridge)
+    monkeypatch.setattr(ui_control_server, "create_skill_server", create_server)
+    monkeypatch.setattr(ui_control_server, "_validate_target", lambda process_id, hwnd: "Unity Player")
+    monkeypatch.setattr(ui_control_server.threading, "Event", StoppedEvent)
+    monkeypatch.setattr(ui_control_server.signal, "signal", lambda *_args: None)
+    for name in (
+        "DCC_MCP_UI_CONTROL_BACKEND",
+        "DCC_MCP_UI_CONTROL_HOST",
+        "DCC_MCP_UI_CONTROL_UIA_WINDOW_HANDLE",
+        "DCC_MCP_UI_CONTROL_UIA_PROCESS_ID",
+        "DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS",
+        "DCC_MCP_DISABLE_ACCUMULATED_SKILLS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("DCC_MCP_COMPUTER_USE_ALLOW_RAW_INPUT", "true")
+
+    args = _required_args(tmp_path)
+    assert ui_control_server.main(args) == 0
+
+    assert events == [
+        "create-server",
+        "transform",
+        "executor-created",
+        "executor-registered",
+        "load-skill",
+        "start",
+        "close-admission",
+        "server-shutdown",
+        "clear-packages",
+    ]
+    assert "DCC_MCP_COMPUTER_USE_ALLOW_RAW_INPUT" not in os.environ
+    ready = json.loads((tmp_path / "ready.json").read_text(encoding="utf-8"))
+    assert ready["status"] == "ready"
+    assert ready["target_process_id"] == 42
+    assert ready["target_window_handle"] == 84
+    assert ready["raw_input_enabled"] is False
+
+
+def test_raw_input_requires_explicit_flag(tmp_path: Path) -> None:
+    args = ui_control_server._parse_args([*_required_args(tmp_path), "--allow-raw-input"])
+    assert args.allow_raw_input is True

--- a/tests/test_ui_control_server.py
+++ b/tests/test_ui_control_server.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -34,8 +33,22 @@ def _required_args(tmp_path: Path) -> list[str]:
     ]
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="_validate_target requires Windows")
+def test_validate_target_rejects_non_windows_before_loading_user32(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ui_control_server.sys, "platform", "linux")
+    monkeypatch.setattr(
+        ui_control_server.ctypes,
+        "WinDLL",
+        lambda *_args, **_kwargs: pytest.fail("WinDLL must not load on non-Windows"),
+        raising=False,
+    )
+
+    with pytest.raises(RuntimeError, match="requires Windows"):
+        ui_control_server._validate_target(42, 84)
+
+
 def test_validate_target_requires_live_window_owned_by_exact_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ui_control_server.sys, "platform", "win32")
+
     class User32:
         @staticmethod
         def IsWindow(_hwnd):

--- a/tests/test_ui_control_skill.py
+++ b/tests/test_ui_control_skill.py
@@ -49,6 +49,7 @@ def _run_tool(
     extra_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     env = dict(os.environ)
+    env["DCC_MCP_UI_CONTROL_BACKEND"] = "mock"
     env["DCC_MCP_UI_CONTROL_MOCK_STATE_DIR"] = str(state_dir)
     if extra_env:
         env.update(extra_env)
@@ -273,6 +274,33 @@ def test_ui_control_entrypoints_accept_inprocess_parameters(
     assert all(row["event"] == "ui_control_operation" for row in audit_rows)
     assert all(row["dcc_type"] == "unreal" for row in audit_rows)
     assert "Signal Forge" not in log_text
+
+
+def test_ui_control_subprocess_forwards_action_to_windows_backend_without_host(tmp_path: Path) -> None:
+    """Standalone-server stdin transport must preserve schema key ``action``."""
+    result = _run_tool(
+        "act",
+        {
+            "session_id": "subprocess-action-transport",
+            "process_id": 424242,
+            "window_handle": 31337,
+            "window_title": "transport-probe",
+            "action": "keyboard_shortcut",
+            "intent": "navigate",
+            "keys": ["ALT", "F4"],
+            "snapshot_id": "accessibility:probe",
+            "policy": {"allow_keyboard_shortcuts": False},
+        },
+        tmp_path,
+        {
+            "DCC_MCP_UI_CONTROL_BACKEND": "windows-uia",
+            "DCC_MCP_DISABLE_FILE_LOGGING": "1",
+        },
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "policy_disabled"
+    assert result["message"] == "ui_control action 'keyboard_shortcut' disabled by policy"
 
 
 def test_ui_control_admin_audit_records_rejection_without_sensitive_text(
@@ -747,6 +775,20 @@ def test_ui_control_windows_host_semantic_action_is_thin_proxy(monkeypatch: Any)
     assert "powershell" not in source.lower()
 
 
+def test_ui_control_windows_uia_post_state_is_optional_after_semantic_success() -> None:
+    source = (_SCRIPTS / "_windows_uia_backend.ps1").read_text(encoding="utf-8")
+    invoke = source.index("$actionResult = Invoke-Action $target")
+    reject_failure = source.index("if (-not [bool]$actionResult.ok)", invoke)
+    optional_control = source.index("$control = $null", reject_failure)
+    success = source.index("ok = $true", optional_control)
+    post_read = source[optional_control:success]
+
+    assert invoke < reject_failure < optional_control < success
+    assert "ok = $false" in source[reject_failure:optional_control]
+    assert 'try {\n      $control = Element-Raw $target 0 "target"\n    } catch {}' in post_read
+    assert "control = $control" in source[success:]
+
+
 def test_ui_control_windows_host_native_action_requires_fresh_snapshot(monkeypatch: Any) -> None:
     backend = _load_windows_uia_module()
     _configure_fake_host(backend, monkeypatch, raw=True)
@@ -797,6 +839,42 @@ def test_ui_control_windows_host_restores_minimized_exact_window_without_snapsho
     assert state["context"]["audit"]["metadata"]["host_enforced"] is True
 
 
+def test_ui_control_windows_host_reports_closed_target_success_and_requires_explicit_rebind(monkeypatch: Any) -> None:
+    backend = _load_windows_uia_module()
+
+    class ClosingTargetHost(_FakeHostClient):
+        def execute(self, action: dict[str, Any]) -> dict[str, Any]:
+            self.executed.append(action)
+            return {
+                "type": "action_completed",
+                "success": True,
+                "target_closed": True,
+                "policy_tier": "task_grant",
+                "message": "completed; the exact target window closed",
+            }
+
+    _configure_fake_host(backend, monkeypatch)
+    monkeypatch.setattr(backend, "_HostClient", ClosingTargetHost)
+    snapshot = backend.snapshot_tool({"session_id": "transition"})
+    result = backend.act_tool(
+        {
+            "session_id": "transition",
+            "snapshot_id": snapshot["context"]["snapshot_id"],
+            "control_id": "uia:42.2",
+            "action": "click",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["context"]["target_closed"] is True
+    assert result["context"]["session_active"] is False
+    assert result["context"]["result"]["metadata"]["target_closed"] is True
+    assert result["context"]["result"]["metadata"]["requires_new_screenshot"] is False
+    assert result["context"]["audit"]["metadata"]["target_closed"] is True
+    assert "Explicitly bind the intended new PID/HWND" in result["prompt"]
+    assert backend._CLIENTS == {}
+
+
 def test_ui_control_windows_host_invalid_snapshot_target_exposes_scoped_recovery() -> None:
     backend = _load_windows_uia_module()
 
@@ -812,6 +890,25 @@ def test_ui_control_windows_host_invalid_snapshot_target_exposes_scoped_recovery
         "activate_window",
     ]
     assert "cannot change the authorized PID/HWND scope" in result["prompt"]
+
+
+def test_ui_control_windows_host_protected_system_ui_requires_manual_operator_recovery() -> None:
+    backend = _load_windows_uia_module()
+
+    result = backend._host_error(
+        backend.UiControlHostError(
+            "invalid_target",
+            "the requested pointer coordinate remains blocked by protected system UI: PickerHost / Shell_SystemDim",
+        )
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "invalid_target"
+    assert result["context"]["recovery_scope"] == "same_exact_pid_hwnd"
+    assert result["context"]["recovery_actions"] == ["stop", "snapshot"]
+    assert "ask the operator to close or move" in result["prompt"]
+    assert "Do not hide, override, click through, or ignore" in result["prompt"]
+    assert "fresh ui_control__snapshot" in result["prompt"]
 
 
 def test_ui_control_windows_host_propagates_trusted_confirmation_denial(monkeypatch: Any) -> None:
@@ -953,6 +1050,74 @@ def test_ui_control_host_client_uses_v2_only_pipe(monkeypatch: Any) -> None:
 
     assert client_module._PROTOCOL_VERSION == 2
     assert client_module._pipe_path() == r"\\.\pipe\dcc-mcp-ui-control-host-v2-session-42"
+
+
+def test_ui_control_host_client_revokes_local_capability_when_exact_target_closes() -> None:
+    import io
+    import struct
+
+    backend = _load_windows_uia_module()
+    client_module = backend._HOST
+
+    def frame(value: dict[str, Any]) -> bytes:
+        body = json.dumps(value).encode("utf-8")
+        return struct.pack(">I", len(body)) + body
+
+    class ScriptedPipe:
+        def __init__(self) -> None:
+            self.responses = io.BytesIO(
+                frame({"type": "hello", "protocol_version": 2, "capabilities": []})
+                + frame(
+                    {
+                        "type": "session_opened",
+                        "session_id": "transition",
+                        "window_capability": "window:opaque",
+                        "target": {"process_id": 42, "window_handle": 500, "window_title": "DCC"},
+                    }
+                )
+                + frame(
+                    {
+                        "type": "action_completed",
+                        "success": True,
+                        "target_closed": True,
+                        "policy_tier": "task_grant",
+                        "message": "completed; the exact target window closed",
+                    }
+                )
+            )
+            self.requests = bytearray()
+            self.closed = False
+
+        def read(self, length: int) -> bytes:
+            return self.responses.read(length)
+
+        def write(self, data: bytes) -> int:
+            self.requests.extend(data)
+            return len(data)
+
+        def close(self) -> None:
+            self.closed = True
+
+    stream = ScriptedPipe()
+    client = client_module.UiControlHostClient(
+        session_id="transition",
+        task_grant_id="grant",
+        dcc_type="unity",
+        process_id=42,
+        window_handle=500,
+        allow_raw_input=False,
+        stream=stream,
+    )
+    client._latest_observation_id = "obs-1"
+    client._latest_accessibility_state_id = "accessibility:1"
+
+    response = client.execute({"action": "click"})
+
+    assert response["target_closed"] is True
+    assert client._window_capability is None
+    assert stream.closed is True
+    with pytest.raises(client_module.UiControlHostError, match="session is closed"):
+        client.window_state()
 
 
 def test_ui_control_system_operation_uses_only_operator_grant_and_redacts_result(monkeypatch: Any) -> None:

--- a/tests/test_ui_control_window_recovery.py
+++ b/tests/test_ui_control_window_recovery.py
@@ -96,6 +96,7 @@ def test_process_scoped_host_session_ignores_transient_uia_root(monkeypatch: Any
 
     monkeypatch.setenv("DCC_MCP_COMPUTER_USE_ALLOW_RAW_INPUT", "true")
     monkeypatch.setenv("DCC_MCP_UI_CONTROL_UIA_PROCESS_ID", "1234")
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_UIA_WINDOW_HANDLE", raising=False)
     monkeypatch.setattr(backend, "_HostClient", FakeHostClient)
 
     policy = {"allow_keyboard_shortcuts": True}

--- a/tests/test_workflow_skill.py
+++ b/tests/test_workflow_skill.py
@@ -291,10 +291,11 @@ class TestRunChainBundledDiscovery:
 
     def test_get_bundled_skill_paths_returns_list(self):
         from dcc_mcp_core import get_bundled_skill_paths
+        from dcc_mcp_core import get_bundled_skills_dir
 
         paths = get_bundled_skill_paths()
         assert isinstance(paths, list)
-        assert len(paths) == 1
+        assert paths == [str(Path(get_bundled_skills_dir()))]
 
     def test_get_bundled_skill_paths_opt_out(self):
         from dcc_mcp_core import get_bundled_skill_paths


### PR DESCRIPTION
## Summary

- add the `dcc-mcp-ui-control-server` console entry point for a persistent, in-process UI Control executor bound to an explicit native PID/HWND and a version-matched Windows Host
- preserve tool arguments in subprocess fallback while keeping snapshot/action state in one gateway backend process; restrict the dedicated server to the canonical UI Control skill and version-owned bundled skills
- harden the native Host for minimized targets, custom-rendered viewport shortcuts, bounded confirmation, protected Windows UI, and exact-window closure without following replacement windows
- make `target_closed` an additive protocol result, revoke completed sessions on closure, and enforce canonical wheel contents after the App UI naming cutover

## Security properties

- raw printable input remains hard-denied by default; raw input requires an explicit launcher flag
- all operations remain capability-bound to the exact authorized PID/HWND
- a closed target revokes the session and never transfers authority to a replacement window
- protected Windows surfaces require operator recovery rather than click-through or concealment

## Validation

- focused Python UI Control/server/gateway and wheel-contract matrix: 112 passed
- native Rust packages: 128 `dcc-mcp-computer-use` tests and 17 `dcc-mcp-ui-control` tests passed serially on Windows
- the gateway regression takes a snapshot and performs a semantic focus action with the same session and snapshot ID, proving state survives across gateway calls
- the ABI3 Windows wheel passes the repository wheel contract, contains the productized module, console entry point, and version-matched Host, and installs into an isolated environment where the generated console shim runs
- a real Windows UIA probe completed snapshot, semantic action, and fresh snapshot through the persistent backend
- a Unity 2018.4.25 custom-rendered Player viewport completed a fresh snapshot and bound-window activation; a separate exact-window proof completed fresh snapshot plus Escape-driven target closure while an unmodified printable key remained hard-denied
- the final Unity 2018.4.25 product-wheel probe bound the exact native target, completed typed Play Mode control plus canonical show/restore/activate/snapshot and a modified shortcut, and kept typed inspection responsive before and after an expected paused Game View capture failure; the Escape latch then failed closed without retry, session cleanup completed, and the gateway port was released
- Rust formatting, Python formatting/lint, Python 3.7 syntax, and diff whitespace checks pass