### PR TITLE
Expose UI Control capture provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,44 @@ or drive the interface state directly. Agents use `ui_control__snapshot`,
 `ui_control__record_clip`, and `ui_control__stop_computer_use` to observe,
 find, act on, and record exact target windows.
 
+Use UI Control as a bounded fallback, not as the default DCC integration:
+
+- Prefer structured adapter tools for scene, asset, render, and project work.
+- Use UI Control for controls that have no API, incomplete adapter coverage,
+  and end-to-end GUI acceptance tests.
+- Do not treat every image in an agent task as UI Control evidence. DCC-native
+  captures, RenderDoc exports, ImageGen output, and video frames have different
+  provenance.
+
 ![Controlled window with corner brackets and capsule overlay](docs/assets/ui-control/corner-brackets-capsule.png)
+
+### How screenshots and clicks work
+
+`ui_control__snapshot` captures only the bound window. It preserves native
+resolution until either the longest edge exceeds 1600 pixels or the image
+exceeds 1.5 million pixels, then downsizes while preserving aspect ratio. A
+1280×720 window stays 1280×720; a 1920×1080 window becomes 1600×900. Smaller
+text and custom-drawn icons are therefore easier to recognize when the target
+window is large and unobstructed.
+
+The agent receives three complementary signals:
+
+1. PNG pixels for visual recognition and spatial understanding.
+2. A Windows UI Automation (UIA) tree with labels, roles, and stable control
+   identifiers when the application exposes them.
+3. Observation metadata for the exact PID, HWND, DPI, source rectangle,
+   desktop generation, session, and snapshot.
+
+Clicks prefer a semantic `control_id`. For custom-drawn UI, screenshot-relative
+coordinates are mapped back through the source rectangle and DPI. Every action
+must cite the latest `snapshot_id`; the host revalidates the window, desktop,
+geometry, and generation before sending input, and rejects stale observations.
+
+Successful snapshots and recordings include `capture_provenance`, including
+the backend, session, target PID/HWND, output and source dimensions, scaling,
+and native capture backend. Preserve that block with screenshots used as
+evidence. Older images without provenance cannot be reliably attributed to UI
+Control after the fact.
 
 ### Capabilities
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -656,7 +656,35 @@ DCC 适配器（如 `dcc-mcp-maya`）默认包含内置 skills。关闭：`start
 Agent 通过 `ui_control__snapshot`（截图）、`ui_control__find`（查找控件）、`ui_control__act`（执行操作）、
 `ui_control__wait_for`（等待条件）和 `ui_control__stop_computer_use`（停止控制）等工具来观测和操作目标窗口。
 
+UI Control 是受限兜底，不是默认的 DCC 集成方式：
+
+- 场景、资产、渲染和项目操作优先使用结构化适配器工具。
+- 仅在应用没有接口、适配器覆盖不完整或需要端到端 GUI 验收时使用 UI Control。
+- Agent 任务中的图片不一定来自 UI Control。DCC 原生截图、RenderDoc 导出、
+  ImageGen 输出和视频抽帧都有各自独立的来源。
+
 ![带角标和底部胶囊的受控窗口](docs/assets/ui-control/corner-brackets-capsule.png)
+
+### 截图识别与点击原理
+
+`ui_control__snapshot` 只捕获绑定窗口。最长边不超过 1600 像素且总像素不超过
+150 万时保留原始分辨率，否则保持宽高比缩小。1280×720 窗口仍为 1280×720；
+1920×1080 窗口会变为 1600×900。因此，窗口越大、遮挡越少，Agent 越容易识别
+小字号文字和自绘图标。
+
+Agent 同时获得三类信息：
+
+1. PNG 像素，用于视觉识别和空间理解。
+2. Windows UI Automation（UIA）语义树；应用支持时包含标签、角色和稳定控件 ID。
+3. 精确 PID、HWND、DPI、源矩形、桌面代际、会话和截图 ID 等观察元数据。
+
+点击优先使用语义 `control_id`。对于自绘 UI，Host 将截图相对坐标通过源矩形和
+DPI 映射回目标窗口。每次操作必须引用最新 `snapshot_id`；发送输入前会重新验证
+窗口、桌面、几何和代际，过期观察会被拒绝。
+
+成功截图和录制会返回 `capture_provenance`，记录后端、会话、目标 PID/HWND、
+输出与源尺寸、是否缩放以及原生捕获后端。用截图作为证据时应一并保存该字段。
+历史图片如果没有来源信息，事后无法可靠证明它是否由 UI Control 产生。
 
 ### 核心能力
 

--- a/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
@@ -417,6 +417,16 @@ fn ui_control_compact_output_keeps_agent_fields_and_drops_bulk_trees() {
                 "width": 1280,
                 "height": 720
             },
+            "capture_provenance": {
+                "tool": "ui_control__snapshot",
+                "backend": "windows-ui-control-host",
+                "session_id": "fab",
+                "snapshot_id": "snapshot-7",
+                "pixels_captured": true,
+                "width": 1280,
+                "height": 720,
+                "downscaled": false
+            },
             "policy": {"allow_raw_coordinates": true},
             "audit": {"coordinates": [1, 2]},
             "__rich__": {
@@ -444,6 +454,11 @@ fn ui_control_compact_output_keeps_agent_fields_and_drops_bulk_trees() {
     assert_eq!(compact["snapshot_id"], "snapshot-7");
     assert_eq!(compact["snapshot"]["node_count"], 501);
     assert_eq!(compact["observation"]["observation_id"], "observation-7");
+    assert_eq!(
+        compact["capture_provenance"]["backend"],
+        "windows-ui-control-host"
+    );
+    assert_eq!(compact["capture_provenance"]["pixels_captured"], true);
     assert_eq!(
         compact["__rich__"]["artifact_path"],
         artifact.display().to_string()

--- a/docs/guide/ui-control-workflows.md
+++ b/docs/guide/ui-control-workflows.md
@@ -50,6 +50,27 @@ key/button release; retry cleanup and do not start another session. The global
 input owner stays held across adapter processes until reconnect allows those
 releases to drain.
 
+## Evidence Attribution
+
+Every successful snapshot or recording includes `capture_provenance`. Keep it
+beside any materialized image or frame sequence instead of inferring origin
+from the filename or picture contents. Native Windows screenshot evidence must
+report `backend="windows-ui-control-host"` and `pixels_captured=true`; mock and
+accessibility-only results do not prove that the native Host captured pixels.
+
+The provenance also reports the logical `session_id`, `snapshot_id`, exact
+PID/HWND when available, image dimensions, native capture backend, and whether
+the bounded PNG was downscaled. The matching redacted
+`ui_control_operation` audit event carries the same `snapshot_id`. It does not
+record typed text or screenshot coordinates.
+
+The exact-window PNG intentionally excludes UI Control's capsule, brackets,
+and cursor marker because those are separate safety overlay windows. Verify
+activation from provenance and audit rather than expecting the overlay inside
+the captured DCC pixels. For acceptance telemetry, route every call through
+the gateway with `--require-gateway` and one stable `--agent-session-id`; keep
+that gateway id distinct from the logical UI Control `session_id`.
+
 For gateway clients, discover and inspect tools before calling:
 
 ```json

--- a/python/dcc_mcp_core/skills/ui-control/SKILL.md
+++ b/python/dcc_mcp_core/skills/ui-control/SKILL.md
@@ -373,30 +373,32 @@ CDP presets:
   `DCC_MCP_UI_CONTROL_AGENT_BROWSER_BIN`; this preset is suitable for CI when
   `agent-browser install` has provisioned Chrome for Testing.
 
-## Agent Loop
+## Evidence Attribution
 
-Use this loop:
+Successful snapshots and recordings return `capture_provenance`. Preserve it
+with every saved or presented image. It identifies the tool, backend, logical
+session, pixel availability, exact target, output dimensions, capture backend,
+and whether the bounded PNG was downscaled.
 
-1. Try the structured DCC skill, host API, or adapter script.
-2. If it returns `unsupported` or `capability_missing`,
-   call `ui_control__snapshot` for the exact application window.
-3. `ui_control__find` to resolve a control by label, role, text, or object name.
-4. `ui_control__act` to perform one scoped action using the resolved control id or
-   screenshot coordinates when no semantic control is available.
-5. `ui_control__snapshot` immediately to verify the result before another action.
-6. Use `ui_control__wait_for` only for a known UI condition, then snapshot again.
-7. Call `ui_control__stop_computer_use` when the fallback is complete or abandoned.
+For native Windows evidence, require
+`backend="windows-ui-control-host"` and `pixels_captured=true`. A mock or
+accessibility-only CDP result is useful for tests and semantic inspection but
+is not native screenshot evidence. Unity Game View captures, RenderDoc exports,
+ImageGen output, and files later opened with an image viewer are separate
+sources; never label them as UI Control evidence.
 
-For gameplay capture, start from a fresh exact-window snapshot, call
-`ui_control__record_clip` once for a bounded shot, validate its manifest and
-hashes through `game-pv-capture`, then stop the same session. Do not send UI
-actions while recording and do not treat a completed frame sequence as a
-finished PV.
+The exact-window PNG intentionally excludes the capsule, corner brackets, and
+cursor marker because they are separate safety overlay windows. Their absence
+inside the PNG does not prove UI Control was inactive; use
+`capture_provenance` plus the matching redacted `ui_control_operation` audit
+event. The audit event carries the same `snapshot_id` without recording text or
+coordinates.
 
-If an action returns `stale_control`, restart at `ui_control__snapshot`. If an
-action returns `policy_disabled`, prefer a native DCC skill or ask for an
-explicit policy change. On `user_interrupted` or `desktop_unavailable`, stop;
-do not follow a generic retry or fallback route.
+For acceptance runs, use one meaningful UI Control `session_id`, route every
+measured CLI call with `--require-gateway`, and use one stable
+`--agent-session-id`. These are separate namespaces. If provenance reports
+`downscaled=true`, prefer semantic `find`; enlarge the target and take a fresh
+snapshot before using coordinates on small controls.
 
 ## Workflow Examples
 

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_entrypoint.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_entrypoint.py
@@ -78,6 +78,119 @@ def _operation_error(result: Dict[str, Any]) -> Optional[str]:
     return str(error) if error else None
 
 
+def _result_context(result: Dict[str, Any]) -> Dict[str, Any]:
+    context = result.get("context")
+    return context if isinstance(context, dict) else {}
+
+
+def _canonical_backend(result: Dict[str, Any]) -> str:
+    context = _result_context(result)
+    snapshot = context.get("snapshot")
+    if isinstance(snapshot, dict):
+        metadata = snapshot.get("metadata")
+        if isinstance(metadata, dict):
+            ui_control = metadata.get("ui_control")
+            if isinstance(ui_control, dict) and ui_control.get("backend"):
+                return str(ui_control["backend"])
+    if context.get("backend"):
+        return str(context["backend"])
+    selected = os.environ.get("DCC_MCP_UI_CONTROL_BACKEND", "mock").strip().lower()
+    if selected in {"windows-uia", "windows_uia", "uia", "win-uia", "win32-uia"}:
+        return "windows-ui-control-host"
+    if selected in {
+        "chrome",
+        "chrome-cdp",
+        "cdp",
+        "edge",
+        "msedge",
+        "microsoft-edge",
+        "agent-browser",
+        "agent_browser",
+        "agentbrowser",
+    }:
+        return "chrome-cdp"
+    return selected or "mock"
+
+
+def _attach_capture_provenance(
+    name: str,
+    params: Dict[str, Any],
+    result: Dict[str, Any],
+) -> Dict[str, Any]:
+    operation = name[:-5] if name.endswith("_tool") else name
+    if not result.get("success") or operation not in {"snapshot", "record_clip"}:
+        return result
+    context = _result_context(result)
+    if not context:
+        return result
+
+    session_id = str(context.get("session_id") or params.get("session_id") or "default")
+    provenance: Dict[str, Any] = {
+        "tool": f"ui_control__{operation}",
+        "backend": _canonical_backend(result),
+        "session_id": session_id,
+        "pixels_captured": operation == "record_clip" or isinstance(context.get("__rich__"), dict),
+    }
+    snapshot_id = context.get("snapshot_id")
+    if snapshot_id:
+        provenance["snapshot_id"] = str(snapshot_id)
+
+    observation = context.get("observation")
+    if isinstance(observation, dict):
+        for key in (
+            "observation_id",
+            "process_id",
+            "window_handle",
+            "capture_backend",
+            "width",
+            "height",
+        ):
+            if observation.get(key) is not None:
+                provenance[key] = observation[key]
+        source_rect = observation.get("source_rect")
+        if isinstance(source_rect, (list, tuple)) and len(source_rect) == 4:
+            source_width = source_rect[2]
+            source_height = source_rect[3]
+            if isinstance(source_width, int) and isinstance(source_height, int):
+                provenance["source_width"] = source_width
+                provenance["source_height"] = source_height
+                width = provenance.get("width")
+                height = provenance.get("height")
+                if isinstance(width, int) and isinstance(height, int):
+                    provenance["downscaled"] = width < source_width or height < source_height
+
+    target = context.get("target")
+    if isinstance(target, dict):
+        for key in ("process_id", "window_handle"):
+            if target.get(key) is not None:
+                provenance[key] = target[key]
+
+    artifact = context.get("artifact")
+    if operation == "record_clip" and isinstance(artifact, dict):
+        for key in ("recording_id", "frame_count", "width", "height", "manifest_sha256"):
+            if artifact.get(key) is not None:
+                provenance[key] = artifact[key]
+
+    context["capture_provenance"] = provenance
+    if operation == "snapshot":
+        if provenance["pixels_captured"]:
+            size = "{}x{}".format(provenance.get("width", "?"), provenance.get("height", "?"))
+            if provenance.get("downscaled"):
+                size += " downscaled from {}x{}".format(
+                    provenance.get("source_width", "?"),
+                    provenance.get("source_height", "?"),
+                )
+        else:
+            size = "accessibility-only"
+        result["message"] = "{} [{}; {}; session={}]".format(
+            str(result.get("message") or "Captured UI Control snapshot.").rstrip("."),
+            provenance["backend"],
+            size,
+            session_id,
+        )
+    return result
+
+
 def _record_operation(name: str, params: Dict[str, Any], result: Dict[str, Any]) -> None:
     """Append one redacted UI Control event to the Admin log stream."""
     if os.environ.get("DCC_MCP_DISABLE_FILE_LOGGING", "0") == "1":
@@ -89,12 +202,16 @@ def _record_operation(name: str, params: Dict[str, Any], result: Dict[str, Any])
         success = bool(result.get("success", False))
         error = _operation_error(result)
         action = str(params.get("action") or operation)
+        context = _result_context(result)
+        session_id = str(context.get("session_id") or params.get("session_id") or "default")
+        snapshot_id = context.get("snapshot_id") or params.get("snapshot_id")
+        capture_provenance = context.get("capture_provenance")
         condition = params.get("condition")
         condition_kind = condition.get("kind") if isinstance(condition, dict) else None
         detail = [
-            f"backend={os.environ.get('DCC_MCP_UI_CONTROL_BACKEND', 'mock')}",
+            f"backend={_canonical_backend(result)}",
             f"action={action}",
-            f"session={params.get('session_id', 'default')}",
+            f"session={session_id}",
         ]
         if condition_kind:
             detail.append(f"condition={condition_kind}")
@@ -105,14 +222,20 @@ def _record_operation(name: str, params: Dict[str, Any], result: Dict[str, Any])
             "tool": f"ui_control__{operation}",
             "dcc_type": os.environ.get("DCC_MCP_UI_CONTROL_DCC_TYPE")
             or os.environ.get("DCC_MCP_DCC_TYPE", "ui-control"),
-            "session_id": str(params.get("session_id", "default")),
-            "backend": os.environ.get("DCC_MCP_UI_CONTROL_BACKEND", "mock"),
+            "session_id": session_id,
+            "backend": _canonical_backend(result),
             "action": action,
             "success": success,
             "error": error,
             "message": f"DCC UI Control {operation} {'succeeded' if success else 'rejected'}",
             "detail": " ".join(detail),
         }
+        if snapshot_id:
+            event["snapshot_id"] = str(snapshot_id)
+        if isinstance(capture_provenance, dict):
+            event["pixels_captured"] = bool(capture_provenance.get("pixels_captured"))
+            if capture_provenance.get("capture_backend"):
+                event["capture_backend"] = capture_provenance["capture_backend"]
         directory = Path(os.environ.get("DCC_MCP_LOG_DIR") or get_log_dir())
         directory.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
@@ -156,6 +279,7 @@ def _call(name: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     except Exception as exc:
         _record_operation(name, call_params, {"success": False, "error": type(exc).__name__})
         raise
+    result = _attach_capture_provenance(name, call_params, result)
     _record_operation(name, call_params, result)
     return result
 

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -91,6 +91,11 @@ does not replace a running server binary.
      `ComputerUseSession` or add adapter-local screenshot/`SendInput` wrappers.
      Keep `ui_control__snapshot` and `ui_control__act` in the same long-lived adapter
      process so one thin named-pipe client retains the opaque host capability.
+     Preserve `capture_provenance` when snapshots or recordings become
+     evidence. Native Windows pixels require
+     `backend=windows-ui-control-host` and `pixels_captured=true`; use one
+     logical UI Control `session_id` plus one stable gateway
+     `agent_context.session_id` for attributable acceptance runs.
      The per-logon-session host owns the screenshot/UIA observations, visible
      banner, Esc stop token, input owner, confirmation, and native input.
      `ui-control` declares `requires_in_process: true` while keeping

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -191,6 +191,10 @@ mid-call interruption.
   `ui_control__snapshot`, and pass the latest `snapshot_id` unchanged. End every
   path with `ui_control__stop_computer_use`. Screenshot coordinates belong to that
   observation only.
+- Preserve `capture_provenance` with saved evidence. Only
+  `backend=windows-ui-control-host` plus `pixels_captured=true` proves native
+  Windows screenshot capture; keep the logical UI Control `session_id`
+  distinct from the gateway agent session used for stats attribution.
 - When the exact HWND is minimized or hidden before the first snapshot, use
   only `get_window_state` followed by the necessary `restore_window`,
   `show_window`, and `activate_window` host actions, then take a fresh

--- a/tests/test_ui_control_skill.py
+++ b/tests/test_ui_control_skill.py
@@ -42,6 +42,15 @@ def _load_windows_uia_module() -> Any:
     return module
 
 
+def _load_entrypoint_module() -> Any:
+    spec = importlib.util.spec_from_file_location("_test_ui_control_entrypoint", _SCRIPTS / "_entrypoint.py")
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def _run_tool(
     name: str,
     payload: dict[str, Any],
@@ -262,6 +271,13 @@ def test_ui_control_entrypoints_accept_inprocess_parameters(
         {"session_id": "inprocess"},
     )
     snapshot_id = snapshot["context"]["snapshot_id"]
+    assert snapshot["context"]["capture_provenance"] == {
+        "tool": "ui_control__snapshot",
+        "backend": "mock",
+        "session_id": "inprocess",
+        "pixels_captured": False,
+        "snapshot_id": snapshot_id,
+    }
 
     found = run_skill_script(
         str(_SCRIPTS / "find.py"),
@@ -280,6 +296,8 @@ def test_ui_control_entrypoints_accept_inprocess_parameters(
         },
     )
     assert changed["success"] is True
+    changed_snapshot_id = changed["context"]["snapshot_id"]
+    assert changed_snapshot_id != snapshot_id
 
     waited = run_skill_script(
         str(_SCRIPTS / "wait_for.py"),
@@ -314,7 +332,102 @@ def test_ui_control_entrypoints_accept_inprocess_parameters(
     ]
     assert all(row["event"] == "ui_control_operation" for row in audit_rows)
     assert all(row["dcc_type"] == "unreal" for row in audit_rows)
+    assert audit_rows[0]["snapshot_id"] == snapshot_id
+    assert audit_rows[0]["backend"] == "mock"
+    assert audit_rows[0]["pixels_captured"] is False
+    assert audit_rows[2]["snapshot_id"] == changed_snapshot_id
     assert "Signal Forge" not in log_text
+
+
+def test_ui_control_entrypoint_reports_real_snapshot_provenance(monkeypatch: Any) -> None:
+    entrypoint = _load_entrypoint_module()
+
+    class Backend:
+        @staticmethod
+        def snapshot_tool(_params: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "success": True,
+                "message": "Captured isolated Windows UI Control snapshot.",
+                "context": {
+                    "session_id": "evidence",
+                    "snapshot_id": "accessibility:1",
+                    "snapshot": {
+                        "metadata": {
+                            "ui_control": {"backend": "windows-ui-control-host"},
+                        }
+                    },
+                    "observation": {
+                        "observation_id": "obs-1",
+                        "process_id": 1234,
+                        "window_handle": 500,
+                        "width": 1600,
+                        "height": 900,
+                        "source_rect": [20, 30, 1920, 1080],
+                        "capture_backend": "windows-graphics-capture",
+                    },
+                    "__rich__": {"kind": "image", "data": "png"},
+                },
+            }
+
+        @staticmethod
+        def record_clip_tool(_params: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "success": True,
+                "message": "Recorded an exact-window JPEG sequence.",
+                "context": {
+                    "session_id": "evidence",
+                    "target": {"process_id": 1234, "window_handle": 500},
+                    "artifact": {
+                        "recording_id": "clip-1",
+                        "frame_count": 90,
+                        "width": 1280,
+                        "height": 720,
+                        "manifest_sha256": "a" * 64,
+                    },
+                },
+            }
+
+    monkeypatch.setattr(entrypoint, "_load_backend", lambda: Backend)
+    monkeypatch.setenv("DCC_MCP_UI_CONTROL_BACKEND", "windows-uia")
+    monkeypatch.setenv("DCC_MCP_DISABLE_FILE_LOGGING", "1")
+
+    result = entrypoint.snapshot_tool({"session_id": "evidence"})
+
+    provenance = result["context"]["capture_provenance"]
+    assert provenance == {
+        "tool": "ui_control__snapshot",
+        "backend": "windows-ui-control-host",
+        "session_id": "evidence",
+        "snapshot_id": "accessibility:1",
+        "observation_id": "obs-1",
+        "process_id": 1234,
+        "window_handle": 500,
+        "capture_backend": "windows-graphics-capture",
+        "pixels_captured": True,
+        "width": 1600,
+        "height": 900,
+        "source_width": 1920,
+        "source_height": 1080,
+        "downscaled": True,
+    }
+    assert "windows-ui-control-host" in result["message"]
+    assert "1600x900" in result["message"]
+    assert "downscaled from 1920x1080" in result["message"]
+
+    clip = entrypoint.record_clip_tool({"session_id": "evidence"})
+    assert clip["context"]["capture_provenance"] == {
+        "tool": "ui_control__record_clip",
+        "backend": "windows-ui-control-host",
+        "session_id": "evidence",
+        "pixels_captured": True,
+        "process_id": 1234,
+        "window_handle": 500,
+        "recording_id": "clip-1",
+        "frame_count": 90,
+        "width": 1280,
+        "height": 720,
+        "manifest_sha256": "a" * 64,
+    }
 
 
 def test_ui_control_subprocess_forwards_action_to_windows_backend_without_host(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add explicit capture provenance to successful UI Control snapshots and recordings
- carry redacted snapshot identity and backend details into audit events
- document when UI Control is appropriate, screenshot scaling, visual/UIA recognition, and safe click mapping
- keep adapter and skill author guidance aligned with the public result contract

## Validation
- UI Control Python: 51 passed
- Rust workspace: 3572 passed
- CLI compact-output contract: passed
- Python 3.7 syntax: 495 files passed
- bundled Skill lint: 31 passed
- Ruff and documentation build: passed