### PR TITLE
fix(py37): keep ui-control entrypoint import-light

### DIFF
--- a/python/dcc_mcp_core/skills/ui-control/scripts/_entrypoint.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_entrypoint.py
@@ -17,9 +17,17 @@ from typing import Callable
 from typing import Dict
 from typing import Optional
 
-from dcc_mcp_core import artefact_put_bytes
-from dcc_mcp_core import artefact_put_file
 from dcc_mcp_core.skill import skill_error
+
+try:
+    from dcc_mcp_core import artefact_put_bytes
+except ImportError:
+    artefact_put_bytes = None
+
+try:
+    from dcc_mcp_core import artefact_put_file
+except ImportError:
+    artefact_put_file = None
 
 _AUDIT_LOCK = threading.Lock()
 _CAPTURE_TTL_SECS = 24 * 60 * 60
@@ -155,7 +163,7 @@ def _attach_capture_artifact(
             return
         mime = str(rich.get("mime") or "image/png").lower()
         extension = {"image/png": "png", "image/jpeg": "jpg", "image/webp": "webp"}.get(mime)
-        if extension is None:
+        if extension is None or artefact_put_bytes is None:
             return
         snapshot_id = str(provenance.get("snapshot_id") or "snapshot")
         display_name = f"ui-control-snapshot-{_artifact_token(session_id)}-{_artifact_token(snapshot_id)}.{extension}"
@@ -182,7 +190,7 @@ def _attach_capture_artifact(
         )
     else:
         clip = context.get("artifact")
-        if not isinstance(clip, dict) or not clip.get("manifest_path"):
+        if not isinstance(clip, dict) or not clip.get("manifest_path") or artefact_put_file is None:
             return
         recording_id = str(clip.get("recording_id") or "recording")
         display_name = f"ui-control-recording-{_artifact_token(session_id)}-{_artifact_token(recording_id)}.json"

--- a/tests/test_ui_control_skill.py
+++ b/tests/test_ui_control_skill.py
@@ -51,6 +51,29 @@ def _load_entrypoint_module() -> Any:
     return module
 
 
+def test_ui_control_entrypoint_imports_without_native_core(monkeypatch: Any) -> None:
+    monkeypatch.setitem(sys.modules, "dcc_mcp_core._core", None)
+    entrypoint = _load_entrypoint_module()
+
+    class Backend:
+        @staticmethod
+        def snapshot_tool(_params: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "success": True,
+                "message": "Captured mock snapshot.",
+                "context": {
+                    "session_id": "mock",
+                    "snapshot": {"metadata": {"ui_control": {"backend": "mock"}}},
+                },
+            }
+
+    monkeypatch.setattr(entrypoint, "_load_backend", lambda: Backend)
+
+    result = entrypoint.snapshot_tool({"session_id": "mock"})
+    assert result["success"] is True
+    assert result["context"]["snapshot"]["metadata"]["ui_control"]["backend"] == "mock"
+
+
 def _run_tool(
     name: str,
     payload: dict[str, Any],


### PR DESCRIPTION
Keeps ui-control snapshot/recording entrypoints importable when `dcc_mcp_core._core` is absent, and adds a regression test.

Validation:
- `python -m py_compile python/dcc_mcp_core/skills/ui-control/scripts/_entrypoint.py tests/test_ui_control_skill.py`
- `python -m pytest tests/test_ui_control_skill.py -q`