### PR TITLE
fix(ui-control): acknowledge barrier before cosmetic refresh

### DIFF
--- a/crates/dcc-mcp-computer-use/src/platform/windows.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows.rs
@@ -1463,6 +1463,15 @@ fn session_event_blocked(event: u32) -> Option<bool> {
     }
 }
 
+fn acknowledge_pending_desktop_barrier(
+    barrier: &DesktopEventBarrier,
+    pending_sequence: &mut Option<u32>,
+) {
+    if let Some(sequence) = pending_sequence.take() {
+        barrier.acknowledge(sequence);
+    }
+}
+
 struct BannerRuntimeSignals {
     stop: Arc<AtomicBool>,
     interrupted: Arc<AtomicBool>,
@@ -1603,6 +1612,10 @@ fn run_banner(
                 Err(error) => return Err(error),
             }
         }
+        // The barrier fences the message queue and display-generation update.
+        // Cosmetic overlay repositioning can be slow under RDP and must not
+        // hold the screenshot/input safety handshake open.
+        acknowledge_pending_desktop_barrier(&signals.desktop_barrier, &mut barrier_sequence);
         rect = match available_target_rect_for_process(target, process_id) {
             Ok(rect) => rect,
             Err(error) if error.code == ComputerUseErrorCode::MissingWindow => {
@@ -1631,9 +1644,6 @@ fn run_banner(
             signals.visible.store(true, Ordering::Release);
         }
         record_desktop_transition(&signals.desktop_state, true);
-        if let Some(sequence) = barrier_sequence.take() {
-            signals.desktop_barrier.acknowledge(sequence);
-        }
         thread::sleep(Duration::from_millis(16));
     }
     Ok(())

--- a/crates/dcc-mcp-computer-use/src/platform/windows/input_tests.rs
+++ b/crates/dcc-mcp-computer-use/src/platform/windows/input_tests.rs
@@ -1,6 +1,18 @@
 use super::*;
 
 #[test]
+fn desktop_barrier_acknowledges_before_cosmetic_refresh() {
+    let barrier = DesktopEventBarrier::default();
+    let sequence = barrier.request_sequence();
+    let mut pending = Some(sequence);
+
+    super::super::acknowledge_pending_desktop_barrier(&barrier, &mut pending);
+
+    assert!(barrier.is_acknowledged(sequence));
+    assert!(pending.is_none());
+}
+
+#[test]
 fn action_feedback_preserves_pointer_point_and_safe_input_label() {
     let feedback: Arc<crate::platform::LastActionFeedback> = Arc::new(std::sync::Mutex::new(None));
     publish_action_feedback(&feedback, Some((1920, 1080)), "MOUSE · DRAG".to_owned());


### PR DESCRIPTION
## Summary

- acknowledge the Windows desktop barrier after queued desktop/display events are processed
- keep slow HUD, glow, cursor-ring, and pointer-feedback repositioning outside the safety handshake
- preserve all desktop, PID/HWND, DPI, generation, policy, and input fences

This prevents false `backend_unavailable` snapshot failures on high-DPI RDP desktops where cosmetic overlay refresh can exceed the bounded barrier timeout.

## Validation

- TDD red: `desktop_barrier_acknowledges_before_cosmetic_refresh` failed before the helper existed
- targeted regression: 1/1 passed twice
- full `dcc-mcp-computer-use` library: 170/170 passed twice
- `cargo fmt --all -- --check`
- `cargo clippy -p dcc-mcp-computer-use --all-targets --all-features -- -D warnings`
- patched 0.19.75 Host built and exercised against Tuanjie Editor PID 60272
- pre-fix snapshots failed with `timed out synchronizing pending Windows desktop events; no UI input was sent`
- post-fix native snapshot request `73ec67c6-de2b-4717-9334-046ef6c0c866` returned `windows-ui-control-host`, `pixels_captured=true`, and FileRef `sha256:7ce75e30f74c8bd645106717d230eb7447332076e5f33abcb1dbe51fdef19ee1`
- visible 1.2s pointer move action `action:43fbbdfe4ac1479b887b1e937e14e423` succeeded
- next snapshot request `8168ae34-83bb-476b-a9d3-36e4916620a9` returned a non-baseline UIA delta correlated by `cause_action_id`
- native session stopped with `cleanup_pending=false`