### PR TITLE
fix: cap capability manifest records and skill stub budgets

### DIFF
--- a/crates/dcc-mcp-http-server/src/mcp_tool_catalog.rs
+++ b/crates/dcc-mcp-http-server/src/mcp_tool_catalog.rs
@@ -382,9 +382,15 @@ pub fn build_skill_stub(summary: &SkillSummary) -> McpTool {
         !summary.search_hint.is_empty() && summary.search_hint != summary.description;
 
     let description = if has_explicit_hint {
+        const MAX_HINT_LEN: usize = 160;
+        let hint = if summary.search_hint.len() > MAX_HINT_LEN {
+            format!("{}…", &summary.search_hint[..MAX_HINT_LEN])
+        } else {
+            summary.search_hint.clone()
+        };
         format!(
             "[{}] {} tools • keywords: {} • Call load_skill(\"{}\")",
-            summary.dcc, summary.tool_count, summary.search_hint, summary.name
+            summary.dcc, summary.tool_count, hint, summary.name
         )
     } else {
         const PREVIEW_LIMIT: usize = 5;

--- a/python/dcc_mcp_core/capabilities.py
+++ b/python/dcc_mcp_core/capabilities.py
@@ -40,6 +40,7 @@ __all__ = [
 
 _SKILL_STUB_PREFIX = "__skill__"
 _GROUP_STUB_PREFIX = "__group__"
+_MAX_TAGS_PER_RECORD = 8
 
 
 @dataclass(frozen=True)
@@ -168,7 +169,7 @@ class CapabilityManifestBuilder:
                 skill_info.get("description"),
                 "",
             ),
-            200,
+            120,
         )
 
         tags: list[str] = []
@@ -179,7 +180,7 @@ class CapabilityManifestBuilder:
             [action.get("group")],
         ):
             tags.extend(_as_str_list(source))
-        tags = sorted({t for t in tags if t})
+        tags = sorted({t for t in tags if t})[:_MAX_TAGS_PER_RECORD]
 
         loaded = self._is_loaded_safe(skill_name) if skill_name else False
         execution = _maybe_str(action.get("execution"))
@@ -233,7 +234,7 @@ class CapabilityManifestBuilder:
             return None
 
         backend_tool = "{}__{}".format(skill_name.replace("-", "_"), tool_name)
-        summary = _truncate(_first_nonempty(tool.get("summary"), tool.get("description"), ""), 160)
+        summary = _truncate(_first_nonempty(tool.get("summary"), tool.get("description"), ""), 120)
 
         tags: list[str] = []
         for source in (
@@ -243,7 +244,7 @@ class CapabilityManifestBuilder:
             [tool.get("group")],
         ):
             tags.extend(_as_str_list(source))
-        tags = sorted({t for t in tags if t})
+        tags = sorted({t for t in tags if t})[:_MAX_TAGS_PER_RECORD]
 
         schema = tool.get("input_schema") or tool.get("inputSchema")
         has_schema = bool(schema) and not _is_stub(tool_name)

--- a/python/dcc_mcp_core/skills/ui-control/SKILL.md
+++ b/python/dcc_mcp_core/skills/ui-control/SKILL.md
@@ -15,8 +15,8 @@ metadata:
     dcc: python
     version: "0.4.0"
     layer: infrastructure
-    search-hint: "dcc ui control, ui-control, ui control, ui automation, exact window recording, gameplay capture, game pv capture, jpeg sequence, frame hash, operate control menu dialog window button click keyboard, windows uia, chrome cdp, edge cdp, agent-browser, modal, settings panel, screenshot, snapshot, find control, custom control, face shaping, sculpt slider, modifier drag, registry, symlink, plugin setup, remote control, scroll, type, keypress, wait for ui, stale control, dcc debugging, operate maya menu, click button in dialog, fill form in 3ds max, 操作, 控制, 界面, 菜单, 弹窗, 窗口, 按钮, 点击, 键盘, 录制游戏, 游戏PV, 捏脸, 操控界面, 点击菜单, 自动化窗口, 界面自动化, 窗口操作, 控件识别"
-    tags: "ui-control, dcc-ui-control, ui-automation, exact-window-recording, gameplay-capture, game-pv, windows-uia, chrome-cdp, edge-cdp, agent-browser, diagnostics, infrastructure, mock, maya-ui, blender-ui, 3dsmax-ui, houdini-ui, photoshop-ui, unreal-ui, unity-ui, zbrush-ui"
+    search-hint: "dcc ui control, ui automation, windows uia, chrome cdp, edge cdp, screenshot snapshot, click type keypress, scroll wait find, window recording, gameplay capture, control menu dialog, plugin setup, registry symlink"
+    tags: "ui-control, ui-automation, windows-uia, dcc-ui-control, chrome-cdp, diagnostics, infrastructure, game-pv"
     tools: tools.yaml
 ---
 


### PR DESCRIPTION
## Problem

Three pre-existing test failures on dcc-mcp-maya main (all related to manifest/stub size budgets):

| Test | Root Cause |
|------|-----------|
| `test_capability_manifest_respects_token_budget` | `ui_control__*` tool records exceed 640B per-record budget (744–774B) |
| `test_manifest_per_record_cost_is_bounded` | Same — 21 tags + 160-char summary overflow per-record budget |
| `test_minimal_mode_skill_stubs_dont_leak_schemas` | `__skill__ui-control` stub 1065B exceeds 1KB budget |

These failures originate in dcc-mcp-core (the manifest builder and skill stub code) but affect dcc-mcp-maya CI.

## Fix

### `capabilities.py` — Cap tag count and summary truncation
- `_MAX_TAGS_PER_RECORD = 8` — caps tags per record (was unlimited, ui-control had 21)
- Summary truncation reduced from 200→120 chars for skill records
- Summary truncation reduced from 160→120 chars for tool records

### `mcp_tool_catalog.rs` — Truncate search_hint in skill stubs
- Clamp `search_hint` to 160 chars when building `__skill__` stubs
- Prevents the 680+ char ui-control search_hint from overflowing the 1KB stub budget

### `SKILL.md` — Shorter metadata (immediate fix for existing wheels)
- Reduce `search-hint` from ~680 chars to ~200 chars
- Reduce `tags` from 21 to 8

## Related

- [PIP-2852](https://github.com/dcc-mcp/dcc-mcp-maya/issues) — tracks the 4 pre-existing failures
- Companion dcc-mcp-maya fix for the sidecar PID test is in a separate PR