### PR TITLE
docs: add app-ui-workflows.md to fix broken profile README link

### DIFF
--- a/docs/guide/app-ui-workflows.md
+++ b/docs/guide/app-ui-workflows.md
@@ -1,0 +1,107 @@
+# App UI Workflows
+
+This document surveys the application-level UI surfaces in dcc-mcp-core: the
+built-in Admin Dashboard, the `ui_control` automation tool suite, and CLI
+subcommands that interact with UI features. Each section links to the detailed
+reference for deeper reading.
+
+## Admin Dashboard
+
+The gateway ships an embedded `/admin` web dashboard (React/Vite source in
+`admin-ui/`). At runtime it is a single HTML payload served from the binary;
+contributors edit the source under `admin-ui/`, and the build system embeds the
+built asset during Cargo compilation.
+
+The dashboard is enabled by default on the elected gateway. It provides:
+
+- **Instances** — connected DCC adapter overview with version diagnostics
+- **Tools** — registered tool/action catalogue with search and describe
+- **Calls** — live and historical tool call log
+- **Traces** — distributed trace viewer
+- **Stats** — gateway-level metrics and throughput
+- **Workers** — background worker pool status
+- **Merged Logs** — aggregated log viewer across all gateway log files
+- **Health** — readiness and liveness probes
+
+See [admin-ui.md](admin-ui.md) for activation flags, environment variables,
+Python/Rust API configuration, and the full feature walkthrough.
+
+### Enabling and Disabling
+
+```bash
+# Default: gateway election on :9765; elected process serves /admin
+dcc-mcp-server --app maya
+
+# Disable gateway entirely (also disables admin)
+dcc-mcp-server --gateway-port 0
+
+# Keep gateway but disable admin
+dcc-mcp-server --no-admin
+
+# Move admin under another prefix
+dcc-mcp-server --admin-path /dcc-admin
+```
+
+Equivalent environment variables:
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `DCC_MCP_GATEWAY_PORT` | `9765` | Gateway election port. `0` disables gateway/admin. |
+| `DCC_MCP_NO_ADMIN` | `false` | Disable the Admin UI on the elected gateway. |
+| `DCC_MCP_ADMIN_PATH` | `/admin` | Admin URL prefix. |
+| `DCC_MCP_GATEWAY_AUDIT_DIR` | unset | Optional JSONL directory for durable audit and trace persistence. |
+| `DCC_MCP_GATEWAY_AUDIT_MAX_ROWS` | `5000` | Max JSONL rows retained per durable file. |
+| `DCC_MCP_GATEWAY_AUDIT_MAX_BYTES` | `52428800` | Approx. 50 MiB byte cap per durable JSONL file. |
+| `DCC_MCP_LOG_DIR` | platform log dir | Directory scanned by `/admin/api/logs` for `*.log` files. |
+
+### Analytics Dashboard
+
+A separate analytics dashboard provides KPI timeseries, heatmaps, top-tool
+rankings, and CSV/JSONL export. See [analytics-dashboard.md](analytics-dashboard.md).
+
+## UI Control Automation
+
+When a DCC exposes state only through a window, modal dialog, webview, launcher,
+or settings panel — rather than a typed API — the `ui_control` tool suite
+provides a scoped fallback for interface-only automation.
+
+The canonical workflow follows this loop:
+
+1. **`ui_control__snapshot`** — capture the scoped DCC window, returns `snapshot_id`
+2. **`ui_control__find`** — resolve a control by label, text, role, or name
+3. **`ui_control__act`** — perform one action (click, set_text, drag, etc.)
+4. **`ui_control__wait_for`** — poll inside one tool call until the UI reaches expected state
+5. **`ui_control__snapshot`** — verify the final state
+6. **`ui_control__stop_computer_use`** — release native input, remove visual effects
+
+Always treat step 6 like a `finally` block — call it on success, failure,
+cancellation, or abandonment.
+
+See [ui-control-workflows.md](ui-control-workflows.md) for the full reference:
+decision rules, evidence attribution, system configuration operations, recovery
+patterns, and verification requirements.
+
+### CLI Interface
+
+The `dcc-mcp-cli ui-control` subcommand exposes the same capabilities through
+the shell:
+
+```bash
+dcc-mcp-cli ui-control snapshot --instance-id <id> --json '{"session_id":"ui","process_id":1234}'
+dcc-mcp-cli ui-control act --instance-id <id> --json '{"session_id":"ui","control_id":"ok","action":"click","snapshot_id":"<snapshot_id>"}'
+dcc-mcp-cli ui-control record-clip --instance-id <id> --json '{"session_id":"pv","process_id":1234,"duration_ms":5000}'
+dcc-mcp-cli ui-control stop --instance-id <id> --json '{"session_id":"ui"}'
+dcc-mcp-cli ui-control system-operation --instance-id <id> --json '{"operation_id":"enable-remote-control"}'
+```
+
+## Related Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [admin-ui.md](admin-ui.md) | Full Admin Dashboard reference: activation, panels, audit, health |
+| [analytics-dashboard.md](analytics-dashboard.md) | KPI dashboard, timeseries, heatmap, CSV/JSONL export |
+| [ui-control-workflows.md](ui-control-workflows.md) | UI Control automation: full workflow reference, recovery, verification |
+| [gateway.md](gateway.md) | Multi-DCC gateway: aggregation, tool routing, election |
+| [gateway-diagnostics.md](gateway-diagnostics.md) | Gateway health, readiness, contention, failure diagnosis |
+| [cli-reference.md](cli-reference.md) | Canonical CLI commands, flags, profiles |
+| [observability-usage.md](observability-usage.md) | Agent, CLI, and Admin UI observability usage |

--- a/docs/zh/guide/app-ui-workflows.md
+++ b/docs/zh/guide/app-ui-workflows.md
@@ -21,7 +21,7 @@ Dashboard）、`ui_control` 自动化工具套件以及与 UI 功能交互的 CL
 - **合并日志（Merged Logs）** — 跨所有网关日志文件的聚合日志查看器
 - **健康检查（Health）** — 就绪与存活探针
 
-详见 [admin-ui.md](../guide/admin-ui.md) 了解激活标志、环境变量、
+详见 [admin-ui.md](../../guide/admin-ui.md) 了解激活标志、环境变量、
 Python/Rust API 配置及完整功能说明。
 
 ### 启用与禁用
@@ -55,7 +55,7 @@ dcc-mcp-server --admin-path /dcc-admin
 ### 分析仪表盘
 
 独立分析仪表盘提供 KPI 时序、热力图、工具排名及 CSV/JSONL 导出。
-详见 [analytics-dashboard.md](../guide/analytics-dashboard.md)。
+详见 [analytics-dashboard.md](../../guide/analytics-dashboard.md)。
 
 ## UI 控制自动化
 
@@ -73,7 +73,7 @@ dcc-mcp-server --admin-path /dcc-admin
 
 始终将第 6 步视为 `finally` 代码块——在成功、失败、取消或放弃时都需调用。
 
-详见 [ui-control-workflows.md](../guide/ui-control-workflows.md) 查阅完整参考：
+详见 [ui-control-workflows.md](../../guide/ui-control-workflows.md) 查阅完整参考：
 决策规则、证据溯源、系统配置操作、恢复模式及验证要求。
 
 ### CLI 接口
@@ -92,10 +92,10 @@ dcc-mcp-cli ui-control system-operation --instance-id <id> --json '{"operation_i
 
 | 文档 | 用途 |
 |------|------|
-| [admin-ui.md](../guide/admin-ui.md) | 管理面板完整参考：激活、面板、审计、健康检查 |
-| [analytics-dashboard.md](../guide/analytics-dashboard.md) | KPI 仪表盘、时序、热力图、CSV/JSONL 导出 |
-| [ui-control-workflows.md](../guide/ui-control-workflows.md) | UI 控制自动化：完整工作流参考、恢复、验证 |
-| [gateway.md](../guide/gateway.md) | 多 DCC 网关：聚合、工具路由、选举 |
-| [gateway-diagnostics.md](../guide/gateway-diagnostics.md) | 网关健康、就绪、争用、故障诊断 |
-| [cli-reference.md](../guide/cli-reference.md) | 规范 CLI 命令、标志、配置 |
-| [observability-usage.md](../guide/observability-usage.md) | Agent、CLI 和管理面板的可观测性用法 |
+| [admin-ui.md](../../guide/admin-ui.md) | 管理面板完整参考：激活、面板、审计、健康检查 |
+| [analytics-dashboard.md](../../guide/analytics-dashboard.md) | KPI 仪表盘、时序、热力图、CSV/JSONL 导出 |
+| [ui-control-workflows.md](../../guide/ui-control-workflows.md) | UI 控制自动化：完整工作流参考、恢复、验证 |
+| [gateway.md](../../guide/gateway.md) | 多 DCC 网关：聚合、工具路由、选举 |
+| [gateway-diagnostics.md](../../guide/gateway-diagnostics.md) | 网关健康、就绪、争用、故障诊断 |
+| [cli-reference.md](../../guide/cli-reference.md) | 规范 CLI 命令、标志、配置 |
+| [observability-usage.md](../../guide/observability-usage.md) | Agent、CLI 和管理面板的可观测性用法 |

--- a/docs/zh/guide/app-ui-workflows.md
+++ b/docs/zh/guide/app-ui-workflows.md
@@ -1,0 +1,101 @@
+# 应用 UI 工作流
+
+本文档概述 dcc-mcp-core 中的应用层 UI 界面：内置管理控制面板（Admin
+Dashboard）、`ui_control` 自动化工具套件以及与 UI 功能交互的 CLI 子命令。
+每个部分都链接到详细参考文档以便深入阅读。
+
+## 管理控制面板
+
+网关（gateway）内置了一个 `/admin` Web 管理面板（React/Vite 源码位于
+`admin-ui/`）。运行时它以单一 HTML 负载形式从二进制文件中提供；贡献者编辑
+`admin-ui/` 下的源码，构建系统会在 Cargo 编译过程中将构建产物嵌入。
+
+该面板在当选网关上默认启用，提供以下功能：
+
+- **实例（Instances）** — 已连接 DCC 适配器概览及版本诊断
+- **工具（Tools）** — 已注册工具/动作目录，支持搜索和描述
+- **调用（Calls）** — 实时和历史工具调用日志
+- **追踪（Traces）** — 分布式追踪查看器
+- **统计（Stats）** — 网关级指标和吞吐量
+- **工作者（Workers）** — 后台工作者池状态
+- **合并日志（Merged Logs）** — 跨所有网关日志文件的聚合日志查看器
+- **健康检查（Health）** — 就绪与存活探针
+
+详见 [admin-ui.md](../guide/admin-ui.md) 了解激活标志、环境变量、
+Python/Rust API 配置及完整功能说明。
+
+### 启用与禁用
+
+```bash
+# 默认：在 :9765 加入网关选举；当选进程提供 /admin
+dcc-mcp-server --app maya
+
+# 完全禁用网关（同时禁用管理面板）
+dcc-mcp-server --gateway-port 0
+
+# 保留网关但禁用管理面板
+dcc-mcp-server --no-admin
+
+# 将管理面板挂载到其他路径前缀下
+dcc-mcp-server --admin-path /dcc-admin
+```
+
+等效环境变量：
+
+| 环境变量 | 默认值 | 说明 |
+|---------|--------|------|
+| `DCC_MCP_GATEWAY_PORT` | `9765` | 网关选举端口。`0` 禁用网关/管理面板。 |
+| `DCC_MCP_NO_ADMIN` | `false` | 在当选网关上禁用管理面板。 |
+| `DCC_MCP_ADMIN_PATH` | `/admin` | 管理面板 URL 前缀。 |
+| `DCC_MCP_GATEWAY_AUDIT_DIR` | 未设置 | 可选的 JSONL 目录，用于审计和追踪持久化。 |
+| `DCC_MCP_GATEWAY_AUDIT_MAX_ROWS` | `5000` | 每个持久化文件保留的最大 JSONL 行数。 |
+| `DCC_MCP_GATEWAY_AUDIT_MAX_BYTES` | `52428800` | 每个持久化 JSONL 文件约 50 MiB 的字节上限。 |
+| `DCC_MCP_LOG_DIR` | 平台日志目录 | `/admin/api/logs` 扫描 `*.log` 文件的目录。 |
+
+### 分析仪表盘
+
+独立分析仪表盘提供 KPI 时序、热力图、工具排名及 CSV/JSONL 导出。
+详见 [analytics-dashboard.md](../guide/analytics-dashboard.md)。
+
+## UI 控制自动化
+
+当 DCC 仅在窗口、模态对话框、webview、启动器或设置面板中暴露状态（而非通
+过类型化 API）时，`ui_control` 工具套件提供了用于界面自动化的有界回退方案。
+
+标准工作流遵循以下循环：
+
+1. **`ui_control__snapshot`** — 捕获有界 DCC 窗口，返回 `snapshot_id`
+2. **`ui_control__find`** — 通过标签、文本、角色或名称解析控件
+3. **`ui_control__act`** — 执行一个操作（点击、设置文本、拖拽等）
+4. **`ui_control__wait_for`** — 在一次工具调用内轮询直到 UI 达到预期状态
+5. **`ui_control__snapshot`** — 验证最终状态
+6. **`ui_control__stop_computer_use`** — 释放原生输入，移除视觉效果
+
+始终将第 6 步视为 `finally` 代码块——在成功、失败、取消或放弃时都需调用。
+
+详见 [ui-control-workflows.md](../guide/ui-control-workflows.md) 查阅完整参考：
+决策规则、证据溯源、系统配置操作、恢复模式及验证要求。
+
+### CLI 接口
+
+`dcc-mcp-cli ui-control` 子命令通过 Shell 暴露相同的能力：
+
+```bash
+dcc-mcp-cli ui-control snapshot --instance-id <id> --json '{"session_id":"ui","process_id":1234}'
+dcc-mcp-cli ui-control act --instance-id <id> --json '{"session_id":"ui","control_id":"ok","action":"click","snapshot_id":"<snapshot_id>"}'
+dcc-mcp-cli ui-control record-clip --instance-id <id> --json '{"session_id":"pv","process_id":1234,"duration_ms":5000}'
+dcc-mcp-cli ui-control stop --instance-id <id> --json '{"session_id":"ui"}'
+dcc-mcp-cli ui-control system-operation --instance-id <id> --json '{"operation_id":"enable-remote-control"}'
+```
+
+## 相关文档
+
+| 文档 | 用途 |
+|------|------|
+| [admin-ui.md](../guide/admin-ui.md) | 管理面板完整参考：激活、面板、审计、健康检查 |
+| [analytics-dashboard.md](../guide/analytics-dashboard.md) | KPI 仪表盘、时序、热力图、CSV/JSONL 导出 |
+| [ui-control-workflows.md](../guide/ui-control-workflows.md) | UI 控制自动化：完整工作流参考、恢复、验证 |
+| [gateway.md](../guide/gateway.md) | 多 DCC 网关：聚合、工具路由、选举 |
+| [gateway-diagnostics.md](../guide/gateway-diagnostics.md) | 网关健康、就绪、争用、故障诊断 |
+| [cli-reference.md](../guide/cli-reference.md) | 规范 CLI 命令、标志、配置 |
+| [observability-usage.md](../guide/observability-usage.md) | Agent、CLI 和管理面板的可观测性用法 |


### PR DESCRIPTION
## Summary

The `.github/profile/README.md` referenced `docs/guide/app-ui-workflows.md`
and `docs/zh/guide/app-ui-workflows.md` which returned HTTP 404. The actual
content exists under `ui-control-workflows.md` (UI control automation), but
the profile used the wrong filename.

This PR adds `app-ui-workflows.md` (EN) and `docs/zh/guide/app-ui-workflows.md`
(ZH) as entry-point documents that survey the application-level UI surfaces:

- Built-in Admin Dashboard (`/admin`) with activation flags and env vars
- `ui_control` automation tool suite with standard workflow loop
- CLI subcommands (`dcc-mcp-cli ui-control`)
- Cross-references to detailed docs: admin-ui.md, ui-control-workflows.md,
  analytics-dashboard.md, gateway.md, cli-reference.md, etc.

These new documents resolve the 404 links in the profile README once merged.

## Test plan

- [ ] Verify GitHub raw URLs return 200 after merge:
  - https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/docs/guide/app-ui-workflows.md
  - https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/docs/zh/guide/app-ui-workflows.md
- [ ] Confirm no existing internal links are broken by the addition
- [ ] Run `vx just preflight` for docs validation