### PR TITLE
fix(ci): ignore superseded release guard runs

### DIFF
--- a/scripts/ci/check_release_please_pr.py
+++ b/scripts/ci/check_release_please_pr.py
@@ -48,6 +48,48 @@ def remote_tag_exists(repo: str, tag_name: str) -> bool:
     fail(f"could not check remote tag {tag_name}: {result.stdout.strip()}")
 
 
+def current_release_pr_head(repo: str, head_ref: str) -> str | None:
+    """Return the current head SHA for the matching open release PR."""
+    owner, separator, _name = repo.partition("/")
+    if not separator or not owner:
+        fail(f"invalid GITHUB_REPOSITORY value: {repo!r}")
+
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/pulls",
+            "--method",
+            "GET",
+            "-f",
+            "state=open",
+            "-f",
+            f"head={owner}:{head_ref}",
+            "-f",
+            "base=main",
+            "-f",
+            "per_page=100",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"could not resolve current release PR head: {result.stdout.strip()}")
+
+    pulls = json.loads(result.stdout or "[]")
+    matches = [pull for pull in pulls if pull.get("head", {}).get("ref") == head_ref]
+    if not matches:
+        return None
+    if len(matches) > 1:
+        fail(f"multiple open release PRs found for branch {head_ref!r}")
+    sha = matches[0].get("head", {}).get("sha")
+    if not isinstance(sha, str) or not sha:
+        fail(f"release PR for branch {head_ref!r} has no head SHA")
+    return sha
+
+
 def check_ci_status(repo: str, sha: str) -> None:
     """Block if any completed CI check runs failed for the commit."""
     if os.environ.get("DCC_RELEASE_GUARD_SKIP_CI_CHECK") == "1":
@@ -126,6 +168,13 @@ def main() -> None:
     if event_name == "workflow_run":
         if not repo or not sha:
             fail("GITHUB_REPOSITORY and PR_HEAD_SHA are required")
+        current_sha = current_release_pr_head(repo, head_ref)
+        if current_sha is None:
+            print(f"::notice::No open release PR remains for {head_ref}; stale workflow result is ignored.")
+            return
+        if current_sha != sha:
+            print(f"::notice::Release PR head advanced from {sha} to {current_sha}; stale workflow result is ignored.")
+            return
         check_ci_status(repo, sha)
         return
 

--- a/tests/test_release_please_pr_guard.py
+++ b/tests/test_release_please_pr_guard.py
@@ -1,0 +1,104 @@
+"""Release-please PR guard behavior tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "check_release_please_pr.py"
+
+
+def _load_guard_module():
+    spec = importlib.util.spec_from_file_location("check_release_please_pr", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_current_release_pr_head_uses_exact_open_branch_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    guard = _load_guard_module()
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs):
+        calls.append(command)
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "head": {
+                            "ref": "release-please--branches--main--components--dcc-mcp-core",
+                            "sha": "current-head",
+                        }
+                    }
+                ]
+            ),
+        )
+
+    monkeypatch.setattr(guard.subprocess, "run", fake_run)
+
+    assert (
+        guard.current_release_pr_head(
+            "dcc-mcp/dcc-mcp-core",
+            "release-please--branches--main--components--dcc-mcp-core",
+        )
+        == "current-head"
+    )
+    assert calls == [
+        [
+            "gh",
+            "api",
+            "repos/dcc-mcp/dcc-mcp-core/pulls",
+            "--method",
+            "GET",
+            "-f",
+            "state=open",
+            "-f",
+            "head=dcc-mcp:release-please--branches--main--components--dcc-mcp-core",
+            "-f",
+            "base=main",
+            "-f",
+            "per_page=100",
+        ]
+    ]
+
+
+@pytest.mark.parametrize("current_sha", ["new-head", None])
+def test_workflow_run_skips_superseded_or_closed_release_pr_heads(
+    monkeypatch: pytest.MonkeyPatch,
+    current_sha: str | None,
+) -> None:
+    guard = _load_guard_module()
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "dcc-mcp/dcc-mcp-core")
+    monkeypatch.setenv("PR_HEAD_REF", "release-please--branches--main--components--dcc-mcp-core")
+    monkeypatch.setenv("PR_HEAD_SHA", "old-head")
+    monkeypatch.setattr(guard, "current_release_pr_head", lambda _repo, _head_ref: current_sha)
+
+    def fail_if_checked(_repo: str, _sha: str) -> None:
+        pytest.fail("superseded or closed release PR heads must not be checked")
+
+    monkeypatch.setattr(guard, "check_ci_status", fail_if_checked)
+
+    guard.main()
+
+
+def test_workflow_run_checks_the_current_release_pr_head(monkeypatch: pytest.MonkeyPatch) -> None:
+    guard = _load_guard_module()
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "dcc-mcp/dcc-mcp-core")
+    monkeypatch.setenv("PR_HEAD_REF", "release-please--branches--main--components--dcc-mcp-core")
+    monkeypatch.setenv("PR_HEAD_SHA", "current-head")
+    monkeypatch.setattr(guard, "current_release_pr_head", lambda _repo, _head_ref: "current-head")
+    checked: list[tuple[str, str]] = []
+    monkeypatch.setattr(guard, "check_ci_status", lambda repo, sha: checked.append((repo, sha)))
+
+    guard.main()
+
+    assert checked == [("dcc-mcp/dcc-mcp-core", "current-head")]


### PR DESCRIPTION
## Summary
- resolve the current open release PR head before evaluating a `workflow_run`
- ignore obsolete results after the release branch advances or closes
- keep failures on the current release PR head blocking

## Validation
- `python -m pytest -q tests/test_release_workflow.py tests/test_release_please_pr_guard.py` (10 passed)
- Ruff check and format check
- live probe against an advanced release PR head