### PR TITLE
fix: clippy unused variable `cached_controls` → `_cached_controls`

### DIFF
--- a/crates/dcc-mcp-computer-use/src/ui_control_host.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host.rs
@@ -1099,7 +1099,7 @@ fn refresh_action_policy(
         .accessibility_root
         .as_ref()
         .ok_or_else(stale_accessibility_state)?;
-    let (cached_tier, cached_controls) = cached_action_fence(
+    let (cached_tier, _cached_controls) = cached_action_fence(
         action,
         cached_root,
         session.focus_runtime_id.as_deref(),
@@ -1110,7 +1110,7 @@ fn refresh_action_policy(
             cached_tier,
             ActionFenceExpectation {
                 #[cfg(any(windows, test))]
-                controls: cached_controls,
+                controls: _cached_controls,
                 #[cfg(any(windows, test))]
                 observation: session.observation.clone(),
                 #[cfg(windows)]


### PR DESCRIPTION
Cherry-pick to fix the Rust clippy failure on ubuntu-latest.\n\n`cached_controls` at `ui_control_host.rs:1102` is only used under `#[cfg(any(windows, test))]`, causing `-D warnings` to fail on Linux.\n\nRef: [PIP-2890](mention://issue/687e5583-acd7-482a-b8b2-d965b624fb51)