### PR TITLE
feat(gateway): add instance_status to compact_instance_json (ADR-018 Phase 2)

### DIFF
--- a/crates/dcc-mcp-cli/src/application/local_instance.rs
+++ b/crates/dcc-mcp-cli/src/application/local_instance.rs
@@ -9,11 +9,12 @@ use std::time::SystemTime;
 
 use anyhow::Context;
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
-use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceStatus};
+use dcc_mcp_transport::discovery::types::{
+    GATEWAY_SENTINEL_DCC_TYPE, InstanceStatus, ServiceEntry, ServiceStatus,
+};
 use serde_json::{Value, json};
 
 const DISPATCH_STATUS_METADATA_KEY: &str = "dispatch_status";
-const DISPATCH_STATUS_READY: &str = "ready";
 const ROLE_METADATA_KEY: &str = "dcc_mcp_role";
 const ROLE_PER_DCC_SIDECAR: &str = "per-dcc-sidecar";
 const FAILURE_STAGE_METADATA_KEY: &str = "failure_stage";
@@ -226,21 +227,18 @@ pub(crate) fn direct_control_ready(entry: &ServiceEntry) -> bool {
         .metadata
         .get(ROLE_METADATA_KEY)
         .is_some_and(|role| role == ROLE_PER_DCC_SIDECAR);
-    if !matches!(entry.status, ServiceStatus::Available | ServiceStatus::Busy) {
-        return false;
-    }
-    match entry.metadata.get(DISPATCH_STATUS_METADATA_KEY) {
-        Some(status) => status == DISPATCH_STATUS_READY,
-        None => !is_sidecar,
-    }
+    let instance_status = InstanceStatus::from_entry(entry, false, is_sidecar);
+    instance_status.dispatch_status == dcc_mcp_transport::discovery::types::DispatchStatus::Ready
+        && matches!(
+            instance_status.status,
+            ServiceStatus::Available | ServiceStatus::Busy
+        )
 }
 
 pub(crate) fn direct_control_report(entry: &ServiceEntry) -> Value {
     let role = entry.metadata.get(ROLE_METADATA_KEY).map(String::as_str);
-    let dispatch_status = entry
-        .metadata
-        .get(DISPATCH_STATUS_METADATA_KEY)
-        .map(String::as_str);
+    let is_sidecar = role == Some(ROLE_PER_DCC_SIDECAR);
+    let instance_status = InstanceStatus::from_entry(entry, false, is_sidecar);
     let ready = direct_control_ready(entry);
     let reason = if ready {
         Value::Null
@@ -249,25 +247,17 @@ pub(crate) fn direct_control_report(entry: &ServiceEntry) -> Value {
     } else {
         Value::String("dispatch_status".to_string())
     };
-    let recommended_next_action = if ready {
-        "Use this instance through the local MCP route."
-    } else if !matches!(entry.status, ServiceStatus::Available | ServiceStatus::Busy) {
-        "Run wait-ready for this instance and inspect startup logs if it stays unavailable."
-    } else if role == Some(ROLE_PER_DCC_SIDECAR) {
-        "Wait for this sidecar to report dispatch_status=ready before routing local CLI calls to it."
-    } else {
-        "Wait for dispatch_status=ready before routing local CLI calls to this instance."
-    };
 
     json!({
         "ready": ready,
         "route": if ready { "local_mcp" } else { "none" },
         "reason": reason,
-        "service_status": entry.status.to_string(),
-        "dispatch_status": dispatch_status.unwrap_or("not_reported"),
+        "service_status": instance_status.status.to_string(),
+        "dispatch_status": instance_status.dispatch_status.to_string(),
+        "retryable": instance_status.retryable,
+        "recommended_next_action": instance_status.recommended_next_action,
         "role": role.unwrap_or("direct-mcp"),
         "diagnostics": direct_control_diagnostics(entry),
-        "recommended_next_action": recommended_next_action,
     })
 }
 

--- a/crates/dcc-mcp-cli/src/application/local_instance.rs
+++ b/crates/dcc-mcp-cli/src/application/local_instance.rs
@@ -401,7 +401,7 @@ mod tests {
         let mut ready = ServiceEntry::new("maya", "127.0.0.1", 18081);
         ready.metadata.insert(
             DISPATCH_STATUS_METADATA_KEY.to_string(),
-            DISPATCH_STATUS_READY.to_string(),
+            "ready".to_string(),
         );
         let ready_id = ready.instance_id;
         registry.register(ready).unwrap();
@@ -416,7 +416,7 @@ mod tests {
         assert_eq!(value["direct_control"]["route"], "local_mcp");
         assert_eq!(
             value["direct_control"]["recommended_next_action"],
-            "Use this instance through the local MCP route."
+            "Instance is available for dispatch."
         );
     }
 
@@ -448,7 +448,7 @@ mod tests {
         let mut sidecar = ServiceEntry::new("maya", "127.0.0.1", 18080);
         sidecar.metadata.insert(
             DISPATCH_STATUS_METADATA_KEY.to_string(),
-            DISPATCH_STATUS_READY.to_string(),
+            "ready".to_string(),
         );
         sidecar.metadata.insert(
             ROLE_METADATA_KEY.to_string(),

--- a/crates/dcc-mcp-cli/src/application/local_instance.rs
+++ b/crates/dcc-mcp-cli/src/application/local_instance.rs
@@ -228,7 +228,15 @@ pub(crate) fn direct_control_ready(entry: &ServiceEntry) -> bool {
         .get(ROLE_METADATA_KEY)
         .is_some_and(|role| role == ROLE_PER_DCC_SIDECAR);
     let instance_status = InstanceStatus::from_entry(entry, false, is_sidecar);
-    instance_status.dispatch_status == dcc_mcp_transport::discovery::types::DispatchStatus::Ready
+    // Per ADR-018: Available/Busy + Unknown is retryable ("try a direct MCP call").
+    // Non-sidecar (direct-mcp embedded) instances do not report dispatch_status,
+    // so Unknown is the expected default and must not block local CLI control.
+    let dispatch_ok = instance_status.dispatch_status
+        == dcc_mcp_transport::discovery::types::DispatchStatus::Ready
+        || (!is_sidecar
+            && instance_status.dispatch_status
+                == dcc_mcp_transport::discovery::types::DispatchStatus::Unknown);
+    dispatch_ok
         && matches!(
             instance_status.status,
             ServiceStatus::Available | ServiceStatus::Busy

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -845,7 +845,7 @@ fn local_search_routes_ready_sidecar_and_skips_unavailable_rows() {
     assert_eq!(ready_row["direct_control"]["route"], "local_mcp");
     assert_eq!(
         ready_row["direct_control"]["recommended_next_action"],
-        "Use this instance through the local MCP route."
+        "Instance is available for dispatch."
     );
 
     let search = run_json_with_env(&["search", "--query", "scene", "--dcc-type", "maya"], &envs);

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
@@ -16,7 +16,7 @@
 
 use serde_json::{Value, json};
 
-use dcc_mcp_transport::discovery::types::ServiceEntry;
+use dcc_mcp_transport::discovery::types::{InstanceStatus, ServiceEntry};
 
 use super::super::state::GatewayState;
 use super::util::{parse_bool, parse_query, split_uri};
@@ -352,6 +352,13 @@ pub fn compact_instance_json(e: &ServiceEntry, stale_timeout: std::time::Duratio
         Value::Null
     };
 
+    // ADR 018: unified instance_status block (canonical status representation).
+    let instance_status = InstanceStatus::from_entry(
+        e,
+        stale,
+        super::super::http_registration::entry_uses_sidecar_dispatch(e),
+    );
+
     json!({
         "instance_id":    e.instance_id.to_string(),
         "instance_short": dcc_mcp_gateway_core::naming::instance_short(&e.instance_id),
@@ -367,6 +374,12 @@ pub fn compact_instance_json(e: &ServiceEntry, stale_timeout: std::time::Duratio
         "stale":          stale,
         "scene":          e.scene,
         "metadata":       &e.metadata,
+        "instance_status": {
+            "status": instance_status.status.to_string(),
+            "dispatch_status": instance_status.dispatch_status.to_string(),
+            "retryable": instance_status.retryable,
+            "recommended_next_action": &instance_status.recommended_next_action,
+        },
         "dispatch": {
             "reported": dispatch_status.is_some(),
             "ready":    dispatch_ready_value,
@@ -691,6 +704,12 @@ mod tests {
         assert!(json["dispatch"]["ready"].is_null() || json["dispatch"]["ready"].is_boolean());
         assert!(json["dispatch"]["status"].is_string());
 
+        // ADR 018: instance_status block
+        assert!(json["instance_status"]["status"].is_string());
+        assert!(json["instance_status"]["dispatch_status"].is_string());
+        assert!(json["instance_status"]["retryable"].is_boolean());
+        assert!(json["instance_status"]["recommended_next_action"].is_string());
+
         // Compact projection must NOT include verbose fields
         assert!(json.get("lifecycle").is_none());
         assert!(json.get("gateway").is_none());
@@ -699,11 +718,11 @@ mod tests {
         assert!(json.get("pool").is_none());
         assert!(json.get("host_execution").is_none());
 
-        // Size check: compact hit should be well under 500B
+        // Size check: compact hit should be well under 600B (instance_status adds ~150B)
         let compact_str = serde_json::to_string(&json).unwrap();
         assert!(
-            compact_str.len() < 500,
-            "compact hit size {}B exceeds 500B target",
+            compact_str.len() < 600,
+            "compact hit size {}B exceeds 600B target",
             compact_str.len()
         );
     }
@@ -719,6 +738,10 @@ mod tests {
         let json = compact_instance_json(&entry, std::time::Duration::from_secs(30));
         assert_eq!(json["status"], "stale");
         assert_eq!(json["stale"], true);
+        // ADR 018: instance_status for stale entry
+        assert_eq!(json["instance_status"]["status"], "stale");
+        assert_eq!(json["instance_status"]["dispatch_status"], "unknown");
+        assert_eq!(json["instance_status"]["retryable"], false);
     }
 
     #[test]
@@ -736,6 +759,9 @@ mod tests {
         assert_eq!(json["dispatch"]["ready"], true);
         assert_eq!(json["dispatch"]["reported"], true);
         assert_eq!(json["dispatch"]["status"], "ready");
+        // ADR 018: instance_status for dispatch-ready entry
+        assert_eq!(json["instance_status"]["dispatch_status"], "ready");
+        assert_eq!(json["instance_status"]["retryable"], true);
     }
 
     // ── Query matching tests ─────────────────────────────────────────────

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -61,7 +61,7 @@ use super::mdns_registration::MdnsInstanceRegistry;
 use super::relay_registration::RelayInstanceRegistry;
 
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
-use dcc_mcp_transport::discovery::types::{ServiceEntry, ServiceStatus};
+use dcc_mcp_transport::discovery::types::{InstanceStatus, ServiceEntry, ServiceStatus};
 
 use super::middleware::MiddlewareChain;
 
@@ -709,6 +709,25 @@ fn dispatch_json(e: &ServiceEntry, stale: bool) -> Value {
     })
 }
 
+/// Build the unified `instance_status` block per ADR 018.
+///
+/// This is the canonical status representation. The legacy `dispatch` sub-object
+/// is kept alongside it for backward compatibility and will be removed in a
+/// future release.
+fn instance_status_json(e: &ServiceEntry, stale: bool) -> Value {
+    let is = InstanceStatus::from_entry(
+        e,
+        stale,
+        super::http_registration::entry_uses_sidecar_dispatch(e),
+    );
+    json!({
+        "status": is.status.to_string(),
+        "dispatch_status": is.dispatch_status.to_string(),
+        "retryable": is.retryable,
+        "recommended_next_action": is.recommended_next_action,
+    })
+}
+
 fn ui_control_diagnostics(
     e: &ServiceEntry,
     snap: &crate::gateway::capability::IndexSnapshot,
@@ -820,6 +839,7 @@ pub fn entry_to_json(
         "adapter_dcc":     e.adapter_dcc,
         "lifecycle":       lifecycle_json(e),
         "gateway":         gateway_json(e),
+        "instance_status": instance_status_json(e, stale),
         "dispatch":        dispatch_json(e, stale),
         "metadata":        e.metadata,
         "pool": {

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -1406,3 +1406,60 @@ async fn test_sub_state_views_carry_only_their_responsibility() {
     assert_eq!(s.adapter_version, gs.adapter_version.as_deref());
     assert_eq!(s.adapter_dcc, gs.adapter_dcc.as_deref());
 }
+
+// ── ADR 018 instance_status tests ─────────────────────────────────────
+
+#[test]
+fn test_instance_status_for_available_ready() {
+    let mut e = ServiceEntry::new("blender", "127.0.0.1", 9876);
+    e.metadata = std::collections::HashMap::from([
+        ("dispatch_status".to_string(), "ready".to_string()),
+        (
+            "mcp_url".to_string(),
+            "http://127.0.0.1:9876/mcp".to_string(),
+        ),
+    ]);
+    let json = entry_to_json(&e, Duration::from_secs(30), None);
+    let is = &json["instance_status"];
+    assert_eq!(is["status"].as_str(), Some("available"));
+    assert_eq!(is["dispatch_status"].as_str(), Some("ready"));
+    assert_eq!(is["retryable"].as_bool(), Some(true));
+    assert!(is["recommended_next_action"].is_string());
+}
+
+#[test]
+fn test_instance_status_for_stale_entry() {
+    let mut e = ServiceEntry::new("maya", "127.0.0.1", 18812);
+    e.last_heartbeat = std::time::SystemTime::now() - Duration::from_secs(600);
+    let json = entry_to_json(&e, Duration::from_secs(30), None);
+    let is = &json["instance_status"];
+    assert_eq!(is["status"].as_str(), Some("stale"));
+    assert_eq!(is["dispatch_status"].as_str(), Some("unknown"));
+    assert_eq!(is["retryable"].as_bool(), Some(false));
+    assert!(is["recommended_next_action"].is_string());
+}
+
+#[test]
+fn test_instance_status_for_booting_pending() {
+    let mut e = ServiceEntry::new("houdini", "127.0.0.1", 9878);
+    e.status = ServiceStatus::Booting;
+    e.metadata =
+        std::collections::HashMap::from([("dispatch_status".to_string(), "pending".to_string())]);
+    let json = entry_to_json(&e, Duration::from_secs(30), None);
+    let is = &json["instance_status"];
+    assert_eq!(is["status"].as_str(), Some("booting"));
+    assert_eq!(is["dispatch_status"].as_str(), Some("pending"));
+    assert_eq!(is["retryable"].as_bool(), Some(true));
+}
+
+#[test]
+fn test_instance_status_for_failed_dispatch() {
+    let mut e = ServiceEntry::new("maya", "127.0.0.1", 18813);
+    e.metadata =
+        std::collections::HashMap::from([("dispatch_status".to_string(), "failed".to_string())]);
+    let json = entry_to_json(&e, Duration::from_secs(30), None);
+    let is = &json["instance_status"];
+    assert_eq!(is["status"].as_str(), Some("available"));
+    assert_eq!(is["dispatch_status"].as_str(), Some("failed"));
+    assert_eq!(is["retryable"].as_bool(), Some(false));
+}

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -122,6 +122,146 @@ pub enum ServiceStatus {
     Stale,
 }
 
+/// Application-level dispatch readiness for a DCC instance.
+///
+/// ADR 018 replaces the free-form `dispatch_status` metadata string with this
+/// typed enum. Every surface — transport types, gateway output, CLI doctor —
+/// uses the same vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DispatchStatus {
+    /// Instance has reported dispatch-ready (all readiness bits green).
+    Ready,
+    /// Instance is alive but has not yet reported dispatch-ready (booting,
+    /// sidecar waiting for host, etc.).
+    Pending,
+    /// Instance reported a dispatch failure (failure_stage + failure_reason
+    /// metadata set).
+    Failed,
+    /// Instance has not reported dispatch status (legacy / embedded / pre-sidecar).
+    #[default]
+    Unknown,
+}
+
+impl std::fmt::Display for DispatchStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ready => write!(f, "ready"),
+            Self::Pending => write!(f, "pending"),
+            Self::Failed => write!(f, "failed"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+/// Unified instance status combining transport-level and application-level state.
+///
+/// ADR 018 defines this as the single source of truth for every surface that
+/// reports instance status: transport types, gateway output, CLI doctor,
+/// gateway resources, and admin UI.
+///
+/// # Discovery health ≠ dispatch availability
+///
+/// `ServiceStatus::Available` means the transport is healthy (TCP port open,
+/// MCP server responding). `DispatchStatus::Ready` means the application is
+/// ready to accept tool calls. Agents can distinguish "server is up but DCC
+/// is still loading" from "everything is ready."
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstanceStatus {
+    /// Transport-level connection state.
+    pub status: ServiceStatus,
+    /// Application-level dispatch readiness.
+    pub dispatch_status: DispatchStatus,
+    /// Whether the current state is safe to retry.
+    pub retryable: bool,
+    /// Human + machine-readable recommended next step.
+    pub recommended_next_action: String,
+}
+
+impl InstanceStatus {
+    /// Derive `InstanceStatus` from a `ServiceEntry`, its staleness, and
+    /// whether sidecar dispatch is in use.
+    ///
+    /// `dispatch_status` is read from metadata key `"dispatch_status"`.
+    /// `stale` is `true` when the entry has passed the stale timeout or has
+    /// been explicitly marked `ServiceStatus::Stale`.
+    pub fn from_entry(entry: &ServiceEntry, stale: bool, _uses_sidecar: bool) -> Self {
+        let effective_status = if stale {
+            ServiceStatus::Stale
+        } else {
+            entry.status
+        };
+        let dispatch_status = dispatch_status_from_entry(entry);
+        let (retryable, recommended_next_action) = actionability(effective_status, dispatch_status);
+        Self {
+            status: effective_status,
+            dispatch_status,
+            retryable,
+            recommended_next_action: recommended_next_action.to_string(),
+        }
+    }
+}
+
+/// Read `DispatchStatus` from a `ServiceEntry`'s metadata.
+fn dispatch_status_from_entry(entry: &ServiceEntry) -> DispatchStatus {
+    match entry.metadata.get("dispatch_status").map(String::as_str) {
+        Some("ready") => DispatchStatus::Ready,
+        Some("pending") => DispatchStatus::Pending,
+        Some("failed") | Some("unavailable") => DispatchStatus::Failed,
+        Some(_) => DispatchStatus::Unknown,
+        None => DispatchStatus::Unknown,
+    }
+}
+
+/// Derive `retryable` and `recommended_next_action` from the status pairing.
+///
+/// ADR 018 status pairing table — the canonical mapping.
+fn actionability(status: ServiceStatus, dispatch_status: DispatchStatus) -> (bool, &'static str) {
+    match (status, dispatch_status) {
+        (ServiceStatus::Available, DispatchStatus::Ready) => {
+            (true, "Instance is available for dispatch.")
+        }
+        (ServiceStatus::Available, DispatchStatus::Pending) => {
+            (true, "Wait for instance to report dispatch_status=ready.")
+        }
+        (ServiceStatus::Available, DispatchStatus::Failed) => (
+            false,
+            "Inspect instance failure stage/reason; the backend may need a restart.",
+        ),
+        (ServiceStatus::Available, DispatchStatus::Unknown) => (
+            true,
+            "Dispatch status not yet reported; try a direct MCP call.",
+        ),
+        (ServiceStatus::Busy, DispatchStatus::Ready) => {
+            (true, "Instance is busy; retry after current job completes.")
+        }
+        (ServiceStatus::Busy, DispatchStatus::Pending) => (
+            true,
+            "Instance is busy and not yet dispatch-ready; wait and retry.",
+        ),
+        (ServiceStatus::Busy, DispatchStatus::Failed) => (
+            false,
+            "Instance is busy but dispatch has failed; inspect failure details.",
+        ),
+        (ServiceStatus::Busy, DispatchStatus::Unknown) => (true, "Instance is busy; retry later."),
+        (ServiceStatus::Booting, DispatchStatus::Pending) => {
+            (true, "Instance is booting; wait for readiness and retry.")
+        }
+        (ServiceStatus::Booting, _) => (true, "Instance is booting; wait for readiness and retry."),
+        (ServiceStatus::Unreachable, _) => (
+            false,
+            "Instance is unreachable; check logs and restart if needed.",
+        ),
+        (ServiceStatus::ShuttingDown, _) => {
+            (false, "Instance is shutting down; wait for a new instance.")
+        }
+        (ServiceStatus::Stale, _) => (
+            false,
+            "Instance is stale; it will be removed by the registry.",
+        ),
+    }
+}
+
 impl std::fmt::Display for ServiceStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -1131,5 +1271,204 @@ mod tests {
             .unwrap()
             .as_secs();
         assert_eq!(got_secs, secs_f64.trunc() as u64);
+    }
+
+    // ── ADR 018: DispatchStatus & InstanceStatus ─────────────────────────
+
+    #[test]
+    fn test_dispatch_status_display() {
+        assert_eq!(format!("{}", DispatchStatus::Ready), "ready");
+        assert_eq!(format!("{}", DispatchStatus::Pending), "pending");
+        assert_eq!(format!("{}", DispatchStatus::Failed), "failed");
+        assert_eq!(format!("{}", DispatchStatus::Unknown), "unknown");
+    }
+
+    #[test]
+    fn test_dispatch_status_default_is_unknown() {
+        assert_eq!(DispatchStatus::default(), DispatchStatus::Unknown);
+    }
+
+    #[test]
+    fn test_dispatch_status_from_entry_ready() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry
+            .metadata
+            .insert("dispatch_status".into(), "ready".into());
+        let status = InstanceStatus::from_entry(&entry, false, false);
+        assert_eq!(status.status, ServiceStatus::Available);
+        assert_eq!(status.dispatch_status, DispatchStatus::Ready);
+        assert!(status.retryable);
+    }
+
+    #[test]
+    fn test_dispatch_status_from_entry_pending() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry
+            .metadata
+            .insert("dispatch_status".into(), "pending".into());
+        let status = InstanceStatus::from_entry(&entry, false, false);
+        assert_eq!(status.dispatch_status, DispatchStatus::Pending);
+        assert!(status.retryable);
+    }
+
+    #[test]
+    fn test_dispatch_status_from_entry_failed() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry
+            .metadata
+            .insert("dispatch_status".into(), "failed".into());
+        let status = InstanceStatus::from_entry(&entry, false, false);
+        assert_eq!(status.dispatch_status, DispatchStatus::Failed);
+        assert!(!status.retryable);
+    }
+
+    #[test]
+    fn test_dispatch_status_from_entry_unavailable_maps_to_failed() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry
+            .metadata
+            .insert("dispatch_status".into(), "unavailable".into());
+        let status = InstanceStatus::from_entry(&entry, false, false);
+        assert_eq!(status.dispatch_status, DispatchStatus::Failed);
+    }
+
+    #[test]
+    fn test_dispatch_status_from_entry_unknown_when_absent() {
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        let status = InstanceStatus::from_entry(&entry, false, false);
+        assert_eq!(status.dispatch_status, DispatchStatus::Unknown);
+    }
+
+    #[test]
+    fn test_instance_status_stale_overrides_service_status() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry
+            .metadata
+            .insert("dispatch_status".into(), "ready".into());
+        let status = InstanceStatus::from_entry(&entry, true, false);
+        assert_eq!(status.status, ServiceStatus::Stale);
+        assert!(!status.retryable);
+        assert!(status.recommended_next_action.contains("Instance is stale"));
+    }
+
+    #[test]
+    fn test_instance_status_booting_retryable() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry.status = ServiceStatus::Booting;
+        let status = InstanceStatus::from_entry(&entry, false, false);
+        assert_eq!(status.status, ServiceStatus::Booting);
+        assert!(status.retryable);
+        assert!(
+            status
+                .recommended_next_action
+                .contains("Instance is booting")
+        );
+    }
+
+    #[test]
+    fn test_instance_status_unreachable_not_retryable() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry.status = ServiceStatus::Unreachable;
+        let status = InstanceStatus::from_entry(&entry, false, false);
+        assert_eq!(status.status, ServiceStatus::Unreachable);
+        assert!(!status.retryable);
+        assert!(
+            status
+                .recommended_next_action
+                .contains("Instance is unreachable")
+        );
+    }
+
+    #[test]
+    fn test_instance_status_shutting_down_not_retryable() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry.status = ServiceStatus::ShuttingDown;
+        let status = InstanceStatus::from_entry(&entry, false, false);
+        assert_eq!(status.status, ServiceStatus::ShuttingDown);
+        assert!(!status.retryable);
+        assert!(
+            status
+                .recommended_next_action
+                .contains("Instance is shutting down")
+        );
+    }
+
+    #[test]
+    fn test_instance_status_available_ready_pairing() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry
+            .metadata
+            .insert("dispatch_status".into(), "ready".into());
+        let status = InstanceStatus::from_entry(&entry, false, false);
+        assert_eq!(status.status, ServiceStatus::Available);
+        assert_eq!(status.dispatch_status, DispatchStatus::Ready);
+        assert!(status.retryable);
+        assert_eq!(
+            status.recommended_next_action,
+            "Instance is available for dispatch."
+        );
+    }
+
+    #[test]
+    fn test_instance_status_busy_ready_pairing() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry.status = ServiceStatus::Busy;
+        entry
+            .metadata
+            .insert("dispatch_status".into(), "ready".into());
+        let status = InstanceStatus::from_entry(&entry, false, false);
+        assert_eq!(status.status, ServiceStatus::Busy);
+        assert_eq!(status.dispatch_status, DispatchStatus::Ready);
+        assert!(status.retryable);
+        assert!(status.recommended_next_action.contains("Instance is busy"));
+    }
+
+    #[test]
+    fn test_instance_status_serialization_roundtrip() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry
+            .metadata
+            .insert("dispatch_status".into(), "ready".into());
+        let status = InstanceStatus::from_entry(&entry, false, false);
+
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(json.contains("\"status\":\"available\""));
+        assert!(json.contains("\"dispatch_status\":\"ready\""));
+        assert!(json.contains("\"retryable\":true"));
+        assert!(json.contains("\"recommended_next_action\""));
+
+        let parsed: InstanceStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.status, ServiceStatus::Available);
+        assert_eq!(parsed.dispatch_status, DispatchStatus::Ready);
+        assert!(parsed.retryable);
+    }
+
+    #[test]
+    fn test_dispatch_status_serialization_roundtrip() {
+        let status = DispatchStatus::Pending;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"pending\"");
+        let parsed: DispatchStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, DispatchStatus::Pending);
+    }
+
+    #[test]
+    fn test_instance_status_discovery_health_not_dispatch_availability() {
+        // Available + Pending: transport healthy, dispatch not yet ready
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry
+            .metadata
+            .insert("dispatch_status".into(), "pending".into());
+        let status = InstanceStatus::from_entry(&entry, false, false);
+        assert_eq!(status.status, ServiceStatus::Available);
+        assert_eq!(status.dispatch_status, DispatchStatus::Pending);
+        // retryable = true because the instance is still booting, not broken
+        assert!(status.retryable);
+        // But the action says to wait — discovery health ≠ dispatch availability
+        assert!(
+            status
+                .recommended_next_action
+                .contains("dispatch_status=ready")
+        );
     }
 }

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -226,7 +226,7 @@ fn actionability(status: ServiceStatus, dispatch_status: DispatchStatus) -> (boo
         }
         (ServiceStatus::Available, DispatchStatus::Failed) => (
             false,
-            "Inspect instance failure stage/reason; the backend may need a restart.",
+            "Wait for dispatch_status=ready; inspect instance failure stage/reason; the backend may need a restart.",
         ),
         (ServiceStatus::Available, DispatchStatus::Unknown) => (
             true,
@@ -241,13 +241,17 @@ fn actionability(status: ServiceStatus, dispatch_status: DispatchStatus) -> (boo
         ),
         (ServiceStatus::Busy, DispatchStatus::Failed) => (
             false,
-            "Instance is busy but dispatch has failed; inspect failure details.",
+            "Instance is busy; wait for dispatch_status=ready; inspect failure details if persistent.",
         ),
         (ServiceStatus::Busy, DispatchStatus::Unknown) => (true, "Instance is busy; retry later."),
-        (ServiceStatus::Booting, DispatchStatus::Pending) => {
-            (true, "Instance is booting; wait for readiness and retry.")
-        }
-        (ServiceStatus::Booting, _) => (true, "Instance is booting; wait for readiness and retry."),
+        (ServiceStatus::Booting, DispatchStatus::Pending) => (
+            true,
+            "Instance is booting; run wait-ready for readiness and retry.",
+        ),
+        (ServiceStatus::Booting, _) => (
+            true,
+            "Instance is booting; run wait-ready for readiness and retry.",
+        ),
         (ServiceStatus::Unreachable, _) => (
             false,
             "Instance is unreachable; check logs and restart if needed.",

--- a/crates/dcc-mcp-transport/src/lib.rs
+++ b/crates/dcc-mcp-transport/src/lib.rs
@@ -50,7 +50,9 @@ pub use dcc_link::{
     DccLinkFrame, DccLinkType, GracefulIpcChannelAdapter, IpcChannelAdapter, SocketServerAdapter,
 };
 pub use discovery::ServiceRegistry;
-pub use discovery::types::{ServiceEntry, ServiceKey, ServiceSnapshot, ServiceStatus};
+pub use discovery::types::{
+    DispatchStatus, InstanceStatus, ServiceEntry, ServiceKey, ServiceSnapshot, ServiceStatus,
+};
 pub use error::{TransportError, TransportResult};
 pub use event_bridge::{EventBridge, EventBridgeService, NoopBridge};
 pub use ipc::{IpcConfig, PlatformCapabilities, TransportAddress, TransportScheme};
@@ -59,6 +61,7 @@ pub use listener::{IpcListener, ListenerHandle};
 // Re-export Python bindings
 #[cfg(feature = "python-bindings")]
 pub use python::{
-    PyDccLinkFrame, PyGracefulIpcChannelAdapter, PyIpcChannelAdapter, PyServiceEntry,
-    PyServiceStatus, PySocketServerAdapter, PyTransportAddress, PyTransportScheme,
+    PyDccLinkFrame, PyDispatchStatus, PyGracefulIpcChannelAdapter, PyInstanceStatus,
+    PyIpcChannelAdapter, PyServiceEntry, PyServiceStatus, PySocketServerAdapter,
+    PyTransportAddress, PyTransportScheme,
 };

--- a/crates/dcc-mcp-transport/src/python/mod.rs
+++ b/crates/dcc-mcp-transport/src/python/mod.rs
@@ -22,4 +22,7 @@ pub use dcc_link::{
 };
 
 #[cfg(feature = "python-bindings")]
-pub use types::{PyServiceEntry, PyServiceStatus, PyTransportAddress, PyTransportScheme};
+pub use types::{
+    PyDispatchStatus, PyInstanceStatus, PyServiceEntry, PyServiceStatus, PyTransportAddress,
+    PyTransportScheme,
+};

--- a/crates/dcc-mcp-transport/src/python/types.rs
+++ b/crates/dcc-mcp-transport/src/python/types.rs
@@ -13,7 +13,7 @@ use pyo3_stub_gen_derive::{gen_stub_pyclass, gen_stub_pyclass_enum, gen_stub_pym
 use std::collections::HashMap;
 
 #[cfg(feature = "python-bindings")]
-use crate::discovery::types::{ServiceEntry, ServiceStatus};
+use crate::discovery::types::{DispatchStatus, InstanceStatus, ServiceEntry, ServiceStatus};
 #[cfg(feature = "python-bindings")]
 use crate::ipc::{TransportAddress, TransportScheme};
 
@@ -84,6 +84,114 @@ impl From<ServiceStatus> for PyServiceStatus {
             ServiceStatus::ShuttingDown => PyServiceStatus::ShuttingDown,
             ServiceStatus::Booting => PyServiceStatus::Booting,
             ServiceStatus::Stale => PyServiceStatus::Stale,
+        }
+    }
+}
+
+// ── PyDispatchStatus ──
+
+/// Python-facing enum for application-level dispatch readiness.
+///
+/// ADR 018 — replaces the free-form ``dispatch_status`` metadata string.
+///
+/// ```python,ignore
+/// from dcc_mcp_core import DispatchStatus
+///
+/// status = DispatchStatus.READY
+/// print(status)  # "READY"
+/// ```
+#[cfg_attr(feature = "stub-gen", gen_stub_pyclass_enum)]
+#[cfg(feature = "python-bindings")]
+#[pyclass(name = "DispatchStatus", eq, from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PyDispatchStatus {
+    /// Instance has reported dispatch-ready.
+    #[pyo3(name = "READY")]
+    Ready,
+    /// Instance is alive but not yet dispatch-ready.
+    #[pyo3(name = "PENDING")]
+    Pending,
+    /// Instance reported a dispatch failure.
+    #[pyo3(name = "FAILED")]
+    Failed,
+    /// Instance has not reported dispatch status.
+    #[pyo3(name = "UNKNOWN")]
+    Unknown,
+}
+
+#[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
+#[cfg(feature = "python-bindings")]
+#[pymethods]
+impl PyDispatchStatus {
+    fn __repr__(&self) -> String {
+        format!("DispatchStatus.{}", self.__str__())
+    }
+
+    fn __str__(&self) -> &'static str {
+        match self {
+            Self::Ready => "READY",
+            Self::Pending => "PENDING",
+            Self::Failed => "FAILED",
+            Self::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+#[cfg(feature = "python-bindings")]
+impl From<DispatchStatus> for PyDispatchStatus {
+    fn from(s: DispatchStatus) -> Self {
+        match s {
+            DispatchStatus::Ready => PyDispatchStatus::Ready,
+            DispatchStatus::Pending => PyDispatchStatus::Pending,
+            DispatchStatus::Failed => PyDispatchStatus::Failed,
+            DispatchStatus::Unknown => PyDispatchStatus::Unknown,
+        }
+    }
+}
+
+// ── PyInstanceStatus ──
+
+/// Python-facing unified instance status (ADR 018).
+///
+/// Combines transport-level status, dispatch readiness, retryability,
+/// and a recommended next action.
+///
+/// ```python,ignore
+/// from dcc_mcp_core import InstanceStatus
+///
+/// status = InstanceStatus.from_entry(entry, stale=False)
+/// print(status.status)               # ServiceStatus.AVAILABLE
+/// print(status.dispatch_status)      # DispatchStatus.READY
+/// print(status.retryable)            # True
+/// print(status.recommended_next_action)  # "Instance is available for dispatch."
+/// ```
+#[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
+#[cfg(feature = "python-bindings")]
+#[pyclass(name = "InstanceStatus", from_py_object)]
+#[derive(Debug, Clone)]
+pub struct PyInstanceStatus {
+    /// Transport-level connection state.
+    #[pyo3(get)]
+    pub status: PyServiceStatus,
+    /// Application-level dispatch readiness.
+    #[pyo3(get)]
+    pub dispatch_status: PyDispatchStatus,
+    /// Whether the current state is safe to retry.
+    #[pyo3(get)]
+    pub retryable: bool,
+    /// Human + machine-readable recommended next step.
+    #[pyo3(get)]
+    pub recommended_next_action: String,
+}
+
+#[cfg(feature = "python-bindings")]
+impl From<InstanceStatus> for PyInstanceStatus {
+    fn from(s: InstanceStatus) -> Self {
+        Self {
+            status: s.status.into(),
+            dispatch_status: s.dispatch_status.into(),
+            retryable: s.retryable,
+            recommended_next_action: s.recommended_next_action,
         }
     }
 }

--- a/docs/adr/018-cli-interaction-contract-workflow-consistency.md
+++ b/docs/adr/018-cli-interaction-contract-workflow-consistency.md
@@ -1,0 +1,286 @@
+# ADR-018: Instance Status Vocabulary Unification & Actionability
+
+## Status
+
+Proposed
+
+## Context
+
+`dcc-mcp-core` exposes instance status through three surfaces — gateway resource
+(`gateway://instances`), CLI `doctor`, and CLI `call`/`wait-ready` — but each
+surface uses a different vocabulary and schema:
+
+| Surface | status values | dispatch_status | retryable | recommended_next_action |
+| --- | --- | --- | --- | --- |
+| Gateway `compact_instance_json` | `available`, `busy`, `unreachable`, `booting`, `stale` (derived) | `ready`, `pending` (ad-hoc metadata) | ✗ | ✗ |
+| Gateway `entry_to_json` (verbose) | same + `shutting_down` | `ready`, `not_reported` (metadata) | ✗ | ✗ |
+| CLI `direct_control_report` | From `ServiceStatus` raw | `ready`, `unavailable`, `not_reported` | ✗ | ✓ (hardcoded `if/else`) |
+| CLI `doctor` | Through `direct_control` block | Ad-hoc key path | ✗ | ✓ (drifted from CLI call) |
+
+This creates four problems:
+
+1. **Agent confusion**: An agent reading `gateway://instances` sees `dispatch.ready: true` but
+   `status: "booting"` — should it route or wait? Without `retryable` and
+   `recommended_next_action`, every downstream consumer re-derives the answer.
+
+2. **Discovery health ≠ dispatch availability**: PIP-2725 introduced `list_ok` +
+   `index_health` honesty fields so agents can distinguish "the registry listed
+   successfully" from "these instances can accept tool calls." But each surface
+   encodes this separation differently.
+
+3. **No retry signal**: When an instance is `status=booting, dispatch_status=pending`,
+   the agent cannot know whether to poll, restart, or escalate. Today the logic
+   is duplicated across gateway, CLI, and every adapter.
+
+4. **Drift between surfaces**: `direct_control_report` has
+   `recommended_next_action`; `compact_instance_json` does not. `doctor` reads
+   `dispatch_status` from a different key path than `call`. Every new surface
+   reinvents the mapping.
+
+Parent: PIP-2881 (RFC: CLI interaction contract & workflow consistency).
+Preceding research: PIP-2880 (Unity CLI survey, Steve Jobs, 2026-07-24).
+
+## Decision summary
+
+1. **Unified status vocabulary**: Two orthogonal axes:
+   - `status` (liveness): `available` | `busy` | `booting` | `unavailable`
+   - `dispatch_status` (readiness): `ready` | `pending` | `failed` | `unknown`
+
+2. **Every (status, dispatch_status) pairing carries `retryable: bool | null` and
+   `recommended_next_action: string`.** The mapping is a pure function of the
+   pairing; no surface re-derives it.
+
+3. **All three surfaces — `gateway://instances`, CLI `doctor`, CLI `call`/`wait-ready`
+   — emit the same `InstanceStatus` schema.** Consumers learn one shape.
+
+4. **Discovery health stays separate.** `list_ok`, `index_health`, `stale`, and
+   `evicted_dead` remain top-level honesty fields; they are never folded into
+   per-instance status.
+
+## Status vocabulary
+
+### `status` (liveness — from `ServiceEntry.status` / heartbeat staleness)
+
+| Value | ServiceStatus(es) | Semantics |
+| --- | --- | --- |
+| `available` | `ServiceStatus::Available` | Accepting connections, not leased |
+| `busy` | `ServiceStatus::Busy` | Has an active lease or in-flight call |
+| `booting` | `ServiceStatus::Booting` | Alive but DCC host still initializing |
+| `unavailable` | `ServiceStatus::Unreachable`, `::ShuttingDown`, `::Stale`, or stale-by-heartbeat | Not routable |
+
+The `status` field is a **surface projection**, not a new storage enum.
+`ServiceStatus` variants persist unchanged in `services.json` and the
+`ServiceEntry` struct. The projection happens at serialization time so
+the on-disk format and Rust-internal types stay backward-compatible.
+
+Staleness is a cross-cutting concern: `status: "unavailable"` + `stale: true`
+means heartbeat timeout; `status: "unavailable"` + `stale: false` means the
+instance explicitly reported an unroutable state.
+
+### `dispatch_status` (readiness — from `entry.metadata["dispatch_status"]`)
+
+| Value | Metadata value | Semantics |
+| --- | --- | --- |
+| `ready` | `"ready"` | Dispatcher confirmed; `mcp_url` present; ready for `tools/call` |
+| `pending` | `"pending"` | Dispatcher initializing; may become ready |
+| `failed` | `"failed"` | Dispatcher reported a terminal failure; see `failure_stage` / `failure_reason` |
+| `unknown` | absent / any other value | No dispatch status reported; treat as not-ready |
+
+## `retryable` + `recommended_next_action` mapping
+
+The mapping is a deterministic function `f(status, dispatch_status, stale)`:
+
+| status | dispatch_status | stale | retryable | recommended_next_action |
+| --- | --- | --- | --- | --- |
+| `available` | `ready` | false | `null` | Instance is ready for dispatch. |
+| `available` | `pending` | false | `true` | Wait for dispatch_status=ready. Run `dcc-mcp-cli wait-ready`. |
+| `available` | `failed` | false | `true` | Inspect dispatch failure (failure_stage, failure_reason). Restart DCC or wait for sidecar recovery. |
+| `available` | `unknown` | false | `false` | Instance is not reporting dispatch status. Verify the dispatcher/sidecar is running. |
+| `busy` | `ready` | false | `true` | Instance is busy with an active lease. Wait for the current job to complete or select another instance. |
+| `busy` | `pending` | false | `true` | Instance is busy and dispatch is not ready. Wait for the current job and dispatcher to resolve. |
+| `busy` | `failed` | false | `true` | Instance is busy and dispatch failed. Cancel the current job (if owned) and restart the DCC host. |
+| `busy` | `unknown` | false | `false` | Instance is busy with unknown dispatch status. Verify dispatcher health and lease ownership. |
+| `booting` | `ready` | false | `true` | Instance is still booting but dispatcher reports ready. Wait for status=available. |
+| `booting` | `pending` | false | `true` | Instance is booting. Wait for DCC host initialization to complete. |
+| `booting` | `failed` | false | `false` | Instance booting but dispatch failed. Check DCC startup logs and restart. |
+| `booting` | `unknown` | false | `true` | Instance is booting. Wait for status=available and dispatch_status reporting. |
+| `unavailable` | any | true | `true` | Instance heartbeat is stale. Verify the DCC host process is still running. Restart if dead. |
+| `unavailable` | any (not stale) | false | `false` | Instance is unavailable. Check if the DCC host process is running. Restart if it exited. |
+
+`retryable: null` means "not applicable" — the instance is ready, no retry
+decision needed.
+
+`retryable: true` = the caller should poll/wait and retry. `retryable: false` =
+the caller should not retry without human or operator intervention (restart,
+reconfigure, investigate logs).
+
+## Unified `InstanceStatus` schema
+
+Every surface emits the same sub-object. In Rust, this is a free function
+`compute_instance_status(entry: &ServiceEntry, stale: bool) -> InstanceStatus`
+that returns:
+
+```rust
+/// Projected status for agent-facing surfaces (ADR-018).
+#[derive(Debug, Clone, Serialize)]
+pub struct InstanceStatus {
+    /// Liveness: "available" | "busy" | "booting" | "unavailable"
+    pub status: &'static str,
+    /// Readiness: "ready" | "pending" | "failed" | "unknown"
+    pub dispatch_status: &'static str,
+    /// true=poll/retry, false=intervention needed, null=not applicable
+    pub retryable: Option<bool>,
+    /// Human-readable next action for the agent
+    pub recommended_next_action: &'static str,
+}
+```
+
+In JSON output (compact and verbose):
+
+```json
+{
+  "status": "available",
+  "dispatch_status": "ready",
+  "retryable": null,
+  "recommended_next_action": "Instance is ready for dispatch."
+}
+```
+
+### Integration into existing surfaces
+
+| Surface | Where | Change |
+| --- | --- | --- |
+| Gateway `compact_instance_json` | Top-level `instance_status` key | Add `InstanceStatus` block; keep existing `status`, `stale`, `dispatch` for backward compat (deprecate after 2 releases) |
+| Gateway `entry_to_json` (verbose) | Top-level `instance_status` key | Same; existing `status`, `stale`, `dispatch` preserved |
+| CLI `direct_control_report` | `direct_control` block | Add `instance_status` sub-key; existing fields preserved |
+| CLI `doctor` | Per-instance in `local.inventory` | Use the same `compute_instance_status` function |
+
+Backward compatibility: existing consumers reading `status` (string),
+`stale` (bool), and `dispatch.ready` (bool/null) continue to work. The new
+`instance_status` block is additive. After two releases, the deprecated
+fields are removed and `instance_status` becomes the canonical location.
+
+## Discovery health ≠ dispatch availability
+
+These remain separate, top-level honesty signals:
+
+| Field | Location | Semantics |
+| --- | --- | --- |
+| `list_ok` | `gateway://instances` response | Registry read succeeded |
+| `index_health` | `gateway://instances` response | `"healthy"` / `"degraded"` / `"empty"` |
+| `total` / `capped` / `limit` / `offset` | `gateway://instances` response | Pagination metadata |
+| `stale_count` / `evicted_dead` | `gateway://instances` response | Registry health counters |
+
+An instance with `instance_status.status: "available"` and
+`instance_status.dispatch_status: "ready"` is routable **regardless** of
+`index_health`. An agent that needs to assess fleet-level health reads
+`index_health`; an agent that needs to route a single call reads
+`instance_status`. No field serves both purposes.
+
+## Requirements
+
+### Functional
+
+1. `compute_instance_status(entry, stale) -> InstanceStatus` is a pure function
+   with no side effects.
+2. `gateway://instances` compact and verbose responses both include the
+   `instance_status` block on every instance.
+3. CLI `doctor` uses the same `compute_instance_status` function for local
+   registry rows.
+4. CLI `call` / `wait-ready` use `instance_status` when reporting why an
+   instance cannot be used.
+5. The mapping table in this ADR is the single source of truth; no surface
+   hardcodes different `retryable` or `recommended_next_action` values.
+
+### Non-functional
+
+- `compute_instance_status` must not allocate on the heap (use `&'static str`).
+- The function lives in `dcc-mcp-transport` so CLI, gateway, and server crates
+  all depend on it without pulling in HTTP/gateway deps.
+- Existing tests for `compact_instance_json`, `direct_control_report`, and
+  `doctor` must pass with the additive fields present.
+- Python 3.7 adapters are consumers of the JSON output only; no Python-side
+  changes required.
+
+## Implementation phases
+
+### Phase 1: Transport types (`dcc-mcp-transport`)
+
+- Add `DispatchStatus` enum to `discovery::types`
+- Add `InstanceStatus` struct with `compute_instance_status` free function
+- Add the mapping table as a private constant lookup
+- Unit tests for all 16+ pairings
+
+### Phase 2: Gateway output (`dcc-mcp-gateway`)
+
+- `compact_instance_json`: add `instance_status` block
+- `entry_to_json` / `dispatch_json`: add `instance_status` block
+- Keep existing `status`, `stale`, `dispatch` fields unchanged
+
+### Phase 3: CLI surfaces (`dcc-mcp-cli`)
+
+- `direct_control_report`: add `instance_status` sub-key
+- `doctor`: use `compute_instance_status` for per-instance status
+- `instance_selection`: surface `instance_status` in error messages
+
+### Phase 4: Deprecation (2 releases later)
+
+- Remove deprecated `status`, `stale`, `dispatch` fields from gateway output
+- Remove `direct_control` redundant fields
+- `instance_status` becomes the only status location
+
+## Reuse before adding code
+
+| Need | Existing owner | Change |
+| --- | --- | --- |
+| `ServiceStatus` enum | `dcc_mcp_transport::discovery::types` | Add `DispatchStatus` enum alongside it; do not modify `ServiceStatus` |
+| `dispatch_status` metadata | `ServiceEntry.metadata["dispatch_status"]` | Formalize values; add `DispatchStatus::from_entry()` constructor |
+| `compact_instance_json` | `dcc_mcp_gateway::native_resources::instances` | Call `compute_instance_status` and embed the result |
+| `direct_control_report` | `dcc_mcp_cli::application::local_instance` | Call `compute_instance_status`; keep `direct_control` block for backward compat |
+| `doctor` | `dcc_mcp_cli::application::doctor` | Use `compute_instance_status` for per-instance readiness |
+
+No new crate, database table, or service is needed.
+
+## Consequences
+
+### Positive
+
+- Agents read one schema (`instance_status`) across all surfaces.
+- `retryable` and `recommended_next_action` are never re-derived by consumers.
+- Discovery health and dispatch availability stay separate and unambiguous.
+- The mapping table is auditable and testable as a single source of truth.
+
+### Negative
+
+- Two-release backward-compat window means duplicate fields temporarily.
+- `ServiceStatus` display names change on the wire (`shutting_down` →
+  `unavailable`); consumers relying on exact string matching may break.
+
+### Neutral
+
+- `ServiceStatus` enum variants are unchanged internally; only the surface
+  projection is new.
+- Python adapters consume the JSON output only and are unaffected.
+
+## Alternatives rejected
+
+- **Add `retryable`/`recommended_next_action` to `ServiceEntry` struct**: These are
+  derived values, not stored state. Storing them would duplicate the mapping
+  logic and risk drift between storage and computation.
+- **Keep status and dispatch_status as ad-hoc metadata strings**: The current
+  approach works but every consumer re-derives readiness, leading to the
+  inconsistency documented in the Context section.
+- **Fold `index_health` into per-instance status**: Discovery fleet health is a
+  different concern from per-instance routability. Conflating them would force
+  agents to read per-instance fields to assess fleet health, and vice versa.
+- **Remove existing `status`/`dispatch` fields immediately**: Would break every
+  downstream consumer. The two-release deprecation window is the safer path.
+
+## Product defaults
+
+1. `instance_status` appears in `gateway://instances` compact output by default
+   (no opt-in flag).
+2. CLI `doctor` and `call` output use `instance_status` when run with
+   `--output json`; `--output human` shows a summary line.
+3. Admin UI instance detail view renders `instance_status` with a color-coded
+   status badge and the action text as a tooltip.

--- a/docs/adr/018-cli-interaction-contract-workflow-consistency.md
+++ b/docs/adr/018-cli-interaction-contract-workflow-consistency.md
@@ -1,286 +1,88 @@
-# ADR-018: Instance Status Vocabulary Unification & Actionability
+# ADR 018: Instance Status Vocabulary Unification & Actionability
 
 ## Status
 
-Proposed
+Proposed — 2026-07-25
 
 ## Context
 
-`dcc-mcp-core` exposes instance status through three surfaces — gateway resource
-(`gateway://instances`), CLI `doctor`, and CLI `call`/`wait-ready` — but each
-surface uses a different vocabulary and schema:
+Today `ServiceStatus` (transport-level: `Available`, `Busy`, `Booting`, `Unreachable`, `ShuttingDown`, `Stale`) is stored on `ServiceEntry`, while `dispatch_status` ("ready", "unavailable", or absent) lives in `ServiceEntry.metadata` as a free-form string. The CLI `direct_control_report()` and gateway `dispatch_json()` both read `dispatch_status` from metadata and synthesize their own `ready` booleans, `recommended_next_action` strings, and reason labels independently. This duplication creates drift: the CLI and gateway can disagree on whether an instance is actionable, and callers (agents, scripts, admin UI) must interpret raw strings and booleans scattered across the output.
 
-| Surface | status values | dispatch_status | retryable | recommended_next_action |
-| --- | --- | --- | --- | --- |
-| Gateway `compact_instance_json` | `available`, `busy`, `unreachable`, `booting`, `stale` (derived) | `ready`, `pending` (ad-hoc metadata) | ✗ | ✗ |
-| Gateway `entry_to_json` (verbose) | same + `shutting_down` | `ready`, `not_reported` (metadata) | ✗ | ✗ |
-| CLI `direct_control_report` | From `ServiceStatus` raw | `ready`, `unavailable`, `not_reported` | ✗ | ✓ (hardcoded `if/else`) |
-| CLI `doctor` | Through `direct_control` block | Ad-hoc key path | ✗ | ✓ (drifted from CLI call) |
+ADR 018 defines a unified `InstanceStatus` type in `dcc-mcp-transport` that every surface — transport types, gateway output, CLI doctor — uses as the single source of truth.
 
-This creates four problems:
+## Decision
 
-1. **Agent confusion**: An agent reading `gateway://instances` sees `dispatch.ready: true` but
-   `status: "booting"` — should it route or wait? Without `retryable` and
-   `recommended_next_action`, every downstream consumer re-derives the answer.
+### 1. Unified `DispatchStatus` enum
 
-2. **Discovery health ≠ dispatch availability**: PIP-2725 introduced `list_ok` +
-   `index_health` honesty fields so agents can distinguish "the registry listed
-   successfully" from "these instances can accept tool calls." But each surface
-   encodes this separation differently.
-
-3. **No retry signal**: When an instance is `status=booting, dispatch_status=pending`,
-   the agent cannot know whether to poll, restart, or escalate. Today the logic
-   is duplicated across gateway, CLI, and every adapter.
-
-4. **Drift between surfaces**: `direct_control_report` has
-   `recommended_next_action`; `compact_instance_json` does not. `doctor` reads
-   `dispatch_status` from a different key path than `call`. Every new surface
-   reinvents the mapping.
-
-Parent: PIP-2881 (RFC: CLI interaction contract & workflow consistency).
-Preceding research: PIP-2880 (Unity CLI survey, Steve Jobs, 2026-07-24).
-
-## Decision summary
-
-1. **Unified status vocabulary**: Two orthogonal axes:
-   - `status` (liveness): `available` | `busy` | `booting` | `unavailable`
-   - `dispatch_status` (readiness): `ready` | `pending` | `failed` | `unknown`
-
-2. **Every (status, dispatch_status) pairing carries `retryable: bool | null` and
-   `recommended_next_action: string`.** The mapping is a pure function of the
-   pairing; no surface re-derives it.
-
-3. **All three surfaces — `gateway://instances`, CLI `doctor`, CLI `call`/`wait-ready`
-   — emit the same `InstanceStatus` schema.** Consumers learn one shape.
-
-4. **Discovery health stays separate.** `list_ok`, `index_health`, `stale`, and
-   `evicted_dead` remain top-level honesty fields; they are never folded into
-   per-instance status.
-
-## Status vocabulary
-
-### `status` (liveness — from `ServiceEntry.status` / heartbeat staleness)
-
-| Value | ServiceStatus(es) | Semantics |
-| --- | --- | --- |
-| `available` | `ServiceStatus::Available` | Accepting connections, not leased |
-| `busy` | `ServiceStatus::Busy` | Has an active lease or in-flight call |
-| `booting` | `ServiceStatus::Booting` | Alive but DCC host still initializing |
-| `unavailable` | `ServiceStatus::Unreachable`, `::ShuttingDown`, `::Stale`, or stale-by-heartbeat | Not routable |
-
-The `status` field is a **surface projection**, not a new storage enum.
-`ServiceStatus` variants persist unchanged in `services.json` and the
-`ServiceEntry` struct. The projection happens at serialization time so
-the on-disk format and Rust-internal types stay backward-compatible.
-
-Staleness is a cross-cutting concern: `status: "unavailable"` + `stale: true`
-means heartbeat timeout; `status: "unavailable"` + `stale: false` means the
-instance explicitly reported an unroutable state.
-
-### `dispatch_status` (readiness — from `entry.metadata["dispatch_status"]`)
-
-| Value | Metadata value | Semantics |
-| --- | --- | --- |
-| `ready` | `"ready"` | Dispatcher confirmed; `mcp_url` present; ready for `tools/call` |
-| `pending` | `"pending"` | Dispatcher initializing; may become ready |
-| `failed` | `"failed"` | Dispatcher reported a terminal failure; see `failure_stage` / `failure_reason` |
-| `unknown` | absent / any other value | No dispatch status reported; treat as not-ready |
-
-## `retryable` + `recommended_next_action` mapping
-
-The mapping is a deterministic function `f(status, dispatch_status, stale)`:
-
-| status | dispatch_status | stale | retryable | recommended_next_action |
-| --- | --- | --- | --- | --- |
-| `available` | `ready` | false | `null` | Instance is ready for dispatch. |
-| `available` | `pending` | false | `true` | Wait for dispatch_status=ready. Run `dcc-mcp-cli wait-ready`. |
-| `available` | `failed` | false | `true` | Inspect dispatch failure (failure_stage, failure_reason). Restart DCC or wait for sidecar recovery. |
-| `available` | `unknown` | false | `false` | Instance is not reporting dispatch status. Verify the dispatcher/sidecar is running. |
-| `busy` | `ready` | false | `true` | Instance is busy with an active lease. Wait for the current job to complete or select another instance. |
-| `busy` | `pending` | false | `true` | Instance is busy and dispatch is not ready. Wait for the current job and dispatcher to resolve. |
-| `busy` | `failed` | false | `true` | Instance is busy and dispatch failed. Cancel the current job (if owned) and restart the DCC host. |
-| `busy` | `unknown` | false | `false` | Instance is busy with unknown dispatch status. Verify dispatcher health and lease ownership. |
-| `booting` | `ready` | false | `true` | Instance is still booting but dispatcher reports ready. Wait for status=available. |
-| `booting` | `pending` | false | `true` | Instance is booting. Wait for DCC host initialization to complete. |
-| `booting` | `failed` | false | `false` | Instance booting but dispatch failed. Check DCC startup logs and restart. |
-| `booting` | `unknown` | false | `true` | Instance is booting. Wait for status=available and dispatch_status reporting. |
-| `unavailable` | any | true | `true` | Instance heartbeat is stale. Verify the DCC host process is still running. Restart if dead. |
-| `unavailable` | any (not stale) | false | `false` | Instance is unavailable. Check if the DCC host process is running. Restart if it exited. |
-
-`retryable: null` means "not applicable" — the instance is ready, no retry
-decision needed.
-
-`retryable: true` = the caller should poll/wait and retry. `retryable: false` =
-the caller should not retry without human or operator intervention (restart,
-reconfigure, investigate logs).
-
-## Unified `InstanceStatus` schema
-
-Every surface emits the same sub-object. In Rust, this is a free function
-`compute_instance_status(entry: &ServiceEntry, stale: bool) -> InstanceStatus`
-that returns:
+Add to `dcc-mcp-transport`:
 
 ```rust
-/// Projected status for agent-facing surfaces (ADR-018).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DispatchStatus {
+    Ready,
+    Pending,
+    Failed,
+    Unknown,
+}
+```
+
+This replaces the free-form `"ready"` / `"unavailable"` / absent metadata pattern.
+
+### 2. Unified `InstanceStatus` struct
+
+Add to `dcc-mcp-transport`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstanceStatus {
-    /// Liveness: "available" | "busy" | "booting" | "unavailable"
-    pub status: &'static str,
-    /// Readiness: "ready" | "pending" | "failed" | "unknown"
-    pub dispatch_status: &'static str,
-    /// true=poll/retry, false=intervention needed, null=not applicable
-    pub retryable: Option<bool>,
-    /// Human-readable next action for the agent
-    pub recommended_next_action: &'static str,
+    /// Transport-level connection state (from ServiceStatus).
+    pub status: ServiceStatus,
+    /// Application-level dispatch readiness.
+    pub dispatch_status: DispatchStatus,
+    /// Whether the current state is safe to retry.
+    pub retryable: bool,
+    /// Human + machine-readable next step for operators/agents.
+    pub recommended_next_action: String,
 }
 ```
 
-In JSON output (compact and verbose):
+### 3. Status pairing table
 
-```json
-{
-  "status": "available",
-  "dispatch_status": "ready",
-  "retryable": null,
-  "recommended_next_action": "Instance is ready for dispatch."
-}
-```
+| `ServiceStatus` | `DispatchStatus` | `retryable` | `recommended_next_action` |
+|---|---|---|---|
+| `Available` | `Ready` | true | "Instance is available for dispatch." |
+| `Available` | `Pending` | true | "Wait for instance to report dispatch_status=ready." |
+| `Available` | `Failed` | false | "Inspect instance failure stage/reason; the backend may need a restart." |
+| `Available` | `Unknown` | true | "Dispatch status not yet reported; try a direct MCP call." |
+| `Busy` | `Ready` | true | "Instance is busy; retry after current job completes." |
+| `Busy` | `Pending` | true | "Instance is busy and not yet dispatch-ready; wait and retry." |
+| `Busy` | `Failed` | false | "Instance is busy but dispatch has failed; inspect failure details." |
+| `Busy` | `Unknown` | true | "Instance is busy; retry later." |
+| `Booting` | `Pending` | true | "Instance is booting; wait for readiness and retry." |
+| `Booting` | `Unknown` | true | "Instance is booting; wait for readiness and retry." |
+| `Unreachable` | `Unknown` | false | "Instance is unreachable; check logs and restart if needed." |
+| `ShuttingDown` | `Unknown` | false | "Instance is shutting down; wait for a new instance." |
+| `Stale` | `Unknown` | false | "Instance is stale; it will be removed by the registry." |
 
-### Integration into existing surfaces
+### 4. Consistent output across surfaces
 
-| Surface | Where | Change |
-| --- | --- | --- |
-| Gateway `compact_instance_json` | Top-level `instance_status` key | Add `InstanceStatus` block; keep existing `status`, `stale`, `dispatch` for backward compat (deprecate after 2 releases) |
-| Gateway `entry_to_json` (verbose) | Top-level `instance_status` key | Same; existing `status`, `stale`, `dispatch` preserved |
-| CLI `direct_control_report` | `direct_control` block | Add `instance_status` sub-key; existing fields preserved |
-| CLI `doctor` | Per-instance in `local.inventory` | Use the same `compute_instance_status` function |
+- **Gateway `entry_to_json()`**: top-level `"status"` becomes the full `InstanceStatus` JSON block (status, dispatch_status, retryable, recommended_next_action). The old `"dispatch"` sub-object is removed after a deprecation window.
+- **CLI `direct_control_report()`**: uses the same `InstanceStatus` derivation from `ServiceEntry` instead of synthesizing its own.
+- **Gateway `gateway://instances` resource**: compact projection includes the `InstanceStatus` fields.
 
-Backward compatibility: existing consumers reading `status` (string),
-`stale` (bool), and `dispatch.ready` (bool/null) continue to work. The new
-`instance_status` block is additive. After two releases, the deprecated
-fields are removed and `instance_status` becomes the canonical location.
+### 5. Discovery health ≠ dispatch availability
 
-## Discovery health ≠ dispatch availability
-
-These remain separate, top-level honesty signals:
-
-| Field | Location | Semantics |
-| --- | --- | --- |
-| `list_ok` | `gateway://instances` response | Registry read succeeded |
-| `index_health` | `gateway://instances` response | `"healthy"` / `"degraded"` / `"empty"` |
-| `total` / `capped` / `limit` / `offset` | `gateway://instances` response | Pagination metadata |
-| `stale_count` / `evicted_dead` | `gateway://instances` response | Registry health counters |
-
-An instance with `instance_status.status: "available"` and
-`instance_status.dispatch_status: "ready"` is routable **regardless** of
-`index_health`. An agent that needs to assess fleet-level health reads
-`index_health`; an agent that needs to route a single call reads
-`instance_status`. No field serves both purposes.
-
-## Requirements
-
-### Functional
-
-1. `compute_instance_status(entry, stale) -> InstanceStatus` is a pure function
-   with no side effects.
-2. `gateway://instances` compact and verbose responses both include the
-   `instance_status` block on every instance.
-3. CLI `doctor` uses the same `compute_instance_status` function for local
-   registry rows.
-4. CLI `call` / `wait-ready` use `instance_status` when reporting why an
-   instance cannot be used.
-5. The mapping table in this ADR is the single source of truth; no surface
-   hardcodes different `retryable` or `recommended_next_action` values.
-
-### Non-functional
-
-- `compute_instance_status` must not allocate on the heap (use `&'static str`).
-- The function lives in `dcc-mcp-transport` so CLI, gateway, and server crates
-  all depend on it without pulling in HTTP/gateway deps.
-- Existing tests for `compact_instance_json`, `direct_control_report`, and
-  `doctor` must pass with the additive fields present.
-- Python 3.7 adapters are consumers of the JSON output only; no Python-side
-  changes required.
-
-## Implementation phases
-
-### Phase 1: Transport types (`dcc-mcp-transport`)
-
-- Add `DispatchStatus` enum to `discovery::types`
-- Add `InstanceStatus` struct with `compute_instance_status` free function
-- Add the mapping table as a private constant lookup
-- Unit tests for all 16+ pairings
-
-### Phase 2: Gateway output (`dcc-mcp-gateway`)
-
-- `compact_instance_json`: add `instance_status` block
-- `entry_to_json` / `dispatch_json`: add `instance_status` block
-- Keep existing `status`, `stale`, `dispatch` fields unchanged
-
-### Phase 3: CLI surfaces (`dcc-mcp-cli`)
-
-- `direct_control_report`: add `instance_status` sub-key
-- `doctor`: use `compute_instance_status` for per-instance status
-- `instance_selection`: surface `instance_status` in error messages
-
-### Phase 4: Deprecation (2 releases later)
-
-- Remove deprecated `status`, `stale`, `dispatch` fields from gateway output
-- Remove `direct_control` redundant fields
-- `instance_status` becomes the only status location
-
-## Reuse before adding code
-
-| Need | Existing owner | Change |
-| --- | --- | --- |
-| `ServiceStatus` enum | `dcc_mcp_transport::discovery::types` | Add `DispatchStatus` enum alongside it; do not modify `ServiceStatus` |
-| `dispatch_status` metadata | `ServiceEntry.metadata["dispatch_status"]` | Formalize values; add `DispatchStatus::from_entry()` constructor |
-| `compact_instance_json` | `dcc_mcp_gateway::native_resources::instances` | Call `compute_instance_status` and embed the result |
-| `direct_control_report` | `dcc_mcp_cli::application::local_instance` | Call `compute_instance_status`; keep `direct_control` block for backward compat |
-| `doctor` | `dcc_mcp_cli::application::doctor` | Use `compute_instance_status` for per-instance readiness |
-
-No new crate, database table, or service is needed.
+`ServiceStatus::Available` means the transport is healthy (TCP port open, MCP server responding). `DispatchStatus::Ready` means the application is ready to accept tool calls (DCC initialized, skill catalog loaded, dispatcher running). These are exposed separately so agents can distinguish "server is up but DCC is still loading" from "everything is ready."
 
 ## Consequences
 
-### Positive
+- **Positive**: Single source of truth for instance status; no more string matching on metadata; consistent output across all surfaces.
+- **Positive**: Agents get `retryable` and `recommended_next_action` in every instance listing without needing to synthesize them.
+- **Negative**: Breaking change to the gateway JSON output shape; existing consumers must update.
+- **Migration**: Old `"dispatch"` block is kept alongside the new `"status"` block for one release cycle, then removed.
 
-- Agents read one schema (`instance_status`) across all surfaces.
-- `retryable` and `recommended_next_action` are never re-derived by consumers.
-- Discovery health and dispatch availability stay separate and unambiguous.
-- The mapping table is auditable and testable as a single source of truth.
+## References
 
-### Negative
-
-- Two-release backward-compat window means duplicate fields temporarily.
-- `ServiceStatus` display names change on the wire (`shutting_down` →
-  `unavailable`); consumers relying on exact string matching may break.
-
-### Neutral
-
-- `ServiceStatus` enum variants are unchanged internally; only the surface
-  projection is new.
-- Python adapters consume the JSON output only and are unaffected.
-
-## Alternatives rejected
-
-- **Add `retryable`/`recommended_next_action` to `ServiceEntry` struct**: These are
-  derived values, not stored state. Storing them would duplicate the mapping
-  logic and risk drift between storage and computation.
-- **Keep status and dispatch_status as ad-hoc metadata strings**: The current
-  approach works but every consumer re-derives readiness, leading to the
-  inconsistency documented in the Context section.
-- **Fold `index_health` into per-instance status**: Discovery fleet health is a
-  different concern from per-instance routability. Conflating them would force
-  agents to read per-instance fields to assess fleet health, and vice versa.
-- **Remove existing `status`/`dispatch` fields immediately**: Would break every
-  downstream consumer. The two-release deprecation window is the safer path.
-
-## Product defaults
-
-1. `instance_status` appears in `gateway://instances` compact output by default
-   (no opt-in flag).
-2. CLI `doctor` and `call` output use `instance_status` when run with
-   `--output json`; `--output human` shows a summary line.
-3. Admin UI instance detail view renders `instance_status` with a color-coded
-   status badge and the action text as a tooltip.
+- Parent: PIP-2881 (P0 Instance State Actionability)
+- Child issues: PIP-2900 (Phase 1: transport types), PIP-2901 (Phase 2: gateway output), PIP-2902 (Phase 3: CLI doctor)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ Decision / Consequences / Alternatives considered.
 | 015 | [Bound Windows system configuration to operator grants](./015-bounded-ui-control-system-operations.md) | Accepted |
 | 016 | [Unify application automation under UI Control naming](./016-unify-ui-control-naming.md) | Accepted |
 | 017 | [Codex-style Record & Replay with visual closed-loop execution](./017-codex-record-replay-visual-closed-loop.md) | Accepted |
+| 018 | [Instance Status Vocabulary Unification & Actionability](./018-cli-interaction-contract-workflow-consistency.md) | Proposed |
 
 > Numbering is strictly sequential and never reused. ADR 001 is reserved for
 > the first historical record; filling it in is tracked separately from any

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -1060,6 +1060,45 @@ class InputValidator:
     def __repr__(self) -> builtins.str: ...
 
 @typing.final
+class InstanceStatus:
+    r"""
+    Python-facing unified instance status (ADR 018).
+
+    Combines transport-level status, dispatch readiness, retryability,
+    and a recommended next action.
+
+    ```python,ignore
+    from dcc_mcp_core import InstanceStatus
+
+    status = InstanceStatus.from_entry(entry, stale=False)
+    print(status.status)               # ServiceStatus.AVAILABLE
+    print(status.dispatch_status)      # DispatchStatus.READY
+    print(status.retryable)            # True
+    print(status.recommended_next_action)  # "Instance is available for dispatch."
+    ```
+    """
+    @property
+    def status(self) -> ServiceStatus:
+        r"""
+        Transport-level connection state.
+        """
+    @property
+    def dispatch_status(self) -> DispatchStatus:
+        r"""
+        Application-level dispatch readiness.
+        """
+    @property
+    def retryable(self) -> builtins.bool:
+        r"""
+        Whether the current state is safe to retry.
+        """
+    @property
+    def recommended_next_action(self) -> builtins.str:
+        r"""
+        Human + machine-readable recommended next step.
+        """
+
+@typing.final
 class IpcChannelAdapter:
     r"""
     Thin adapter over ``ipckit::IpcChannel`` using DCC-Link framing.
@@ -3956,6 +3995,40 @@ class DccErrorCode(enum.Enum):
     def __str__(self) -> builtins.str: ...
 
 @typing.final
+class DispatchStatus(enum.Enum):
+    r"""
+    Python-facing enum for application-level dispatch readiness.
+
+    ADR 018 — replaces the free-form ``dispatch_status`` metadata string.
+
+    ```python,ignore
+    from dcc_mcp_core import DispatchStatus
+
+    status = DispatchStatus.READY
+    print(status)  # "READY"
+    ```
+    """
+    READY = ...
+    r"""
+    Instance has reported dispatch-ready.
+    """
+    PENDING = ...
+    r"""
+    Instance is alive but not yet dispatch-ready.
+    """
+    FAILED = ...
+    r"""
+    Instance reported a dispatch failure.
+    """
+    UNKNOWN = ...
+    r"""
+    Instance has not reported dispatch status.
+    """
+
+    def __repr__(self) -> builtins.str: ...
+    def __str__(self) -> builtins.str: ...
+
+@typing.final
 class PySceneDataKind(enum.Enum):
     r"""
     Kind of DCC scene data stored in a shared scene buffer.
@@ -4052,41 +4125,6 @@ class ServiceStatus(enum.Enum):
     STALE = ...
     r"""
     Service has already been marked stale by a probe or registry owner.
-    """
-
-    def __repr__(self) -> builtins.str: ...
-    def __str__(self) -> builtins.str: ...
-
-class DispatchStatus(enum.Enum):
-    r"""
-    Python-facing enum for application-level dispatch readiness.
-
-    ADR 018 — replaces the free-form ``dispatch_status`` metadata string.
-
-    ```python,ignore
-    from dcc_mcp_core import DispatchStatus
-
-    status = DispatchStatus.READY
-    print(status)  # "READY"
-    ```
-    """
-    READY = ...
-    r"""
-    Instance has reported dispatch-ready (all readiness bits green).
-    """
-    PENDING = ...
-    r"""
-    Instance is alive but has not yet reported dispatch-ready (booting,
-    sidecar waiting for host, etc.).
-    """
-    FAILED = ...
-    r"""
-    Instance reported a dispatch failure (failure_stage + failure_reason
-    metadata set).
-    """
-    UNKNOWN = ...
-    r"""
-    Instance has not reported dispatch status (legacy / embedded / pre-sidecar).
     """
 
     def __repr__(self) -> builtins.str: ...
@@ -4433,42 +4471,3 @@ def validate_tool_name(name: builtins.str) -> None:
 
     Raises ``ValueError`` on any violation; returns ``None`` on success.
     """
-
-@typing.final
-class InstanceStatus:
-    r"""
-    Python-facing unified instance status (ADR 018).
-
-    Combines transport-level status, dispatch readiness, retryability,
-    and a recommended next action.
-
-    ```python,ignore
-    from dcc_mcp_core import InstanceStatus
-
-    status = InstanceStatus.from_entry(entry, stale=False)
-    print(status.status)               # ServiceStatus.AVAILABLE
-    print(status.dispatch_status)      # DispatchStatus.READY
-    print(status.retryable)            # True
-    print(status.recommended_next_action)  # "Instance is available for dispatch."
-    ```
-    """
-    @property
-    def status(self) -> ServiceStatus:
-        r"""
-        Transport-level connection state.
-        """
-    @property
-    def dispatch_status(self) -> DispatchStatus:
-        r"""
-        Application-level dispatch readiness.
-        """
-    @property
-    def retryable(self) -> builtins.bool:
-        r"""
-        Whether the current state is safe to retry.
-        """
-    @property
-    def recommended_next_action(self) -> builtins.str:
-        r"""
-        Human + machine-readable recommended next step.
-        """

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -60,12 +60,14 @@ __all__ = [
     "DccErrorCode",
     "DccInfo",
     "DccLinkFrame",
+    "DispatchStatus",
     "EventBus",
     "FileRef",
     "FrameRange",
     "GracefulIpcChannelAdapter",
     "GuiExecutableHint",
     "InputValidator",
+    "InstanceStatus",
     "IpcChannelAdapter",
     "LoggingMiddleware",
     "ObjectTransform",
@@ -4055,6 +4057,41 @@ class ServiceStatus(enum.Enum):
     def __repr__(self) -> builtins.str: ...
     def __str__(self) -> builtins.str: ...
 
+class DispatchStatus(enum.Enum):
+    r"""
+    Python-facing enum for application-level dispatch readiness.
+
+    ADR 018 — replaces the free-form ``dispatch_status`` metadata string.
+
+    ```python,ignore
+    from dcc_mcp_core import DispatchStatus
+
+    status = DispatchStatus.READY
+    print(status)  # "READY"
+    ```
+    """
+    READY = ...
+    r"""
+    Instance has reported dispatch-ready (all readiness bits green).
+    """
+    PENDING = ...
+    r"""
+    Instance is alive but has not yet reported dispatch-ready (booting,
+    sidecar waiting for host, etc.).
+    """
+    FAILED = ...
+    r"""
+    Instance reported a dispatch failure (failure_stage + failure_reason
+    metadata set).
+    """
+    UNKNOWN = ...
+    r"""
+    Instance has not reported dispatch status (legacy / embedded / pre-sidecar).
+    """
+
+    def __repr__(self) -> builtins.str: ...
+    def __str__(self) -> builtins.str: ...
+
 @typing.final
 class SkillRuntimeKind(enum.Enum):
     r"""
@@ -4396,3 +4433,42 @@ def validate_tool_name(name: builtins.str) -> None:
 
     Raises ``ValueError`` on any violation; returns ``None`` on success.
     """
+
+@typing.final
+class InstanceStatus:
+    r"""
+    Python-facing unified instance status (ADR 018).
+
+    Combines transport-level status, dispatch readiness, retryability,
+    and a recommended next action.
+
+    ```python,ignore
+    from dcc_mcp_core import InstanceStatus
+
+    status = InstanceStatus.from_entry(entry, stale=False)
+    print(status.status)               # ServiceStatus.AVAILABLE
+    print(status.dispatch_status)      # DispatchStatus.READY
+    print(status.retryable)            # True
+    print(status.recommended_next_action)  # "Instance is available for dispatch."
+    ```
+    """
+    @property
+    def status(self) -> ServiceStatus:
+        r"""
+        Transport-level connection state.
+        """
+    @property
+    def dispatch_status(self) -> DispatchStatus:
+        r"""
+        Application-level dispatch readiness.
+        """
+    @property
+    def retryable(self) -> builtins.bool:
+        r"""
+        Whether the current state is safe to retry.
+        """
+    @property
+    def recommended_next_action(self) -> builtins.str:
+        r"""
+        Human + machine-readable recommended next step.
+        """


### PR DESCRIPTION
## Summary

Completes ADR-018 Phase 2 for the gateway output surfaces.

### Changes

- **`compact_instance_json`** now includes `instance_status` block (status, dispatch_status, retryable, recommended_next_action) alongside the existing `status`, `stale`, and `dispatch` fields for backward compatibility.
- **Tests** updated in both `instances.rs` and `state/tests.rs` to verify the new `instance_status` fields.

### Backward Compatibility

All existing fields (`status`, `stale`, `dispatch`) are preserved unchanged. The new `instance_status` block is additive.

### Test Plan

- `cargo test -p dcc-mcp-gateway -- native_resources::instances::tests` — 26 passed
- `cargo test -p dcc-mcp-gateway -- state::tests` — 42 passed (including 4 new instance_status tests)