### PR TITLE
feat(ui-control): progressive semantic UI tree query chain (PIP-2781)

### DIFF
--- a/crates/dcc-mcp-ui-control/src/lib.rs
+++ b/crates/dcc-mcp-ui-control/src/lib.rs
@@ -649,6 +649,132 @@ pub struct UiWaitResult {
     pub metadata: Value,
 }
 
+/// Request for root-level window controls without full subtree expansion.
+///
+/// This is the first step in the progressive query chain:
+/// observe → expand → inspect. Unlike `snapshot`, it returns only the
+/// top-level controls with minimal metadata — no full subtree dump.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UiObserveRequest {
+    /// Maximum root-level controls to return.
+    #[serde(default = "default_observe_max_roots")]
+    pub max_roots: u32,
+}
+
+const fn default_observe_max_roots() -> u32 {
+    20
+}
+
+/// Request to expand a specific control node to reveal its direct children.
+///
+/// This is step two in the progressive query chain. Agents call this
+/// after `observe` identified an interesting root, and can continue
+/// expanding children to drill down the tree lazily.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UiExpandRequest {
+    /// Stable control id from a prior observation or expand call.
+    pub control_id: String,
+    /// Maximum direct children to return.
+    #[serde(default = "default_expand_max_children")]
+    pub max_children: u32,
+}
+
+const fn default_expand_max_children() -> u32 {
+    50
+}
+
+/// Request for detailed properties of a specific control.
+///
+/// This is the final step in the progressive query chain. Returns
+/// richer metadata than `find`: bounds, states, supported UIA patterns,
+/// runtime property bag, and position in the control tree.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UiInspectRequest {
+    /// Stable control id from a prior observation, find, or expand call.
+    pub control_id: String,
+}
+
+/// Detailed control properties returned by `inspect_ui`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UiControlDetail {
+    /// Stable control id.
+    pub id: String,
+    /// Role/type.
+    pub role: String,
+    /// Visible label or accessible name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Current visible text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Host object/control name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub object_name: Option<String>,
+    /// Tooltip/help text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tooltip: Option<String>,
+    /// Whether the control is enabled.
+    pub enabled: bool,
+    /// Whether the control is visible.
+    pub visible: bool,
+    /// Whether the control has keyboard focus.
+    pub focused: bool,
+    /// Control bounds when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bounds: Option<UiBounds>,
+    /// Current value for value-bearing controls.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    /// Checked state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checked: Option<bool>,
+    /// Number of direct children (expanded or not).
+    #[serde(default)]
+    pub child_count: u32,
+    /// Supported UIA/accessibility pattern names.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub supported_patterns: Vec<String>,
+    /// Supported action names.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub supported_actions: Vec<String>,
+    /// Whether this control can receive keyboard focus.
+    #[serde(default)]
+    pub is_keyboard_focusable: bool,
+    /// Whether this control is a password field.
+    #[serde(default)]
+    pub is_password: bool,
+    /// Position in the tree as a dot-separated index path (e.g. "0.2.1").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tree_path: Option<String>,
+    /// Adapter-specific metadata.
+    #[serde(default)]
+    pub metadata: Value,
+}
+
+/// Result of a progressive observe call.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UiObserveResult {
+    /// Root-level controls returned (children collapsed).
+    pub roots: Vec<UiControlNode>,
+    /// Total root-level controls found (may exceed max_roots).
+    pub total_roots: u32,
+    /// Whether the result was truncated by max_roots.
+    pub truncated: bool,
+}
+
+/// Result of a progressive expand call.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UiExpandResult {
+    /// Parent control id that was expanded.
+    pub control_id: String,
+    /// Direct children of the parent node.
+    pub children: Vec<UiControlNode>,
+    /// Total direct children (may exceed max_children).
+    pub total_children: u32,
+    /// Whether the result was truncated by max_children.
+    pub truncated: bool,
+}
+
 /// Small audit record for a `ui_control` action decision or outcome.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UiControlAuditRecord {

--- a/python/dcc_mcp_core/adapter_contracts.py
+++ b/python/dcc_mcp_core/adapter_contracts.py
@@ -468,6 +468,84 @@ class UiControlAuditRecord:
         return _drop_none(asdict(self))
 
 
+@dataclass
+class UiObserveRequest:
+    """Request for root-level window controls without full subtree expansion."""
+
+    max_roots: int = 20
+
+
+@dataclass
+class UiExpandRequest:
+    """Request to expand a specific control node to reveal its direct children."""
+
+    control_id: str
+    max_children: int = 50
+
+
+@dataclass
+class UiInspectRequest:
+    """Request for detailed properties of a specific control."""
+
+    control_id: str
+
+
+@dataclass
+class UiControlDetail:
+    """Detailed control properties returned by inspect_ui."""
+
+    id: str
+    role: str
+    enabled: bool
+    visible: bool
+    focused: bool = False
+    label: Optional[str] = None
+    text: Optional[str] = None
+    object_name: Optional[str] = None
+    tooltip: Optional[str] = None
+    bounds: Optional[UiBounds] = None
+    value: Optional[str] = None
+    checked: Optional[bool] = None
+    child_count: int = 0
+    supported_patterns: List[str] = field(default_factory=list)
+    supported_actions: List[str] = field(default_factory=list)
+    is_keyboard_focusable: bool = False
+    is_password: bool = False
+    tree_path: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the wire dictionary."""
+        return _drop_none(asdict(self))
+
+
+@dataclass
+class UiObserveResult:
+    """Result of a progressive observe call."""
+
+    roots: List[UiControlNode]
+    total_roots: int
+    truncated: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the wire dictionary."""
+        return _drop_none(asdict(self))
+
+
+@dataclass
+class UiExpandResult:
+    """Result of a progressive expand call."""
+
+    control_id: str
+    children: List[UiControlNode]
+    total_children: int
+    truncated: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the wire dictionary."""
+        return _drop_none(asdict(self))
+
+
 __all__ = [
     "DebugPathMapping",
     "DebugSessionDescriptor",
@@ -478,10 +556,16 @@ __all__ = [
     "UiArtifactRef",
     "UiBounds",
     "UiControlAuditRecord",
+    "UiControlDetail",
     "UiControlNode",
     "UiControlPolicy",
     "UiErrorCode",
+    "UiExpandRequest",
+    "UiExpandResult",
     "UiFindRequest",
+    "UiInspectRequest",
+    "UiObserveRequest",
+    "UiObserveResult",
     "UiPoint",
     "UiSnapshot",
     "UiWaitCondition",

--- a/python/dcc_mcp_core/skills/ui-control/SKILL.md
+++ b/python/dcc_mcp_core/skills/ui-control/SKILL.md
@@ -72,6 +72,9 @@ The Windows backend exposes DCC UI Control through the existing `ui_control` too
 | DCC UI Control operation | DCC-MCP tool |
 |------------------------|--------------|
 | `screenshot` | `ui_control__snapshot` |
+| `observe` (root-level structural view) | `ui_control__observe` |
+| `expand` (drill into a node's children) | `ui_control__expand` |
+| `inspect` (detailed control properties) | `ui_control__inspect` |
 | semantic `click`, `set_text`, `toggle`, `set_checked`, `select_option`, `focus` | `ui_control__act` with an exact `control_id` |
 | raw `click`, `move`, `double_click`, `scroll`, `drag`, `keypress`, `game_navigation` | `ui_control__act` with the latest `snapshot_id` |
 | typed HKCU value or symbolic-link ensure | `ui_control__system_operation` |
@@ -276,6 +279,73 @@ For native DCC UI Control actions, keep one `session_id` and use this loop:
 `ui_control__wait_for` remains interruptible while polling: Esc, an
 explicit `ui_control__stop_computer_use`, desktop loss, or backend cleanup cancels
 the wait without waiting for its condition timeout.
+
+### Progressive Semantic UI Tree Query
+
+For structural navigation without pixel data, prefer the progressive query
+chain over full snapshots. This is lighter on bandwidth, avoids loading the
+entire UIA tree into context, and maps directly to agent exploration patterns:
+
+```
+observe → expand → inspect → (act)
+```
+
+1. **`ui_control__observe`** — Return top-level root controls of the scoped
+   window **without** expanding their children. Each root node reports its
+   `child_count` so agents can decide whether to drill down. Returns root
+   metadata: id, role, label, enabled/visible state, and bounds when available.
+   Use this to get a high-level structural overview before deciding which
+   subtree to explore.
+
+2. **`ui_control__expand`** — Expand a specific `control_id` to reveal its
+   direct children. Each returned child also reports its own `child_count`,
+   enabling iterative drill-down one level at a time. This is idempotent and
+   read-only; call it repeatedly to walk the tree.
+
+3. **`ui_control__inspect`** — Return detailed properties of a specific
+   `control_id`: bounds, enabled/visible/focused state, `child_count`,
+   supported UIA patterns (`ValuePattern`, `InvokePattern`, …), supported
+   actions, keyboard-focusability, password-field detection, and tree position
+   (`tree_path`). Use this to verify a control's capabilities before calling
+   `ui_control__act`.
+
+4. **Act** — Once the correct control is identified, call `ui_control__act`
+   with its `control_id` as usual. After the action, re-observe or snapshot
+   to verify the result.
+
+**Workflow example** (structural navigation without pixel capture):
+
+```bash
+# Step 1: observe root structure
+dcc-mcp-cli ui-control observe --instance-id <id> --json '{"session_id":"ui","process_id":1234}'
+# Returns roots like: [menu_bar (child_count=5), tool_bar (child_count=12), canvas (child_count=0)]
+
+# Step 2: expand the menu bar
+dcc-mcp-cli ui-control expand --instance-id <id> --json '{"session_id":"ui","process_id":1234,"control_id":"menu_bar"}'
+# Returns: [file_menu, edit_menu, view_menu, ...]
+
+# Step 3: inspect the file menu for available actions
+dcc-mcp-cli ui-control inspect --instance-id <id> --json '{"session_id":"ui","process_id":1234,"control_id":"file_menu"}'
+# Returns: {role: "menu_item", supported_patterns: ["InvokePattern"], supported_actions: ["click"], ...}
+
+# Step 4: act
+dcc-mcp-cli ui-control act --instance-id <id> --json '{"session_id":"ui","process_id":1234,"control_id":"file_menu","action":"click"}'
+```
+
+**When to use progressive query vs. snapshot**:
+
+| Scenario | Use |
+|---|---|
+| Structural navigation (menus, trees, tabs) | `observe` → `expand` → `inspect` |
+| Need pixel image for visual verification | `snapshot` |
+| Need to interact with custom-drawn controls | `snapshot` (for coordinates) |
+| Quick text-based control lookup | `find` (still works on any snapshot) |
+| Polling for a UI state change | `wait_for` |
+
+Progressive query tools are read-only and idempotent. They do not capture
+pixels, consume observations, or trigger the visual overlay. Use them freely
+for exploration; switch to `snapshot` when you need the pixel image or
+coordinate space.
 
 Agents should enter this loop only after a structured DCC operation returns
 `unsupported` or `capability_missing`; they should not ask the user to manually

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_backend.py
@@ -746,54 +746,23 @@ def wait_for_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
 def _build_detailed_node(
     snapshot: Dict[str, Any],
     node: Dict[str, Any],
-    tree_path: str,
 ) -> Dict[str, Any]:
-    """Build a UiControlDetail dict from a snapshot node."""
-    role = str(node.get("role") or "unknown")
-    is_text_field = role == "text_field"
-    is_checkbox = role == "checkbox"
-    is_button = role == "button"
-
-    patterns = []
-    actions = []
-    if is_text_field:
-        patterns = ["ValuePattern", "TextPattern"]
-        actions = ["set_text", "focus"]
-    elif is_checkbox:
-        patterns = ["TogglePattern"]
-        actions = ["toggle", "set_checked", "click"]
-    elif is_button:
-        patterns = ["InvokePattern"]
-        actions = ["click"]
+    """Build a UiControlDetail dict, delegating to shared progressive query helpers."""
+    if __package__:
+        from ._progressive_query import build_control_detail
     else:
-        patterns = ["SelectionItemPattern"] if role in ("list_item", "menu_item", "combo_box") else []
-        actions = ["click", "focus"]
+        from _progressive_query import build_control_detail
 
-    return {
-        "id": node.get("id", ""),
-        "role": role,
-        "enabled": bool(node.get("enabled", True)),
-        "visible": bool(node.get("visible", True)),
-        "focused": snapshot.get("focus_id") == node.get("id"),
-        "label": node.get("label"),
-        "text": node.get("text"),
-        "object_name": node.get("object_name"),
-        "tooltip": node.get("tooltip"),
-        "bounds": node.get("bounds"),
-        "value": node.get("value"),
-        "checked": node.get("checked"),
-        "child_count": len(node.get("children", []) or []),
-        "supported_patterns": patterns,
-        "supported_actions": actions,
-        "is_keyboard_focusable": role in ("text_field", "button", "checkbox", "combo_box"),
-        "is_password": role == "password",
-        "tree_path": tree_path,
-        "metadata": {"backend": "mock"},
-    }
+    return build_control_detail(node, snapshot, "mock")
 
 
 def observe_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Return root-level controls without expanding children."""
+    if __package__:
+        from ._progressive_query import observe_from_snapshot
+    else:
+        from _progressive_query import observe_from_snapshot
+
     params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     state = _load_state(session_id)
@@ -814,33 +783,26 @@ def observe_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         )
 
     snapshot = _snapshot_dict(state)
-    # Return root-level children without their children expanded
-    all_roots = list(snapshot["root"].get("children", []) or [])
-    total_roots = len(all_roots)
-    truncated = total_roots > max_roots
-
-    roots = []
-    for i, child in enumerate(all_roots[:max_roots]):
-        # Strip children to return only root-level metadata
-        stripped = dict(child)
-        child_count = len(stripped.get("children", []) or [])
-        stripped["children"] = []
-        stripped["child_count"] = child_count
-        roots.append(stripped)
+    result = observe_from_snapshot(snapshot, max_roots)
 
     return skill_success(
-        f"Observed {len(roots)} root-level control(s).",
+        f"Observed {len(result['roots'])} root-level control(s).",
         prompt="Use ui_control__expand to drill into a node, or ui_control__inspect for details.",
         session_id=session_id,
         snapshot_id=snapshot["metadata"]["snapshot_id"],
-        roots=roots,
-        total_roots=total_roots,
-        truncated=truncated,
+        roots=result["roots"],
+        total_roots=result["total_roots"],
+        truncated=result["truncated"],
     )
 
 
 def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Return direct children of a specific control node."""
+    if __package__:
+        from ._progressive_query import expand_from_snapshot
+    else:
+        from _progressive_query import expand_from_snapshot
+
     params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     state = _load_state(session_id)
@@ -868,8 +830,8 @@ def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         )
 
     snapshot = _snapshot_dict(state)
-    parent = _find_by_id(snapshot, control_id)
-    if not parent:
+    result = expand_from_snapshot(snapshot, control_id, max_children)
+    if result is None:
         return skill_error(
             f"control {control_id!r} not found; refresh observation",
             UiErrorCode.NOT_FOUND,
@@ -877,27 +839,15 @@ def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
             session_id=session_id,
         )
 
-    all_children = list(parent.get("children", []) or [])
-    total_children = len(all_children)
-    truncated = total_children > max_children
-
-    children = []
-    for i, child in enumerate(all_children[:max_children]):
-        stripped = dict(child)
-        grandchild_count = len(stripped.get("children", []) or [])
-        stripped["children"] = []
-        stripped["child_count"] = grandchild_count
-        children.append(stripped)
-
     return skill_success(
-        f"Expanded {control_id!r}: {len(children)} direct child(ren).",
+        f"Expanded {control_id!r}: {len(result['children'])} direct child(ren).",
         prompt="Use ui_control__expand again to drill deeper, or ui_control__inspect for details on a child.",
         session_id=session_id,
         snapshot_id=snapshot["metadata"]["snapshot_id"],
-        control_id=control_id,
-        children=children,
-        total_children=total_children,
-        truncated=truncated,
+        control_id=result["control_id"],
+        children=result["children"],
+        total_children=result["total_children"],
+        truncated=result["truncated"],
     )
 
 
@@ -938,8 +888,7 @@ def inspect_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
             session_id=session_id,
         )
 
-    tree_path = _compute_tree_path(snapshot["root"], control_id)
-    detail = _build_detailed_node(snapshot, node, tree_path)
+    detail = _build_detailed_node(snapshot, node)
 
     return skill_success(
         f"Inspected control {control_id!r} ({detail['role']}).",
@@ -948,20 +897,6 @@ def inspect_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         snapshot_id=snapshot["metadata"]["snapshot_id"],
         control=detail,
     )
-
-
-def _compute_tree_path(root: Dict[str, Any], target_id: str) -> str:
-    """Compute a dot-separated index path from root to target_id."""
-    queue = [(root, "")]
-    while queue:
-        node, prefix = queue.pop(0)
-        children = node.get("children", []) or []
-        for i, child in enumerate(children):
-            path = f"{prefix}{i}" if prefix else str(i)
-            if child.get("id") == target_id:
-                return path
-            queue.append((child, path + "."))
-    return ""
 
 
 def emit(result: Dict[str, Any]) -> None:

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_backend.py
@@ -743,5 +743,226 @@ def wait_for_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     )
 
 
+def _build_detailed_node(
+    snapshot: Dict[str, Any],
+    node: Dict[str, Any],
+    tree_path: str,
+) -> Dict[str, Any]:
+    """Build a UiControlDetail dict from a snapshot node."""
+    role = str(node.get("role") or "unknown")
+    is_text_field = role == "text_field"
+    is_checkbox = role == "checkbox"
+    is_button = role == "button"
+
+    patterns = []
+    actions = []
+    if is_text_field:
+        patterns = ["ValuePattern", "TextPattern"]
+        actions = ["set_text", "focus"]
+    elif is_checkbox:
+        patterns = ["TogglePattern"]
+        actions = ["toggle", "set_checked", "click"]
+    elif is_button:
+        patterns = ["InvokePattern"]
+        actions = ["click"]
+    else:
+        patterns = ["SelectionItemPattern"] if role in ("list_item", "menu_item", "combo_box") else []
+        actions = ["click", "focus"]
+
+    return {
+        "id": node.get("id", ""),
+        "role": role,
+        "enabled": bool(node.get("enabled", True)),
+        "visible": bool(node.get("visible", True)),
+        "focused": snapshot.get("focus_id") == node.get("id"),
+        "label": node.get("label"),
+        "text": node.get("text"),
+        "object_name": node.get("object_name"),
+        "tooltip": node.get("tooltip"),
+        "bounds": node.get("bounds"),
+        "value": node.get("value"),
+        "checked": node.get("checked"),
+        "child_count": len(node.get("children", []) or []),
+        "supported_patterns": patterns,
+        "supported_actions": actions,
+        "is_keyboard_focusable": role in ("text_field", "button", "checkbox", "combo_box"),
+        "is_password": role == "password",
+        "tree_path": tree_path,
+        "metadata": {"backend": "mock"},
+    }
+
+
+def observe_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return root-level controls without expanding children."""
+    params = dict(params) if params is not None else _read_params()
+    session_id = _safe_session_id(params.get("session_id"))
+    state = _load_state(session_id)
+    policy = _policy_from_params(params)
+    max_roots = max(1, min(100, int(params.get("max_roots") or 20)))
+
+    if not policy.allow_snapshot:
+        return skill_error(
+            "ui_control observation disabled by policy",
+            UiErrorCode.POLICY_DISABLED,
+            error_code=UiErrorCode.POLICY_DISABLED,
+        )
+    if not _window_allowed(state, policy):
+        return skill_error(
+            "scoped ui_control window is not allowed by policy",
+            UiErrorCode.MISSING_WINDOW,
+            error_code=UiErrorCode.MISSING_WINDOW,
+        )
+
+    snapshot = _snapshot_dict(state)
+    # Return root-level children without their children expanded
+    all_roots = list(snapshot["root"].get("children", []) or [])
+    total_roots = len(all_roots)
+    truncated = total_roots > max_roots
+
+    roots = []
+    for i, child in enumerate(all_roots[:max_roots]):
+        # Strip children to return only root-level metadata
+        stripped = dict(child)
+        child_count = len(stripped.get("children", []) or [])
+        stripped["children"] = []
+        stripped["child_count"] = child_count
+        roots.append(stripped)
+
+    return skill_success(
+        f"Observed {len(roots)} root-level control(s).",
+        prompt="Use ui_control__expand to drill into a node, or ui_control__inspect for details.",
+        session_id=session_id,
+        snapshot_id=snapshot["metadata"]["snapshot_id"],
+        roots=roots,
+        total_roots=total_roots,
+        truncated=truncated,
+    )
+
+
+def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return direct children of a specific control node."""
+    params = dict(params) if params is not None else _read_params()
+    session_id = _safe_session_id(params.get("session_id"))
+    state = _load_state(session_id)
+    policy = _policy_from_params(params)
+    control_id = str(params.get("control_id") or "")
+    max_children = max(1, min(200, int(params.get("max_children") or 50)))
+
+    if not policy.allow_find:
+        return skill_error(
+            "ui_control find disabled by policy",
+            UiErrorCode.POLICY_DISABLED,
+            error_code=UiErrorCode.POLICY_DISABLED,
+        )
+    if not _window_allowed(state, policy):
+        return skill_error(
+            "scoped ui_control window is not allowed by policy",
+            UiErrorCode.MISSING_WINDOW,
+            error_code=UiErrorCode.MISSING_WINDOW,
+        )
+    if not control_id:
+        return skill_error(
+            "control_id is required for expand",
+            UiErrorCode.INVALID_ACTION,
+            error_code=UiErrorCode.INVALID_ACTION,
+        )
+
+    snapshot = _snapshot_dict(state)
+    parent = _find_by_id(snapshot, control_id)
+    if not parent:
+        return skill_error(
+            f"control {control_id!r} not found; refresh observation",
+            UiErrorCode.NOT_FOUND,
+            error_code=UiErrorCode.NOT_FOUND,
+            session_id=session_id,
+        )
+
+    all_children = list(parent.get("children", []) or [])
+    total_children = len(all_children)
+    truncated = total_children > max_children
+
+    children = []
+    for i, child in enumerate(all_children[:max_children]):
+        stripped = dict(child)
+        grandchild_count = len(stripped.get("children", []) or [])
+        stripped["children"] = []
+        stripped["child_count"] = grandchild_count
+        children.append(stripped)
+
+    return skill_success(
+        f"Expanded {control_id!r}: {len(children)} direct child(ren).",
+        prompt="Use ui_control__expand again to drill deeper, or ui_control__inspect for details on a child.",
+        session_id=session_id,
+        snapshot_id=snapshot["metadata"]["snapshot_id"],
+        control_id=control_id,
+        children=children,
+        total_children=total_children,
+        truncated=truncated,
+    )
+
+
+def inspect_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return detailed properties of a specific control."""
+    params = dict(params) if params is not None else _read_params()
+    session_id = _safe_session_id(params.get("session_id"))
+    state = _load_state(session_id)
+    policy = _policy_from_params(params)
+    control_id = str(params.get("control_id") or "")
+
+    if not policy.allow_find:
+        return skill_error(
+            "ui_control find disabled by policy",
+            UiErrorCode.POLICY_DISABLED,
+            error_code=UiErrorCode.POLICY_DISABLED,
+        )
+    if not _window_allowed(state, policy):
+        return skill_error(
+            "scoped ui_control window is not allowed by policy",
+            UiErrorCode.MISSING_WINDOW,
+            error_code=UiErrorCode.MISSING_WINDOW,
+        )
+    if not control_id:
+        return skill_error(
+            "control_id is required for inspect",
+            UiErrorCode.INVALID_ACTION,
+            error_code=UiErrorCode.INVALID_ACTION,
+        )
+
+    snapshot = _snapshot_dict(state)
+    node = _find_by_id(snapshot, control_id)
+    if not node:
+        return skill_error(
+            f"control {control_id!r} not found; refresh observation",
+            UiErrorCode.NOT_FOUND,
+            error_code=UiErrorCode.NOT_FOUND,
+            session_id=session_id,
+        )
+
+    tree_path = _compute_tree_path(snapshot["root"], control_id)
+    detail = _build_detailed_node(snapshot, node, tree_path)
+
+    return skill_success(
+        f"Inspected control {control_id!r} ({detail['role']}).",
+        prompt="Use ui_control__act with this control_id, or ui_control__expand to see its children.",
+        session_id=session_id,
+        snapshot_id=snapshot["metadata"]["snapshot_id"],
+        control=detail,
+    )
+
+
+def _compute_tree_path(root: Dict[str, Any], target_id: str) -> str:
+    """Compute a dot-separated index path from root to target_id."""
+    queue = [(root, "")]
+    while queue:
+        node, prefix = queue.pop(0)
+        children = node.get("children", []) or []
+        for i, child in enumerate(children):
+            path = f"{prefix}{i}" if prefix else str(i)
+            if child.get("id") == target_id:
+                return path
+            queue.append((child, path + "."))
+    return ""
+
+
 def emit(result: Dict[str, Any]) -> None:
     print(json.dumps(result, sort_keys=True))

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_chrome_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_chrome_backend.py
@@ -21,10 +21,12 @@ if __package__:
     from ._cdp_runtime import CdpBackendError as ChromeBackendError
     from ._cdp_runtime import CdpClient as _CdpClient
     from ._cdp_runtime import ensure_cdp_target as _ensure_cdp_target
+    from ._progressive_query import build_control_detail, expand_from_snapshot, observe_from_snapshot
 else:
     from _cdp_runtime import CdpBackendError as ChromeBackendError
     from _cdp_runtime import CdpClient as _CdpClient
     from _cdp_runtime import ensure_cdp_target as _ensure_cdp_target
+    from _progressive_query import build_control_detail, expand_from_snapshot, observe_from_snapshot
 
 from dcc_mcp_core.adapter_contracts import UiActionKind
 from dcc_mcp_core.adapter_contracts import UiActionResult
@@ -37,8 +39,7 @@ from dcc_mcp_core.adapter_contracts import UiSnapshot
 from dcc_mcp_core.adapter_contracts import UiWaitCondition
 from dcc_mcp_core.adapter_contracts import UiWaitConditionKind
 from dcc_mcp_core.adapter_contracts import UiWaitResult
-from dcc_mcp_core.skill import skill_error
-from dcc_mcp_core.skill import skill_success
+from dcc_mcp_core.skill import skill_error, skill_success
 
 _POLICY_KEYS = {
     "allow_snapshot",
@@ -860,7 +861,7 @@ def wait_for_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
 
 
 def observe_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Return root-level controls from the CDP backend without subtree expansion."""
+    """Return root-level controls from the CDP backend."""
     params = dict(params) if params is not None else _read_params()
     session_id = _safe_session_id(params.get("session_id"))
     state = _load_state(session_id)
@@ -887,26 +888,16 @@ def observe_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     _save_state(state)
 
     snapshot = _snapshot_dict(state)
-    all_roots = list(snapshot["root"].get("children", []) or [])
-    total_roots = len(all_roots)
-    truncated = total_roots > max_roots
-
-    roots = []
-    for child in all_roots[:max_roots]:
-        stripped = dict(child)
-        child_count = len(stripped.get("children", []) or [])
-        stripped["children"] = []
-        stripped["child_count"] = child_count
-        roots.append(stripped)
+    result = observe_from_snapshot(snapshot, max_roots)
 
     return skill_success(
-        f"Observed {len(roots)} root-level control(s).",
+        f"Observed {len(result['roots'])} root-level control(s).",
         prompt="Use ui_control__expand to drill into a node, or ui_control__inspect for details.",
         session_id=session_id,
         snapshot_id=snapshot["metadata"]["snapshot_id"],
-        roots=roots,
-        total_roots=total_roots,
-        truncated=truncated,
+        roots=result["roots"],
+        total_roots=result["total_roots"],
+        truncated=result["truncated"],
     )
 
 
@@ -939,8 +930,8 @@ def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         )
 
     snapshot = _snapshot_dict(state)
-    parent = _find_by_id(snapshot, control_id)
-    if not parent:
+    result = expand_from_snapshot(snapshot, control_id, max_children)
+    if result is None:
         return skill_error(
             f"control {control_id!r} not found; refresh observation",
             UiErrorCode.NOT_FOUND,
@@ -948,27 +939,15 @@ def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
             session_id=session_id,
         )
 
-    all_children = list(parent.get("children", []) or [])
-    total_children = len(all_children)
-    truncated = total_children > max_children
-
-    children = []
-    for child in all_children[:max_children]:
-        stripped = dict(child)
-        grandchild_count = len(stripped.get("children", []) or [])
-        stripped["children"] = []
-        stripped["child_count"] = grandchild_count
-        children.append(stripped)
-
     return skill_success(
-        f"Expanded {control_id!r}: {len(children)} direct child(ren).",
+        f"Expanded {control_id!r}: {len(result['children'])} direct child(ren).",
         prompt="Use ui_control__expand again to drill deeper, or ui_control__inspect for details on a child.",
         session_id=session_id,
         snapshot_id=snapshot["metadata"]["snapshot_id"],
-        control_id=control_id,
-        children=children,
-        total_children=total_children,
-        truncated=truncated,
+        control_id=result["control_id"],
+        children=result["children"],
+        total_children=result["total_children"],
+        truncated=result["truncated"],
     )
 
 
@@ -1009,47 +988,7 @@ def inspect_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
             session_id=session_id,
         )
 
-    role = str(node.get("role") or "unknown")
-    is_text_field = role == "text_field"
-    is_checkbox = role == "checkbox"
-    is_button = role == "button"
-
-    patterns = []
-    actions = []
-    if is_text_field:
-        patterns = ["ValuePattern", "TextPattern"]
-        actions = ["set_text", "focus"]
-    elif is_checkbox:
-        patterns = ["TogglePattern"]
-        actions = ["toggle", "set_checked", "click"]
-    elif is_button:
-        patterns = ["InvokePattern"]
-        actions = ["click"]
-    elif role in ("link", "list_item", "menu_item", "combo_box", "option", "listbox"):
-        patterns = ["SelectionItemPattern"]
-        actions = ["click", "focus"]
-
-    detail = {
-        "id": node.get("id", ""),
-        "role": role,
-        "enabled": bool(node.get("enabled", True)),
-        "visible": bool(node.get("visible", True)),
-        "focused": snapshot.get("focus_id") == node.get("id"),
-        "label": node.get("label"),
-        "text": node.get("text"),
-        "object_name": node.get("object_name"),
-        "tooltip": node.get("tooltip"),
-        "bounds": node.get("bounds"),
-        "value": node.get("value"),
-        "checked": node.get("checked"),
-        "child_count": len(node.get("children", []) or []),
-        "supported_patterns": patterns,
-        "supported_actions": actions,
-        "is_keyboard_focusable": role in ("text_field", "button", "checkbox", "combo_box", "link"),
-        "is_password": role == "password",
-        "tree_path": None,
-        "metadata": {"backend": "chrome-cdp"},
-    }
+    detail = build_control_detail(node, snapshot, "chrome-cdp")
 
     return skill_success(
         f"Inspected control {control_id!r} ({detail['role']}).",

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_chrome_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_chrome_backend.py
@@ -857,3 +857,204 @@ def wait_for_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         audit=audit,
         attempts=attempts,
     )
+
+
+def observe_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return root-level controls from the CDP backend without subtree expansion."""
+    params = dict(params) if params is not None else _read_params()
+    session_id = _safe_session_id(params.get("session_id"))
+    state = _load_state(session_id)
+    policy = _policy_from_params(params)
+    max_roots = max(1, min(100, int(params.get("max_roots") or 20)))
+
+    if not policy.allow_snapshot:
+        return skill_error(
+            "ui_control observation disabled by policy",
+            UiErrorCode.POLICY_DISABLED,
+            error_code=UiErrorCode.POLICY_DISABLED,
+        )
+    if not _window_allowed(state, policy):
+        return skill_error(
+            "scoped Chrome window is not allowed by policy",
+            UiErrorCode.MISSING_WINDOW,
+            error_code=UiErrorCode.MISSING_WINDOW,
+        )
+
+    try:
+        state = _refresh_from_browser(_ensure_chrome(state))
+    except Exception as exc:
+        return _backend_unavailable(exc, state)
+    _save_state(state)
+
+    snapshot = _snapshot_dict(state)
+    all_roots = list(snapshot["root"].get("children", []) or [])
+    total_roots = len(all_roots)
+    truncated = total_roots > max_roots
+
+    roots = []
+    for child in all_roots[:max_roots]:
+        stripped = dict(child)
+        child_count = len(stripped.get("children", []) or [])
+        stripped["children"] = []
+        stripped["child_count"] = child_count
+        roots.append(stripped)
+
+    return skill_success(
+        f"Observed {len(roots)} root-level control(s).",
+        prompt="Use ui_control__expand to drill into a node, or ui_control__inspect for details.",
+        session_id=session_id,
+        snapshot_id=snapshot["metadata"]["snapshot_id"],
+        roots=roots,
+        total_roots=total_roots,
+        truncated=truncated,
+    )
+
+
+def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return direct children of a specific control from the CDP backend."""
+    params = dict(params) if params is not None else _read_params()
+    session_id = _safe_session_id(params.get("session_id"))
+    state = _load_state(session_id)
+    policy = _policy_from_params(params)
+    control_id = str(params.get("control_id") or "")
+    max_children = max(1, min(200, int(params.get("max_children") or 50)))
+
+    if not policy.allow_find:
+        return skill_error(
+            "ui_control find disabled by policy",
+            UiErrorCode.POLICY_DISABLED,
+            error_code=UiErrorCode.POLICY_DISABLED,
+        )
+    if not _window_allowed(state, policy):
+        return skill_error(
+            "scoped Chrome window is not allowed by policy",
+            UiErrorCode.MISSING_WINDOW,
+            error_code=UiErrorCode.MISSING_WINDOW,
+        )
+    if not control_id:
+        return skill_error(
+            "control_id is required for expand",
+            UiErrorCode.INVALID_ACTION,
+            error_code=UiErrorCode.INVALID_ACTION,
+        )
+
+    snapshot = _snapshot_dict(state)
+    parent = _find_by_id(snapshot, control_id)
+    if not parent:
+        return skill_error(
+            f"control {control_id!r} not found; refresh observation",
+            UiErrorCode.NOT_FOUND,
+            error_code=UiErrorCode.NOT_FOUND,
+            session_id=session_id,
+        )
+
+    all_children = list(parent.get("children", []) or [])
+    total_children = len(all_children)
+    truncated = total_children > max_children
+
+    children = []
+    for child in all_children[:max_children]:
+        stripped = dict(child)
+        grandchild_count = len(stripped.get("children", []) or [])
+        stripped["children"] = []
+        stripped["child_count"] = grandchild_count
+        children.append(stripped)
+
+    return skill_success(
+        f"Expanded {control_id!r}: {len(children)} direct child(ren).",
+        prompt="Use ui_control__expand again to drill deeper, or ui_control__inspect for details on a child.",
+        session_id=session_id,
+        snapshot_id=snapshot["metadata"]["snapshot_id"],
+        control_id=control_id,
+        children=children,
+        total_children=total_children,
+        truncated=truncated,
+    )
+
+
+def inspect_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return detailed properties of a specific control from the CDP backend."""
+    params = dict(params) if params is not None else _read_params()
+    session_id = _safe_session_id(params.get("session_id"))
+    state = _load_state(session_id)
+    policy = _policy_from_params(params)
+    control_id = str(params.get("control_id") or "")
+
+    if not policy.allow_find:
+        return skill_error(
+            "ui_control find disabled by policy",
+            UiErrorCode.POLICY_DISABLED,
+            error_code=UiErrorCode.POLICY_DISABLED,
+        )
+    if not _window_allowed(state, policy):
+        return skill_error(
+            "scoped Chrome window is not allowed by policy",
+            UiErrorCode.MISSING_WINDOW,
+            error_code=UiErrorCode.MISSING_WINDOW,
+        )
+    if not control_id:
+        return skill_error(
+            "control_id is required for inspect",
+            UiErrorCode.INVALID_ACTION,
+            error_code=UiErrorCode.INVALID_ACTION,
+        )
+
+    snapshot = _snapshot_dict(state)
+    node = _find_by_id(snapshot, control_id)
+    if not node:
+        return skill_error(
+            f"control {control_id!r} not found; refresh observation",
+            UiErrorCode.NOT_FOUND,
+            error_code=UiErrorCode.NOT_FOUND,
+            session_id=session_id,
+        )
+
+    role = str(node.get("role") or "unknown")
+    is_text_field = role == "text_field"
+    is_checkbox = role == "checkbox"
+    is_button = role == "button"
+
+    patterns = []
+    actions = []
+    if is_text_field:
+        patterns = ["ValuePattern", "TextPattern"]
+        actions = ["set_text", "focus"]
+    elif is_checkbox:
+        patterns = ["TogglePattern"]
+        actions = ["toggle", "set_checked", "click"]
+    elif is_button:
+        patterns = ["InvokePattern"]
+        actions = ["click"]
+    elif role in ("link", "list_item", "menu_item", "combo_box", "option", "listbox"):
+        patterns = ["SelectionItemPattern"]
+        actions = ["click", "focus"]
+
+    detail = {
+        "id": node.get("id", ""),
+        "role": role,
+        "enabled": bool(node.get("enabled", True)),
+        "visible": bool(node.get("visible", True)),
+        "focused": snapshot.get("focus_id") == node.get("id"),
+        "label": node.get("label"),
+        "text": node.get("text"),
+        "object_name": node.get("object_name"),
+        "tooltip": node.get("tooltip"),
+        "bounds": node.get("bounds"),
+        "value": node.get("value"),
+        "checked": node.get("checked"),
+        "child_count": len(node.get("children", []) or []),
+        "supported_patterns": patterns,
+        "supported_actions": actions,
+        "is_keyboard_focusable": role in ("text_field", "button", "checkbox", "combo_box", "link"),
+        "is_password": role == "password",
+        "tree_path": None,
+        "metadata": {"backend": "chrome-cdp"},
+    }
+
+    return skill_success(
+        f"Inspected control {control_id!r} ({detail['role']}).",
+        prompt="Use ui_control__act with this control_id, or ui_control__expand to see its children.",
+        session_id=session_id,
+        snapshot_id=snapshot["metadata"]["snapshot_id"],
+        control=detail,
+    )

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_entrypoint.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_entrypoint.py
@@ -317,3 +317,18 @@ def wait_for_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
 def stop_computer_use_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Dispatch ui_control__stop_computer_use to the selected backend."""
     return _call("stop_computer_use_tool", params)
+
+
+def observe_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Dispatch ui_control__observe to the selected backend."""
+    return _call("observe_tool", params)
+
+
+def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Dispatch ui_control__expand to the selected backend."""
+    return _call("expand_tool", params)
+
+
+def inspect_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Dispatch ui_control__inspect to the selected backend."""
+    return _call("inspect_tool", params)

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_progressive_query.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_progressive_query.py
@@ -1,0 +1,192 @@
+"""Shared progressive query helpers for mock, CDP, and Windows UIA backends.
+
+Each backend supplies a snapshot dictionary and its own find_by_id callback;
+the core observe/expand/inspect logic is backend-agnostic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+
+
+def _find_by_id(snapshot: Dict[str, Any], control_id: str) -> Optional[Dict[str, Any]]:
+    """Walk a UiSnapshot dict breadth-first and return the first node with a matching id."""
+    root = snapshot.get("root")
+    if not isinstance(root, dict):
+        return None
+    queue: List[Dict[str, Any]] = [root]
+    while queue:
+        node = queue.pop(0)
+        if node.get("id") == control_id:
+            return node
+        for child in node.get("children", []) or []:
+            if isinstance(child, dict):
+                queue.append(child)
+    return None
+
+
+def _strip_children(node: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of node with children collapsed to child_count."""
+    stripped = dict(node)
+    child_count = len(stripped.get("children", []) or [])
+    stripped["children"] = []
+    stripped["child_count"] = child_count
+    return stripped
+
+
+def observe_from_snapshot(
+    snapshot: Dict[str, Any],
+    max_roots: int,
+) -> Dict[str, Any]:
+    """Return root-level controls without expanding children.
+
+    Returns (roots, total_roots, truncated).
+    """
+    all_roots = list(snapshot.get("root", {}).get("children", []) or [])
+    total_roots = len(all_roots)
+    truncated = total_roots > max_roots
+
+    roots = [_strip_children(child) for child in all_roots[:max_roots]]
+    return {"roots": roots, "total_roots": total_roots, "truncated": truncated}
+
+
+def expand_from_snapshot(
+    snapshot: Dict[str, Any],
+    control_id: str,
+    max_children: int,
+) -> Optional[Dict[str, Any]]:
+    """Return direct children of a specific control node.
+
+    Returns None when control_id is not found.
+    """
+    parent = _find_by_id(snapshot, control_id)
+    if not parent:
+        return None
+
+    all_children = list(parent.get("children", []) or [])
+    total_children = len(all_children)
+    truncated = total_children > max_children
+
+    children = [_strip_children(child) for child in all_children[:max_children]]
+    return {
+        "control_id": control_id,
+        "children": children,
+        "total_children": total_children,
+        "truncated": truncated,
+    }
+
+
+def _compute_tree_path(snapshot_root: Dict[str, Any], target_id: str) -> str:
+    """Compute a dot-separated index path from root to target_id."""
+    queue: List[tuple] = [(snapshot_root, "")]
+    while queue:
+        node, prefix = queue.pop(0)
+        children = node.get("children", []) or []
+        for idx, child in enumerate(children):
+            if not isinstance(child, dict):
+                continue
+            path = f"{prefix}{idx}" if prefix else str(idx)
+            if child.get("id") == target_id:
+                return path
+            queue.append((child, path + "."))
+    return ""
+
+
+def _classify_role(role: str) -> Dict[str, Any]:
+    """Return patterns, actions, and keyboard focusability for a role."""
+    role = str(role).lower()
+    if role == "text_field":
+        return {
+            "patterns": ["ValuePattern", "TextPattern"],
+            "actions": ["set_text", "focus"],
+            "is_keyboard_focusable": True,
+        }
+    if role == "checkbox":
+        return {
+            "patterns": ["TogglePattern"],
+            "actions": ["toggle", "set_checked", "click"],
+            "is_keyboard_focusable": True,
+        }
+    if role == "button":
+        return {
+            "patterns": ["InvokePattern"],
+            "actions": ["click"],
+            "is_keyboard_focusable": True,
+        }
+    if role in ("link", "menu_item", "combo_box", "list_item"):
+        return {
+            "patterns": ["SelectionItemPattern"],
+            "actions": ["click", "focus"],
+            "is_keyboard_focusable": True,
+        }
+    if role == "password":
+        return {
+            "patterns": ["ValuePattern"],
+            "actions": ["set_text", "focus"],
+            "is_keyboard_focusable": True,
+            "is_password": True,
+        }
+    return {
+        "patterns": [],
+        "actions": ["click", "focus"],
+        "is_keyboard_focusable": False,
+    }
+
+
+def build_control_detail(
+    node: Dict[str, Any],
+    snapshot: Dict[str, Any],
+    backend_name: str,
+    override_fields: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a UiControlDetail dict from a snapshot node.
+
+    Args:
+        node: The raw control node from the snapshot.
+        snapshot: The full snapshot dict (for focus_id lookup).
+        backend_name: Label for the metadata.backend field.
+        override_fields: Optional dict of field name mappings for backend-specific
+            keys (e.g. windows-uia uses 'name' instead of 'label').
+    """
+    override = override_fields or {}
+
+    role = str(
+        node.get(override.get("role_key", "role"))
+        or node.get("control_type")
+        or "unknown"
+    )
+    classified = _classify_role(role)
+
+    detail: Dict[str, Any] = {
+        "id": node.get(override.get("id_key", "id"), node.get("id", "")),
+        "role": role,
+        "enabled": bool(node.get(override.get("enabled_key", "enabled"), True)),
+        "visible": bool(node.get(override.get("visible_key", "visible"), True)),
+        "focused": node.get(override.get("focused_key", "focused"))
+        or node.get("has_focus")
+        or snapshot.get("focus_id") == node.get("id")
+        or False,
+        "label": node.get(override.get("label_key", "label"))
+        or node.get("name"),
+        "text": node.get(override.get("text_key", "text")),
+        "object_name": node.get(override.get("object_name_key", "object_name"))
+        or node.get("automation_id"),
+        "tooltip": node.get(override.get("tooltip_key", "tooltip"))
+        or node.get("help_text"),
+        "bounds": node.get(override.get("bounds_key", "bounds")),
+        "value": node.get(override.get("value_key", "value")),
+        "checked": node.get(override.get("checked_key", "checked")),
+        "child_count": len(node.get("children", []) or []),
+        "supported_patterns": classified.get("patterns", []),
+        "supported_actions": classified.get("actions", []),
+        "is_keyboard_focusable": classified.get("is_keyboard_focusable", False),
+        "is_password": node.get("is_password") or role == "password" or False,
+        "tree_path": _compute_tree_path(snapshot.get("root", {}), node.get("id", "")),
+        "metadata": {"backend": backend_name},
+    }
+
+    return detail

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.py
@@ -795,6 +795,8 @@ def wait_for_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
 @_serialize_session_call
 def observe_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Return root-level controls from the Windows UIA backend without subtree expansion."""
+    _progressive = _load_sibling("_progressive_query")
+
     params = dict(params or {})
     session_id = _safe_session_id(params.get("session_id"))
     policy = _policy_from_params(params)
@@ -807,38 +809,28 @@ def observe_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
             error_code=UiErrorCode.POLICY_DISABLED,
         )
 
-    # Use accessibility snapshot to get the UIA tree
     capture = _capture_accessibility_snapshot(session_id, policy, params)
     if not capture.get("success"):
         return capture
 
-    snapshot = capture["snapshot"]
-    all_roots = list(snapshot.get("root", {}).get("children", []) or [])
-    total_roots = len(all_roots)
-    truncated = total_roots > max_roots
-
-    roots = []
-    for child in all_roots[:max_roots]:
-        stripped = dict(child) if isinstance(child, dict) else {"id": str(child), "role": "unknown"}
-        child_count = len(stripped.get("children", []) or [])
-        stripped["children"] = []
-        stripped["child_count"] = child_count
-        roots.append(stripped)
+    result = _progressive.observe_from_snapshot(capture["snapshot"], max_roots)
 
     return skill_success(
-        f"Observed {len(roots)} root-level control(s).",
+        f"Observed {len(result['roots'])} root-level control(s).",
         prompt="Use ui_control__expand to drill into a node, or ui_control__inspect for details.",
         session_id=session_id,
         snapshot_id=capture.get("snapshot_id"),
-        roots=roots,
-        total_roots=total_roots,
-        truncated=truncated,
+        roots=result["roots"],
+        total_roots=result["total_roots"],
+        truncated=result["truncated"],
     )
 
 
 @_serialize_session_call
 def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Return direct children of a specific control from the Windows UIA backend."""
+    _progressive = _load_sibling("_progressive_query")
+
     params = dict(params or {})
     session_id = _safe_session_id(params.get("session_id"))
     policy = _policy_from_params(params)
@@ -862,8 +854,8 @@ def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     if not capture.get("success"):
         return capture
 
-    parent = _find_by_id(capture["snapshot"], control_id)
-    if not parent:
+    result = _progressive.expand_from_snapshot(capture["snapshot"], control_id, max_children)
+    if result is None:
         return skill_error(
             f"control {control_id!r} not found; refresh observation",
             UiErrorCode.NOT_FOUND,
@@ -871,33 +863,23 @@ def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
             session_id=session_id,
         )
 
-    all_children = list(parent.get("children", []) or [])
-    total_children = len(all_children)
-    truncated = total_children > max_children
-
-    children = []
-    for child in all_children[:max_children]:
-        stripped = dict(child) if isinstance(child, dict) else {"id": str(child), "role": "unknown"}
-        grandchild_count = len(stripped.get("children", []) or [])
-        stripped["children"] = []
-        stripped["child_count"] = grandchild_count
-        children.append(stripped)
-
     return skill_success(
-        f"Expanded {control_id!r}: {len(children)} direct child(ren).",
+        f"Expanded {control_id!r}: {len(result['children'])} direct child(ren).",
         prompt="Use ui_control__expand again to drill deeper, or ui_control__inspect for details on a child.",
         session_id=session_id,
         snapshot_id=capture.get("snapshot_id"),
-        control_id=control_id,
-        children=children,
-        total_children=total_children,
-        truncated=truncated,
+        control_id=result["control_id"],
+        children=result["children"],
+        total_children=result["total_children"],
+        truncated=result["truncated"],
     )
 
 
 @_serialize_session_call
 def inspect_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Return detailed properties of a specific control from the Windows UIA backend."""
+    _progressive = _load_sibling("_progressive_query")
+
     params = dict(params or {})
     session_id = _safe_session_id(params.get("session_id"))
     policy = _policy_from_params(params)
@@ -920,7 +902,7 @@ def inspect_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     if not capture.get("success"):
         return capture
 
-    node = _find_by_id(capture["snapshot"], control_id)
+    node = _progressive._find_by_id(capture["snapshot"], control_id)
     if not node:
         return skill_error(
             f"control {control_id!r} not found; refresh observation",
@@ -929,28 +911,15 @@ def inspect_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
             session_id=session_id,
         )
 
-    role = str(node.get("role") or node.get("control_type") or "unknown")
-    detail = {
-        "id": node.get("id", control_id),
-        "role": role,
-        "enabled": bool(node.get("enabled", True)),
-        "visible": bool(node.get("visible", True)),
-        "focused": node.get("focused") or node.get("has_focus") or False,
-        "label": node.get("label") or node.get("name"),
-        "text": node.get("text"),
-        "object_name": node.get("object_name") or node.get("automation_id"),
-        "tooltip": node.get("tooltip") or node.get("help_text"),
-        "bounds": node.get("bounds"),
-        "value": node.get("value"),
-        "checked": node.get("checked"),
-        "child_count": len(node.get("children", []) or []),
-        "supported_patterns": node.get("supported_patterns", []) or [],
-        "supported_actions": node.get("supported_actions", []) or [],
-        "is_keyboard_focusable": bool(node.get("is_keyboard_focusable", False)),
-        "is_password": bool(node.get("is_password", False)),
-        "tree_path": node.get("tree_path"),
-        "metadata": {"backend": "windows-ui-control-host"},
+    override = {
+        "label_key": "name",
+        "object_name_key": "automation_id",
+        "tooltip_key": "help_text",
+        "role_key": "control_type",
     }
+    detail = _progressive.build_control_detail(
+        node, capture["snapshot"], "windows-ui-control-host", override
+    )
 
     return skill_success(
         f"Inspected control {control_id!r} ({detail['role']}).",

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.py
@@ -792,6 +792,175 @@ def wait_for_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         time.sleep(min(interval_ms / 1000.0, max(0.0, deadline - time.monotonic())))
 
 
+@_serialize_session_call
+def observe_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return root-level controls from the Windows UIA backend without subtree expansion."""
+    params = dict(params or {})
+    session_id = _safe_session_id(params.get("session_id"))
+    policy = _policy_from_params(params)
+    max_roots = max(1, min(100, int(params.get("max_roots") or 20)))
+
+    if not policy.allow_snapshot and not policy.allow_find:
+        return skill_error(
+            "ui_control observation disabled by policy",
+            UiErrorCode.POLICY_DISABLED,
+            error_code=UiErrorCode.POLICY_DISABLED,
+        )
+
+    # Use accessibility snapshot to get the UIA tree
+    capture = _capture_accessibility_snapshot(session_id, policy, params)
+    if not capture.get("success"):
+        return capture
+
+    snapshot = capture["snapshot"]
+    all_roots = list(snapshot.get("root", {}).get("children", []) or [])
+    total_roots = len(all_roots)
+    truncated = total_roots > max_roots
+
+    roots = []
+    for child in all_roots[:max_roots]:
+        stripped = dict(child) if isinstance(child, dict) else {"id": str(child), "role": "unknown"}
+        child_count = len(stripped.get("children", []) or [])
+        stripped["children"] = []
+        stripped["child_count"] = child_count
+        roots.append(stripped)
+
+    return skill_success(
+        f"Observed {len(roots)} root-level control(s).",
+        prompt="Use ui_control__expand to drill into a node, or ui_control__inspect for details.",
+        session_id=session_id,
+        snapshot_id=capture.get("snapshot_id"),
+        roots=roots,
+        total_roots=total_roots,
+        truncated=truncated,
+    )
+
+
+@_serialize_session_call
+def expand_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return direct children of a specific control from the Windows UIA backend."""
+    params = dict(params or {})
+    session_id = _safe_session_id(params.get("session_id"))
+    policy = _policy_from_params(params)
+    control_id = str(params.get("control_id") or "")
+    max_children = max(1, min(200, int(params.get("max_children") or 50)))
+
+    if not policy.allow_find:
+        return skill_error(
+            "ui_control find disabled by policy",
+            UiErrorCode.POLICY_DISABLED,
+            error_code=UiErrorCode.POLICY_DISABLED,
+        )
+    if not control_id:
+        return skill_error(
+            "control_id is required for expand",
+            UiErrorCode.INVALID_ACTION,
+            error_code=UiErrorCode.INVALID_ACTION,
+        )
+
+    capture = _capture_accessibility_snapshot(session_id, policy, params)
+    if not capture.get("success"):
+        return capture
+
+    parent = _find_by_id(capture["snapshot"], control_id)
+    if not parent:
+        return skill_error(
+            f"control {control_id!r} not found; refresh observation",
+            UiErrorCode.NOT_FOUND,
+            error_code=UiErrorCode.NOT_FOUND,
+            session_id=session_id,
+        )
+
+    all_children = list(parent.get("children", []) or [])
+    total_children = len(all_children)
+    truncated = total_children > max_children
+
+    children = []
+    for child in all_children[:max_children]:
+        stripped = dict(child) if isinstance(child, dict) else {"id": str(child), "role": "unknown"}
+        grandchild_count = len(stripped.get("children", []) or [])
+        stripped["children"] = []
+        stripped["child_count"] = grandchild_count
+        children.append(stripped)
+
+    return skill_success(
+        f"Expanded {control_id!r}: {len(children)} direct child(ren).",
+        prompt="Use ui_control__expand again to drill deeper, or ui_control__inspect for details on a child.",
+        session_id=session_id,
+        snapshot_id=capture.get("snapshot_id"),
+        control_id=control_id,
+        children=children,
+        total_children=total_children,
+        truncated=truncated,
+    )
+
+
+@_serialize_session_call
+def inspect_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return detailed properties of a specific control from the Windows UIA backend."""
+    params = dict(params or {})
+    session_id = _safe_session_id(params.get("session_id"))
+    policy = _policy_from_params(params)
+    control_id = str(params.get("control_id") or "")
+
+    if not policy.allow_find:
+        return skill_error(
+            "ui_control find disabled by policy",
+            UiErrorCode.POLICY_DISABLED,
+            error_code=UiErrorCode.POLICY_DISABLED,
+        )
+    if not control_id:
+        return skill_error(
+            "control_id is required for inspect",
+            UiErrorCode.INVALID_ACTION,
+            error_code=UiErrorCode.INVALID_ACTION,
+        )
+
+    capture = _capture_accessibility_snapshot(session_id, policy, params)
+    if not capture.get("success"):
+        return capture
+
+    node = _find_by_id(capture["snapshot"], control_id)
+    if not node:
+        return skill_error(
+            f"control {control_id!r} not found; refresh observation",
+            UiErrorCode.NOT_FOUND,
+            error_code=UiErrorCode.NOT_FOUND,
+            session_id=session_id,
+        )
+
+    role = str(node.get("role") or node.get("control_type") or "unknown")
+    detail = {
+        "id": node.get("id", control_id),
+        "role": role,
+        "enabled": bool(node.get("enabled", True)),
+        "visible": bool(node.get("visible", True)),
+        "focused": node.get("focused") or node.get("has_focus") or False,
+        "label": node.get("label") or node.get("name"),
+        "text": node.get("text"),
+        "object_name": node.get("object_name") or node.get("automation_id"),
+        "tooltip": node.get("tooltip") or node.get("help_text"),
+        "bounds": node.get("bounds"),
+        "value": node.get("value"),
+        "checked": node.get("checked"),
+        "child_count": len(node.get("children", []) or []),
+        "supported_patterns": node.get("supported_patterns", []) or [],
+        "supported_actions": node.get("supported_actions", []) or [],
+        "is_keyboard_focusable": bool(node.get("is_keyboard_focusable", False)),
+        "is_password": bool(node.get("is_password", False)),
+        "tree_path": node.get("tree_path"),
+        "metadata": {"backend": "windows-ui-control-host"},
+    }
+
+    return skill_success(
+        f"Inspected control {control_id!r} ({detail['role']}).",
+        prompt="Use ui_control__act with this control_id, or ui_control__expand to see its children.",
+        session_id=session_id,
+        snapshot_id=capture.get("snapshot_id"),
+        control=detail,
+    )
+
+
 def request_stop() -> None:
     """Interrupt package waits and request immediate host-session stops."""
     _STOP_EVENT.set()

--- a/python/dcc_mcp_core/skills/ui-control/scripts/expand.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/expand.py
@@ -1,0 +1,19 @@
+"""ui_control__expand entry point."""
+
+from __future__ import annotations
+
+if __package__:
+    from ._entrypoint import emit
+    from ._entrypoint import expand_tool
+else:
+    from _entrypoint import emit
+    from _entrypoint import expand_tool
+
+
+def main(**kwargs):
+    """Run the tool in an in-process DCC executor."""
+    return expand_tool(kwargs)
+
+
+if __name__ == "__main__":
+    emit(expand_tool())

--- a/python/dcc_mcp_core/skills/ui-control/scripts/inspect_control.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/inspect_control.py
@@ -1,0 +1,19 @@
+"""ui_control__inspect entry point."""
+
+from __future__ import annotations
+
+if __package__:
+    from ._entrypoint import emit
+    from ._entrypoint import inspect_tool
+else:
+    from _entrypoint import emit
+    from _entrypoint import inspect_tool
+
+
+def main(**kwargs):
+    """Run the tool in an in-process DCC executor."""
+    return inspect_tool(kwargs)
+
+
+if __name__ == "__main__":
+    emit(inspect_tool())

--- a/python/dcc_mcp_core/skills/ui-control/scripts/observe.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/observe.py
@@ -1,0 +1,19 @@
+"""ui_control__observe entry point."""
+
+from __future__ import annotations
+
+if __package__:
+    from ._entrypoint import emit
+    from ._entrypoint import observe_tool
+else:
+    from _entrypoint import emit
+    from _entrypoint import observe_tool
+
+
+def main(**kwargs):
+    """Run the tool in an in-process DCC executor."""
+    return observe_tool(kwargs)
+
+
+if __name__ == "__main__":
+    emit(observe_tool())

--- a/python/dcc_mcp_core/skills/ui-control/tools.yaml
+++ b/python/dcc_mcp_core/skills/ui-control/tools.yaml
@@ -544,3 +544,186 @@ tools:
       on-success:
         - ui_control__snapshot
         - ui_control__stop_computer_use
+
+  - name: observe
+    description: >-
+      Return top-level root controls of the scoped application window without
+      expanding their children. This is the first step in the progressive
+      semantic UI tree query chain: observe → expand → inspect → act.
+
+      Unlike ui_control__snapshot which returns the full UIA tree, observe only
+      returns root-level nodes with minimal metadata. Use this to get a
+      high-level view of the window structure before drilling down with expand
+      and inspect. Each root node reports its child_count so agents can decide
+      whether to expand.
+
+      Prefer this progressive path over snapshot when you only need structural
+      navigation and don't need pixel data. For visual verification or
+      coordinate-based actions, use snapshot instead.
+    input_schema:
+      type: object
+      properties:
+        session_id:
+          type: string
+          description: "ui_control session id. Defaults to 'default'."
+        process_id:
+          type: integer
+          description: "Process id that owns the scoped application window."
+        window_handle:
+          type: integer
+          description: "Native handle of the scoped application window."
+        window_title:
+          type: string
+          description: "Title substring for the scoped application window."
+        process_name:
+          type: string
+          description: "Process name used to resolve the scoped application window."
+        max_roots:
+          type: integer
+          default: 20
+          minimum: 1
+          maximum: 100
+          description: "Maximum root-level controls to return."
+        policy:
+          type: object
+          description: "Optional ui_control policy override for this call."
+    read_only: true
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 5
+    source_file: scripts/observe.py
+    requires_in_process: true
+    next-tools:
+      on-success:
+        - ui_control__expand
+        - ui_control__inspect
+        - ui_control__find
+        - ui_control__snapshot
+
+  - name: expand
+    description: >-
+      Expand a specific control node to reveal its direct children. This is the
+      second step in the progressive semantic UI tree query chain. Call this
+      after observe or a previous expand to drill down into the control tree
+      one level at a time.
+
+      Each returned child node includes its child_count and bounds (when
+      available), so agents can iteratively explore the tree without ever
+      loading the full snapshot. Combine with inspect for detailed properties of
+      a specific child before deciding whether to act on it or expand further.
+
+      On failure (stale_control), re-observe and restart the drill-down from
+      the root.
+    input_schema:
+      type: object
+      required: [control_id]
+      properties:
+        session_id:
+          type: string
+          description: "ui_control session id. Defaults to 'default'."
+        process_id:
+          type: integer
+          description: "Process id that owns the scoped application window."
+        window_handle:
+          type: integer
+          description: "Native handle of the scoped application window."
+        window_title:
+          type: string
+          description: "Title substring for the scoped application window."
+        process_name:
+          type: string
+          description: "Process name used to resolve the scoped application window."
+        control_id:
+          type: string
+          minLength: 1
+          description: "Control id from a prior observe, expand, or find result."
+        max_children:
+          type: integer
+          default: 50
+          minimum: 1
+          maximum: 200
+          description: "Maximum direct children to return."
+        policy:
+          type: object
+          description: "Optional ui_control policy override for this call."
+    read_only: true
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 5
+    source_file: scripts/expand.py
+    requires_in_process: true
+    next-tools:
+      on-success:
+        - ui_control__expand
+        - ui_control__inspect
+        - ui_control__find
+        - ui_control__act
+
+  - name: inspect
+    description: >-
+      Return detailed properties of a specific control identified by control_id
+      from a prior observe, expand, or find result. This is the final
+      inspection step in the progressive query chain before acting.
+
+      Returns richer metadata than find: bounds, enabled/visible/focused state,
+      child_count, supported UIA patterns and actions, keyboard-focusability,
+      password-field detection, and tree position. Use this to verify a
+      control's capabilities before calling ui_control__act.
+
+      On failure (stale_control), re-observe and restart the drill-down.
+    input_schema:
+      type: object
+      required: [control_id]
+      properties:
+        session_id:
+          type: string
+          description: "ui_control session id. Defaults to 'default'."
+        process_id:
+          type: integer
+          description: "Process id that owns the scoped application window."
+        window_handle:
+          type: integer
+          description: "Native handle of the scoped application window."
+        window_title:
+          type: string
+          description: "Title substring for the scoped application window."
+        process_name:
+          type: string
+          description: "Process name used to resolve the scoped application window."
+        control_id:
+          type: string
+          minLength: 1
+          description: "Control id from a prior observe, expand, or find result."
+        policy:
+          type: object
+          description: "Optional ui_control policy override for this call."
+    read_only: true
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 5
+    source_file: scripts/inspect_control.py
+    requires_in_process: true
+    next-tools:
+      on-success:
+        - ui_control__act
+        - ui_control__expand
+        - ui_control__find
+        - ui_control__snapshot


### PR DESCRIPTION
## Summary

Implements PIP-2781 — progressive semantic UI tree query chain for the UI Control system: `observe → expand → inspect → act`.

This provides agent-friendly UI tree navigation without requiring full snapshot dumps. Agents can now drill down the UI tree progressively, one level at a time, rather than loading the entire UIA tree on every interaction.

## Changes

### New Tools

| Tool | Description |
|------|-------------|
| `ui_control__observe` | Return root-level controls with `child_count`, no full subtree |
| `ui_control__expand` | Expand a specific `control_id` to reveal direct children |
| `ui_control__inspect` | Return detailed properties (bounds, patterns, actions, focusability, tree position) |

### Files Changed

- **Rust contracts**: `UiObserveRequest`, `UiExpandRequest`, `UiInspectRequest`, `UiControlDetail` types
- **Python dataclasses**: Matching types in `adapter_contracts.py`
- **Backends**: Implementations for mock, chrome-cdp, and windows-uia backends
- **tools.yaml**: Registered with schemas, annotations, and next-tools chains
- **SKILL.md**: Progressive query workflow documented with examples and comparison table
- **Entry points**: `observe.py`, `expand.py`, `inspect_control.py`

## Validation

- `cargo check` — passes
- `cargo test -p dcc-mcp-ui-control` — 22/22 pass
- Python `py_compile` — all files pass
- Mock backend integration test — observe/expand/inspect functional
- Existing `snapshot` and `find` tools — verified unchanged

## Design

The progressive query chain is read-only and idempotent. It does NOT capture pixels, consume observations, or trigger the visual overlay. Agents can use it freely for structural exploration and switch to `snapshot` only when pixel data or coordinates are needed.

See [PIP-2777](https://github.com/dcc-mcp/dcc-mcp-core/pull/1995) for the original analysis that motivated this design.