### PR TITLE
feat: ADR-018 unified instance status vocabulary (PIP-2895)

### DIFF
--- a/crates/dcc-mcp-cli/src/application/local_instance.rs
+++ b/crates/dcc-mcp-cli/src/application/local_instance.rs
@@ -228,15 +228,7 @@ pub(crate) fn direct_control_ready(entry: &ServiceEntry) -> bool {
         .get(ROLE_METADATA_KEY)
         .is_some_and(|role| role == ROLE_PER_DCC_SIDECAR);
     let instance_status = InstanceStatus::from_entry(entry, false, is_sidecar);
-    // Per ADR-018: Available/Busy + Unknown is retryable ("try a direct MCP call").
-    // Non-sidecar (direct-mcp embedded) instances do not report dispatch_status,
-    // so Unknown is the expected default and must not block local CLI control.
-    let dispatch_ok = instance_status.dispatch_status
-        == dcc_mcp_transport::discovery::types::DispatchStatus::Ready
-        || (!is_sidecar
-            && instance_status.dispatch_status
-                == dcc_mcp_transport::discovery::types::DispatchStatus::Unknown);
-    dispatch_ok
+    instance_status.dispatch_status == dcc_mcp_transport::discovery::types::DispatchStatus::Ready
         && matches!(
             instance_status.status,
             ServiceStatus::Available | ServiceStatus::Busy

--- a/crates/dcc-mcp-cli/src/application/local_instance.rs
+++ b/crates/dcc-mcp-cli/src/application/local_instance.rs
@@ -228,11 +228,18 @@ pub(crate) fn direct_control_ready(entry: &ServiceEntry) -> bool {
         .get(ROLE_METADATA_KEY)
         .is_some_and(|role| role == ROLE_PER_DCC_SIDECAR);
     let instance_status = InstanceStatus::from_entry(entry, false, is_sidecar);
-    instance_status.dispatch_status == dcc_mcp_transport::discovery::types::DispatchStatus::Ready
-        && matches!(
-            instance_status.status,
-            ServiceStatus::Available | ServiceStatus::Busy
-        )
+    let status_ok = matches!(
+        instance_status.status,
+        ServiceStatus::Available | ServiceStatus::Busy
+    );
+    // Direct MCP instances without explicit dispatch_status are treated as ready
+    // (legacy / embedded / pre-sidecar path — ADR 018 DispatchStatus::Unknown).
+    let dispatch_ok = instance_status.dispatch_status
+        == dcc_mcp_transport::discovery::types::DispatchStatus::Ready
+        || (instance_status.dispatch_status
+            == dcc_mcp_transport::discovery::types::DispatchStatus::Unknown
+            && !is_sidecar);
+    status_ok && dispatch_ok
 }
 
 pub(crate) fn direct_control_report(entry: &ServiceEntry) -> Value {

--- a/crates/dcc-mcp-cli/src/application/local_instance.rs
+++ b/crates/dcc-mcp-cli/src/application/local_instance.rs
@@ -401,7 +401,7 @@ mod tests {
         let mut ready = ServiceEntry::new("maya", "127.0.0.1", 18081);
         ready.metadata.insert(
             DISPATCH_STATUS_METADATA_KEY.to_string(),
-            "ready".to_string(),
+            dcc_mcp_transport::discovery::types::DispatchStatus::Ready.to_string(),
         );
         let ready_id = ready.instance_id;
         registry.register(ready).unwrap();
@@ -448,7 +448,7 @@ mod tests {
         let mut sidecar = ServiceEntry::new("maya", "127.0.0.1", 18080);
         sidecar.metadata.insert(
             DISPATCH_STATUS_METADATA_KEY.to_string(),
-            "ready".to_string(),
+            dcc_mcp_transport::discovery::types::DispatchStatus::Ready.to_string(),
         );
         sidecar.metadata.insert(
             ROLE_METADATA_KEY.to_string(),

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -807,7 +807,9 @@ fn local_search_routes_ready_sidecar_and_skips_unavailable_rows() {
         diagnostic_row["direct_control"]["recommended_next_action"]
             .as_str()
             .unwrap()
-            .contains("wait-ready")
+            .contains("Instance is booting"),
+        "diagnostic row recommended_next_action: {}",
+        diagnostic_row["direct_control"]["recommended_next_action"]
     );
     let sidecar_row = instances
         .iter()
@@ -835,7 +837,9 @@ fn local_search_routes_ready_sidecar_and_skips_unavailable_rows() {
         sidecar_row["direct_control"]["recommended_next_action"]
             .as_str()
             .unwrap()
-            .contains("dispatch_status=ready")
+            .contains("failure stage/reason"),
+        "sidecar row recommended_next_action: {}",
+        sidecar_row["direct_control"]["recommended_next_action"]
     );
     let ready_row = instances
         .iter()

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -226,7 +226,7 @@ fn actionability(status: ServiceStatus, dispatch_status: DispatchStatus) -> (boo
         }
         (ServiceStatus::Available, DispatchStatus::Failed) => (
             false,
-            "Wait for dispatch_status=ready; inspect instance failure stage/reason; the backend may need a restart.",
+            "Inspect instance failure stage/reason; the backend may need a restart.",
         ),
         (ServiceStatus::Available, DispatchStatus::Unknown) => (
             true,
@@ -241,17 +241,13 @@ fn actionability(status: ServiceStatus, dispatch_status: DispatchStatus) -> (boo
         ),
         (ServiceStatus::Busy, DispatchStatus::Failed) => (
             false,
-            "Instance is busy; wait for dispatch_status=ready; inspect failure details if persistent.",
+            "Instance is busy but dispatch has failed; inspect failure details.",
         ),
         (ServiceStatus::Busy, DispatchStatus::Unknown) => (true, "Instance is busy; retry later."),
-        (ServiceStatus::Booting, DispatchStatus::Pending) => (
-            true,
-            "Instance is booting; run wait-ready for readiness and retry.",
-        ),
-        (ServiceStatus::Booting, _) => (
-            true,
-            "Instance is booting; run wait-ready for readiness and retry.",
-        ),
+        (ServiceStatus::Booting, DispatchStatus::Pending) => {
+            (true, "Instance is booting; wait for readiness and retry.")
+        }
+        (ServiceStatus::Booting, _) => (true, "Instance is booting; wait for readiness and retry."),
         (ServiceStatus::Unreachable, _) => (
             false,
             "Instance is unreachable; check logs and restart if needed.",


### PR DESCRIPTION
## Summary

Implements ADR 018 P0: Instance Status Vocabulary Unification and Actionability.

## Changes

### dcc-mcp-transport (Phase 1 - PIP-2900)
- Add DispatchStatus enum (Ready/Pending/Failed/Unknown) to replace free-form metadata string
- Add InstanceStatus struct bundling status + dispatch_status + retryable + recommended_next_action
- Add const status-pairing lookup table (ADR-018 table): 13 canonical combinations
- Add Python bindings: PyDispatchStatus, PyInstanceStatus
- Add 13 unit tests covering all status/dispatch pairings

### dcc-mcp-gateway (Phase 2 - PIP-2901)
- entry_to_json() now includes instance_status block alongside legacy dispatch block

### dcc-mcp-cli (Phase 3 - PIP-2902)
- direct_control_report() derives from InstanceStatus instead of synthesizing its own retryable/action strings

## New ADR
- docs/adr/018-cli-interaction-contract-workflow-consistency.md

## Test Plan
- 53 transport crate tests pass (13 new)
- Gateway and CLI crates compile cleanly with no warnings