### PR TITLE
feat: add dcc_diagnostics__get_instance_info builtin tool

### DIFF
--- a/python/dcc_mcp_core/dcc_server.py
+++ b/python/dcc_mcp_core/dcc_server.py
@@ -53,6 +53,7 @@ The ``dcc_name`` argument is used to derive the default IPC pipe name when
 from __future__ import annotations
 
 import base64
+import contextlib
 import logging
 import os
 import sys
@@ -475,38 +476,30 @@ def _handle_get_instance_info(params_json: str) -> str:
     # Resolve instance UUID from the server handle when available.
     instance_uuid = None
     if server is not None:
-        try:
+        with contextlib.suppress(Exception):
             instance_uuid = server.instance_id
-        except Exception:
-            pass
 
     # Resolve MCP URL from the server handle when available.
     mcp_url = None
     if server is not None:
-        try:
+        with contextlib.suppress(Exception):
             mcp_url = server.mcp_url()
-        except Exception:
-            pass
 
     # Resolve server port from the server handle when available.
     server_port = None
     if server is not None:
-        try:
+        with contextlib.suppress(Exception):
             server_port = server.port
-        except Exception:
-            pass
 
     # Resolve gateway port from the failover resolver or config.
     gateway_port = None
     gateway_failover_resolver = ctx.get("gateway_failover_resolver")
     if callable(gateway_failover_resolver):
-        try:
+        with contextlib.suppress(Exception):
             raw = gateway_failover_resolver() or {}
             gp = raw.get("gateway_port")
             if gp is not None and int(gp) > 0:
                 gateway_port = int(gp)
-        except Exception:
-            pass
 
     # Resolve dcc-mcp-core package version.
     try:
@@ -607,6 +600,8 @@ def register_diagnostic_handlers(
             ``take_screenshot`` to resolve the window target.
         dcc_window_handle: Pre-resolved native window handle (HWND / XID).
         dcc_window_title: Substring of the DCC window title for title lookup.
+        dcc_version: DCC application version string (e.g. ``"2024.2"``).
+            Stored in instance context for diagnostic tools.
         resolver: Optional callback returning the current native window handle
             when neither ``dcc_window_handle`` nor a cache hit is available.
 

--- a/python/dcc_mcp_core/dcc_server.py
+++ b/python/dcc_mcp_core/dcc_server.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import sys
 import time
 from typing import Any
 from typing import Callable
@@ -85,6 +86,7 @@ _WIN_PROCESS_QUERY_LIMITED_INFORMATION: int = 0x1000
 _sandbox_context: Any = None  # SandboxContext | None
 _action_recorder: Any = None  # ToolRecorder | None
 _dispatcher_ref: Any = None  # ToolDispatcher | None
+_server_ref: Any = None  # McpHttpServer | None — set by register_diagnostic_mcp_tools
 
 # Diagnostic instance context (DCC PID / window / resolver callback).
 _instance_context: dict[str, Any] = {
@@ -96,6 +98,9 @@ _instance_context: dict[str, Any] = {
     # Optional zero-arg callable returning the current gateway failover
     # state dict. Wired by DccServerBase via register_diagnostic_mcp_tools.
     "gateway_failover_resolver": None,
+    # DCC application version string (e.g. "2024.2"). Set by DccServerBase
+    # or adapter startup code via _instance_context or the register_* kwargs.
+    "dcc_version": None,
 }
 
 # Lazily-constructed capturers (one per kind, reused across screenshots).
@@ -458,6 +463,76 @@ def _handle_gateway_failover_status(params_json: str) -> str:
     return json_dumps(payload)
 
 
+def _handle_get_instance_info(params_json: str) -> str:
+    """Return DCC instance metadata (UUID, DCC type, version, PID, URLs)."""
+    _ = params_json
+    ctx = _instance_context
+    dcc_name = ctx.get("dcc_name") or "dcc"
+    dcc_pid = ctx.get("dcc_pid")
+    dcc_version = ctx.get("dcc_version")
+    server = _server_ref
+
+    # Resolve instance UUID from the server handle when available.
+    instance_uuid = None
+    if server is not None:
+        try:
+            instance_uuid = server.instance_id
+        except Exception:
+            pass
+
+    # Resolve MCP URL from the server handle when available.
+    mcp_url = None
+    if server is not None:
+        try:
+            mcp_url = server.mcp_url()
+        except Exception:
+            pass
+
+    # Resolve server port from the server handle when available.
+    server_port = None
+    if server is not None:
+        try:
+            server_port = server.port
+        except Exception:
+            pass
+
+    # Resolve gateway port from the failover resolver or config.
+    gateway_port = None
+    gateway_failover_resolver = ctx.get("gateway_failover_resolver")
+    if callable(gateway_failover_resolver):
+        try:
+            raw = gateway_failover_resolver() or {}
+            gp = raw.get("gateway_port")
+            if gp is not None and int(gp) > 0:
+                gateway_port = int(gp)
+        except Exception:
+            pass
+
+    # Resolve dcc-mcp-core package version.
+    try:
+        from dcc_mcp_core.server_base import _package_version
+
+        core_version = _package_version()
+    except Exception:
+        core_version = None
+
+    payload: dict[str, Any] = {
+        "success": True,
+        "dcc_name": dcc_name,
+        "dcc_pid": dcc_pid,
+        "dcc_version": dcc_version,
+        "adapter_pid": os.getpid(),
+        "instance_uuid": instance_uuid,
+        "mcp_url": mcp_url,
+        "server_port": server_port,
+        "gateway_port": gateway_port,
+        "dcc_mcp_core_version": core_version,
+        "python_version": "{}.{}.{}".format(*sys.version_info[:3]) if hasattr(sys, "version_info") else None,
+        "timestamp_ms": int(time.time() * 1000),
+    }
+    return json_dumps(payload)
+
+
 def _metadata_truthy(value: Any) -> bool:
     if isinstance(value, bool):
         return value
@@ -508,6 +583,7 @@ def register_diagnostic_handlers(
     dcc_pid: int | None = None,
     dcc_window_handle: int | None = None,
     dcc_window_title: str | None = None,
+    dcc_version: str | None = None,
     resolver: Callable[[], int | None] | None = None,
 ) -> None:
     """Register the standard diagnostic IPC action handlers on *server*.
@@ -561,6 +637,7 @@ def register_diagnostic_handlers(
             "dcc_pid": dcc_pid,
             "dcc_window_handle": dcc_window_handle,
             "dcc_window_title": dcc_window_title,
+            "dcc_version": dcc_version,
             "resolver": resolver,
         }
     )
@@ -664,6 +741,12 @@ _GATEWAY_FAILOVER_SCHEMA: dict = {
     "additionalProperties": False,
 }
 
+_INSTANCE_INFO_SCHEMA: dict = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
 
 def register_diagnostic_mcp_tools(
     server: Any,
@@ -672,10 +755,11 @@ def register_diagnostic_mcp_tools(
     dcc_pid: int | None = None,
     dcc_window_handle: int | None = None,
     dcc_window_title: str | None = None,
+    dcc_version: str | None = None,
     resolver: Callable[[], int | None] | None = None,
     gateway_failover_resolver: Callable[[], dict[str, Any]] | None = None,
 ) -> None:
-    """Register the four ``dcc_diagnostics__*`` MCP tools on *server*.
+    """Register the ``dcc_diagnostics__*`` MCP tools on *server*.
 
     Tools are registered as regular :class:`ToolRegistry` entries so they
     appear in ``tools/list`` and can be invoked via ``tools/call``. Must be
@@ -694,6 +778,8 @@ def register_diagnostic_mcp_tools(
       ``dcc_diagnostics__action_metrics`` in 0.14.0, no compat alias)
     - ``dcc_diagnostics__process_status`` — adapter process / DCC alive check
     - ``dcc_diagnostics__gateway_failover`` — gateway election state (#1355)
+    - ``dcc_diagnostics__get_instance_info`` — DCC instance metadata (UUID,
+      DCC type, version, PID, MCP URL, gateway port)
 
     Args:
         server: An :class:`McpHttpServer` instance (must expose a
@@ -704,6 +790,7 @@ def register_diagnostic_mcp_tools(
         dcc_window_handle: Optional HWND / X11 window ID to capture directly.
         dcc_window_title: Optional window title substring used as a fallback
             when neither ``dcc_pid`` nor ``dcc_window_handle`` resolves.
+        dcc_version: Optional DCC application version string (e.g. "2024.2").
         resolver: Optional callable returning the current DCC PID on demand.
             Evaluated lazily per request so long-lived servers can track DCC
             process restarts.
@@ -717,12 +804,16 @@ def register_diagnostic_mcp_tools(
             (see #1355).
 
     """
+    global _server_ref
+    _server_ref = server
+
     _instance_context.update(
         {
             "dcc_name": dcc_name,
             "dcc_pid": dcc_pid,
             "dcc_window_handle": dcc_window_handle,
             "dcc_window_title": dcc_window_title,
+            "dcc_version": dcc_version,
             "resolver": resolver,
             "gateway_failover_resolver": gateway_failover_resolver,
         }
@@ -760,6 +851,12 @@ def register_diagnostic_mcp_tools(
             "Gateway election state (enabled, running, consecutive_failures, reason).",
             _GATEWAY_FAILOVER_SCHEMA,
             _handle_gateway_failover_status,
+        ),
+        (
+            "dcc_diagnostics__get_instance_info",
+            "DCC instance metadata (UUID, DCC type, version, PID, MCP URL, gateway port).",
+            _INSTANCE_INFO_SCHEMA,
+            _handle_get_instance_info,
         ),
     ]
 

--- a/tests/test_diagnostics_mcp_tools.py
+++ b/tests/test_diagnostics_mcp_tools.py
@@ -39,6 +39,7 @@ EXPECTED_TOOLS = [
     "dcc_diagnostics__tool_metrics",
     "dcc_diagnostics__process_status",
     "dcc_diagnostics__gateway_failover",
+    "dcc_diagnostics__get_instance_info",
 ]
 
 
@@ -108,6 +109,79 @@ class TestProcessStatusHandler:
             assert isinstance(payload["timestamp_ms"], int)
         finally:
             _instance_context.update(original)
+
+
+class TestGetInstanceInfoHandler:
+    def test_reports_context(self) -> None:
+        # Import local modules
+        from dcc_mcp_core.dcc_server import _handle_get_instance_info
+        from dcc_mcp_core.dcc_server import _instance_context
+
+        original = dict(_instance_context)
+        _instance_context.update(
+            {
+                "dcc_name": "maya",
+                "dcc_pid": 99999,
+                "dcc_window_handle": None,
+                "dcc_window_title": "Maya 2024",
+                "dcc_version": "2024.2",
+                "resolver": None,
+                "gateway_failover_resolver": None,
+            }
+        )
+        try:
+            payload = json.loads(_handle_get_instance_info("{}"))
+            assert payload["success"] is True
+            assert payload["dcc_name"] == "maya"
+            assert payload["dcc_pid"] == 99999
+            assert payload["dcc_version"] == "2024.2"
+            assert isinstance(payload["adapter_pid"], int)
+            assert isinstance(payload["timestamp_ms"], int)
+            # Fields that are None when no server is wired
+            assert payload["instance_uuid"] is None
+            assert payload["mcp_url"] is None
+            assert payload["server_port"] is None
+            assert payload["gateway_port"] is None
+            # Static fields
+            assert payload["dcc_mcp_core_version"] is not None
+            assert payload["python_version"] is not None
+        finally:
+            _instance_context.update(original)
+
+    def test_with_server_ref(self, server) -> None:
+        """Handler returns server-attached fields when server is wired."""
+        # Import local modules
+        from dcc_mcp_core.dcc_server import _handle_get_instance_info
+        from dcc_mcp_core.dcc_server import _instance_context
+        from dcc_mcp_core.dcc_server import _server_ref
+
+        register_diagnostic_mcp_tools(
+            server,
+            dcc_name="test-dcc",
+            dcc_pid=12345,
+            dcc_version="2025.1",
+        )
+
+        try:
+            payload = json.loads(_handle_get_instance_info("{}"))
+            assert payload["success"] is True
+            assert payload["dcc_name"] == "test-dcc"
+            assert payload["dcc_pid"] == 12345
+            assert payload["dcc_version"] == "2025.1"
+            # Server ref should be set by register_diagnostic_mcp_tools
+            assert _server_ref is not None
+        finally:
+            _instance_context.update(
+                {
+                    "dcc_name": None,
+                    "dcc_pid": None,
+                    "dcc_window_handle": None,
+                    "dcc_window_title": None,
+                    "dcc_version": None,
+                    "resolver": None,
+                    "gateway_failover_resolver": None,
+                }
+            )
 
 
 class TestToolCategoryAndMetadata:


### PR DESCRIPTION
Add a new `dcc_diagnostics__get_instance_info` MCP tool that returns instance-level metadata for DCC adapters.

**Returns:**
- `instance_uuid` — server instance UUID
- `dcc_name` — DCC type (maya, blender, houdini, etc.)
- `dcc_pid` — DCC process PID
- `dcc_version` — DCC application version (e.g. "2024.2")
- `adapter_pid` — adapter process PID
- `mcp_url` — MCP endpoint URL
- `server_port` — server port
- `gateway_port` — gateway port
- `dcc_mcp_core_version` — dcc-mcp-core package version
- `python_version` — Python version
- `timestamp_ms` — capture timestamp

**Changes:**
- New `_handle_get_instance_info` handler in `dcc_server.py`
- Store `_server_ref` module-level for handler access to server properties
- Add `dcc_version` field to `_instance_context` and both `register_*` kwargs
- Register `dcc_diagnostics__get_instance_info` in `register_diagnostic_mcp_tools`
- Tests in `test_diagnostics_mcp_tools.py`

This is a prerequisite for unified menu structure in gateway diagnostics.