### PR TITLE
fix: restore non-sidecar Unknown dispatch_status as ready for direct control

### DIFF
--- a/crates/dcc-mcp-cli/src/application/local_instance.rs
+++ b/crates/dcc-mcp-cli/src/application/local_instance.rs
@@ -228,7 +228,15 @@ pub(crate) fn direct_control_ready(entry: &ServiceEntry) -> bool {
         .get(ROLE_METADATA_KEY)
         .is_some_and(|role| role == ROLE_PER_DCC_SIDECAR);
     let instance_status = InstanceStatus::from_entry(entry, false, is_sidecar);
-    instance_status.dispatch_status == dcc_mcp_transport::discovery::types::DispatchStatus::Ready
+    // Per ADR-018: Available/Busy + Unknown is retryable ("try a direct MCP call").
+    // Non-sidecar (direct-mcp embedded) instances do not report dispatch_status,
+    // so Unknown is the expected default and must not block local CLI control.
+    let dispatch_ok = instance_status.dispatch_status
+        == dcc_mcp_transport::discovery::types::DispatchStatus::Ready
+        || (!is_sidecar
+            && instance_status.dispatch_status
+                == dcc_mcp_transport::discovery::types::DispatchStatus::Unknown);
+    dispatch_ok
         && matches!(
             instance_status.status,
             ServiceStatus::Available | ServiceStatus::Busy


### PR DESCRIPTION
## Problem

ADR-018 refactoring of `direct_control_ready` in `af34c64a` removed the `None => !is_sidecar` fallback. Non-sidecar (direct-mcp embedded) instances without explicit `dispatch_status` metadata became unroutable, causing CI failure in `local_call_requires_owner_metadata_for_leased_instance`.

**Error**: `local DCC instance matched the request but is not ready for direct local CLI control` with `dispatch_status=not_reported`.

## Root Cause

The old code treated non-sidecar entries without `dispatch_status` metadata as ready:
```rust
match entry.metadata.get(DISPATCH_STATUS_METADATA_KEY) {
    Some(status) => status == DISPATCH_STATUS_READY,
    None => !is_sidecar,  // direct-mcp embedded instances are ready by default
}
```

The new code maps missing `dispatch_status` to `DispatchStatus::Unknown` and requires exact match with `Ready` — rejecting all entries without explicit `dispatch_status=ready`.

**This contradicts ADR-018's own pairing table**: `Available + Unknown → retryable=true, "try a direct MCP call."`

## Fix

Restore backward-compatible behavior in `direct_control_ready`: non-sidecar entries with `Unknown` dispatch_status are treated as ready for direct local CLI control.

## Validation

- `cargo check -p dcc-mcp-cli` — compiles clean
- `cargo test -p dcc-mcp-cli -- routable_selection` — all 3 existing unit tests pass
- E2E test `local_call_requires_owner_metadata_for_leased_instance` — fix addresses the root cause (verified by unit tests; E2E needs Ubuntu runner with MCP fixture)

## References

- [CI failure run](https://github.com/dcc-mcp/dcc-mcp-core/actions/runs/30144669186)
- [ADR-018](docs/adr/018-cli-interaction-contract-workflow-consistency.md)
