### PR TITLE
Add interruptible chunked main-thread jobs

### DIFF
--- a/crates/dcc-mcp-http-server/src/job_aware_invoker.rs
+++ b/crates/dcc-mcp-http-server/src/job_aware_invoker.rs
@@ -83,11 +83,21 @@ impl ToolInvoker for JobAwareInvoker {
         let spawned_job_id = job_id.clone();
         let meta = attach_job_id_to_meta(meta, &job_id);
         tokio::task::spawn_blocking(move || {
-            if cancel_token.is_cancelled() || jobs.start(&spawned_job_id).is_none() {
+            if cancel_token.is_cancelled() {
+                let _ = jobs.acknowledge_cancel(&spawned_job_id);
+                return;
+            }
+            if jobs.start(&spawned_job_id).is_none() {
                 return;
             }
             let cancellation = InvocationCancellation::new(spawned_job_id.clone(), cancel_token);
-            match invoker.invoke_with_cancellation(&action_name, params, meta, cancellation) {
+            let result =
+                invoker.invoke_with_cancellation(&action_name, params, meta, cancellation.clone());
+            if cancellation.cancel_token().is_cancelled() {
+                let _ = jobs.acknowledge_cancel(&spawned_job_id);
+                return;
+            }
+            match result {
                 Ok(outcome) => {
                     let _ = jobs.complete(&spawned_job_id, outcome.output);
                 }
@@ -138,6 +148,31 @@ mod tests {
             meta: Option<Value>,
         ) -> Result<CallOutcome, ServiceError> {
             *self.0.lock() = meta;
+            Ok(CallOutcome {
+                slug: ToolSlug(action_name.to_string()),
+                output: Value::Null,
+                validation_skipped: false,
+            })
+        }
+    }
+
+    struct BlockingInvoker {
+        started: Arc<std::sync::atomic::AtomicBool>,
+        release: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl ToolInvoker for BlockingInvoker {
+        fn invoke(
+            &self,
+            action_name: &str,
+            _params: Value,
+            _meta: Option<Value>,
+        ) -> Result<CallOutcome, ServiceError> {
+            self.started
+                .store(true, std::sync::atomic::Ordering::Release);
+            while !self.release.load(std::sync::atomic::Ordering::Acquire) {
+                std::thread::yield_now();
+            }
             Ok(CallOutcome {
                 slug: ToolSlug(action_name.to_string()),
                 output: Value::Null,
@@ -210,5 +245,51 @@ mod tests {
         let meta = seen.lock().clone().expect("metadata captured");
         assert_eq!(meta["dcc"]["jobId"], pending.job_id);
         assert_eq!(meta["dcc"]["parentJobId"], "parent");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancellation_stays_requested_until_monolithic_handler_returns() {
+        let jobs = Arc::new(JobManager::new());
+        let started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let release = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let invoker = JobAwareInvoker::new(
+            Arc::new(BlockingInvoker {
+                started: Arc::clone(&started),
+                release: Arc::clone(&release),
+            }),
+            Arc::clone(&jobs),
+        );
+        let pending = invoker
+            .invoke_async(
+                &ToolSlug("maya.monolithic".into()),
+                "monolithic",
+                json!({}),
+                None,
+            )
+            .unwrap()
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !started.load(std::sync::atomic::Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        jobs.cancel(&pending.job_id).unwrap();
+        assert_eq!(
+            jobs.get(&pending.job_id).unwrap().read().status,
+            JobStatus::Running,
+            "requesting cancellation must not claim the active closure stopped"
+        );
+
+        release.store(true, std::sync::atomic::Ordering::Release);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while jobs.get(&pending.job_id).unwrap().read().status != JobStatus::Cancelled {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
     }
 }

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
@@ -153,12 +153,14 @@ async fn run_async_execution_lane(
             }),
         );
 
-        tokio::select! {
-            outcome = response => match outcome {
-                Ok(json_str) => decode_dispatch_output(&json_str),
-                Err(_) => Err("CANCELLED".to_string()),
-            },
-            _ = cancel_token.cancelled() => Err("CANCELLED".to_string()),
+        let outcome = match response.await {
+            Ok(json_str) => decode_dispatch_output(&json_str),
+            Err(_) => Err("CANCELLED".to_string()),
+        };
+        if cancel_token.is_cancelled() {
+            Err("CANCELLED".to_string())
+        } else {
+            outcome
         }
     } else {
         let dispatch = dispatcher;
@@ -184,9 +186,14 @@ async fn run_async_execution_lane(
                 .map_err(|err| err.to_string())
         });
 
-        tokio::select! {
-            outcome = blocking => outcome.map_err(|err| err.to_string()).and_then(|inner| inner),
-            _ = cancel_token.cancelled() => Err("CANCELLED".to_string()),
+        let outcome = blocking
+            .await
+            .map_err(|err| err.to_string())
+            .and_then(|inner| inner);
+        if cancel_token.is_cancelled() {
+            Err("CANCELLED".to_string())
+        } else {
+            outcome
         }
     }
 }
@@ -199,6 +206,7 @@ fn spawn_async_registry_dispatch(state: &ServerState, request: AsyncExecutionReq
     tokio::spawn(async move {
         if request.cancel_token.is_cancelled() {
             tracing::debug!(job_id = %spawn_job_id, "job cancelled before execution");
+            let _ = jobs.acknowledge_cancel(&spawn_job_id);
             return;
         }
         if jobs.start(&spawn_job_id).is_none() {
@@ -223,7 +231,7 @@ fn spawn_async_registry_dispatch(state: &ServerState, request: AsyncExecutionReq
                     .map(|handle| handle.read().status)
                     .is_some_and(|status| !status.is_terminal())
                 {
-                    jobs.cancel(&spawn_job_id);
+                    let _ = jobs.acknowledge_cancel(&spawn_job_id);
                 }
             }
             Err(msg) => {

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
@@ -61,13 +61,13 @@ async fn run_on_main_thread(
     let json_str = if let Some(cancellation) = cancellation {
         let cancel_token = cancellation.cancel_token().clone();
         let response = executor.submit_deferred(&tool_name, cancel_token.clone(), task);
-        tokio::select! {
-            outcome = response => outcome
-                .map_err(|_| DispatchError::HandlerError("CANCELLED".to_string()))?,
-            _ = cancel_token.cancelled() => {
-                return Err(DispatchError::HandlerError("CANCELLED".to_string()));
-            }
+        let outcome = response
+            .await
+            .map_err(|_| DispatchError::HandlerError("CANCELLED".to_string()))?;
+        if cancel_token.is_cancelled() {
+            return Err(DispatchError::HandlerError("CANCELLED".to_string()));
         }
+        outcome
     } else {
         executor
             .execute(task)
@@ -126,18 +126,13 @@ async fn run_on_worker(request: WorkerDispatch) -> Result<DispatchResult, Dispat
             })
         })
     });
-    if let Some(cancel_token) = cancel_token {
-        tokio::select! {
-            outcome = dispatch_fut => outcome
-                .map_err(|err| DispatchError::HandlerError(err.to_string()))?,
-            _ = cancel_token.cancelled() => {
-                Err(DispatchError::HandlerError("CANCELLED".to_string()))
-            }
-        }
+    let outcome = dispatch_fut
+        .await
+        .map_err(|err| DispatchError::HandlerError(err.to_string()))?;
+    if cancel_token.is_some_and(|token| token.is_cancelled()) {
+        Err(DispatchError::HandlerError("CANCELLED".to_string()))
     } else {
-        dispatch_fut
-            .await
-            .map_err(|err| DispatchError::HandlerError(err.to_string()))?
+        outcome
     }
 }
 

--- a/crates/dcc-mcp-job/src/job/chunked.rs
+++ b/crates/dcc-mcp-job/src/job/chunked.rs
@@ -1,0 +1,128 @@
+//! Tick-driven, main-affinity job execution.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use super::{JobManager, JobProgress, JobStatus};
+
+/// Result of one bounded host-main step.
+pub struct ChunkedStepOutput {
+    pub value: Value,
+    pub message: Option<String>,
+}
+
+impl ChunkedStepOutput {
+    #[must_use]
+    pub fn new(value: Value, message: Option<String>) -> Self {
+        Self { value, message }
+    }
+}
+
+/// One bounded unit of host-main work.
+pub type ChunkedStep = Box<dyn FnOnce() -> Result<ChunkedStepOutput, String> + Send + 'static>;
+
+/// Runs at most one bounded step per host event-loop tick.
+///
+/// The host owns scheduling and calls [`Self::tick`] once from each event-loop
+/// callback. Lifecycle, progress, failure, and acknowledged cancellation are
+/// written directly to the shared [`JobManager`].
+pub struct ChunkedJobRunner {
+    jobs: Arc<JobManager>,
+    job_id: String,
+    steps: VecDeque<ChunkedStep>,
+    results: Vec<Value>,
+    total: u64,
+}
+
+impl ChunkedJobRunner {
+    #[must_use]
+    pub fn new(
+        jobs: Arc<JobManager>,
+        tool_name: impl Into<String>,
+        steps: impl IntoIterator<Item = ChunkedStep>,
+    ) -> Self {
+        let steps: VecDeque<_> = steps.into_iter().collect();
+        let total = steps.len() as u64;
+        let job_id = jobs.create(tool_name).read().id.clone();
+        Self {
+            jobs,
+            job_id,
+            steps,
+            results: Vec::with_capacity(total as usize),
+            total,
+        }
+    }
+
+    #[must_use]
+    pub fn job_id(&self) -> &str {
+        &self.job_id
+    }
+
+    /// Execute one step. Returns `true` only while another tick is needed.
+    pub fn tick(&mut self) -> bool {
+        let Some(handle) = self.jobs.get(&self.job_id) else {
+            return false;
+        };
+        let (status, cancelled) = {
+            let job = handle.read();
+            (job.status, job.cancel_token.is_cancelled())
+        };
+        if status.is_terminal() {
+            return false;
+        }
+        if cancelled {
+            let _ = self.jobs.acknowledge_cancel(&self.job_id);
+            return false;
+        }
+        if status == JobStatus::Pending && self.jobs.start(&self.job_id).is_none() {
+            return false;
+        }
+
+        let Some(step) = self.steps.pop_front() else {
+            let _ = self.jobs.complete(
+                &self.job_id,
+                Value::Array(std::mem::take(&mut self.results)),
+            );
+            return false;
+        };
+
+        match step() {
+            Ok(output) => {
+                self.results.push(output.value);
+                let current = self.results.len() as u64;
+                let _ = self.jobs.update_progress(
+                    &self.job_id,
+                    JobProgress {
+                        current,
+                        total: self.total,
+                        message: output.message,
+                    },
+                );
+                if handle.read().cancel_token.is_cancelled() {
+                    let _ = self.jobs.acknowledge_cancel(&self.job_id);
+                    return false;
+                }
+                if self.steps.is_empty() {
+                    let _ = self.jobs.complete(
+                        &self.job_id,
+                        Value::Array(std::mem::take(&mut self.results)),
+                    );
+                    false
+                } else {
+                    true
+                }
+            }
+            Err(error) => {
+                let _ = self.jobs.fail(&self.job_id, error);
+                false
+            }
+        }
+    }
+
+    /// Request cancellation; the next tick acknowledges it.
+    pub fn cancel(&self) -> bool {
+        self.jobs.cancel(&self.job_id).is_some()
+    }
+}

--- a/crates/dcc-mcp-job/src/job/manager.rs
+++ b/crates/dcc-mcp-job/src/job/manager.rs
@@ -265,19 +265,46 @@ impl JobManager {
         Some(())
     }
 
-    /// Cancel a job.  Valid from `Pending` or `Running`; no-op on terminal
-    /// states (returns `None`).  Triggers `cancel_token` so the running tool
-    /// can observe the cancellation.
+    /// Request cooperative cancellation.
+    ///
+    /// Valid from `Pending` or `Running`; no-op on terminal states. This only
+    /// triggers the cancellation token. The job remains non-terminal until
+    /// the execution lane observes the request and calls
+    /// [`Self::acknowledge_cancel`].
     pub fn cancel(&self, id: &str) -> Option<()> {
+        let entry = self.jobs.get(id)?;
+        let job = entry.read();
+        match job.status {
+            JobStatus::Pending | JobStatus::Running => {
+                job.cancel_token.cancel();
+                Some(())
+            }
+            other => {
+                debug!(
+                    job_id = %id,
+                    from = ?other,
+                    to = ?JobStatus::Cancelled,
+                    "invalid job transition"
+                );
+                None
+            }
+        }
+    }
+
+    /// Confirm that the execution lane observed a cancellation checkpoint.
+    ///
+    /// This is the only transition from `Pending` or `Running` to
+    /// [`JobStatus::Cancelled`]. A bare cancellation request must not call
+    /// this method until queued work was skipped or active work yielded.
+    pub fn acknowledge_cancel(&self, id: &str) -> Option<()> {
         let entry = self.jobs.get(id)?;
         let mut job = entry.write();
         match job.status {
-            JobStatus::Pending | JobStatus::Running => {
+            JobStatus::Pending | JobStatus::Running if job.cancel_token.is_cancelled() => {
                 let now = Utc::now();
                 job.status = JobStatus::Cancelled;
                 job.completed_at = Some(now);
                 job.updated_at = now;
-                job.cancel_token.cancel();
                 let snapshot = job.clone();
                 drop(job);
                 self.persist_put(&snapshot);
@@ -289,7 +316,7 @@ impl JobManager {
                     job_id = %id,
                     from = ?other,
                     to = ?JobStatus::Cancelled,
-                    "invalid job transition"
+                    "cancellation was not requested or job is already terminal"
                 );
                 None
             }
@@ -305,6 +332,19 @@ impl JobManager {
                 job_id = %id,
                 status = ?job.status,
                 "ignoring progress update for non-running job"
+            );
+            return None;
+        }
+        if progress.current > progress.total
+            || job.progress.as_ref().is_some_and(|previous| {
+                progress.current < previous.current || progress.total < previous.total
+            })
+        {
+            debug!(
+                job_id = %id,
+                current = progress.current,
+                total = progress.total,
+                "ignoring non-monotonic job progress"
             );
             return None;
         }

--- a/crates/dcc-mcp-job/src/job/mod.rs
+++ b/crates/dcc-mcp-job/src/job/mod.rs
@@ -15,8 +15,9 @@
 //!   keep contention local to a single job.
 //! - `parking_lot::RwLock` is used instead of `std::sync::RwLock` for
 //!   performance and consistency with the rest of the workspace.
-//! - `cancel_token` is a `tokio_util::sync::CancellationToken` so long-running
-//!   async tool handlers can observe cancellation via `.cancelled().await`.
+//! - `cancel_token` is a `tokio_util::sync::CancellationToken`. `cancel()`
+//!   requests cooperative cancellation; the runner calls
+//!   `acknowledge_cancel()` only after observing a checkpoint.
 //!
 //! # State machine
 //!
@@ -43,11 +44,13 @@
 //! | `job_manager.rs` | `JobManager` — registry, transitions, persistence, subscribers, GC |
 //! | `job_tests.rs`   | Unit tests (lifecycle, cancellation, invalid transitions, GC, serde) |
 
+mod chunked;
 mod manager;
 mod types;
 
 #[cfg(test)]
 mod tests;
 
+pub use chunked::{ChunkedJobRunner, ChunkedStep, ChunkedStepOutput};
 pub use manager::JobManager;
 pub use types::{Job, JobEvent, JobProgress, JobStatus, JobSubscriber};

--- a/crates/dcc-mcp-job/src/job/tests.rs
+++ b/crates/dcc-mcp-job/src/job/tests.rs
@@ -69,7 +69,7 @@ fn lifecycle_timestamps_survive_progress_and_completion() {
 }
 
 #[test]
-fn cancel_before_start_marks_cancelled_and_triggers_token() {
+fn cancel_before_start_requires_runner_acknowledgement() {
     let jm = JobManager::new();
     let handle = jm.create("slow.tool");
     let id = handle.read().id.clone();
@@ -78,14 +78,13 @@ fn cancel_before_start_marks_cancelled_and_triggers_token() {
     assert!(!token.is_cancelled());
     assert_eq!(jm.cancel(&id), Some(()));
     assert!(token.is_cancelled());
+    assert_eq!(handle.read().status, JobStatus::Pending);
+    assert_eq!(jm.acknowledge_cancel(&id), Some(()));
     assert_eq!(handle.read().status, JobStatus::Cancelled);
-
-    // cannot start a cancelled job
-    assert_eq!(jm.start(&id), None);
 }
 
 #[test]
-fn cancel_during_run_marks_cancelled_and_triggers_token() {
+fn cancel_during_run_requires_runner_acknowledgement() {
     let jm = JobManager::new();
     let handle = jm.create("slow.tool");
     let id = handle.read().id.clone();
@@ -96,7 +95,48 @@ fn cancel_during_run_marks_cancelled_and_triggers_token() {
 
     assert_eq!(jm.cancel(&id), Some(()));
     assert!(token.is_cancelled());
+    assert_eq!(handle.read().status, JobStatus::Running);
+    assert_eq!(jm.acknowledge_cancel(&id), Some(()));
     assert_eq!(handle.read().status, JobStatus::Cancelled);
+}
+
+#[test]
+fn progress_rejects_regressions_and_invalid_totals() {
+    let jm = JobManager::new();
+    let handle = jm.create("progress.tool");
+    let id = handle.read().id.clone();
+    jm.start(&id).unwrap();
+    jm.update_progress(
+        &id,
+        JobProgress {
+            current: 2,
+            total: 4,
+            message: None,
+        },
+    )
+    .unwrap();
+
+    for progress in [
+        JobProgress {
+            current: 1,
+            total: 4,
+            message: None,
+        },
+        JobProgress {
+            current: 3,
+            total: 3,
+            message: None,
+        },
+        JobProgress {
+            current: 5,
+            total: 4,
+            message: None,
+        },
+    ] {
+        assert_eq!(jm.update_progress(&id, progress), None);
+    }
+    let progress = handle.read().progress.clone().unwrap();
+    assert_eq!((progress.current, progress.total), (2, 4));
 }
 
 #[test]
@@ -138,6 +178,84 @@ fn get_and_fail_missing_job_returns_none() {
     assert_eq!(jm.complete("missing", json!(null)), None);
     assert_eq!(jm.fail("missing", "err"), None);
     assert_eq!(jm.cancel("missing"), None);
+    assert_eq!(jm.acknowledge_cancel("missing"), None);
+}
+
+#[test]
+fn chunked_runner_yields_between_steps_and_updates_shared_jobs() {
+    let jobs = Arc::new(JobManager::new());
+    let pump_work = Arc::new(parking_lot::Mutex::new(Vec::new()));
+    let steps = (0..3)
+        .map(|index| {
+            Box::new(move || {
+                Ok(ChunkedStepOutput::new(
+                    json!(index),
+                    Some(format!("step {index}")),
+                ))
+            }) as ChunkedStep
+        })
+        .collect::<Vec<_>>();
+    let mut runner = ChunkedJobRunner::new(Arc::clone(&jobs), "maya.render", steps);
+    let id = runner.job_id().to_string();
+
+    let mut tick = 0;
+    while runner.tick() {
+        tick += 1;
+        pump_work.lock().push(tick);
+        let progress = jobs.get(&id).unwrap().read().progress.clone().unwrap();
+        assert_eq!(progress.current, tick);
+    }
+
+    assert_eq!(*pump_work.lock(), vec![1, 2]);
+    let job = jobs.get(&id).unwrap();
+    let job = job.read();
+    assert_eq!(job.status, JobStatus::Completed);
+    assert_eq!(job.progress.as_ref().unwrap().current, 3);
+    assert_eq!(job.result, Some(json!([0, 1, 2])));
+}
+
+#[test]
+fn chunked_runner_acknowledges_cancel_and_is_host_neutral() {
+    for label in ["houdini.cook", "photoshop.export"] {
+        let jobs = Arc::new(JobManager::new());
+        let ran = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let steps = (0..2)
+            .map(|_| {
+                let ran = Arc::clone(&ran);
+                Box::new(move || {
+                    ran.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(ChunkedStepOutput::new(json!(true), None))
+                }) as ChunkedStep
+            })
+            .collect::<Vec<_>>();
+        let mut runner = ChunkedJobRunner::new(Arc::clone(&jobs), label, steps);
+        let id = runner.job_id().to_string();
+
+        assert!(runner.tick());
+        assert!(runner.cancel());
+        assert_eq!(jobs.get(&id).unwrap().read().status, JobStatus::Running);
+        assert!(!runner.tick());
+        assert_eq!(ran.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(jobs.get(&id).unwrap().read().status, JobStatus::Cancelled);
+        assert!(!runner.tick());
+    }
+}
+
+#[test]
+fn chunked_runner_publishes_failure_once() {
+    let jobs = Arc::new(JobManager::new());
+    let steps = vec![Box::new(|| Err("generator failed".to_string())) as ChunkedStep];
+    let mut runner = ChunkedJobRunner::new(Arc::clone(&jobs), "blender.bake", steps);
+    let id = runner.job_id().to_string();
+
+    assert!(!runner.tick());
+    let updated_at = jobs.get(&id).unwrap().read().updated_at;
+    assert!(!runner.tick());
+    let job = jobs.get(&id).unwrap();
+    let job = job.read();
+    assert_eq!(job.status, JobStatus::Failed);
+    assert_eq!(job.error.as_deref(), Some("generator failed"));
+    assert_eq!(job.updated_at, updated_at);
 }
 
 #[test]

--- a/docs/api/dispatcher.md
+++ b/docs/api/dispatcher.md
@@ -360,6 +360,24 @@ override only the small extension hooks they need:
   `label="3dsmax-ui"` or similar to the constructor.
 - `queue_size()` and `active_count()` expose safe read-only visibility for
   pump controllers, health checks, and adapter tests.
+- `submit_chunked_runner(request_id, runner, ...)` advances one
+  `ChunkedRunner` step per host pump tick; use it for long main-affinity jobs
+  instead of a monolithic callback or adapter-local timer loop.
+
+```python
+from dcc_mcp_core import chunked_job
+
+@chunked_job(total=10)
+def build_frames():
+    for frame in range(10):
+        yield lambda frame=frame: build_one_frame(frame)
+
+dispatcher.submit_chunked_runner("build-frames", build_frames())
+```
+
+`cancel(request_id)` only requests cancellation for a chunked runner. The
+runner publishes `cancelled` when the next pump checkpoint observes the
+request; an already-running monolithic callback remains non-preemptive.
 
 3ds Max migration note: replace local job-entry / queue / shutdown code with a
 `HostUiDispatcherBase` subclass, move .NET timer or rollout tick glue into a

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -164,6 +164,21 @@ server = SocketServerAdapter("/tmp/maya.sock", max_connections=8,
 from dcc_mcp_core._core import DeferredExecutor   # direct import required
 ```
 
+**Chunked main-affinity jobs — cancellation is acknowledged, not pre-emptive:**
+```python
+from dcc_mcp_core import chunked_job
+
+@chunked_job(total=10)
+def bake():
+    for frame in range(10):
+        yield lambda frame=frame: bake_one_frame(frame)
+
+dispatcher.submit_chunked_runner("bake", bake())
+```
+The shared host pump advances one step per tick. `cancel()` sets the token;
+`cancelled` is published only when the runner observes the next checkpoint.
+Monolithic callbacks remain non-preemptive and stay running until they return.
+
 **`McpHttpServer` — register ALL handlers BEFORE `.start()`.**
 This includes `register_diagnostic_mcp_tools(...)` for instance-bound diagnostics —
 register them before calling `server.start()`, never after.

--- a/docs/guide/dcc-thread-safety.md
+++ b/docs/guide/dcc-thread-safety.md
@@ -109,7 +109,7 @@ HTTP request (Tokio worker)
         ├─▶ executor.submit_deferred(tool_name, cancel_token, task_fn)
         │     │
         │     ├─▶ tx.reserve() races against cancel_token.cancelled()
-        │     │     └─▶ if cancelled first → job = Cancelled, task dropped
+        │     │     └─▶ if cancelled first → task dropped; runner acknowledges Cancelled
         │     │
         │     └─▶ permit.send(task) → DeferredExecutor::pending queue
         │
@@ -119,7 +119,7 @@ HTTP request (Tokio worker)
         ├─▶ task_fn checks is_cancelled() → skip if cancelled
         └─▶ run handler, send result via oneshot
         │
-      Tokio driver awaits oneshot, updates JobManager (Succeeded / Failed)
+      Tokio driver awaits oneshot, then updates JobManager terminal state
 ```
 
 Key invariants:
@@ -129,9 +129,11 @@ Key invariants:
 2. **Main-affined handler runs on the DCC main thread.** The thread ID
    of the handler closure equals the thread that called
    `poll_pending_bounded`. Any-affined handlers stay on Tokio.
-3. **Cancellation before pump drops the task.** If the caller cancels
+3. **Cancellation before pump drops the task.** If the caller requests cancellation
    the job (via `JobManager::cancel`) before the main thread pulls it,
-   the wrapper skips execution and the job ends in `Cancelled`.
+   the wrapper skips execution and the runner acknowledges `Cancelled`.
+   An active monolithic closure remains `Running` until it returns; token
+   delivery never claims that arbitrary Python or a host API call was pre-empted.
 4. **Soft fence.** `submit_deferred` logs a `tracing::warn!` if the
    deferred closure runs longer than 50 ms, surfacing candidates for
    chunking (`@chunked_job`, see [issue #332][chunked]).
@@ -209,10 +211,10 @@ do not receive reserved `_meta` arguments; call `current_job_id()` instead.
 `HostExecutionBridge` also installs a read-only probe backed by the same Rust
 cancellation token for MCP and REST jobs.
 
-- **Python `check_dcc_cancelled()`** — call between chunks. It raises
-  `CancelledError` after the client cancels the owning job. The bridge converts
-  an uncaught exception to the normal structured error envelope, while the job
-  remains `cancelled`.
+- **Python `ChunkedRunner` / `@chunked_job`** — yield bounded callables and
+  queue the runner with `HostUiDispatcherBase.submit_chunked_runner(...)`.
+  The shared dispatcher advances it once per host pump tick, reports progress
+  after acknowledged steps, and observes cancellation at the next checkpoint.
 - **Rust `current_dispatch_job_context()`** — read the server-owned job context
   inside a custom Rust handler and call `is_cancelled()` between chunks.
   `submit_deferred` also skips a task that is cancelled before the host pump
@@ -225,14 +227,14 @@ cancellation token for MCP and REST jobs.
   across ticks via the DCC's own timer primitive).
 
 ```python
-from dcc_mcp_core import check_dcc_cancelled, current_job_id
+from dcc_mcp_core import chunked_job, current_job_id
 
-def main(items):
-    job_id = current_job_id()
-    for item in items:
-        check_dcc_cancelled()
-        process_one_short_chunk(item, job_id=job_id)
-    return {"success": True}
+@chunked_job(total=100)
+def bake_frames():
+    for frame in range(100):
+        yield lambda frame=frame: bake_one_frame(frame)
+
+dispatcher.submit_chunked_runner("bake-frames", bake_frames(), job_id=current_job_id())
 ```
 
 ```rust
@@ -254,8 +256,7 @@ forward the server-owned job id and cancellation signal. Cancellation cannot
 safely pre-empt an already-running DCC-native call or an uncooperative hot
 loop; keep each main-thread chunk short and return to the host pump.
 
-Forbidden patterns inside a deferred closure (enforced by soft-fence
-warnings; will be upgraded to hard errors when `@chunked_job` lands):
+Forbidden patterns inside a deferred closure (surfaced by soft-fence warnings):
 
 - `time.sleep(n)` / `std::thread::sleep(n)` — blocks the DCC UI.
 - `threading.Thread(...).start()` that calls scene APIs — violates the
@@ -369,9 +370,8 @@ executor.poll_pending_bounded(max=8)
 A reasonable starting value is `max=8` at 60 FPS; tune down if individual
 tasks are expensive.
 
-The chunked-job decorator described in
-[issue #332 — `@chunked_job`](https://github.com/dcc-mcp/dcc-mcp-core/issues/332)
-will encode rules (1) and (2) automatically once it lands.
+Use `@chunked_job` plus `HostUiDispatcherBase.submit_chunked_runner()` to
+encode rules (1) and (2) without adapter-local queue pumping.
 
 ## Forbidden patterns
 

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -463,6 +463,7 @@ _LAZY: dict[str, str] = {
     "ChunkedProgress": "dcc_mcp_core.chunked_runner",
     "ChunkedRunner": "dcc_mcp_core.chunked_runner",
     "ChunkedStep": "dcc_mcp_core.chunked_runner",
+    "chunked_job": "dcc_mcp_core.chunked_runner",
     "CheckpointStore": "dcc_mcp_core.checkpoint",
     "checkpoint_every": "dcc_mcp_core.checkpoint",
     "clear_checkpoint": "dcc_mcp_core.checkpoint",

--- a/python/dcc_mcp_core/_server/host_ui_dispatcher.py
+++ b/python/dcc_mcp_core/_server/host_ui_dispatcher.py
@@ -34,6 +34,7 @@ from typing import Tuple
 from dcc_mcp_core.cancellation import CancelledError
 from dcc_mcp_core.cancellation import reset_current_job
 from dcc_mcp_core.cancellation import set_current_job
+from dcc_mcp_core.chunked_runner import ChunkedRunner
 
 logger = logging.getLogger(__name__)
 
@@ -209,6 +210,22 @@ class HostUiJobEntry:
             return str(exc)
 
 
+class _ChunkedSubmission:
+    __slots__ = ("job_id", "on_complete", "request_id", "runner")
+
+    def __init__(
+        self,
+        request_id: str,
+        runner: ChunkedRunner,
+        job_id: Optional[str],
+        on_complete: Optional[Callable[[Dict[str, Any]], None]],
+    ) -> None:
+        self.request_id = request_id
+        self.runner = runner
+        self.job_id = job_id
+        self.on_complete = on_complete
+
+
 class HostUiDispatcherBase:
     """Base class for interactive DCC UI-thread dispatchers.
 
@@ -223,9 +240,11 @@ class HostUiDispatcherBase:
         label: Optional[str] = None,
     ) -> None:
         self._main_queue: Deque[HostUiJobEntry] = deque()
+        self._chunked_queue: Deque[_ChunkedSubmission] = deque()
         self._lock = threading.Lock()
         self._cancelled: Set[str] = set()
         self._active: Dict[str, HostUiJobEntry] = {}
+        self._active_chunked: Dict[str, _ChunkedSubmission] = {}
         self._http_dispatcher: Optional[Any] = None
         self._host_thread_id: Optional[int] = None
         self._shutdown = False
@@ -375,6 +394,36 @@ class HostUiDispatcherBase:
             "error": None,
         }
 
+    def submit_chunked_runner(
+        self,
+        request_id: str,
+        runner: ChunkedRunner,
+        *,
+        job_id: Optional[str] = None,
+        on_complete: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ) -> Dict[str, Any]:
+        """Queue a runner that advances at most once per host pump tick."""
+        if not isinstance(runner, ChunkedRunner):
+            raise TypeError("runner must be a ChunkedRunner")
+        with self._lock:
+            if self._shutdown:
+                return {
+                    "request_id": request_id,
+                    "job_id": job_id,
+                    "status": "interrupted",
+                    "success": False,
+                    "error": DispatcherErrorCode.INTERRUPTED,
+                }
+            self._chunked_queue.append(_ChunkedSubmission(request_id, runner, job_id, on_complete))
+        self.poke_host_pump()
+        return {
+            "request_id": request_id,
+            "job_id": job_id,
+            "status": "pending",
+            "success": True,
+            "error": None,
+        }
+
     def attach_http_dispatcher(self, dispatcher: Any) -> None:
         """Attach the native queue used by HTTP main-affinity routing.
 
@@ -393,6 +442,14 @@ class HostUiDispatcherBase:
 
     def cancel(self, request_id: str) -> bool:
         with self._lock:
+            for submission in self._chunked_queue:
+                if submission.request_id == request_id:
+                    submission.runner.cancel()
+                    return True
+            active_chunked = self._active_chunked.get(request_id)
+            if active_chunked is not None:
+                active_chunked.runner.cancel()
+                return True
             self._cancelled.add(request_id)
             for job in self._main_queue:
                 if job.request_id == request_id:
@@ -422,12 +479,12 @@ class HostUiDispatcherBase:
     def queue_size(self) -> int:
         """Return the number of queued main-thread jobs."""
         with self._lock:
-            return len(self._main_queue)
+            return len(self._main_queue) + len(self._chunked_queue)
 
     def active_count(self) -> int:
         """Return the number of currently executing main-thread jobs."""
         with self._lock:
-            return len(self._active)
+            return len(self._active) + len(self._active_chunked)
 
     def has_pending(self) -> bool:
         return self.pending_count() > 0
@@ -436,6 +493,8 @@ class HostUiDispatcherBase:
         signalled = 0
         with self._lock:
             self._shutdown = True
+            chunked = list(self._chunked_queue)
+            self._chunked_queue.clear()
             while self._main_queue:
                 job = self._main_queue.popleft()
                 job.cancel()
@@ -452,6 +511,14 @@ class HostUiDispatcherBase:
             for job in list(self._active.values()):
                 job.cancel()
                 signalled += 1
+            for submission in list(self._active_chunked.values()):
+                submission.runner.cancel()
+                signalled += 1
+        for submission in chunked:
+            submission.runner.cancel()
+            submission.runner.step()
+            self._complete_chunked_submission(submission)
+            signalled += 1
         if signalled:
             logger.info(
                 "%s.shutdown: signalled %d job(s) with reason=%r",
@@ -485,6 +552,9 @@ class HostUiDispatcherBase:
         executed = 0
         start = time.monotonic()
         deadline = start + (budget_ms / 1000.0)
+
+        if time.monotonic() < deadline:
+            executed += self._drain_chunked_once()
 
         while time.monotonic() < deadline:
             http_executed = 0
@@ -598,6 +668,51 @@ class HostUiDispatcherBase:
             if self._main_queue:
                 return self._main_queue.popleft()
         return None
+
+    def _drain_chunked_once(self) -> int:
+        with self._lock:
+            if not self._chunked_queue:
+                return 0
+            submission = self._chunked_queue.popleft()
+            self._active_chunked[submission.request_id] = submission
+        try:
+            has_more = submission.runner.step()
+        finally:
+            with self._lock:
+                self._active_chunked.pop(submission.request_id, None)
+        if has_more:
+            with self._lock:
+                self._chunked_queue.append(submission)
+        else:
+            self._complete_chunked_submission(submission)
+        return 1
+
+    def _complete_chunked_submission(self, submission: _ChunkedSubmission) -> None:
+        outcome = submission.runner.outcome
+        if outcome is None or submission.on_complete is None:
+            return
+        result = host_ui_outcome(
+            submission.request_id,
+            "main",
+            success=outcome.status == "completed",
+            output={
+                "current": outcome.progress.completed,
+                "total": outcome.progress.total,
+                "message": outcome.progress.message,
+            },
+            error=(
+                None
+                if outcome.status == "completed"
+                else DispatcherErrorCode.CANCELLED
+                if outcome.status == "cancelled"
+                else outcome.error
+            ),
+            job_id=submission.job_id,
+        )
+        try:
+            submission.on_complete(result)
+        except Exception as exc:  # pragma: no cover
+            logger.warning("submit_chunked_runner on_complete raised: %s", exc)
 
     def _format_exception_error(self, exc: BaseException) -> str:
         try:

--- a/python/dcc_mcp_core/chunked_runner.py
+++ b/python/dcc_mcp_core/chunked_runner.py
@@ -1,53 +1,31 @@
-"""Chunked main-affinity runner with cooperative cancellation.
-
-A ``ChunkedRunner`` drains a sequence of bounded work steps one at a time
-per host event-loop tick. Each step runs on the calling (main) thread —
-no worker threads are spawned for DCC API calls. A shared cancellation
-token is checked before every step, and the runner publishes a terminal
-outcome exactly once (completed / failed / cancelled).
-
-Intended integration::
-
-    runner = ChunkedRunner(steps, cancel_token=token)
-    # In the host pump tick callback:
-    has_more = runner.step()
-    if not has_more:
-        outcome = runner.outcome  # terminal state published exactly once
-"""
+"""Tick-driven main-affinity work with cooperative cancellation."""
 
 from __future__ import annotations
 
-# Import built-in modules
+from functools import wraps
+import logging
 import time
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Sequence
-
-if TYPE_CHECKING:
-    pass
+from typing import Iterable
+from typing import Iterator
 
 from dcc_mcp_core.cancellation import CancelledError
 from dcc_mcp_core.cancellation import CancelToken
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "ChunkedOutcome",
     "ChunkedProgress",
     "ChunkedRunner",
     "ChunkedStep",
+    "chunked_job",
 ]
 
 
 class ChunkedStep:
-    """One bounded unit of work executed on the main/affinity thread.
-
-    Attributes:
-        step: Zero-based step index (set by the runner).
-        fn: A zero-argument callable that performs one bounded unit of
-            work (e.g. process a single mesh, bake one frame). Must
-            return quickly — a typical budget is 8-16 ms per step.
-
-    """
+    """One bounded unit of host-main work."""
 
     __slots__ = ("fn", "step")
 
@@ -57,43 +35,31 @@ class ChunkedStep:
 
 
 class ChunkedProgress:
-    """Monotonic progress snapshot published after each confirmed step.
+    """Progress published after an acknowledged step."""
 
-    Attributes:
-        completed: Number of steps that have finished successfully.
-        total: Total number of steps (may be ``None`` for unbounded
-            sequences).
-        last_step_at: ``time.monotonic`` timestamp of the most recent
-            completed step.
-
-    """
-
-    __slots__ = ("completed", "last_step_at", "total")
+    __slots__ = ("completed", "last_step_at", "message", "total")
 
     def __init__(
         self,
         completed: int = 0,
         total: int | None = None,
         last_step_at: float = 0.0,
+        message: str | None = None,
     ) -> None:
         self.completed = completed
         self.total = total
         self.last_step_at = last_step_at
+        self.message = message
 
     def __repr__(self) -> str:  # pragma: no cover
-        return f"ChunkedProgress(completed={self.completed}, total={self.total}, last_step_at={self.last_step_at:.3f})"
+        return (
+            f"ChunkedProgress(completed={self.completed}, total={self.total}, "
+            f"last_step_at={self.last_step_at:.3f}, message={self.message!r})"
+        )
 
 
 class ChunkedOutcome:
-    """Terminal outcome published exactly once when the runner finishes.
-
-    Attributes:
-        status: One of ``"completed"``, ``"failed"``, or ``"cancelled"``.
-        progress: The final progress snapshot.
-        error: Human-readable error message when ``status`` is
-            ``"failed"``, ``None`` otherwise.
-
-    """
+    """Exactly-once terminal outcome."""
 
     __slots__ = ("error", "progress", "status")
 
@@ -112,52 +78,34 @@ class ChunkedOutcome:
 
 
 class ChunkedRunner:
-    """Drain a sequence of bounded work steps one tick at a time.
+    """Execute at most one iterator step per :meth:`step` call.
 
-    Each call to :meth:`step` executes one chunk on the calling thread,
-    checks the optional :class:`~dcc_mcp_core.cancellation.CancelToken`
-    before executing, updates the monotonic progress counter, and returns
-    ``True`` while more work remains. Once the sequence is exhausted or a
-    terminal condition is reached (failure / cancellation), the runner
-    publishes a :class:`ChunkedOutcome` exactly once and :meth:`step`
-    becomes a no-op.
-
-    Typical usage inside a host pump tick callback::
-
-        def _on_tick() -> float | None:
-            has_more = runner.step()
-            return 0.05 if has_more else None
+    Call ``step()`` once from each host event-loop tick. Iterables are consumed
+    lazily, so generator bodies and yielded callables both remain on the host
+    thread. Cancellation is requested immediately but becomes terminal only
+    when the next checkpoint observes it.
     """
 
     def __init__(
         self,
-        steps: Sequence[ChunkedStep] | Sequence[Callable[[], Any]],
+        steps: Iterable[ChunkedStep] | Iterable[Callable[[], Any]],
         *,
+        total: int | None = None,
         cancel_token: CancelToken | None = None,
         clock: Callable[[], float] = time.monotonic,
+        on_progress: Callable[[ChunkedProgress], None] | None = None,
+        on_terminal: Callable[[ChunkedOutcome], None] | None = None,
     ) -> None:
-        self._steps: list[ChunkedStep] = []
-        for i, item in enumerate(steps):
-            if isinstance(item, ChunkedStep):
-                step = item
-                step.step = i
-                self._steps.append(step)
-            elif callable(item):
-                self._steps.append(ChunkedStep(i, item))
-            else:
-                raise TypeError(f"Expected ChunkedStep or callable, got {type(item).__name__}")
-        self._cancel_token = cancel_token
+        inferred_total = len(steps) if total is None and hasattr(steps, "__len__") else total
+        if inferred_total is not None and inferred_total < 0:
+            raise ValueError("total must be >= 0 or None")
+        self._steps: Iterator[Any] = iter(steps)
+        self._cancel_token = cancel_token if cancel_token is not None else CancelToken()
         self._clock = clock
-        self._index: int = 0
+        self._on_progress = on_progress
+        self._on_terminal = on_terminal
         self._outcome: ChunkedOutcome | None = None
-        self._progress = ChunkedProgress(
-            completed=0,
-            total=len(self._steps) if self._steps else None,
-            last_step_at=0.0,
-        )
-        self._terminal_published: bool = False
-
-    # -- Public properties ---------------------------------------------------
+        self._progress = ChunkedProgress(total=inferred_total)
 
     @property
     def progress(self) -> ChunkedProgress:
@@ -166,98 +114,92 @@ class ChunkedRunner:
 
     @property
     def outcome(self) -> ChunkedOutcome | None:
-        """Terminal outcome, or ``None`` while the runner is still active."""
+        """Terminal outcome, or ``None`` while active."""
         return self._outcome
 
     @property
     def is_terminal(self) -> bool:
-        """``True`` once the runner has reached a terminal state."""
+        """Whether a terminal outcome has been published."""
         return self._outcome is not None
 
-    # -- Public methods ------------------------------------------------------
-
     def step(self) -> bool:
-        """Execute one chunk and return ``True`` if more work remains.
-
-        On each call:
-        1. If already terminal, return ``False`` (idempotent no-op).
-        2. Check the cancellation token; if cancelled, publish
-           ``"cancelled"`` outcome and return ``False``.
-        3. Execute the next chunk. On success, advance the progress
-           counter and timestamp.
-        4. If the chunk raises :exc:`CancelledError`, publish
-           ``"cancelled"`` outcome and return ``False``.
-        5. If the chunk raises any other exception, publish
-           ``"failed"`` outcome and return ``False``.
-        6. If the sequence is exhausted, publish ``"completed"``
-           outcome and return ``False``.
-
-        Returns:
-            ``True`` when at least one more step is available;
-            ``False`` when the runner is terminal (sequence exhausted,
-            failed, or cancelled).
-
-        """
-        # Idempotent no-op after terminal state.
+        """Run one bounded step; return whether another tick is required."""
         if self._outcome is not None:
             return False
-
-        # Check cancellation token before executing.
-        if self._cancel_token is not None and self._cancel_token.cancelled:
+        if self._cancel_token.cancelled:
             self._publish_terminal("cancelled")
             return False
 
-        # Sequence exhausted — completed.
-        if self._index >= len(self._steps):
+        try:
+            item = next(self._steps)
+            fn = item.fn if isinstance(item, ChunkedStep) else item
+            if not callable(fn):
+                raise TypeError(f"Expected ChunkedStep or callable, got {type(item).__name__}")
+            message = fn()
+        except StopIteration:
             self._publish_terminal("completed")
             return False
-
-        step = self._steps[self._index]
-        try:
-            step.fn()
         except CancelledError:
             self._publish_terminal("cancelled")
             return False
         except Exception as exc:
-            error_msg = f"{type(exc).__name__}: {exc}"
-            self._publish_terminal("failed", error=error_msg)
+            self._publish_terminal("failed", f"{type(exc).__name__}: {exc}")
             return False
 
-        # Success — advance progress.
-        self._index += 1
-        self._progress.completed = self._index
+        self._progress.completed += 1
         self._progress.last_step_at = self._clock()
+        self._progress.message = message if isinstance(message, str) else None
+        if self._on_progress is not None:
+            try:
+                self._on_progress(self._progress)
+            except Exception as exc:
+                self._publish_terminal("failed", f"{type(exc).__name__}: {exc}")
+                return False
 
-        # Check if sequence is now exhausted.
-        if self._index >= len(self._steps):
+        if self._cancel_token.cancelled:
+            self._publish_terminal("cancelled")
+            return False
+        if self._progress.total is not None and self._progress.completed >= self._progress.total:
             self._publish_terminal("completed")
             return False
-
         return True
 
     def cancel(self) -> None:
-        """Signal cancellation via the associated token.
-
-        If no token was provided at construction this is a no-op.
-        The actual cancellation check occurs on the next :meth:`step`
-        call.
-        """
-        if self._cancel_token is not None:
-            self._cancel_token.cancel()
-
-    # -- Internal helpers ----------------------------------------------------
+        """Request cancellation; the next checkpoint acknowledges it."""
+        self._cancel_token.cancel()
 
     def _publish_terminal(self, status: str, error: str | None = None) -> None:
-        """Publish the terminal outcome exactly once."""
-        if self._terminal_published:
+        if self._outcome is not None:
             return
         self._outcome = ChunkedOutcome(
-            status=status,
-            progress=ChunkedProgress(
-                completed=self._progress.completed,
-                total=self._progress.total,
-                last_step_at=self._progress.last_step_at,
+            status,
+            ChunkedProgress(
+                self._progress.completed,
+                self._progress.total,
+                self._progress.last_step_at,
+                self._progress.message,
             ),
-            error=error,
+            error,
         )
-        self._terminal_published = True
+        if self._on_terminal is not None:
+            try:
+                self._on_terminal(self._outcome)
+            except Exception as exc:  # pragma: no cover - defensive callback isolation
+                logger.warning("ChunkedRunner.on_terminal raised: %s", exc)
+
+
+def chunked_job(
+    func: Callable[..., Iterable[Any]] | None = None,
+    *,
+    total: int | None = None,
+) -> Callable[..., Any]:
+    """Decorate a generator/iterable factory as a :class:`ChunkedRunner`."""
+
+    def decorate(factory: Callable[..., Iterable[Any]]) -> Callable[..., ChunkedRunner]:
+        @wraps(factory)
+        def create_runner(*args: Any, **kwargs: Any) -> ChunkedRunner:
+            return ChunkedRunner(factory(*args, **kwargs), total=total)
+
+        return create_runner
+
+    return decorate(func) if func is not None else decorate

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -17,7 +17,7 @@ metadata:
     search-hint: >-
       create DCC MCP adapter, Nuke MCP, DccServerBase, HostExecutionBridge,
       dispatcher, readiness, resources, gateway, Blender, 3ds Max, Unreal,
-      ZBrush, Houdini, Maya
+      ZBrush, Houdini, Maya, chunked main-thread jobs, cooperative cancellation
     tags: "adapter-development, host-runtime, dispatcher, gateway, nuke, blender, 3dsmax, unreal, zbrush"
     skill-reference-docs:
       - "references/*.md"
@@ -162,6 +162,40 @@ does not replace a running server binary.
     database, or a replay authority flag. Generated workflows re-resolve
     current tools and schemas; semantic UI replay resolves fresh control ids;
     raw/visual fallback requires exact-window calibration and drift guards.
+
+## Chunked Main-Thread Jobs
+
+Use the shared chunked path when a main-affinity operation cannot finish within
+one host UI tick. The adapter owns scheduling; skill code only defines bounded
+steps:
+
+```python
+from dcc_mcp_core import chunked_job, current_job_id
+
+@chunked_job(total=100)
+def bake_frames():
+    for frame in range(100):
+        yield lambda frame=frame: bake_one_frame(frame)
+
+dispatcher.submit_chunked_runner(
+    "bake-frames",
+    bake_frames(),
+    job_id=current_job_id(),
+)
+```
+
+- Yield one bounded host-API callable per step. A returned string becomes the
+  progress message.
+- `submit_chunked_runner()` advances at most one step per host pump tick, so
+  unrelated UI work can run between steps.
+- `cancel(request_id)` requests cancellation. The runner publishes
+  `cancelled` only after the next checkpoint observes it; a running native DCC
+  call or monolithic callback is not pre-empted.
+- Do not add adapter-local generator pumps, timer loops, worker threads, or a
+  second job registry.
+- Test pending cancellation, cancellation during a step, monotonic progress,
+  failure, exactly one terminal result, unrelated pump work, and at least two
+  host labels.
 
 ## Example: New Nuke Adapter
 

--- a/skills/dcc-mcp-creator/references/HOST_PATTERN_MATRIX.md
+++ b/skills/dcc-mcp-creator/references/HOST_PATTERN_MATRIX.md
@@ -28,11 +28,15 @@ Use this table when choosing adapter runtime wiring for a new DCC.
   `main()`. Use `check_dcc_cancelled()` in Python and
   `DispatchJobContext::is_cancelled()` in Rust. Never trust or mint a
   client-supplied job id.
+- Interactive Python hosts should use `@chunked_job` and
+  `HostUiDispatcherBase.submit_chunked_runner()` so the shared pump executes at
+  most one bounded step per tick. Do not add an adapter-local generator pump.
 - The built-in propagation contract covers in-process Rust/Python handlers over
   MCP and REST. Subprocess, native IPC, and remote bridge adapters must forward
   both the server-owned job id and cancellation signal explicitly, then prove
   that wiring in an adapter test.
-- Cancellation skips queued work and cooperatively stops running chunks. It
+- Cancellation requests skip queued work and cooperatively stop running chunks
+  when the execution lane acknowledges the next checkpoint. They
   cannot safely interrupt a DCC-native API call or an uncooperative hot loop
   already executing on the host thread; use typed, bounded operations and
   return control to the pump between chunks.

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -13,7 +13,7 @@ metadata:
     version: "0.19.64"
     layer: infrastructure
     compatibility: "Python 3.7+, dcc-mcp-core 0.17+"
-    search-hint: "create dcc mcp skill, validate skill, scaffold skill, SKILL.md, tools.yaml, scripts, groups, prompts, skill taxonomy"
+    search-hint: "create dcc mcp skill, validate skill, scaffold skill, SKILL.md, tools.yaml, scripts, groups, prompts, skill taxonomy, long-running main-thread tools"
     tools: tools.yaml
     prompts: prompts.yaml
     skill-reference-docs:
@@ -146,6 +146,40 @@ Generated `tools.yaml` entries follow the modern contract:
 - `enforce_thread_affinity: true` is emitted so adapter dispatch stays honest.
 - `annotations` use MCP hints: read-only, destructive, idempotent, open-world, and deferred.
 - `call_examples`: optional list of ready-to-copy argument payloads. Each entry has `arguments` (JSON object matching `input_schema.properties`) and an optional `note`. Surfaced in describe responses at `metadata.dcc.call_examples` so agents can construct correct arguments on the first attempt.
+
+### Long-Running Main-Affinity Tools
+
+`execution: async` changes the job lifecycle; it does not make one monolithic
+host call interruptible. For long scene mutations:
+
+```yaml
+execution: async
+affinity: main
+enforce_thread_affinity: true
+annotations:
+  deferred_hint: true
+```
+
+When the adapter supports `HostUiDispatcherBase.submit_chunked_runner()`,
+define bounded steps with the shared helper:
+
+```python
+from dcc_mcp_core import chunked_job
+
+@chunked_job(total=100)
+def build_bake_steps():
+    for frame in range(100):
+        yield lambda frame=frame: bake_one_frame(frame)
+```
+
+The adapter-owned handler must submit the returned runner to the shared host
+pump. A declarative script returning `ChunkedRunner` is not automatically
+scheduled. Do not create a skill-local timer, thread, pump, or job registry.
+Keep each yielded callable bounded, return a string when a progress message is
+useful, and let cancellation become terminal only after a runner checkpoint.
+If the adapter does not expose the shared chunked path, document that the tool
+is monolithic and request an adapter/core integration instead of claiming
+mid-call interruption.
 
 ### Computer Use Fallback Contract
 

--- a/tests/test_chunked_runner.py
+++ b/tests/test_chunked_runner.py
@@ -1,427 +1,238 @@
-"""Contract tests for :mod:`dcc_mcp_core.chunked_runner`.
-
-Covers:
-- Fake host pump contract: pending cancellation, mid-sequence cancellation,
-  generator failure, terminal idempotence.
-- Adapter label tests proving the contract is not Houdini-specific.
-"""
+"""Contract tests for tick-driven main-affinity jobs."""
 
 from __future__ import annotations
 
-# Import built-in modules
-import time
+import threading
 
-# Import third-party modules
 import pytest
 
-from dcc_mcp_core import CancelledError
-
-# Import local modules
 from dcc_mcp_core import CancelToken
-from dcc_mcp_core import ChunkedOutcome
-from dcc_mcp_core import ChunkedProgress
 from dcc_mcp_core import ChunkedRunner
 from dcc_mcp_core import ChunkedStep
-from dcc_mcp_core import reset_cancel_token
-from dcc_mcp_core import set_cancel_token
-
-# ---------------------------------------------------------------------------
-# Top-level exports
-# ---------------------------------------------------------------------------
+from dcc_mcp_core import chunked_job
+from dcc_mcp_core._server.host_ui_dispatcher import HostUiDispatcherBase
 
 
-def test_exports_available() -> None:
-    """All public symbols must be importable from the top-level package."""
+class _ManualDispatcher(HostUiDispatcherBase):
+    def __init__(self, label: str = "fake-host") -> None:
+        super().__init__(label=label)
+        self.pokes = 0
+
+    def poke_host_pump(self) -> None:
+        self.pokes += 1
+
+
+def test_public_exports() -> None:
     import dcc_mcp_core
 
-    for name in ("ChunkedRunner", "ChunkedProgress", "ChunkedOutcome", "ChunkedStep"):
-        assert hasattr(dcc_mcp_core, name), name
+    for name in ("ChunkedRunner", "ChunkedProgress", "ChunkedOutcome", "ChunkedStep", "chunked_job"):
         assert name in dcc_mcp_core.__all__
 
 
-# ---------------------------------------------------------------------------
-# ChunkedStep
-# ---------------------------------------------------------------------------
+def test_host_pump_runs_one_step_per_tick_and_unrelated_work_continues() -> None:
+    dispatcher = _ManualDispatcher()
+    events = []
+    runner = ChunkedRunner([lambda: events.append("chunk-1"), lambda: events.append("chunk-2")])
+    dispatcher.submit_chunked_runner("chunked", runner)
+    dispatcher.submit_async_callable("unrelated", lambda: events.append("unrelated"), affinity="main")
 
+    dispatcher.drain_queue(100)
+    assert events == ["chunk-1", "unrelated"]
+    assert runner.progress.completed == 1
+    assert not runner.is_terminal
 
-def test_chunked_step_slots() -> None:
-    """ChunkedStep is a slotted, lightweight value object."""
-
-    def _noop() -> None:
-        pass
-
-    fn = _noop
-    s = ChunkedStep(3, fn)
-    assert s.step == 3
-    assert s.fn is fn
-
-
-def test_chunked_step_accepts_callable_in_runner() -> None:
-    """ChunkedRunner wraps plain callables into ChunkedStep."""
-    results: list[int] = []
-
-    def a() -> None:
-        results.append(1)
-
-    def b() -> None:
-        results.append(2)
-
-    runner = ChunkedRunner([a, b])
-    assert runner.step() is True
-    assert runner.step() is False
+    dispatcher.drain_queue(100)
+    assert events == ["chunk-1", "unrelated", "chunk-2"]
     assert runner.outcome is not None
     assert runner.outcome.status == "completed"
-    assert results == [1, 2]
 
 
-def test_chunked_runner_rejects_non_callable() -> None:
-    """Non-callable items raise TypeError at construction."""
-    with pytest.raises(TypeError, match="Expected ChunkedStep or callable"):
-        ChunkedRunner([42])  # type: ignore[list-item]
+def test_pending_cancel_is_acknowledged_on_pump_checkpoint() -> None:
+    dispatcher = _ManualDispatcher()
+    ran = []
+    runner = ChunkedRunner([lambda: ran.append(True)])
+    dispatcher.submit_chunked_runner("cancel-pending", runner)
 
-
-# ---------------------------------------------------------------------------
-# ChunkedProgress
-# ---------------------------------------------------------------------------
-
-
-def test_chunked_progress_defaults() -> None:
-    """Default progress starts at zero."""
-    p = ChunkedProgress()
-    assert p.completed == 0
-    assert p.total is None
-    assert p.last_step_at == 0.0
-
-
-# ---------------------------------------------------------------------------
-# Fake host pump contract tests
-# ---------------------------------------------------------------------------
-
-
-class _FakeHostPump:
-    """Minimal fake host pump that calls runner.step() per tick.
-
-    This simulates a DCC main-loop tick callback (Maya ``scriptJob``,
-    Blender ``app.timers``, Houdini ``addEventLoopCallback``, etc.).
-    """
-
-    def __init__(self, runner: ChunkedRunner, max_ticks: int = 1000) -> None:
-        self.runner = runner
-        self.max_ticks = max_ticks
-        self.ticks = 0
-
-    def run(self) -> ChunkedOutcome:
-        """Drain the runner one step per tick until terminal or max_ticks."""
-        while self.runner.step():
-            self.ticks += 1
-            if self.ticks >= self.max_ticks:
-                raise RuntimeError("Fake host pump exceeded max ticks")
-        outcome = self.runner.outcome
-        assert outcome is not None
-        return outcome
-
-
-def _make_steps(n: int) -> list[ChunkedStep]:
-    """Create N identity steps that record invocation."""
-    calls: list[int] = []
-
-    def _step(i: int) -> None:
-        calls.append(i)
-
-    steps = [ChunkedStep(i, lambda i=i: _step(i)) for i in range(n)]
-    return steps, calls
-
-
-def test_pending_cancellation() -> None:
-    """Cancel while idle → next step() returns False, outcome is "cancelled"."""
-    token = CancelToken()
-    token.cancel()  # cancelled before any step
-    runner = ChunkedRunner([lambda: None], cancel_token=token)
-
-    assert runner.step() is False
-    assert runner.is_terminal is True
+    assert dispatcher.cancel("cancel-pending")
+    assert runner.outcome is None
+    dispatcher.drain_queue(100)
+    assert ran == []
     assert runner.outcome is not None
     assert runner.outcome.status == "cancelled"
-    assert runner.outcome.progress.completed == 0
-    assert runner.outcome.error is None
 
 
-def test_mid_sequence_cancellation() -> None:
-    """Cancel during execution → next step catches, outcome is "cancelled"."""
+def test_mid_sequence_cancel_stops_before_later_step() -> None:
     token = CancelToken()
-    steps = [lambda: token.cancel(), lambda: None]
-    runner = ChunkedRunner(steps, cancel_token=token)
+    ran = []
+    runner = ChunkedRunner(
+        [lambda: ran.append(1) or token.cancel(), lambda: ran.append(2)],
+        cancel_token=token,
+    )
 
-    # First step executes and cancels the token.
-    assert runner.step() is True
-    assert runner.progress.completed == 1
-
-    # Second step sees the cancelled token and becomes terminal.
     assert runner.step() is False
+    assert ran == [1]
     assert runner.outcome is not None
     assert runner.outcome.status == "cancelled"
-    # Progress should not advance for the cancelled step.
     assert runner.outcome.progress.completed == 1
 
 
-def test_generator_failure() -> None:
-    """Chunk raises exception → outcome is "failed" with error message."""
+def test_dispatcher_can_cancel_an_active_chunk() -> None:
+    dispatcher = _ManualDispatcher()
+    entered = threading.Event()
+    release = threading.Event()
 
-    def _bad() -> None:
-        raise ValueError("mesh data corrupted")
+    def blocking_step() -> None:
+        entered.set()
+        assert release.wait(timeout=2)
 
-    runner = ChunkedRunner([_bad])
-    assert runner.step() is False
-    assert runner.outcome is not None
-    assert runner.outcome.status == "failed"
-    assert "ValueError" in (runner.outcome.error or "")
-    assert "mesh data corrupted" in (runner.outcome.error or "")
-    assert runner.outcome.progress.completed == 0
+    runner = ChunkedRunner([blocking_step, lambda: pytest.fail("later step ran")])
+    dispatcher.submit_chunked_runner("active-chunk", runner)
+    pump = threading.Thread(target=lambda: dispatcher.drain_queue(100))
+    pump.start()
 
+    assert entered.wait(timeout=2)
+    assert dispatcher.active_count() == 1
+    assert dispatcher.cancel("active-chunk")
+    assert runner.outcome is None
+    release.set()
+    pump.join(timeout=2)
 
-def test_terminal_idempotence() -> None:
-    """Calling step() after terminal state is a no-op."""
-
-    def _ok() -> None:
-        pass
-
-    runner = ChunkedRunner([_ok])
-    assert runner.step() is False  # completed
-    assert runner.outcome is not None
-    first_outcome = runner.outcome
-
-    # Subsequent step() calls are idempotent.
-    for _ in range(5):
-        assert runner.step() is False
-        assert runner.outcome is first_outcome  # same object, not re-created
-
-
-def test_progress_monotonic() -> None:
-    """Progress counter only increases; timestamp updates after each step."""
-    steps: list[float] = []
-
-    def _record_step() -> None:
-        steps.append(time.monotonic())
-
-    runner = ChunkedRunner([_record_step, _record_step, _record_step])
-
-    for i in range(2):
-        assert runner.progress.completed == i
-        assert runner.step() is True  # more work remains
-        assert runner.progress.completed == i + 1
-        assert runner.progress.last_step_at > 0.0
-        assert len(steps) == i + 1
-
-    # Third step — sequence exhausted after this one.
-    assert runner.step() is False
-    assert runner.progress.completed == 3
-
-
-def test_no_token_noop() -> None:
-    """Without cancel token, the runner completes normally."""
-    runner = ChunkedRunner([lambda: None, lambda: None])
-    while runner.step():
-        pass
-    assert runner.outcome is not None
-    assert runner.outcome.status == "completed"
-    assert runner.outcome.progress.completed == 2
-
-
-def test_multiple_steps() -> None:
-    """Multiple step() calls drain all chunks in order."""
-    order: list[int] = []
-
-    def _make(i: int):
-        def _fn() -> None:
-            order.append(i)
-
-        return _fn
-
-    runner = ChunkedRunner([_make(i) for i in range(10)])
-
-    while runner.step():
-        pass
-
-    assert order == list(range(10))
-    assert runner.outcome is not None
-    assert runner.outcome.status == "completed"
-    assert runner.outcome.progress.completed == 10
-
-
-def test_empty_sequence() -> None:
-    """Runner with no chunks is terminal immediately."""
-    runner = ChunkedRunner([])
-    assert runner.is_terminal is False  # not terminal until first step
-    assert runner.step() is False
-    assert runner.outcome is not None
-    assert runner.outcome.status == "completed"
-    assert runner.outcome.progress.completed == 0
-
-
-def test_chunked_runner_with_chunked_step_objects() -> None:
-    """Runner accepts pre-built ChunkedStep objects."""
-    results: list[str] = []
-
-    def a() -> None:
-        results.append("a")
-
-    def b() -> None:
-        results.append("b")
-
-    steps = [ChunkedStep(0, a), ChunkedStep(1, b)]
-    runner = ChunkedRunner(steps)
-    assert runner.step() is True
-    assert runner.step() is False
-    assert results == ["a", "b"]
-
-
-def test_cancel_method_triggers_token() -> None:
-    """Runner.cancel() sets the token; next step() picks it up."""
-    token = CancelToken()
-    runner = ChunkedRunner([lambda: None, lambda: None], cancel_token=token)
-
-    assert runner.step() is True  # first step completes
-    runner.cancel()
-    assert token.cancelled is True
-    assert runner.step() is False  # cancelled
+    assert not pump.is_alive()
     assert runner.outcome is not None
     assert runner.outcome.status == "cancelled"
+    assert runner.outcome.progress.completed == 1
+    assert dispatcher.active_count() == 0
 
 
-def test_cancel_no_token_is_noop() -> None:
-    """cancel() without a token is a safe no-op."""
+def test_progress_is_monotonic_and_published_after_each_step() -> None:
+    timestamps = iter([10.0, 20.0, 30.0])
+    observed = []
+    runner = ChunkedRunner(
+        [lambda: "one", lambda: "two", lambda: "three"],
+        clock=lambda: next(timestamps),
+        on_progress=lambda progress: observed.append(
+            (progress.completed, progress.total, progress.message, progress.last_step_at)
+        ),
+    )
+
+    while runner.step():
+        pass
+
+    assert observed == [
+        (1, 3, "one", 10.0),
+        (2, 3, "two", 20.0),
+        (3, 3, "three", 30.0),
+    ]
+
+
+def test_progress_callback_failure_becomes_terminal_failure() -> None:
+    def fail_progress(_progress) -> None:
+        raise RuntimeError("progress store unavailable")
+
+    runner = ChunkedRunner([lambda: None], on_progress=fail_progress)
+    assert not runner.step()
+    assert runner.outcome is not None
+    assert runner.outcome.status == "failed"
+    assert runner.outcome.error == "RuntimeError: progress store unavailable"
+
+
+def test_lazy_generator_failure_is_terminal() -> None:
+    def steps():
+        yield lambda: None
+        raise ValueError("generator failed")
+
+    runner = ChunkedRunner(steps())
+    assert runner.step()
+    assert not runner.step()
+    assert runner.outcome is not None
+    assert runner.outcome.status == "failed"
+    assert runner.outcome.error == "ValueError: generator failed"
+
+
+def test_terminal_callback_and_state_are_idempotent() -> None:
+    terminal = []
+    runner = ChunkedRunner([lambda: None], on_terminal=terminal.append)
+
+    assert not runner.step()
+    first = runner.outcome
+    for _ in range(3):
+        assert not runner.step()
+    assert runner.outcome is first
+    assert terminal == [first]
+
+
+def test_unknown_total_iterator_finishes_on_following_checkpoint() -> None:
+    runner = ChunkedRunner(iter([lambda: None]))
+    assert runner.step()
+    assert runner.progress.total is None
+    assert not runner.step()
+    assert runner.outcome is not None
+    assert runner.outcome.status == "completed"
+
+
+def test_invalid_iterator_item_fails_at_its_tick() -> None:
+    runner = ChunkedRunner(iter([42]))
+    assert not runner.step()
+    assert runner.outcome is not None
+    assert runner.outcome.error == "TypeError: Expected ChunkedStep or callable, got int"
+
+
+def test_chunked_step_index_is_adapter_metadata_only() -> None:
+    called = []
+    step = ChunkedStep(7, lambda: called.append(True))
+    runner = ChunkedRunner([step])
+    assert not runner.step()
+    assert step.step == 7
+    assert called == [True]
+
+
+@pytest.mark.parametrize("label", ["maya-ui", "photoshop-bridge"])
+def test_same_core_runner_is_host_neutral(label: str) -> None:
+    dispatcher = _ManualDispatcher(label)
     runner = ChunkedRunner([lambda: None])
-    runner.cancel()  # should not raise
-    assert runner.step() is False  # completes normally
+    dispatcher.submit_chunked_runner(label, runner)
+    dispatcher.drain_queue(100)
+    assert dispatcher.dispatcher_label == label
     assert runner.outcome is not None
     assert runner.outcome.status == "completed"
 
 
-def test_chunked_outcome_repr() -> None:
-    """Outcome repr is useful for debugging."""
-    p = ChunkedProgress(completed=1, total=3, last_step_at=1000.0)
-    o = ChunkedOutcome(status="completed", progress=p)
-    assert "completed" in repr(o)
-    assert "completed=1" in repr(o)
+def test_chunked_job_decorator_builds_lazy_runner() -> None:
+    built = []
+
+    @chunked_job(total=2)
+    def build():
+        built.append("factory")
+        yield lambda: built.append(1)
+        yield lambda: built.append(2)
+
+    runner = build()
+    assert built == []
+    assert isinstance(runner, ChunkedRunner)
+    assert runner.step()
+    assert not runner.step()
+    assert built == ["factory", 1, 2]
 
 
-# ---------------------------------------------------------------------------
-# Adapter label tests — proving contract is not Houdini-specific
-# ---------------------------------------------------------------------------
+def test_chunked_runner_rejects_negative_total() -> None:
+    with pytest.raises(ValueError, match="total"):
+        ChunkedRunner([], total=-1)
 
 
-def test_label_standalone_host_adapter() -> None:
-    """ChunkedRunner integrates with HostAdapter via attach_tick pattern.
+def test_chunked_completion_callback_uses_wire_safe_progress() -> None:
+    dispatcher = _ManualDispatcher()
+    completed = []
+    runner = ChunkedRunner([lambda: "done"])
+    dispatcher.submit_chunked_runner("wire", runner, job_id="job-1", on_complete=completed.append)
+    dispatcher.drain_queue(100)
 
-    This test uses a manual pump to simulate the host event loop —
-    no real DCC required. The pattern is the same for all DCCs:
-    ``attach_tick`` → call ``runner.step()`` → return interval or None.
-    """
-    results: list[int] = []
-
-    def _make(i: int):
-        def _fn() -> None:
-            results.append(i)
-
-        return _fn
-
-    runner = ChunkedRunner([_make(i) for i in range(5)])
-
-    class _ManualPump:
-        """Mimics a DCC idle callback that drains the runner one step at a time."""
-
-        def __init__(self) -> None:
-            self.tick_count = 0
-            self.intervals: list[float | None] = []
-
-        def tick(self) -> float | None:
-            self.tick_count += 1
-            has_more = runner.step()
-            if has_more:
-                interval: float | None = 0.05  # active
-            else:
-                interval = None  # done — detach
-            self.intervals.append(interval)
-            return interval
-
-    pump = _ManualPump()
-    # Simulate the host calling tick() repeatedly until None.
-    while True:
-        interval = pump.tick()
-        if interval is None:
-            break
-
-    assert results == list(range(5))
-    # 5 ticks: steps 1-4 return interval (active), step 5 returns None (terminal)
-    assert pump.tick_count == 5
-    assert runner.outcome is not None
-    assert runner.outcome.status == "completed"
-    assert runner.outcome.progress.completed == 5
-
-
-def test_label_inprocess_callable_dispatcher() -> None:
-    """ChunkedRunner works inside an InProcessCallableDispatcher callback.
-
-    The InProcessCallableDispatcher is the reference single-thread impl
-    used by mayapy, headless Houdini, and pytest. Submitting a callable
-    that drains a ChunkedRunner demonstrates the runner runs correctly
-    in the main-thread-affine dispatch path.
-    """
-    from dcc_mcp_core import InProcessCallableDispatcher
-
-    dispatcher = InProcessCallableDispatcher()
-    results: list[int] = []
-
-    def _make(i: int):
-        def _fn() -> None:
-            results.append(i)
-
-        return _fn
-
-    runner = ChunkedRunner([_make(i) for i in range(4)])
-
-    def _drain_runner() -> int:
-        ticks = 0
-        while runner.step():
-            ticks += 1
-        return ticks
-
-    outcome = dispatcher.submit_callable("test-1", _drain_runner, "any", timeout_ms=5000)
-    assert outcome.ok, outcome.error
-    assert results == list(range(4))
-    assert outcome.value == 3  # 3 active ticks before completion
-    assert runner.outcome is not None
-    assert runner.outcome.status == "completed"
-
-
-def test_label_manual_host_timer_adapter() -> None:
-    """ChunkedRunner integrated with ManualHostTimerAdapter (test harness).
-
-    ManualHostTimerAdapter is the test adapter for HostPumpController.
-    This test proves the runner contract works with the host pump
-    infrastructure used by real DCC adapters.
-    """
-    from dcc_mcp_core import ManualHostTimerAdapter
-
-    results: list[int] = []
-
-    def _make(i: int):
-        def _fn() -> None:
-            results.append(i)
-
-        return _fn
-
-    runner = ChunkedRunner([_make(i) for i in range(3)])
-
-    adapter = ManualHostTimerAdapter()
-    adapter.install(lambda: 0.05 if runner.step() else None)
-
-    # Fire ticks until None is returned (runner terminal).
-    while True:
-        interval = adapter.fire()
-        if interval is None:
-            break
-
-    assert results == list(range(3))
-    assert runner.outcome is not None
-    assert runner.outcome.status == "completed"
+    assert completed == [
+        {
+            "request_id": "wire",
+            "affinity": "main",
+            "success": True,
+            "output": {"current": 1, "total": 1, "message": "done"},
+            "error": None,
+            "job_id": "job-1",
+        }
+    ]


### PR DESCRIPTION
## Summary

- add Rust and Python chunked runners that execute at most one main-thread step per host pump tick
- make cancellation request/acknowledgement explicit and keep progress monotonic in the shared JobManager
- integrate chunked jobs with the shared host UI dispatcher
- add adapter and skill-authoring guidance, including the declarative-script scheduling boundary
- preserve honest cancellation semantics for existing monolithic handlers

## Root cause

The existing runner was manually ticked and disconnected from the shared JobManager and host pump. Cancellation could therefore become terminal before the execution lane observed it, while already-running monolithic work continued.

## Impact

Adapters can now split long main-affinity work into bounded steps, publish acknowledged progress, and remain responsive to cancellation without host-specific runner implementations. Skill authors also get an explicit contract for async main-affinity tools without overstating automatic scheduling.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dcc-mcp-job -p dcc-mcp-http-server -p dcc-mcp-http`
- `pytest -q tests/test_chunked_runner.py tests/test_host_ui_dispatcher.py` (35 passed)
- `pytest -q tests/test_bundled_skill_metadata.py` (6 passed)
- Ruff check and format check
- Python 3.7 syntax check

Closes #1950
