### PR TITLE
Fix ClawHub publishing from release workflow

### DIFF
--- a/.github/workflows/clawhub.yml
+++ b/.github/workflows/clawhub.yml
@@ -81,9 +81,7 @@ jobs:
           if-no-files-found: error
 
       - name: Require ClawHub token
-        if: >-
-          (github.event_name == 'workflow_call' && inputs.publish) ||
-          (github.event_name == 'workflow_dispatch' && inputs.publish)
+        if: inputs.publish
         shell: bash
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
@@ -94,9 +92,7 @@ jobs:
           fi
 
       - name: Login to ClawHub
-        if: >-
-          (github.event_name == 'workflow_call' && inputs.publish) ||
-          (github.event_name == 'workflow_dispatch' && inputs.publish)
+        if: inputs.publish
         shell: bash
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
@@ -105,14 +101,9 @@ jobs:
           npx "$CLAWHUB_CLI_PACKAGE" --no-input login --token "$CLAWHUB_TOKEN" --no-browser
 
       - name: Dry-run ClawHub publish
-        if: >-
-          github.event_name == 'pull_request' ||
-          (github.event_name == 'workflow_call' && !inputs.publish) ||
-          (github.event_name == 'workflow_dispatch' && !inputs.publish)
+        if: ${{ !inputs.publish }}
         run: python scripts/clawhub_sync.py --dry-run
 
       - name: Publish skills to ClawHub
-        if: >-
-          (github.event_name == 'workflow_call' && inputs.publish) ||
-          (github.event_name == 'workflow_dispatch' && inputs.publish)
+        if: inputs.publish
         run: python scripts/clawhub_sync.py

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -1247,9 +1247,11 @@ class TestClawhubSync:
         assert steps["Set up Rust"]["uses"] == "dtolnay/rust-toolchain@stable"
         assert "cargo-clippy" in steps["Remove pre-installed Rust component shims"]["run"]
         assert dry_run["run"] == "python scripts/clawhub_sync.py --dry-run"
-        assert "github.event_name == 'pull_request'" in dry_run["if"]
+        assert dry_run["if"] == "${{ !inputs.publish }}"
         assert publish["run"] == "python scripts/clawhub_sync.py"
-        assert "github.event_name == 'workflow_call' && inputs.publish" in publish["if"]
+        assert publish["if"] == "inputs.publish"
+        assert steps["Require ClawHub token"]["if"] == "inputs.publish"
+        assert steps["Login to ClawHub"]["if"] == "inputs.publish"
 
         release = yaml_loads(release_workflow)
         release_job = release["jobs"]["publish-clawhub-skills"]


### PR DESCRIPTION
## Summary
- gate ClawHub credentials, login, and publish directly on the reusable workflow boolean input
- keep non-publishing invocations on the dry-run path
- cover the release caller contract with regression assertions

## Validation
- `53 passed` (`tests/test_clawhub_sync.py`)
- `actionlint` passed for ClawHub and release workflows
- confirmed the v0.19.70 release job skipped all publish steps while packaging succeeded