### PR TITLE
fix: ruff lint + format — RUF036, RUF063 suppression, and SKILL.md formatting

### DIFF
--- a/examples/skills/dcc-diagnostics/SKILL.md
+++ b/examples/skills/dcc-diagnostics/SKILL.md
@@ -55,9 +55,11 @@ Lists tracked PIDs and their liveness status.
 
 ```python
 import os
+
 os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/dcc-diagnostics"
 
 from dcc_mcp_maya import start_server  # or dcc_mcp_blender, etc.
+
 handle = start_server(port=8765)
 # dcc_diagnostics__screenshot is now available as an MCP tool
 ```

--- a/examples/skills/hello-world/SKILL.md
+++ b/examples/skills/hello-world/SKILL.md
@@ -40,6 +40,7 @@ Scripts in this skill read JSON parameters from stdin and write JSON results to 
 
 ```python
 import json, sys
+
 params = json.load(sys.stdin)
 name = params.get("name", "World")
 print(json.dumps({"success": True, "message": f"Hello, {name}!"}))

--- a/examples/skills/maya-pipeline/metadata/install.md
+++ b/examples/skills/maya-pipeline/metadata/install.md
@@ -36,8 +36,8 @@
 ```python
 import dcc_mcp_core
 
-meta = dcc_mcp_core._core.parse_skill_md('/path/to/maya-pipeline')
+meta = dcc_mcp_core._core.parse_skill_md("/path/to/maya-pipeline")
 assert meta is not None
-assert meta.name == 'maya-pipeline'
+assert meta.name == "maya-pipeline"
 assert len(meta.scripts) >= 2
 ```

--- a/examples/skills/multi-script/SKILL.md
+++ b/examples/skills/multi-script/SKILL.md
@@ -59,6 +59,7 @@ a JSON result to **stdout**:
 ```python
 # action_python.py
 import json, sys
+
 params = json.load(sys.stdin)
 msg = params.get("message", "hello")
 print(json.dumps({"success": True, "message": f"Python says: {msg}"}))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,8 @@ known-first-party = ["dcc_mcp_core"]
 # instead of ``from dcc_mcp_core import …`` so submodules avoid the lazy package facade.
 
 [tool.ruff.lint.per-file-ignores]
+# Python 3.7 compat: deliberate __dict__ access; get_annotations() would eval string annotations unnecessarily.
+"python/dcc_mcp_core/_typing_compat.py" = ["RUF063"]
 # Python 3.7 (Maya 2022) compat: use typing.Optional/Dict/List instead of PEP 604 syntax.
 "python/dcc_mcp_core/_server/host_ui_dispatcher.py" = ["UP006", "UP045"]
 "python/dcc_mcp_core/_server/tools_list_policy.py" = ["UP006", "UP045"]

--- a/python/dcc_mcp_core/sidecar.py
+++ b/python/dcc_mcp_core/sidecar.py
@@ -207,7 +207,7 @@ class SidecarActionDispatcher:
         *,
         action: str,
         request_id: str | None,
-    ) -> str | None | dict[str, Any]:
+    ) -> str | dict[str, Any] | None:
         for key in ("script_path", "source_file"):
             raw = payload.get(key)
             if raw is None:

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/SKILL.md
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/SKILL.md
@@ -80,9 +80,11 @@ Lists tracked PIDs and their liveness status.
 
 ```python
 import os
+
 os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/dcc-diagnostics"
 
 from dcc_mcp_maya import start_server  # or dcc_mcp_blender, etc.
+
 handle = start_server(port=8765)
 # dcc_diagnostics__error_report and all other tools are now available
 ```


### PR DESCRIPTION
## Summary

Fixes pre-existing ruff lint and formatting issues that cause CI failures on release-please PRs.

### Changes

- **sidecar.py**: Move `None` to end of union type (`str | dict[str, Any] | None`) — fixes RUF036
- **pyproject.toml**: Add `_typing_compat.py` to per-file-ignores for RUF063 — the `__dict__` access is deliberate in the Python 3.7 compat layer
- **SKILL.md files** (5): ruff format — pre-existing formatting issues

### Background

These issues were discovered during CI triage of release-please PR #2043 (PIP-2844). The fixes need to land on main so future release-please regenerations inherit them.

Related: [PR #2043](https://github.com/dcc-mcp/dcc-mcp-core/pull/2043)