### PR TITLE
fix: verify CLI release installs

### DIFF
--- a/.github/clawhub-skills.json
+++ b/.github/clawhub-skills.json
@@ -3,7 +3,7 @@
     "path": "skills/dcc-mcp",
     "slug": "dcc-mcp",
     "owner": "loonghao",
-    "version": "0.19.64"
+    "version": "0.19.65"
   },
   {
     "path": "skills/dcc-mcp-skills-creator",

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -50,16 +50,22 @@ CLI-first does **not** deprecate MCP. The gateway always exposes both MCP and RE
 
 ### Install and keep the CLI current
 
-If `dcc-mcp-cli` is missing, obtain the user's consent before installing the
-latest official release:
+If `dcc-mcp-cli` is missing, obtain the user's consent, install the public
+`dcc-mcp` Skill, and run its bundled verified helper from the Skill directory:
 
 ```bash
-# Linux/macOS
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
-
-# Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+python scripts/check_cli.py --ensure-cli --pretty
 ```
+
+The helper is fixed to the official `dcc-mcp/dcc-mcp-core` release. It checks
+the platform update manifest and CLI SHA-256 before replacing anything, and
+fails closed on an invalid URL, manifest, digest, or download. SHA-256 verifies
+that the binary matches the release manifest; it is not a digital signature. If
+the Skill is unavailable,
+[download the official installer to a local file, inspect it, and then execute
+that file](docs/guide/getting-started.md#cli-from-the-dcc-mcp-skill). Never pipe
+a remote installer directly into a shell or bypass the machine's script
+execution policy.
 
 Keep an official build current through the release manifest:
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,37 @@ exposes them. New gateway integrations should use the canonical names above.
 ## Quick start: operate a DCC
 
 `dcc-mcp-cli` is the preferred control path for every shell-capable agent.
-If it is missing, obtain the user's consent before installing the latest
-official release:
+If it is missing, obtain the user's consent, install the public `dcc-mcp`
+Skill below, and run its bundled verified helper from the Skill directory:
+
+~~~bash
+python scripts/check_cli.py --ensure-cli --pretty
+~~~
+
+Without the Skill, download the official installer to a local file, inspect it,
+and only then execute that file:
 
 ~~~bash
 # Linux/macOS
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
-
-# Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+curl -fL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh -o install-cli.sh
+cat install-cli.sh
+# After reviewing the file:
+sh ./install-cli.sh
 ~~~
+
+~~~powershell
+# Windows PowerShell
+Invoke-WebRequest https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 -OutFile .\install-cli.ps1
+Get-Content -Raw .\install-cli.ps1
+# After reviewing the file and subject to the current execution policy:
+& .\install-cli.ps1
+~~~
+
+Both paths accept only the official `dcc-mcp/dcc-mcp-core` release, validate
+the platform update manifest and CLI SHA-256, and leave any existing binary
+untouched if validation or download fails. This is an integrity check, not a
+digital signature. Never pipe a remote installer directly into a shell or
+bypass the machine's script execution policy.
 
 ### Install the agent Skill suite
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -88,18 +88,47 @@ instance row -> gateway 统一路由所有 live DCC instance。
 
 ## 快速开始
 
+### 安装 Agent Skill 套件
+
+可以直接从 ClawHub 安装三个公开 Skill，无需克隆本仓库：
+
+```bash
+openclaw skills install @loonghao/dcc-mcp
+openclaw skills install @loonghao/dcc-mcp-skills-creator
+openclaw skills install @loonghao/dcc-mcp-creator
+```
+
+需要让本机所有 OpenClaw Agent 共享时，给每条命令加 `--global`。其他兼容
+ClawHub 的 workspace 可以直接使用 registry CLI：
+
+```bash
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-skills-creator
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-creator
+```
+
+| Skill | Agent 职责 |
+|---|---|
+| [`dcc-mcp`](skills/dcc-mcp/) | 默认实时 DCC 控制和 marketplace 发现；Skill 商城请求先运行 `dcc-mcp-cli marketplace search` |
+| [`dcc-mcp-skills-creator`](skills/dcc-mcp-skills-creator/) | 创建、验证、打包和评审 DCC-MCP Skill |
+| [`dcc-mcp-creator`](skills/dcc-mcp-creator/) | 创建或现代化完整 DCC adapter 及运行时接线 |
+
 ### 安装独立 CLI
 
 `dcc-mcp-cli` 是所有具备 shell 能力的 Agent 的首选控制路径。如果尚未安装，
-先征得用户同意，再安装最新的官方 release 二进制：
+先征得用户同意，再从已安装的 `dcc-mcp` Skill 目录运行 bundled verified
+helper：
 
 ```bash
-# Linux/macOS
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
-
-# Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+python scripts/check_cli.py --ensure-cli --pretty
 ```
+
+helper 固定使用 `dcc-mcp/dcc-mcp-core` 官方 release，先验证当前平台的 update
+manifest 和 CLI SHA-256，再替换二进制。URL、manifest、摘要或下载异常时会
+fail closed，不会覆盖已有 CLI。SHA-256 用于确认二进制与 release manifest
+一致，不等同于数字签名。没有 Skill 时，请按下方“安装详情”下载并检查本地
+installer；不要把远程 installer 通过管道交给 shell，也不要绕过机器的脚本执行
+策略。
 
 官方构建通过 release manifest 保持最新：
 
@@ -280,15 +309,27 @@ Admin 重点能力：
 ### 安装独立 CLI
 
 对于具备 shell 能力的 Agent，独立 CLI 是首选控制路径。尚未安装时，先征得
-用户同意，再安装官方 release 二进制：
+用户同意，把官方 installer 下载为本地文件，先检查，再执行：
 
 ```bash
 # Linux/macOS
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
-
-# Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+curl -fL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh -o install-cli.sh
+cat install-cli.sh
+# 检查完成后：
+sh ./install-cli.sh
 ```
+
+```powershell
+# Windows PowerShell
+Invoke-WebRequest https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 -OutFile .\install-cli.ps1
+Get-Content -Raw .\install-cli.ps1
+# 检查完成后，遵循当前执行策略：
+& .\install-cli.ps1
+```
+
+installer 固定使用 `dcc-mcp/dcc-mcp-core` 官方 release，并在替换现有 CLI 前
+验证 release manifest 中的 URL 和 SHA-256。任何异常都会 fail closed；这项
+完整性校验不等同于数字签名。
 
 默认会下载最新 GitHub Release 里的对应资产：
 
@@ -301,15 +342,11 @@ powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc
 也可以固定版本或自定义安装目录：
 
 ```bash
-export DCC_MCP_VERSION=v0.x.y
-export DCC_MCP_INSTALL_DIR="$HOME/bin"
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
+sh ./install-cli.sh --version v0.x.y --install-dir "$HOME/bin"
 ```
 
 ```powershell
-$env:DCC_MCP_VERSION = "v0.x.y"
-$env:DCC_MCP_INSTALL_DIR = "$env:USERPROFILE\bin"
-irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex
+& .\install-cli.ps1 -Version "v0.x.y" -InstallDir "$env:USERPROFILE\bin"
 ```
 
 安装后：

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -9,17 +9,38 @@ same configuration surface.
 `dcc-mcp-cli` and `dcc-mcp-server` are published as raw GitHub Release
 assets on every release. It is the preferred control path for shell-capable
 agents. If it is missing, obtain the user's consent before installing it from
-the official URL:
+the official release. From the installed `dcc-mcp` Skill directory, run:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
-
-# Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+python scripts/check_cli.py --ensure-cli --pretty
 ```
 
-Pin a release by setting `DCC_MCP_VERSION=v0.17.17` or passing
-`--version v0.17.17` to the install script.
+The bundled helper is fixed to `dcc-mcp/dcc-mcp-core`, validates the platform
+update manifest and CLI SHA-256, and leaves the existing binary untouched if
+the URL, manifest, digest, or download is invalid. SHA-256 is an integrity
+check, not a digital signature. Without the Skill, download the official
+installer as a local file, inspect it, and only then execute it:
+
+```bash
+curl -fL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh -o install-cli.sh
+cat install-cli.sh
+# After reviewing the file:
+sh ./install-cli.sh
+```
+
+```powershell
+Invoke-WebRequest https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 -OutFile .\install-cli.ps1
+Get-Content -Raw .\install-cli.ps1
+# After reviewing the file and subject to the current execution policy:
+& .\install-cli.ps1
+```
+
+The local installer uses the same fixed source and verification contract.
+Never pipe it directly into a shell or bypass the machine's script execution
+policy.
+
+Pin a release with `sh ./install-cli.sh --version v0.19.63` or
+`& .\install-cli.ps1 -Version v0.19.63`.
 
 A standalone CLI-only ZIP (`dcc-mcp-cli-<version>-<platform>.zip`) is
 also published as a GitHub Release asset alongside the server bundle.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -2,19 +2,44 @@
 
 ## Installation
 
-### CLI from GitHub Releases
+### CLI from the `dcc-mcp` Skill
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
-
-# Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+# Run from the installed dcc-mcp Skill directory.
+python scripts/check_cli.py --ensure-cli --pretty
 ```
 
-This installs the standalone `dcc-mcp-cli` control-plane binary from the
-latest GitHub Release. Pin a release with `DCC_MCP_VERSION=v0.17.17`.
-
 For agents, obtain user consent before installing or downloading a new binary.
+The bundled helper is fixed to the official `dcc-mcp/dcc-mcp-core` release. It
+validates the platform update manifest and CLI SHA-256 before replacing the
+binary, and fails closed on an invalid URL, manifest, digest, or download.
+SHA-256 verifies that the binary matches the release manifest; it is not a
+digital signature.
+
+Without the Skill, download the official installer to a local file, inspect it,
+and only then execute that file:
+
+```bash
+curl -fL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh -o install-cli.sh
+cat install-cli.sh
+# After reviewing the file:
+sh ./install-cli.sh
+```
+
+```powershell
+Invoke-WebRequest https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 -OutFile .\install-cli.ps1
+Get-Content -Raw .\install-cli.ps1
+# After reviewing the file and subject to the current execution policy:
+& .\install-cli.ps1
+```
+
+The installer uses the same fixed official source, manifest, and SHA-256
+checks as the bundled helper. Never pipe it directly into a shell or bypass the
+machine's script execution policy.
+
+Pin a release with `sh ./install-cli.sh --version v0.19.63` or
+`& .\install-cli.ps1 -Version v0.19.63`.
+
 Keep an official installation current with:
 
 ```bash

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -6,17 +6,37 @@
 
 `dcc-mcp-cli` 与 `dcc-mcp-server` 会在每个 Release 作为原生 GitHub
 Release 资产发布。它是所有具备 shell 能力的 Agent 的首选控制路径。如果尚未
-安装，先征得用户同意，再通过官方 URL 安装：
+安装，先征得用户同意，再从已安装的 `dcc-mcp` Skill 目录运行：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
-
-# Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+python scripts/check_cli.py --ensure-cli --pretty
 ```
 
-需要固定版本时，设置 `DCC_MCP_VERSION=v0.17.17`，或给安装脚本传
-`--version v0.17.17`。
+这个 bundled helper 固定使用 `dcc-mcp/dcc-mcp-core` 官方 release，先验证
+当前平台的 update manifest 和 CLI SHA-256，再替换二进制。URL、manifest、
+摘要或下载异常时会 fail closed，不会覆盖已有 CLI。SHA-256 是完整性检查，
+不等同于数字签名。如果没有安装 Skill，请把官方 installer 下载为本地文件，
+先检查，再执行：
+
+```bash
+curl -fL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh -o install-cli.sh
+cat install-cli.sh
+# 检查完成后：
+sh ./install-cli.sh
+```
+
+```powershell
+Invoke-WebRequest https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 -OutFile .\install-cli.ps1
+Get-Content -Raw .\install-cli.ps1
+# 检查完成后，遵循当前执行策略：
+& .\install-cli.ps1
+```
+
+本地 installer 使用相同的固定来源和验证契约。不要把它通过管道直接交给 shell，
+也不要绕过机器的脚本执行策略。
+
+固定版本可运行 `sh ./install-cli.sh --version v0.19.63`，或
+`& .\install-cli.ps1 -Version v0.19.63`。
 
 | 二进制 | 角色 | 源码位置 |
 |---|---|---|

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -2,20 +2,44 @@
 
 ## 安装
 
-### 从 GitHub Release 安装 CLI
+### 从 `dcc-mcp` Skill 安装 CLI
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
-
-# Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+# 在已安装的 dcc-mcp Skill 目录中运行。
+python scripts/check_cli.py --ensure-cli --pretty
 ```
 
-这会从最新 GitHub Release 安装独立的 `dcc-mcp-cli` 控制面二进制。
-需要固定版本时设置 `DCC_MCP_VERSION=v0.17.17`。
+Agent 在安装或下载新二进制前必须先征得用户同意。这个 bundled helper 只接受
+官方 `dcc-mcp/dcc-mcp-core` release；它会先验证当前平台的 update manifest 和
+CLI SHA-256，再替换二进制。URL、manifest、摘要或下载异常时会 fail closed，
+不会覆盖已有 CLI。SHA-256 用于确认二进制与 release manifest 一致，不等同于
+数字签名。
 
-Agent 在安装或下载新二进制前必须先征得用户同意。官方安装可以通过以下命令
-保持最新：
+如果没有安装 Skill，请把官方 installer 下载为本地文件，先检查内容，再执行该
+本地文件：
+
+```bash
+curl -fL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh -o install-cli.sh
+cat install-cli.sh
+# 检查完成后：
+sh ./install-cli.sh
+```
+
+```powershell
+Invoke-WebRequest https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 -OutFile .\install-cli.ps1
+Get-Content -Raw .\install-cli.ps1
+# 检查完成后，遵循当前执行策略：
+& .\install-cli.ps1
+```
+
+installer 与 bundled helper 使用相同的固定官方来源、manifest 和 SHA-256
+校验。不要把远程 installer 直接通过管道交给 shell，也不要绕过机器的脚本执行
+策略。
+
+固定版本可运行 `sh ./install-cli.sh --version v0.19.63`，或
+`& .\install-cli.ps1 -Version v0.19.63`。
+
+官方安装可以通过以下命令保持最新：
 
 ```bash
 dcc-mcp-cli update check

--- a/scripts/install-cli.ps1
+++ b/scripts/install-cli.ps1
@@ -1,13 +1,13 @@
 param(
     [string] $Version = $env:DCC_MCP_VERSION,
-    [string] $InstallDir = $env:DCC_MCP_INSTALL_DIR,
-    [string] $Repo = $env:DCC_MCP_REPO
+    [string] $InstallDir = $env:DCC_MCP_INSTALL_DIR
 )
 
-# One-line install:
-# powershell -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
-
 $ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+$officialReleases = "https://github.com/dcc-mcp/dcc-mcp-core/releases"
+$platform = "windows-x86_64"
+$asset = "dcc-mcp-cli-windows-x86_64.exe"
 
 if ([string]::IsNullOrWhiteSpace($Version)) {
     $Version = "latest"
@@ -15,39 +15,86 @@ if ([string]::IsNullOrWhiteSpace($Version)) {
 if ([string]::IsNullOrWhiteSpace($InstallDir)) {
     $InstallDir = Join-Path $env:LOCALAPPDATA "dcc-mcp\bin"
 }
-if ([string]::IsNullOrWhiteSpace($Repo)) {
-    $Repo = "dcc-mcp/dcc-mcp-core"
-}
 
-$asset = "dcc-mcp-cli-windows-x86_64.exe"
 if ($Version -eq "latest") {
-    $url = "https://github.com/$Repo/releases/latest/download/$asset"
+    $requestedVersion = $null
+    $manifestUrl = "$officialReleases/latest/download/dcc-mcp-update-manifest-$platform.json"
 } else {
-    $url = "https://github.com/$Repo/releases/download/$Version/$asset"
+    if ($Version -notmatch '^v?([0-9]+\.[0-9]+\.[0-9]+([.+-][0-9A-Za-z.-]+)?)$') {
+        throw "Invalid release version: $Version"
+    }
+    $requestedVersion = $Matches[1]
+    $manifestUrl = "$officialReleases/download/v$requestedVersion/dcc-mcp-update-manifest-$platform.json"
 }
 
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 $target = Join-Path $InstallDir "dcc-mcp-cli.exe"
-$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("dcc-mcp-cli-" + [System.Guid]::NewGuid() + ".exe")
+$manifestTmp = Join-Path $InstallDir (".dcc-mcp-manifest-" + [System.Guid]::NewGuid() + ".json")
+$binaryTmp = Join-Path $InstallDir (".dcc-mcp-cli-" + [System.Guid]::NewGuid() + ".exe")
 
 try {
-    Write-Host "Downloading $url"
-    Invoke-WebRequest -Uri $url -OutFile $tmp
-    Move-Item -Force -Path $tmp -Destination $target
+    Write-Host "Downloading $manifestUrl"
+    Invoke-WebRequest -Uri $manifestUrl -OutFile $manifestTmp
+
+    $manifestText = Get-Content -LiteralPath $manifestTmp -Raw
+    if ([regex]::Matches($manifestText, '"dcc-mcp-cli"\s*:').Count -ne 1) {
+        throw "Official release manifest must contain one dcc-mcp-cli entry"
+    }
+    try {
+        $manifest = $manifestText | ConvertFrom-Json
+    } catch {
+        throw "Official release manifest is not valid JSON: $($_.Exception.Message)"
+    }
+    $entry = $manifest.'dcc-mcp-cli'
+    if ($null -eq $entry) {
+        throw "Official release manifest is missing dcc-mcp-cli"
+    }
+
+    $manifestVersion = [string] $entry.version
+    $assetUrl = [string] $entry.url
+    $expectedSha256 = [string] $entry.sha256
+    if ($manifestVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+([.+-][0-9A-Za-z.-]+)?$') {
+        throw "Official release manifest contains an invalid dcc-mcp-cli version"
+    }
+    if ($Version -ne "latest" -and $manifestVersion -ne $requestedVersion) {
+        throw "Official release manifest version does not match requested version $requestedVersion"
+    }
+
+    $expectedUrl = "$officialReleases/download/v$manifestVersion/$asset"
+    if ($assetUrl -cne $expectedUrl) {
+        throw "Official release manifest contains a non-official dcc-mcp-cli URL"
+    }
+    if ($expectedSha256 -notmatch '^[0-9A-Fa-f]{64}$') {
+        throw "Official release manifest contains an invalid SHA-256"
+    }
+
+    Write-Host "Downloading $assetUrl"
+    Invoke-WebRequest -Uri $assetUrl -OutFile $binaryTmp
+    $actualSha256 = (Get-FileHash -LiteralPath $binaryTmp -Algorithm SHA256).Hash
+    if ($actualSha256 -ine $expectedSha256) {
+        throw "dcc-mcp-cli SHA-256 does not match the official release manifest"
+    }
+
+    if (Test-Path -LiteralPath $target) {
+        [System.IO.File]::Replace($binaryTmp, $target, $null)
+    } else {
+        [System.IO.File]::Move($binaryTmp, $target)
+    }
 } finally {
-    if (Test-Path $tmp) {
-        Remove-Item -Force $tmp
+    foreach ($path in @($manifestTmp, $binaryTmp)) {
+        if (Test-Path -LiteralPath $path) {
+            Remove-Item -LiteralPath $path -Force
+        }
     }
 }
 
-Write-Host "Installed dcc-mcp-cli to $target"
+Write-Host "Installed verified dcc-mcp-cli $manifestVersion to $target"
 
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
 $pathParts = @()
 if ($userPath) {
     $pathParts = $userPath -split ";"
 }
-
 if ($pathParts -notcontains $InstallDir) {
     $newPath = if ($userPath) { "$userPath;$InstallDir" } else { $InstallDir }
     [Environment]::SetEnvironmentVariable("Path", $newPath, "User")

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,47 +1,41 @@
 #!/usr/bin/env sh
 set -eu
 
-REPO="${DCC_MCP_REPO:-dcc-mcp/dcc-mcp-core}"
+OFFICIAL_RELEASES="https://github.com/dcc-mcp/dcc-mcp-core/releases"
 VERSION="${DCC_MCP_VERSION:-latest}"
 INSTALL_DIR="${DCC_MCP_INSTALL_DIR:-$HOME/.local/bin}"
-RELEASE_FALLBACK="${DCC_MCP_RELEASE_FALLBACK:-1}"
 
 usage() {
     cat <<'EOF'
-Install dcc-mcp-cli from GitHub Releases.
+Install dcc-mcp-cli from its official GitHub release manifest.
 
 Usage:
-  install-cli.sh [--version v0.17.4] [--install-dir ~/.local/bin]
+  install-cli.sh [--version v0.19.63] [--install-dir ~/.local/bin]
 
-One-line install:
-  curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | bash
+Download this script first, inspect it, then run the local file.
+The installer verifies the release-manifest URL and SHA-256 before replacing
+an existing dcc-mcp-cli binary.
 
 Environment:
-  DCC_MCP_REPO         GitHub repo, default dcc-mcp/dcc-mcp-core
-  DCC_MCP_VERSION      Release tag, default latest
+  DCC_MCP_VERSION      Release version, default latest
   DCC_MCP_INSTALL_DIR  Install directory, default ~/.local/bin
-  DCC_MCP_RELEASE_FALLBACK
-                       When latest asset is missing, download the newest
-                       release that includes the asset. Set to 0/false/no to
-                       disable. Default enabled.
 EOF
+}
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
 }
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --version)
-            if [ "$#" -lt 2 ]; then
-                echo "--version requires a value" >&2
-                exit 2
-            fi
+            [ "$#" -ge 2 ] || fail "--version requires a value"
             VERSION="$2"
             shift 2
             ;;
         --install-dir)
-            if [ "$#" -lt 2 ]; then
-                echo "--install-dir requires a value" >&2
-                exit 2
-            fi
+            [ "$#" -ge 2 ] || fail "--install-dir requires a value"
             INSTALL_DIR="$2"
             shift 2
             ;;
@@ -59,114 +53,119 @@ done
 
 OS="$(uname -s)"
 ARCH="$(uname -m)"
-
 case "$OS" in
     Linux)
         if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "amd64" ]; then
-            echo "Unsupported Linux architecture: $ARCH" >&2
-            exit 1
+            fail "unsupported Linux architecture: $ARCH"
         fi
+        PLATFORM="linux-x86_64"
         ASSET="dcc-mcp-cli-linux-x86_64"
         ;;
     Darwin)
+        PLATFORM="macos-universal2"
         ASSET="dcc-mcp-cli-macos-universal2"
         ;;
     *)
-        echo "Unsupported OS: $OS" >&2
-        exit 1
+        fail "unsupported OS: $OS"
         ;;
 esac
 
+REQUESTED_VERSION="${VERSION#v}"
 if [ "$VERSION" = "latest" ]; then
-    URL="https://github.com/$REPO/releases/latest/download/$ASSET"
+    MANIFEST_URL="$OFFICIAL_RELEASES/latest/download/dcc-mcp-update-manifest-$PLATFORM.json"
 else
-    URL="https://github.com/$REPO/releases/download/$VERSION/$ASSET"
+    printf '%s' "$REQUESTED_VERSION" \
+        | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.+-][0-9A-Za-z.-]+)?$' \
+        || fail "invalid release version: $VERSION"
+    MANIFEST_URL="$OFFICIAL_RELEASES/download/v$REQUESTED_VERSION/dcc-mcp-update-manifest-$PLATFORM.json"
 fi
-
-TMP_DIR="$(mktemp -d)"
-cleanup() {
-    rm -rf "$TMP_DIR"
-}
-trap cleanup EXIT INT TERM
-
-download_url() {
-    url="$1"
-    echo "Downloading $url"
-    if command -v curl >/dev/null 2>&1; then
-        curl -fL "$url" -o "$TMP_DIR/dcc-mcp-cli"
-    elif command -v wget >/dev/null 2>&1; then
-        wget -O "$TMP_DIR/dcc-mcp-cli" "$url"
-    else
-        echo "curl or wget is required to download release assets" >&2
-        return 1
-    fi
-}
-
-release_fallback_enabled() {
-    case "$RELEASE_FALLBACK" in
-        0|false|FALSE|no|NO)
-            return 1
-            ;;
-        *)
-            return 0
-            ;;
-    esac
-}
-
-latest_release_asset_url() {
-    releases_json="$TMP_DIR/releases.json"
-    api_url="https://api.github.com/repos/$REPO/releases?per_page=30"
-    echo "Looking for the newest release containing $ASSET" >&2
-    if command -v curl >/dev/null 2>&1; then
-        if [ -n "${GITHUB_TOKEN:-}" ]; then
-            curl -fsSL \
-                -H "Authorization: Bearer $GITHUB_TOKEN" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "$api_url" -o "$releases_json"
-        else
-            curl -fsSL "$api_url" -o "$releases_json"
-        fi
-    elif command -v wget >/dev/null 2>&1; then
-        if [ -n "${GITHUB_TOKEN:-}" ]; then
-            wget -q \
-                --header="Authorization: Bearer $GITHUB_TOKEN" \
-                --header="X-GitHub-Api-Version: 2022-11-28" \
-                -O "$releases_json" "$api_url"
-        else
-            wget -q -O "$releases_json" "$api_url"
-        fi
-    else
-        return 1
-    fi
-    tr ',' '\n' < "$releases_json" \
-        | sed -n 's/.*"browser_download_url":[[:space:]]*"\([^"]*\/'"$ASSET"'\)".*/\1/p' \
-        | head -n 1
-}
 
 mkdir -p "$INSTALL_DIR"
-if ! download_url "$URL"; then
-    if [ "$VERSION" = "latest" ] && release_fallback_enabled; then
-        fallback_url="$(latest_release_asset_url || true)"
-        if [ -n "$fallback_url" ]; then
-            echo "Latest release did not provide $ASSET; falling back to $fallback_url"
-            download_url "$fallback_url"
-        else
-            echo "No release asset named $ASSET was found in recent releases." >&2
-            exit 1
-        fi
+MANIFEST_TMP="$(mktemp "$INSTALL_DIR/.dcc-mcp-manifest.XXXXXX")"
+BINARY_TMP="$(mktemp "$INSTALL_DIR/.dcc-mcp-cli.XXXXXX")"
+cleanup() {
+    rm -f "$MANIFEST_TMP" "$BINARY_TMP"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+download_to() {
+    url="$1"
+    output="$2"
+    echo "Downloading $url"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$output"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q -O "$output" "$url"
     else
-        echo "Release asset download failed." >&2
-        exit 1
+        fail "curl or wget is required to download release assets"
     fi
+}
+
+manifest_field() {
+    field="$1"
+    awk -v field="$field" '
+        /^[[:space:]]*"dcc-mcp-cli"[[:space:]]*:[[:space:]]*\{[[:space:]]*$/ {
+            in_cli = 1
+            next
+        }
+        in_cli && /^[[:space:]]*\}[,]?[[:space:]]*$/ { exit }
+        in_cli && $0 ~ "^[[:space:]]*\"" field "\"[[:space:]]*:" {
+            value = $0
+            sub("^[^:]*:[[:space:]]*\"", "", value)
+            sub("\"[[:space:]]*,?[[:space:]]*$", "", value)
+            print value
+        }
+    ' "$MANIFEST_TMP"
+}
+
+calculate_sha256() {
+    path="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$path" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$path" | awk '{print $1}'
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$path" | awk '{print $NF}'
+    else
+        fail "sha256sum, shasum, or openssl is required to verify dcc-mcp-cli"
+    fi
+}
+
+download_to "$MANIFEST_URL" "$MANIFEST_TMP" \
+    || fail "official release manifest download failed"
+
+ENTRY_COUNT="$(grep -Ec '^[[:space:]]*"dcc-mcp-cli"[[:space:]]*:[[:space:]]*\{' "$MANIFEST_TMP" || true)"
+[ "$ENTRY_COUNT" = "1" ] || fail "official release manifest must contain one dcc-mcp-cli entry"
+
+MANIFEST_VERSION="$(manifest_field version)"
+ASSET_URL="$(manifest_field url)"
+EXPECTED_SHA256="$(manifest_field sha256)"
+printf '%s' "$MANIFEST_VERSION" \
+    | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.+-][0-9A-Za-z.-]+)?$' \
+    || fail "official release manifest contains an invalid dcc-mcp-cli version"
+if [ "$VERSION" != "latest" ] && [ "$MANIFEST_VERSION" != "$REQUESTED_VERSION" ]; then
+    fail "official release manifest version does not match requested version $REQUESTED_VERSION"
 fi
 
-chmod 0755 "$TMP_DIR/dcc-mcp-cli"
-mv "$TMP_DIR/dcc-mcp-cli" "$INSTALL_DIR/dcc-mcp-cli"
+EXPECTED_URL="$OFFICIAL_RELEASES/download/v$MANIFEST_VERSION/$ASSET"
+[ "$ASSET_URL" = "$EXPECTED_URL" ] \
+    || fail "official release manifest contains a non-official dcc-mcp-cli URL"
+[ "${#EXPECTED_SHA256}" -eq 64 ] \
+    && ! printf '%s' "$EXPECTED_SHA256" | grep -Eq '[^0-9A-Fa-f]' \
+    || fail "official release manifest contains an invalid SHA-256"
 
-echo "Installed dcc-mcp-cli to $INSTALL_DIR/dcc-mcp-cli"
+download_to "$ASSET_URL" "$BINARY_TMP" || fail "dcc-mcp-cli download failed"
+ACTUAL_SHA256="$(calculate_sha256 "$BINARY_TMP")"
+[ "$(printf '%s' "$ACTUAL_SHA256" | tr 'A-F' 'a-f')" = "$(printf '%s' "$EXPECTED_SHA256" | tr 'A-F' 'a-f')" ] \
+    || fail "dcc-mcp-cli SHA-256 does not match the official release manifest"
+
+chmod 0755 "$BINARY_TMP"
+TARGET="$INSTALL_DIR/dcc-mcp-cli"
+mv -f "$BINARY_TMP" "$TARGET"
+
+echo "Installed verified dcc-mcp-cli $MANIFEST_VERSION to $TARGET"
 case ":$PATH:" in
     *":$INSTALL_DIR:"*) ;;
-    *)
-        echo "Add $INSTALL_DIR to PATH to run dcc-mcp-cli from any shell."
-        ;;
+    *) echo "Add $INSTALL_DIR to PATH to run dcc-mcp-cli from any shell." ;;
 esac

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -19,8 +19,8 @@ metadata:
   dcc-mcp:
     dcc: python
     layer: infrastructure
-    compatibility: Cross-platform Windows/macOS/Linux. Prefers dcc-mcp-cli on PATH; can download release asset from GitHub; local profile needs no gateway env. DCC_MCP_BASE_URL is optional for remote/legacy gateway REST fallback.
-    version: "0.19.64"
+    compatibility: Cross-platform Windows/macOS/Linux. Prefers dcc-mcp-cli on PATH; its consent-gated bootstrap accepts only the official release manifest and verifies SHA-256 before replacement. Local profile needs no gateway env. DCC_MCP_BASE_URL is optional for remote/legacy gateway REST fallback.
+    version: "0.19.65"
     search-hint: "dcc control operate UI control menu dialog window button click keyboard Maya Blender Houdini Photoshop 3ds Max Nuke Unreal Godot RenderDoc Substance connect create edit render automate cli gateway stats marketplace skill catalog recommend install update 商城 技能 操作 控制 界面 菜单 弹窗 窗口 按钮 点击 键盘"
     tags: "dcc, dcc-ui-control, ui-control, maya, blender, houdini, photoshop, nuke, unreal, godot, renderdoc, cli, gateway, marketplace, skill-catalog, clawhub, openclaw"
   openclaw:
@@ -147,8 +147,11 @@ or when the user explicitly chooses that integration.
 ### CLI installation
 
 If `dcc-mcp-cli` is missing, obtain the user's consent before installing the
-latest official release. Exact Linux/macOS and Windows commands, update
-semantics, and development fallbacks live in
+latest official release. The bundled installer is fixed to the official
+repository, validates the release-manifest URL and version, and verifies the
+binary SHA-256 before atomically replacing any existing CLI. A missing or
+invalid manifest, unexpected URL, or digest mismatch fails closed. Exact
+commands, update semantics, and development fallbacks live in
 [`references/CLI_CHEATSHEET.md`](references/CLI_CHEATSHEET.md).
 
 ### DCC UI Control fallback
@@ -233,8 +236,8 @@ when setup, lifecycle, or transport troubleshooting is needed.
 
 1. Use `dcc-mcp-cli list` for local inventory, or `dcc-mcp-cli list --gateway <name>` for a remote profile.
 2. Use `dcc-mcp-cli` for all subsequent commands when it is on `PATH`.
-3. If missing, ask user permission, then download `dcc-mcp-cli` from GitHub Releases.
-4. If the download fails, use the bundled Python stdlib REST fallback.
+3. If missing, ask user permission, then use the bundled verified installer for the official GitHub release.
+4. If manifest or SHA-256 verification fails, preserve any existing CLI and use the bundled Python stdlib REST fallback where supported.
 
 Install via OpenClaw/ClawHub, or point your agent at this `SKILL.md` after cloning
 [`dcc-mcp-core/skills/dcc-mcp/`](https://github.com/dcc-mcp/dcc-mcp-core/tree/main/skills/dcc-mcp).
@@ -253,7 +256,7 @@ remove the old package to avoid duplicate intent routing.
 | **Starting any local DCC task** | Run `dcc-mcp-cli list`; it ensures the local gateway, then reads the local FileRegistry |
 | **Startup state is ambiguous** | Run `dcc-mcp-cli doctor`; inspect selected profile, registry dir, local inventory, direct-control readiness counts, daemon status, and server binary diagnostics |
 | **Starting any remote DCC task** | Select or override a profile with `dcc-mcp-cli gateway set <name>` or `dcc-mcp-cli list --gateway <name>` |
-| `dcc-mcp-cli` missing | Ask permission before `--ensure-cli`; fallback Python REST is allowed if download fails |
+| `dcc-mcp-cli` missing | Ask permission before `--ensure-cli`; it must verify the official manifest and SHA-256, and Python REST fallback is allowed if verification or download fails |
 | CLI auto-ensure fails | Stop; explain the result; do not run agent-control or gateway endpoint commands until the gateway is reachable |
 | Inventory returns `total == 0` | Stop; do not run `search`, `describe`, or `call` |
 | Remote gateway unreachable | Stop; explain; ask user permission before troubleshooting |
@@ -469,5 +472,5 @@ the returned policy prompt and hand off to the named deployment owner.
 
 The CLI is the **default agent-facing control plane**. The Python fallback uses
 the same gateway REST endpoints only when the CLI is unavailable after a
-download attempt fails. The gateway still serves MCP for IDE clients in parallel;
-choosing this skill does not replace or disable the IDE MCP path.
+verified install attempt fails. The gateway still serves MCP for IDE clients in
+parallel; choosing this skill does not replace or disable the IDE MCP path.

--- a/skills/dcc-mcp/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-mcp/references/CLI_CHEATSHEET.md
@@ -10,15 +10,18 @@ explicit user choice.
 ## CLI setup
 
 If `dcc-mcp-cli` is missing, obtain user consent before installing the latest
-official release:
+official release. From the installed `dcc-mcp` Skill directory, run the bundled
+verified helper:
 
 ```bash
-# Linux/macOS
-curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
-
-# Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+python scripts/check_cli.py --ensure-cli --pretty
 ```
+
+The helper accepts only the official `dcc-mcp/dcc-mcp-core` release manifest,
+validates its version and asset URL, and verifies the downloaded binary's
+SHA-256 before an atomic replacement. It fails closed and preserves an existing
+CLI when the manifest, URL, download, or digest is invalid. SHA-256 provides
+release-manifest integrity checking; it is not a publisher signature.
 
 Keep an official build current through the release manifest:
 
@@ -30,7 +33,8 @@ dcc-mcp-cli update apply
 `update apply` downloads and stages the latest CLI for the next launch. It does
 not update a running `dcc-mcp-server`; update that server in its own environment.
 
-For repository development only, the consent-gated bootstrap/fallback is:
+For repository development only, the same consent-gated verified
+bootstrap/fallback is:
 
 ```bash
 vx python scripts/dcc_gateway.py --ensure-cli list
@@ -171,7 +175,7 @@ python scripts/dcc_gateway.py call maya.a1b2c3d4.maya_primitives__create_sphere 
 
 | Symptom | Action |
 |---------|--------|
-| CLI not found | Ask user permission, then run `vx python scripts/dcc_gateway.py --ensure-cli list` to download `dcc-mcp-cli`; Python fallback runs if download fails |
+| CLI not found | Ask user permission, then run `vx python scripts/dcc_gateway.py --ensure-cli list`; it verifies the official manifest and SHA-256 before install, and Python fallback runs if verification or download fails |
 | Gateway health fails | Run `dcc-mcp-cli doctor` and inspect the CLI JSON/stderr. Agent-control and endpoint/admin/update commands auto-ensure only loopback gateway targets. For remote profiles or `--base-url`, auto-start is not possible. Ask before installing adapters or launching GUI DCC apps |
 | `total == 0` | Start a DCC adapter, then re-run `dcc-mcp-cli list` |
 | Listed row is booting or `dispatch_status=unavailable` | Read `direct_control.recommended_next_action` and `direct_control.diagnostics`, then run `dcc-mcp-cli wait-ready --dcc-type <dcc> --instance-id <id>` or `dcc-mcp-cli doctor`; do not call tools until `direct_control.ready=true` |

--- a/skills/dcc-mcp/references/ZERO_INSTANCES_CLI.md
+++ b/skills/dcc-mcp/references/ZERO_INSTANCES_CLI.md
@@ -88,8 +88,12 @@ python scripts/dcc_gateway.py install --dcc-type maya
 python scripts/dcc_gateway.py install --dcc-type blender
 ```
 
-The Python fallback auto-downloads the CLI if needed (with user consent, pass
-`--ensure-cli`), then delegates to `dcc-mcp-cli install`.
+The Python fallback can install the CLI if needed only after user consent (pass
+`--ensure-cli`). It accepts the fixed official release manifest, validates the
+version and asset URL, verifies SHA-256, and only then delegates to
+`dcc-mcp-cli install`. Verification failure preserves any existing CLI and
+falls back to the supported Python REST operations; adapter installation itself
+still requires the CLI.
 
 ---
 
@@ -126,12 +130,6 @@ carries sidecar `failure_stage`, `failure_reason`, host RPC metadata, gateway
 recovery fields, and any supervisor-recorded stdout/stderr log paths. If
 marketplace skills are installed, finish with `reload-skills`.
 
-If Python is not available as `python` / `py`, install vx first:
-
-```bash
-# Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
-
-# Windows PowerShell
-powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
-```
+If neither Python nor `py` is available, stop and ask the operator to provision
+Python or `vx` through a trusted OS or studio package manager. Do not fetch and
+execute a remote installer through a shell pipeline.

--- a/skills/dcc-mcp/scripts/check_cli.py
+++ b/skills/dcc-mcp/scripts/check_cli.py
@@ -1,4 +1,4 @@
-"""Probe dcc-mcp-cli availability and gateway instance inventory."""
+"""Probe dcc-mcp-cli, optionally install it verified, and inspect inventory."""
 
 from __future__ import annotations
 
@@ -46,7 +46,7 @@ def probe(
     ensure_cli: bool = False,
     install_dir: str | None = None,
 ) -> dict[str, Any]:
-    """Return CLI availability, health, and instance inventory."""
+    """Return CLI availability and inventory, with opt-in verified install."""
     resolved = shutil.which(cli)
     url = base_url or os.environ.get("DCC_MCP_BASE_URL") or DEFAULT_BASE_URL
     result: dict[str, Any] = {
@@ -63,8 +63,6 @@ def probe(
         resolved_install_dir = install_dir or os.environ.get("DCC_MCP_INSTALL_DIR") or str(default_install_dir)
         ok, message, download_url = dcc_gateway.install_cli(
             install_dir=Path(resolved_install_dir),
-            repo=os.environ.get("DCC_MCP_REPO") or dcc_gateway.DEFAULT_REPO,
-            version=os.environ.get("DCC_MCP_VERSION") or dcc_gateway.DEFAULT_VERSION,
         )
         result["install_attempted"] = True
         result["install_ok"] = ok
@@ -119,10 +117,16 @@ def probe(
 
 def main() -> int:
     """CLI entry point."""
-    parser = argparse.ArgumentParser(description="Probe dcc-mcp-cli and gateway inventory")
+    parser = argparse.ArgumentParser(
+        description="Probe dcc-mcp-cli and gateway inventory with optional verified installation"
+    )
     parser.add_argument("--cli", default="dcc-mcp-cli")
     parser.add_argument("--base-url", default=os.environ.get("DCC_MCP_BASE_URL") or DEFAULT_BASE_URL)
-    parser.add_argument("--ensure-cli", action="store_true")
+    parser.add_argument(
+        "--ensure-cli",
+        action="store_true",
+        help="After explicit user consent, install from the verified official release manifest",
+    )
     parser.add_argument("--install-dir", default=os.environ.get("DCC_MCP_INSTALL_DIR"))
     parser.add_argument("--pretty", action="store_true")
     args = parser.parse_args()

--- a/skills/dcc-mcp/scripts/dcc_gateway.py
+++ b/skills/dcc-mcp/scripts/dcc_gateway.py
@@ -1,15 +1,16 @@
-"""Cross-platform gateway helper with CLI download and Python REST fallback."""
+"""Cross-platform gateway helper with verified CLI install and REST fallback."""
 
 from __future__ import annotations
 
 import argparse
 import contextlib
+import hashlib
 import json
 import os
 from pathlib import Path
 import platform
+import re
 import shutil
-import stat
 import subprocess
 import tempfile
 from typing import Any
@@ -17,8 +18,12 @@ import urllib.error
 import urllib.request
 
 DEFAULT_BASE_URL = "http://127.0.0.1:9765"
-DEFAULT_REPO = "dcc-mcp/dcc-mcp-core"
+OFFICIAL_REPO = "dcc-mcp/dcc-mcp-core"
 DEFAULT_VERSION = "latest"
+MAX_MANIFEST_BYTES = 64 * 1024
+MAX_CLI_BYTES = 256 * 1024 * 1024
+_VERSION_RE = re.compile(r"^(?:v)?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?)$")
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 
 
 def _json_dumps(payload: Any, *, pretty: bool = False) -> str:
@@ -72,57 +77,150 @@ def _request_json(base_url: str, method: str, path: str, body: dict[str, Any] | 
         return {"success": False, "error": "invalid-json", "detail": str(exc), "body": text}
 
 
-def _asset_name() -> str | None:
+def _release_assets() -> tuple[str, str] | None:
     system = platform.system().lower()
     machine = platform.machine().lower()
     if system == "windows" and machine in {"amd64", "x86_64"}:
-        return "dcc-mcp-cli-windows-x86_64.exe"
+        return (
+            "dcc-mcp-cli-windows-x86_64.exe",
+            "dcc-mcp-update-manifest-windows-x86_64.json",
+        )
     if system == "linux" and machine in {"amd64", "x86_64"}:
-        return "dcc-mcp-cli-linux-x86_64"
+        return (
+            "dcc-mcp-cli-linux-x86_64",
+            "dcc-mcp-update-manifest-linux-x86_64.json",
+        )
     if system == "darwin":
-        return "dcc-mcp-cli-macos-universal2"
+        return (
+            "dcc-mcp-cli-macos-universal2",
+            "dcc-mcp-update-manifest-macos-universal2.json",
+        )
     return None
 
 
-def _download_url(repo: str, version: str, asset: str) -> str:
+def _normalized_version(version: str) -> str | None:
     if version == "latest":
-        return f"https://github.com/{repo}/releases/latest/download/{asset}"
-    return f"https://github.com/{repo}/releases/download/{version}/{asset}"
+        return None
+    match = _VERSION_RE.fullmatch(version)
+    if match is None:
+        raise ValueError("version must be 'latest' or a stable release such as v0.19.63")
+    return match.group(1)
+
+
+def _manifest_url(version: str, manifest_asset: str) -> str:
+    normalized = _normalized_version(version)
+    if normalized is None:
+        return f"https://github.com/{OFFICIAL_REPO}/releases/latest/download/{manifest_asset}"
+    return f"https://github.com/{OFFICIAL_REPO}/releases/download/v{normalized}/{manifest_asset}"
+
+
+def _read_limited(response: Any, limit: int) -> bytes:
+    payload = response.read(limit + 1)
+    if len(payload) > limit:
+        raise ValueError(f"response exceeds the {limit}-byte safety limit")
+    return payload
+
+
+def _verified_manifest_entry(
+    payload: bytes,
+    *,
+    requested_version: str,
+    asset: str,
+) -> tuple[str, str]:
+    try:
+        manifest = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid official release manifest: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError("invalid official release manifest: expected an object")
+    entry = manifest.get("dcc-mcp-cli")
+    if not isinstance(entry, dict):
+        raise ValueError("invalid official release manifest: dcc-mcp-cli entry is missing")
+
+    entry_version = entry.get("version")
+    url = entry.get("url")
+    digest = entry.get("sha256")
+    if not isinstance(entry_version, str) or _VERSION_RE.fullmatch(entry_version) is None:
+        raise ValueError("invalid official release manifest: CLI version is invalid")
+    normalized_entry_version = _normalized_version(entry_version)
+    normalized_requested_version = _normalized_version(requested_version)
+    if normalized_requested_version is not None and normalized_entry_version != normalized_requested_version:
+        raise ValueError("official release manifest version does not match the requested version")
+    expected_url = f"https://github.com/{OFFICIAL_REPO}/releases/download/v{normalized_entry_version}/{asset}"
+    if url != expected_url:
+        raise ValueError("official release manifest points outside the expected official release asset")
+    if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
+        raise ValueError("invalid official release manifest: CLI SHA-256 is invalid")
+    return url, digest.lower()
 
 
 def install_cli(
     *,
     install_dir: Path,
-    repo: str = DEFAULT_REPO,
     version: str = DEFAULT_VERSION,
 ) -> tuple[bool, str, str | None]:
-    """Download dcc-mcp-cli for the current platform."""
-    asset = _asset_name()
-    if asset is None:
+    """Install dcc-mcp-cli only after its official manifest verifies SHA-256."""
+    assets = _release_assets()
+    if assets is None:
         return False, "unsupported platform for release asset", None
+    asset, manifest_asset = assets
 
-    install_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        manifest_url = _manifest_url(version, manifest_asset)
+        with urllib.request.urlopen(manifest_url, timeout=60) as response:
+            manifest_payload = _read_limited(response, MAX_MANIFEST_BYTES)
+        url, expected_digest = _verified_manifest_entry(
+            manifest_payload,
+            requested_version=version,
+            asset=asset,
+        )
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return False, f"verified install failed: {exc}", None
+
     executable_name = "dcc-mcp-cli.exe" if platform.system().lower() == "windows" else "dcc-mcp-cli"
     target = install_dir / executable_name
-    url = _download_url(repo, version, asset)
 
-    fd, tmp_name = tempfile.mkstemp(prefix="dcc-mcp-cli-", suffix=target.suffix)
-    os.close(fd)
+    try:
+        install_dir.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=".dcc-mcp-cli-",
+            suffix=target.suffix,
+            dir=str(install_dir),
+        )
+        os.close(fd)
+    except OSError as exc:
+        return False, f"verified install failed: cannot prepare install directory: {exc}", url
     tmp_path = Path(tmp_name)
     try:
-        urllib.request.urlretrieve(url, tmp_path)
+        digest = hashlib.sha256()
+        total = 0
+        with urllib.request.urlopen(url, timeout=60) as response, tmp_path.open("wb") as output:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > MAX_CLI_BYTES:
+                    raise ValueError(f"CLI asset exceeds the {MAX_CLI_BYTES}-byte safety limit")
+                digest.update(chunk)
+                output.write(chunk)
+        if total == 0:
+            raise ValueError("CLI asset is empty")
+        actual_digest = digest.hexdigest()
+        if actual_digest != expected_digest:
+            raise ValueError(f"CLI SHA-256 mismatch: expected {expected_digest}, got {actual_digest}")
         if platform.system().lower() != "windows":
-            tmp_path.chmod(tmp_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        shutil.move(str(tmp_path), str(target))
-    except (urllib.error.URLError, OSError) as exc:
+            tmp_path.chmod(0o755)
+        tmp_path.replace(target)
+    except (urllib.error.URLError, OSError, ValueError) as exc:
         with contextlib.suppress(OSError):
-            tmp_path.unlink(missing_ok=True)
-        return False, f"download failed: {exc}", url
+            tmp_path.unlink()
+        return False, f"verified install failed: {exc}", url
     return True, str(target), url
 
 
 def resolve_cli(args: argparse.Namespace) -> tuple[str | None, dict[str, Any]]:
-    """Find the CLI; optionally install it from GitHub releases."""
+    """Find the CLI; optionally install a verified official release."""
     found = shutil.which(args.cli)
     details: dict[str, Any] = {"cli": args.cli, "cli_path": found, "installed": False}
     if found:
@@ -132,7 +230,7 @@ def resolve_cli(args: argparse.Namespace) -> tuple[str | None, dict[str, Any]]:
         return None, details
 
     install_dir = Path(args.install_dir).expanduser()
-    ok, message, url = install_cli(install_dir=install_dir, repo=args.repo, version=args.version)
+    ok, message, url = install_cli(install_dir=install_dir, version=args.version)
     details.update({"install_attempted": True, "install_ok": ok, "install_message": message, "download_url": url})
     if not ok:
         return None, details
@@ -218,13 +316,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="DCC-MCP gateway helper with CLI-first execution.")
     parser.add_argument("--base-url", default=os.environ.get("DCC_MCP_BASE_URL") or DEFAULT_BASE_URL)
     parser.add_argument("--cli", default="dcc-mcp-cli")
-    parser.add_argument("--ensure-cli", action="store_true", help="Download dcc-mcp-cli from GitHub if it is missing")
+    parser.add_argument(
+        "--ensure-cli",
+        action="store_true",
+        help="After explicit user consent, install dcc-mcp-cli from its verified official release manifest",
+    )
     parser.add_argument(
         "--install-dir",
         default=os.environ.get("DCC_MCP_INSTALL_DIR") or str(Path.home() / ".local" / "bin"),
     )
-    parser.add_argument("--repo", default=os.environ.get("DCC_MCP_REPO") or DEFAULT_REPO)
-    parser.add_argument("--version", default=os.environ.get("DCC_MCP_VERSION") or DEFAULT_VERSION)
+    parser.add_argument("--version", default=DEFAULT_VERSION)
     parser.add_argument("--pretty", action="store_true")
     sub = parser.add_subparsers(dest="command", required=True)
 

--- a/tests/test_cli_install_scripts.py
+++ b/tests/test_cli_install_scripts.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SH_INSTALLER = ROOT / "scripts" / "install-cli.sh"
+PS_INSTALLER = ROOT / "scripts" / "install-cli.ps1"
+OFFICIAL_RELEASE = "https://github.com/dcc-mcp/dcc-mcp-core/releases/download"
+INSTALL_DOCS = (
+    ROOT / "README.md",
+    ROOT / "README_zh.md",
+    ROOT / "AI_AGENT_GUIDE.md",
+    ROOT / "docs" / "guide" / "getting-started.md",
+    ROOT / "docs" / "zh" / "guide" / "getting-started.md",
+    ROOT / "docs" / "guide" / "cli-reference.md",
+    ROOT / "docs" / "zh" / "guide" / "cli-reference.md",
+)
+
+
+def _shell() -> str:
+    executable = shutil.which("sh")
+    if executable:
+        return executable
+    git_sh = Path(r"C:\Program Files\Git\bin\sh.exe")
+    if not git_sh.is_file():
+        pytest.skip("sh is unavailable")
+    return str(git_sh)
+
+
+def _shell_path(path: Path) -> str:
+    value = path.resolve().as_posix()
+    if os.name == "nt" and len(value) > 2 and value[1] == ":":
+        return f"/{value[0].lower()}{value[2:]}"
+    return value
+
+
+def _write_fake_unix_tools(bin_dir: Path) -> None:
+    bin_dir.mkdir()
+    curl = bin_dir / "curl"
+    with curl.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write(
+            """#!/bin/sh
+url=""
+out=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) out="$2"; shift 2 ;;
+        http*) url="$1"; shift ;;
+        *) shift ;;
+    esac
+done
+printf '%s\n' "$url" >> "$REQUEST_LOG"
+case "$url" in
+    *dcc-mcp-update-manifest-*) cp "$FIXTURE_MANIFEST" "$out" ;;
+    *dcc-mcp-cli-*) cp "$FIXTURE_BINARY" "$out" ;;
+    *) exit 22 ;;
+esac
+"""
+        )
+    uname = bin_dir / "uname"
+    with uname.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write(
+            """#!/bin/sh
+case "$1" in
+    -s) echo Linux ;;
+    -m) echo x86_64 ;;
+    *) exit 1 ;;
+esac
+"""
+        )
+    curl.chmod(0o755)
+    uname.chmod(0o755)
+
+
+def _run_sh_installer(tmp_path: Path, manifest: dict, binary: bytes) -> subprocess.CompletedProcess[str]:
+    fake_bin = tmp_path / "bin"
+    _write_fake_unix_tools(fake_bin)
+    manifest_path = tmp_path / "manifest.json"
+    binary_path = tmp_path / "cli.bin"
+    request_log = tmp_path / "requests.log"
+    install_dir = tmp_path / "install"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    binary_path.write_bytes(binary)
+    env = os.environ.copy()
+    env.update(
+        {
+            "DCC_MCP_VERSION": "latest",
+            "DCC_MCP_INSTALL_DIR": _shell_path(install_dir),
+            "FIXTURE_MANIFEST": _shell_path(manifest_path),
+            "FIXTURE_BINARY": _shell_path(binary_path),
+            "REQUEST_LOG": _shell_path(request_log),
+        }
+    )
+    return subprocess.run(
+        [
+            _shell(),
+            "-c",
+            'PATH="$1:/usr/bin:/bin"; export PATH; exec "$2"',
+            "installer-test",
+            _shell_path(fake_bin),
+            _shell_path(SH_INSTALLER),
+        ],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def _powershell() -> str:
+    executable = shutil.which("pwsh") or shutil.which("powershell")
+    if not executable:
+        pytest.skip("PowerShell is unavailable")
+    return executable
+
+
+def _run_ps_installer(tmp_path: Path, manifest: dict, binary: bytes) -> subprocess.CompletedProcess[str]:
+    manifest_path = tmp_path / "manifest.json"
+    binary_path = tmp_path / "cli.exe"
+    request_log = tmp_path / "requests.log"
+    install_dir = tmp_path / "install"
+    wrapper = tmp_path / "invoke-installer.ps1"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    binary_path.write_bytes(binary)
+    wrapper.write_text(
+        """$ErrorActionPreference = "Stop"
+$originalUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+function Invoke-WebRequest {
+    param([string] $Uri, [string] $OutFile)
+    Add-Content -LiteralPath $env:REQUEST_LOG -Value $Uri
+    if ($Uri -like "*dcc-mcp-update-manifest-*") {
+        Copy-Item -LiteralPath $env:FIXTURE_MANIFEST -Destination $OutFile
+    } elseif ($Uri -like "*dcc-mcp-cli-*") {
+        Copy-Item -LiteralPath $env:FIXTURE_BINARY -Destination $OutFile
+    } else {
+        throw "Unexpected URL: $Uri"
+    }
+}
+try {
+    & $env:INSTALL_SCRIPT -Version latest -InstallDir $env:TEST_INSTALL_DIR
+} finally {
+    $currentUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($currentUserPath -cne $originalUserPath) {
+        [Environment]::SetEnvironmentVariable("Path", $originalUserPath, "User")
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "INSTALL_SCRIPT": str(PS_INSTALLER),
+            "TEST_INSTALL_DIR": str(install_dir),
+            "FIXTURE_MANIFEST": str(manifest_path),
+            "FIXTURE_BINARY": str(binary_path),
+            "REQUEST_LOG": str(request_log),
+        }
+    )
+    return subprocess.run(
+        [_powershell(), "-NoLogo", "-NoProfile", "-File", str(wrapper)],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def _manifest(*, asset: str, binary: bytes, url=None, sha256=None) -> dict:
+    return {
+        "dcc-mcp-cli": {
+            "version": "0.19.63",
+            "url": url or f"{OFFICIAL_RELEASE}/v0.19.63/{asset}",
+            "sha256": sha256 or hashlib.sha256(binary).hexdigest(),
+        }
+    }
+
+
+def test_installers_do_not_recommend_remote_pipe_execution() -> None:
+    forbidden = re.compile(
+        r"(?:curl|irm|invoke-restmethod)[^\r\n|]*\|[^\r\n]*(?:sh|bash|iex|invoke-expression)|ExecutionPolicy\s+Bypass",
+        re.IGNORECASE,
+    )
+    for path in (SH_INSTALLER, PS_INSTALLER):
+        assert forbidden.search(path.read_text(encoding="utf-8")) is None, path
+
+
+def test_install_docs_do_not_recommend_remote_pipe_or_policy_bypass() -> None:
+    forbidden = re.compile(
+        r"(?:curl|irm|invoke-restmethod)[^\r\n|]*\|[^\r\n]*(?:sh|bash|iex|invoke-expression)|ExecutionPolicy\s+Bypass",
+        re.IGNORECASE,
+    )
+    for path in INSTALL_DOCS:
+        assert forbidden.search(path.read_text(encoding="utf-8")) is None, path
+
+
+def test_installers_use_fixed_official_update_manifests() -> None:
+    sh_source = SH_INSTALLER.read_text(encoding="utf-8")
+    ps_source = PS_INSTALLER.read_text(encoding="utf-8")
+    for source in (sh_source, ps_source):
+        assert "DCC_MCP_REPO" not in source
+        assert "api.github.com" not in source
+        assert "dcc-mcp/dcc-mcp-core/releases" in source
+        assert "dcc-mcp-update-manifest-" in source
+        assert "sha256" in source.lower()
+    assert "DCC_MCP_RELEASE_FALLBACK" not in sh_source
+    assert "[string] $Repo" not in ps_source
+
+
+def test_sh_latest_uses_manifest_pinned_url_and_installs_verified_binary(tmp_path: Path) -> None:
+    binary = b"verified linux cli"
+    result = _run_sh_installer(
+        tmp_path,
+        _manifest(asset="dcc-mcp-cli-linux-x86_64", binary=binary),
+        binary,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "install" / "dcc-mcp-cli").read_bytes() == binary
+    requests = (tmp_path / "requests.log").read_text(encoding="utf-8").splitlines()
+    assert requests == [
+        "https://github.com/dcc-mcp/dcc-mcp-core/releases/latest/download/dcc-mcp-update-manifest-linux-x86_64.json",
+        f"{OFFICIAL_RELEASE}/v0.19.63/dcc-mcp-cli-linux-x86_64",
+    ]
+
+
+def test_sh_checksum_mismatch_preserves_existing_binary(tmp_path: Path) -> None:
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+    target = install_dir / "dcc-mcp-cli"
+    target.write_bytes(b"known good")
+    binary = b"tampered"
+    result = _run_sh_installer(
+        tmp_path,
+        _manifest(asset="dcc-mcp-cli-linux-x86_64", binary=binary, sha256="0" * 64),
+        binary,
+    )
+
+    assert result.returncode != 0
+    assert "SHA-256" in result.stderr
+    assert target.read_bytes() == b"known good"
+
+
+def test_sh_rejects_non_official_asset_before_download(tmp_path: Path) -> None:
+    binary = b"must not download"
+    result = _run_sh_installer(
+        tmp_path,
+        _manifest(
+            asset="dcc-mcp-cli-linux-x86_64",
+            binary=binary,
+            url="https://example.invalid/dcc-mcp-cli-linux-x86_64",
+        ),
+        binary,
+    )
+
+    assert result.returncode != 0
+    assert "official" in result.stderr.lower()
+    requests = (tmp_path / "requests.log").read_text(encoding="utf-8").splitlines()
+    assert requests == [
+        "https://github.com/dcc-mcp/dcc-mcp-core/releases/latest/download/dcc-mcp-update-manifest-linux-x86_64.json"
+    ]
+    assert not (tmp_path / "install" / "dcc-mcp-cli").exists()
+
+
+def test_powershell_latest_uses_manifest_pinned_url_and_installs_verified_binary(
+    tmp_path: Path,
+) -> None:
+    binary = b"verified windows cli"
+    result = _run_ps_installer(
+        tmp_path,
+        _manifest(asset="dcc-mcp-cli-windows-x86_64.exe", binary=binary),
+        binary,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "install" / "dcc-mcp-cli.exe").read_bytes() == binary
+    requests = (tmp_path / "requests.log").read_text(encoding="utf-8").splitlines()
+    assert requests == [
+        "https://github.com/dcc-mcp/dcc-mcp-core/releases/latest/download/dcc-mcp-update-manifest-windows-x86_64.json",
+        f"{OFFICIAL_RELEASE}/v0.19.63/dcc-mcp-cli-windows-x86_64.exe",
+    ]
+
+
+def test_powershell_checksum_mismatch_preserves_existing_binary(tmp_path: Path) -> None:
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+    target = install_dir / "dcc-mcp-cli.exe"
+    target.write_bytes(b"known good")
+    binary = b"tampered"
+    result = _run_ps_installer(
+        tmp_path,
+        _manifest(asset="dcc-mcp-cli-windows-x86_64.exe", binary=binary, sha256="0" * 64),
+        binary,
+    )
+
+    assert result.returncode != 0
+    assert "SHA-256" in result.stderr
+    assert target.read_bytes() == b"known good"
+
+
+def test_powershell_rejects_non_official_asset_before_download(tmp_path: Path) -> None:
+    binary = b"must not download"
+    result = _run_ps_installer(
+        tmp_path,
+        _manifest(
+            asset="dcc-mcp-cli-windows-x86_64.exe",
+            binary=binary,
+            url="https://example.invalid/dcc-mcp-cli-windows-x86_64.exe",
+        ),
+        binary,
+    )
+
+    assert result.returncode != 0
+    assert "official release" in result.stderr.lower()
+    requests = (tmp_path / "requests.log").read_text(encoding="utf-8").splitlines()
+    assert requests == [
+        "https://github.com/dcc-mcp/dcc-mcp-core/releases/latest/download/dcc-mcp-update-manifest-windows-x86_64.json"
+    ]
+    assert not (tmp_path / "install" / "dcc-mcp-cli.exe").exists()

--- a/tests/test_dcc_mcp_skill.py
+++ b/tests/test_dcc_mcp_skill.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import ast
+import hashlib
+import io
 import json
 from pathlib import Path
+import re
 import subprocess
 import sys
 from unittest.mock import patch
@@ -20,6 +24,14 @@ import check_cli as check_cli_mod  # noqa: E402
 import dcc_gateway as dcc_gateway_mod  # noqa: E402
 
 sys.path.pop(0)
+
+
+class _BytesResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
 
 
 class TestDccMcpSkill:
@@ -116,10 +128,205 @@ class TestDccMcpSkill:
         assert (root / "references" / "ZERO_INSTANCES_CLI.md").is_file()
         assert len((root / "SKILL.md").read_text(encoding="utf-8").splitlines()) <= 500
 
+    def test_public_skill_has_no_remote_pipe_to_shell_bootstrap(self) -> None:
+        pattern = re.compile(
+            r"(?:curl|irm|invoke-restmethod)[^\r\n|]*\|[^\r\n]*(?:sh|bash|iex|invoke-expression)",
+            re.IGNORECASE,
+        )
+        root = Path(DCC_MCP_SKILL_DIR)
+        for path in sorted(root.rglob("*")):
+            if path.is_file() and path.suffix.lower() in {".md", ".py", ".yaml", ".yml", ".json"}:
+                assert pattern.search(path.read_text(encoding="utf-8")) is None, path
+
+    def test_cli_bootstrap_uses_fixed_official_source(self) -> None:
+        source = (Path(DCC_MCP_SKILL_DIR) / "scripts" / "dcc_gateway.py").read_text(encoding="utf-8")
+        assert "DCC_MCP_REPO" not in source
+        assert "--repo" not in source
+        assert "sha256" in source.lower()
+        assert "update-manifest" in source
+        assert "verified" in (check_cli_mod.__doc__ or "").lower()
+
+    def test_packaged_helpers_keep_python_37_syntax_compatibility(self) -> None:
+        parse_kwargs = {"feature_version": 7} if sys.version_info >= (3, 8) else {}
+        scripts = Path(DCC_MCP_SKILL_DIR) / "scripts"
+        for path in (scripts / "dcc_gateway.py", scripts / "check_cli.py"):
+            source = path.read_text(encoding="utf-8")
+            assert "from __future__ import annotations" in source
+            ast.parse(source, filename=str(path), **parse_kwargs)
+
+    def test_verified_cli_bootstrap_accepts_matching_manifest(self, tmp_path) -> None:
+        binary = b"verified dcc-mcp-cli"
+        digest = hashlib.sha256(binary).hexdigest()
+        asset_url = "https://github.com/dcc-mcp/dcc-mcp-core/releases/download/v0.19.63/dcc-mcp-cli-linux-x86_64"
+        manifest = json.dumps(
+            {
+                "dcc-mcp-cli": {
+                    "version": "0.19.63",
+                    "url": asset_url,
+                    "sha256": digest,
+                }
+            }
+        ).encode()
+
+        with patch.object(dcc_gateway_mod.platform, "system", return_value="Linux"):
+            with patch.object(dcc_gateway_mod.platform, "machine", return_value="x86_64"):
+                with patch.object(
+                    dcc_gateway_mod.urllib.request,
+                    "urlopen",
+                    side_effect=[_BytesResponse(manifest), _BytesResponse(binary)],
+                ):
+                    with patch.object(
+                        dcc_gateway_mod.urllib.request,
+                        "urlretrieve",
+                        side_effect=AssertionError("unverified downloader must not be used"),
+                    ):
+                        ok, installed, resolved_url = dcc_gateway_mod.install_cli(
+                            install_dir=tmp_path,
+                            version="v0.19.63",
+                        )
+
+        assert ok is True
+        assert Path(installed).read_bytes() == binary
+        assert resolved_url == asset_url
+
+    def test_verified_cli_bootstrap_rejects_checksum_mismatch_without_replacing_binary(self, tmp_path) -> None:
+        target = tmp_path / "dcc-mcp-cli"
+        target.write_bytes(b"known-good-existing-cli")
+        binary = b"tampered download"
+        asset_url = "https://github.com/dcc-mcp/dcc-mcp-core/releases/download/v0.19.63/dcc-mcp-cli-linux-x86_64"
+        manifest = json.dumps(
+            {
+                "dcc-mcp-cli": {
+                    "version": "0.19.63",
+                    "url": asset_url,
+                    "sha256": "0" * 64,
+                }
+            }
+        ).encode()
+
+        with patch.object(dcc_gateway_mod.platform, "system", return_value="Linux"):
+            with patch.object(dcc_gateway_mod.platform, "machine", return_value="x86_64"):
+                with patch.object(
+                    dcc_gateway_mod.urllib.request,
+                    "urlopen",
+                    side_effect=[_BytesResponse(manifest), _BytesResponse(binary)],
+                ):
+                    with patch.object(
+                        dcc_gateway_mod.urllib.request,
+                        "urlretrieve",
+                        side_effect=AssertionError("unverified downloader must not be used"),
+                    ):
+                        ok, message, resolved_url = dcc_gateway_mod.install_cli(
+                            install_dir=tmp_path,
+                            version="v0.19.63",
+                        )
+
+        assert ok is False
+        assert "sha-256" in message.lower()
+        assert resolved_url == asset_url
+        assert target.read_bytes() == b"known-good-existing-cli"
+
+    def test_verified_cli_bootstrap_rejects_non_official_asset_url(self, tmp_path) -> None:
+        manifest = json.dumps(
+            {
+                "dcc-mcp-cli": {
+                    "version": "0.19.63",
+                    "url": "https://example.invalid/dcc-mcp-cli-linux-x86_64",
+                    "sha256": "a" * 64,
+                }
+            }
+        ).encode()
+
+        with patch.object(dcc_gateway_mod.platform, "system", return_value="Linux"):
+            with patch.object(dcc_gateway_mod.platform, "machine", return_value="x86_64"):
+                with patch.object(
+                    dcc_gateway_mod.urllib.request,
+                    "urlopen",
+                    return_value=_BytesResponse(manifest),
+                ) as opener:
+                    ok, message, resolved_url = dcc_gateway_mod.install_cli(
+                        install_dir=tmp_path,
+                        version="v0.19.63",
+                    )
+
+        assert ok is False
+        assert "official release" in message.lower()
+        assert resolved_url is None
+        assert opener.call_count == 1
+        assert not (tmp_path / "dcc-mcp-cli").exists()
+
+    def test_verified_cli_bootstrap_latest_uses_manifest_pinned_asset(self, tmp_path) -> None:
+        binary = b"release-pinned-cli"
+        digest = hashlib.sha256(binary).hexdigest()
+        asset_url = "https://github.com/dcc-mcp/dcc-mcp-core/releases/download/v0.19.63/dcc-mcp-cli-linux-x86_64"
+        manifest = json.dumps(
+            {
+                "dcc-mcp-cli": {
+                    "version": "0.19.63",
+                    "url": asset_url,
+                    "sha256": digest,
+                }
+            }
+        ).encode()
+        requested_urls: list[str] = []
+
+        def open_url(url, **_kwargs):
+            requested_urls.append(str(url))
+            return _BytesResponse(manifest if len(requested_urls) == 1 else binary)
+
+        with patch.object(dcc_gateway_mod.platform, "system", return_value="Linux"):
+            with patch.object(dcc_gateway_mod.platform, "machine", return_value="x86_64"):
+                with patch.object(dcc_gateway_mod.urllib.request, "urlopen", side_effect=open_url):
+                    ok, installed, resolved_url = dcc_gateway_mod.install_cli(install_dir=tmp_path)
+
+        assert ok is True
+        assert Path(installed).read_bytes() == binary
+        assert resolved_url == asset_url
+        assert requested_urls == [
+            "https://github.com/dcc-mcp/dcc-mcp-core/releases/latest/download/"
+            "dcc-mcp-update-manifest-linux-x86_64.json",
+            asset_url,
+        ]
+
+    def test_verified_cli_bootstrap_rejects_requested_version_mismatch(self, tmp_path) -> None:
+        asset_url = "https://github.com/dcc-mcp/dcc-mcp-core/releases/download/v0.19.62/dcc-mcp-cli-linux-x86_64"
+        manifest = json.dumps(
+            {
+                "dcc-mcp-cli": {
+                    "version": "0.19.62",
+                    "url": asset_url,
+                    "sha256": "a" * 64,
+                }
+            }
+        ).encode()
+
+        with patch.object(dcc_gateway_mod.platform, "system", return_value="Linux"):
+            with patch.object(dcc_gateway_mod.platform, "machine", return_value="x86_64"):
+                with patch.object(
+                    dcc_gateway_mod.urllib.request,
+                    "urlopen",
+                    return_value=_BytesResponse(manifest),
+                ) as opener:
+                    ok, message, resolved_url = dcc_gateway_mod.install_cli(
+                        install_dir=tmp_path,
+                        version="v0.19.63",
+                    )
+
+        assert ok is False
+        assert "does not match" in message.lower()
+        assert resolved_url is None
+        assert opener.call_count == 1
+        assert not (tmp_path / "dcc-mcp-cli").exists()
+
     def test_probe_cli_missing(self) -> None:
         with patch.object(check_cli_mod.shutil, "which", return_value=None):
-            with patch.object(check_cli_mod.dcc_gateway, "python_fallback", return_value={}):
-                payload = check_cli_mod.probe(cli="missing-dcc-mcp-cli", base_url="http://127.0.0.1:9765")
+            with patch.object(check_cli_mod.dcc_gateway, "install_cli") as installer:
+                with patch.object(check_cli_mod.dcc_gateway, "python_fallback", return_value={}):
+                    payload = check_cli_mod.probe(
+                        cli="missing-dcc-mcp-cli",
+                        base_url="http://127.0.0.1:9765",
+                    )
+        installer.assert_not_called()
         assert payload["cli_ok"] is False
         assert payload["gateway_ok"] is False
         assert payload["total"] == 0


### PR DESCRIPTION
## Summary
- verify the fixed official release manifest and CLI SHA-256 before atomic replacement
- fail closed across the bundled helper and both platform installers while preserving an existing CLI
- remove remote pipe-to-shell guidance and document the CLI plus three-Skill ClawHub suite in English and Chinese
- publish `dcc-mcp` independently as Skill version `0.19.65`

## Validation
- `109 passed` across Skill, installer, ClawHub sync/package, bundled metadata, and update-manifest tests
- Python 3.7 packaged-helper compatibility check
- POSIX shell and PowerShell syntax checks
- VitePress build and markdownlint (`226` files, `0` issues)
- ClawHub dry-run: `dcc-mcp@0.19.65`, 6 files, fingerprint `28ce1e01ecf4fb644a428f765079fd8bf22eec73386839d0ba6fbead99598ee1`

SHA-256 confirms that the binary matches the official release manifest; it is not a publisher signature.