### PR TITLE
fix(ui-control): treat blank host override as unset

### DIFF
--- a/python/dcc_mcp_core/skills/ui-control/scripts/_ui_control_host_resolver.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_ui_control_host_resolver.py
@@ -392,10 +392,8 @@ def _downloaded_host(version: str) -> Path:
 def resolve_ui_control_host() -> Path:
     """Return an exact-version Host from trusted env configuration or GitHub Release."""
     version = _package_version()
-    if HOST_ENV in os.environ:
-        configured = os.environ[HOST_ENV].strip()
-        if not configured:
-            raise HostResolutionError(f"{HOST_ENV} must name an absolute Host executable.")
+    configured = os.environ.get(HOST_ENV, "").strip()
+    if configured:
         try:
             candidate = Path(configured)
         except (OSError, ValueError):

--- a/tests/test_ui_control_host_resolver.py
+++ b/tests/test_ui_control_host_resolver.py
@@ -324,7 +324,7 @@ def test_environment_host_requires_the_exact_client_version(tmp_path: Path, monk
         resolver.resolve_ui_control_host()
 
 
-@pytest.mark.parametrize("configured", ["", "relative\\dcc-mcp-ui-control-host.exe"])
+@pytest.mark.parametrize("configured", ["relative\\dcc-mcp-ui-control-host.exe"])
 def test_invalid_environment_path_never_downloads(
     configured: str,
     monkeypatch: pytest.MonkeyPatch,
@@ -336,6 +336,22 @@ def test_invalid_environment_path_never_downloads(
 
     with pytest.raises(resolver.HostResolutionError, match=r"must (name an absolute|be an absolute)"):
         resolver.resolve_ui_control_host()
+
+
+@pytest.mark.parametrize("configured", ["", "  "])
+def test_blank_environment_uses_the_release_download_route(
+    configured: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolver = _load_resolver()
+    expected = tmp_path / "downloaded-host.exe"
+    monkeypatch.setenv(resolver.HOST_ENV, configured)
+    monkeypatch.setattr(resolver, "_package_version", lambda: VERSION)
+    monkeypatch.setattr(resolver, "_downloaded_host", lambda version: expected if version == VERSION else None)
+    monkeypatch.setattr(resolver, "_validate_host_file", lambda *_args: pytest.fail("blank env is not an override"))
+
+    assert resolver.resolve_ui_control_host() == expected
 
 
 def test_no_environment_has_only_the_release_download_route(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- treat an empty or whitespace-only `DCC_MCP_UI_CONTROL_HOST` value as not configured
- preserve fail-closed validation for non-empty relative or invalid paths
- cover both empty and whitespace-only values with resolver regression tests

## Validation
- `vx ruff check python/dcc_mcp_core/skills/ui-control/scripts/_ui_control_host_resolver.py tests/test_ui_control_host_resolver.py`
- `vx ruff format --check python/dcc_mcp_core/skills/ui-control/scripts/_ui_control_host_resolver.py tests/test_ui_control_host_resolver.py`
- `python -m pytest tests/test_ui_control_host_resolver.py -q --tb=short --show-capture=no` (49 passed)
- live resolver probe with a blank override selected the exact-version 0.19.71 release Host and verified its SHA-256

## Notes
- No Skill or documentation update is needed because this restores the documented env-first / exact-version release fallback contract.
- A full Windows `vx just dev` attempt reached the Admin UI build and stopped because `tsc` was unavailable after dependency bootstrap; CI remains the authoritative full-build gate.