### PR TITLE
Keep ClawHub release manifest valid

### DIFF
--- a/.github/clawhub-skills.json
+++ b/.github/clawhub-skills.json
@@ -1,20 +1,22 @@
-[
-  {
-    "path": "skills/dcc-mcp",
-    "slug": "dcc-mcp",
-    "owner": "loonghao",
-    "version": "0.19.69"
-  },
-  {
-    "path": "skills/dcc-mcp-skills-creator",
-    "slug": "dcc-mcp-skills-creator",
-    "owner": "loonghao",
-    "version": "0.19.69"
-  },
-  {
-    "path": "skills/dcc-mcp-creator",
-    "slug": "dcc-mcp-creator",
-    "owner": "loonghao",
-    "version": "0.19.69"
-  }
-]
+{
+  "skills": [
+    {
+      "path": "skills/dcc-mcp",
+      "slug": "dcc-mcp",
+      "owner": "loonghao",
+      "version": "0.19.69"
+    },
+    {
+      "path": "skills/dcc-mcp-skills-creator",
+      "slug": "dcc-mcp-skills-creator",
+      "owner": "loonghao",
+      "version": "0.19.69"
+    },
+    {
+      "path": "skills/dcc-mcp-creator",
+      "slug": "dcc-mcp-creator",
+      "owner": "loonghao",
+      "version": "0.19.69"
+    }
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -63,7 +63,7 @@
         {
           "type": "json",
           "path": ".github/clawhub-skills.json",
-          "jsonpath": "$[*].version"
+          "jsonpath": "$.skills[*].version"
         },
         {
           "type": "generic",

--- a/scripts/clawhub_sync.py
+++ b/scripts/clawhub_sync.py
@@ -65,7 +65,7 @@ def parse_args() -> argparse.Namespace:
         "--manifest",
         type=Path,
         default=MANIFEST,
-        help="JSON manifest: [{path, slug, owner, version}]",
+        help="JSON manifest: {skills: [{path, slug, owner, version}]}",
     )
     parser.add_argument(
         "--dry-run",
@@ -81,10 +81,12 @@ def parse_args() -> argparse.Namespace:
 
 
 def load_manifest(path: Path) -> list[dict[str, Any]]:
-    """Load [{path, slug, owner, version}, ...] entries from the JSON manifest."""
+    """Load Skill entries from an object manifest, accepting the legacy array."""
     data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, dict):
+        data = data.get("skills")
     if not isinstance(data, list):
-        raise ValueError(f"manifest must be a JSON array: {path}")
+        raise ValueError(f"manifest must contain a JSON skills array: {path}")
     return data
 
 

--- a/scripts/package_openclaw_skill.py
+++ b/scripts/package_openclaw_skill.py
@@ -138,9 +138,10 @@ def resolve_manifest_skills(manifest: Path, repo_root: Path) -> list[tuple[Path,
     """Resolve Skill directories and immutable versions from a ClawHub manifest."""
     if not manifest.is_file():
         raise ValueError(f"ClawHub manifest does not exist: {manifest}")
-    entries = json.loads(manifest.read_text(encoding="utf-8"))
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    entries = data.get("skills") if isinstance(data, dict) else data
     if not isinstance(entries, list) or not entries:
-        raise ValueError(f"ClawHub manifest must be a non-empty JSON array: {manifest}")
+        raise ValueError(f"ClawHub manifest must contain a non-empty JSON skills array: {manifest}")
     resolved: list[tuple[Path, str]] = []
     for entry in entries:
         if not isinstance(entry, dict) or not entry.get("path") or not entry.get("version"):

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -25,6 +25,13 @@ SYNC_SCRIPT = REPO_ROOT / "scripts" / "clawhub_sync.py"
 README = REPO_ROOT / "README.md"
 
 
+def manifest_entries() -> list[dict[str, str]]:
+    """Return the official ClawHub Skill entries."""
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    assert set(manifest) == {"skills"}
+    return manifest["skills"]
+
+
 def load_sync_module():
     """Load clawhub_sync.py as an importable module for focused unit tests."""
     spec = importlib.util.spec_from_file_location("clawhub_sync_under_test", SYNC_SCRIPT)
@@ -37,7 +44,7 @@ def load_sync_module():
 
 class TestClawhubSync:
     def test_manifest_lists_clawhub_skills(self) -> None:
-        entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        entries = manifest_entries()
         slugs = {e["slug"] for e in entries}
         assert "dcc-mcp" in slugs
         assert "dcc-mcp-skills-creator" in slugs
@@ -46,7 +53,7 @@ class TestClawhubSync:
         assert all(re.fullmatch(r"\d+\.\d+\.\d+", entry["version"]) for entry in entries)
 
     def test_published_skills_include_codex_interface_metadata(self) -> None:
-        entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        entries = manifest_entries()
         for entry in entries:
             metadata_path = REPO_ROOT / entry["path"] / "agents" / "openai.yaml"
             assert metadata_path.is_file(), metadata_path
@@ -83,7 +90,7 @@ class TestClawhubSync:
             return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(payload), stderr="")
 
         monkeypatch.setattr(sync.subprocess, "run", fake_run)
-        entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        entries = manifest_entries()
         for entry in entries:
             assert sync.publish_one(entry, dry_run=True, cli=sync.DEFAULT_CLI) == 0
 
@@ -1200,14 +1207,14 @@ class TestClawhubSync:
         assert len(calls) == 1
 
     def test_clawhub_skill_versions_follow_independent_manifest(self) -> None:
-        entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        entries = manifest_entries()
         for entry in entries:
             meta = parse_skill_md(str(REPO_ROOT / entry["path"]))
             assert meta is not None
             assert meta.version == entry["version"]
 
     def test_release_please_updates_all_clawhub_skill_versions(self) -> None:
-        entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        entries = manifest_entries()
         config = json.loads(RELEASE_PLEASE_CONFIG.read_text(encoding="utf-8"))
         extra_files = config["packages"]["."]["extra-files"]
         generic_paths = {item["path"] for item in extra_files if item.get("type") == "generic"}
@@ -1218,7 +1225,7 @@ class TestClawhubSync:
         }
         release_version = json.loads((REPO_ROOT / ".release-please-manifest.json").read_text(encoding="utf-8"))["."]
 
-        assert manifest_jsonpaths == {"$[*].version"}
+        assert manifest_jsonpaths == {"$.skills[*].version"}
         for entry in entries:
             skill_path = REPO_ROOT / entry["path"] / "SKILL.md"
             assert f"{entry['path']}/SKILL.md" in generic_paths

--- a/tests/test_dcc_mcp_skill.py
+++ b/tests/test_dcc_mcp_skill.py
@@ -42,7 +42,7 @@ class TestDccMcpSkill:
         meta = dcc_mcp_core.parse_skill_md(DCC_MCP_SKILL_DIR)
         assert meta is not None
         assert meta.name == "dcc-mcp"
-        entries = json.loads(CLAWHUB_MANIFEST.read_text(encoding="utf-8"))
+        entries = json.loads(CLAWHUB_MANIFEST.read_text(encoding="utf-8"))["skills"]
         manifest_version = next(entry["version"] for entry in entries if entry["slug"] == "dcc-mcp")
         assert meta.version == manifest_version
 

--- a/tests/test_package_openclaw_skill.py
+++ b/tests/test_package_openclaw_skill.py
@@ -93,7 +93,7 @@ def test_manifest_cli_packages_the_repository_suite(tmp_path: Path) -> None:
     )
 
     assert proc.returncode == 0, proc.stderr
-    entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    entries = json.loads(MANIFEST.read_text(encoding="utf-8"))["skills"]
     expected = {f"{Path(entry['path']).name}-{entry['version']}.zip" for entry in entries}
     assert {path.name for path in tmp_path.glob("*.zip")} == expected
 


### PR DESCRIPTION
## Summary

- wrap the ClawHub skill list in an object so release-please can update it without nesting the root array
- preserve legacy array manifest support in publishing and packaging scripts
- validate the release-please JSONPath and official manifest shape

## Validation

- `91 passed`
- Ruff passed
- release-please 17.10.4 `GenericJson` updated all three skills to 0.19.70 without changing the manifest shape
- `cargo fmt --all -- --check`

Unblocks the 0.19.70 release PR.