### PR TITLE
fix(gateway): accept params alias in REST calls

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -1072,7 +1072,8 @@ pub async fn handle_v1_dcc_instance_describe(
 /// via `calls[]`.
 ///
 /// **Single call** (backward compatible):
-/// `{"tool_slug": "...", "arguments": {...}, "meta": {...}}` (meta optional).
+/// `{"tool_slug": "...", "arguments": {...}, "meta": {...}}` (meta optional;
+/// `params` is accepted as an alias for `arguments`).
 ///
 /// **Batch call** (same semantics as `POST /v1/call_batch`):
 /// `{"calls": [{ "tool_slug", "arguments"?, "meta"?, "id"? }, ...],
@@ -1135,21 +1136,24 @@ pub async fn handle_v1_call(
             false,
         );
     };
-    let arguments =
-        match dcc_mcp_jsonrpc::coerce_tool_arguments_object(body.get("arguments").cloned()) {
-            Ok(v) => v,
-            Err(msg) => {
-                let metadata = RestResponseMetadata::from_trace_context(&trace_context)
-                    .with_index_generation(index_generation(&gs.capability_index));
-                return service_error_response_with_metadata(
-                    &headers,
-                    &body,
-                    &ServiceError::new("bad-request", msg),
-                    &metadata,
-                    false,
-                );
-            }
-        };
+    let args = body
+        .get("arguments")
+        .or_else(|| body.get("params"))
+        .cloned();
+    let arguments = match dcc_mcp_jsonrpc::coerce_tool_arguments_object(args) {
+        Ok(v) => v,
+        Err(msg) => {
+            let metadata = RestResponseMetadata::from_trace_context(&trace_context)
+                .with_index_generation(index_generation(&gs.capability_index));
+            return service_error_response_with_metadata(
+                &headers,
+                &body,
+                &ServiceError::new("bad-request", msg),
+                &metadata,
+                false,
+            );
+        }
+    };
     let meta = body.get("meta").cloned();
 
     match call_service_with_admin_trace(

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -1943,8 +1943,13 @@ async fn gateway_rest_v1_call_batch_via_calls_dispatches_batch_response() {
 }
 
 #[tokio::test]
-async fn gateway_rest_v1_call_single_tool_slug_still_works() {
-    let gs = test_gateway_state("1.2.3");
+async fn gateway_rest_v1_call_single_tool_slug_accepts_params_alias() {
+    use crate::gateway::middleware::{AuditMiddleware, MiddlewareChain};
+
+    let sink = Arc::new(CaptureSink::default());
+    let mut gs = test_gateway_state("1.2.3");
+    gs.middleware_chain =
+        Arc::new(MiddlewareChain::new().with_after(Arc::new(AuditMiddleware::new(sink.clone()))));
     // Without a live backend single-call returns SERVICE_UNAVAILABLE,
     // but the dispatch path must still be exercised (backward compat).
     seed_unloaded_render_capability(&gs);
@@ -1954,7 +1959,7 @@ async fn gateway_rest_v1_call_single_tool_slug_still_works() {
         handle_v1_call(
             State(gs),
             HeaderMap::new(),
-            Json(json!({"tool_slug": slug, "arguments": {"radius": 3.0}})),
+            Json(json!({"tool_slug": slug, "params": {"radius": 3.0}})),
         )
         .await,
     )
@@ -1971,4 +1976,14 @@ async fn gateway_rest_v1_call_single_tool_slug_still_works() {
         body.get("success").is_none(),
         "single-call error should NOT have batch 'success' field"
     );
+    let entries = sink.0.lock().unwrap();
+    let input: Value = serde_json::from_str(
+        &entries[0]
+            .input_payload
+            .as_ref()
+            .expect("REST audit should capture call arguments")
+            .content,
+    )
+    .unwrap();
+    assert_eq!(input["radius"], 3.0);
 }


### PR DESCRIPTION
## Summary
- accept `params` as the documented compatibility alias for `arguments` on single `POST /v1/call` requests
- preserve canonical `arguments` precedence when both fields are present
- extend the existing single-call regression to verify the effective audited arguments

## Validation
- Red: alias regression failed with a null audited payload before the fix
- `cargo test -p dcc-mcp-gateway gateway_rest_v1_call -- --nocapture` (5/5, repeated twice)
- `cargo test -p dcc-mcp-gateway --lib` (549/549)
- `cargo fmt --all -- --check`
- `git diff --check`