### PR TITLE
fix: align ADR-018 actionability messages with E2E test contract

### DIFF
--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -226,7 +226,7 @@ fn actionability(status: ServiceStatus, dispatch_status: DispatchStatus) -> (boo
         }
         (ServiceStatus::Available, DispatchStatus::Failed) => (
             false,
-            "Inspect instance failure stage/reason; the backend may need a restart.",
+            "Wait for dispatch_status=ready; inspect instance failure stage/reason; the backend may need a restart.",
         ),
         (ServiceStatus::Available, DispatchStatus::Unknown) => (
             true,
@@ -241,13 +241,17 @@ fn actionability(status: ServiceStatus, dispatch_status: DispatchStatus) -> (boo
         ),
         (ServiceStatus::Busy, DispatchStatus::Failed) => (
             false,
-            "Instance is busy but dispatch has failed; inspect failure details.",
+            "Instance is busy; wait for dispatch_status=ready; inspect failure details if persistent.",
         ),
         (ServiceStatus::Busy, DispatchStatus::Unknown) => (true, "Instance is busy; retry later."),
-        (ServiceStatus::Booting, DispatchStatus::Pending) => {
-            (true, "Instance is booting; wait for readiness and retry.")
-        }
-        (ServiceStatus::Booting, _) => (true, "Instance is booting; wait for readiness and retry."),
+        (ServiceStatus::Booting, DispatchStatus::Pending) => (
+            true,
+            "Instance is booting; run wait-ready for readiness and retry.",
+        ),
+        (ServiceStatus::Booting, _) => (
+            true,
+            "Instance is booting; run wait-ready for readiness and retry.",
+        ),
         (ServiceStatus::Unreachable, _) => (
             false,
             "Instance is unreachable; check logs and restart if needed.",


### PR DESCRIPTION
## Problem

PR #2064 CI still fails after the first fix (PR #2068). The  E2E test panics because the ADR-018 `actionability()` messages don't contain substrings that the existing E2E tests assert:

- `(Booting, _)` → "Instance is booting; wait for readiness and retry." — **missing** "wait-ready"
- `(Available, Failed)` → "Inspect instance failure stage/reason; the backend may need a restart." — **missing** "dispatch_status=ready"

## Fix

Updated 3 `actionability()` messages to include the expected substrings:

| Pairing | Before | After |
|---|---|---|
| (Booting, Pending) | "wait for readiness and retry" | "run **wait-ready** for readiness and retry" |
| (Booting, _) | "wait for readiness and retry" | "run **wait-ready** for readiness and retry" |
| (Available, Failed) | no dispatch_status mention | "Wait for **dispatch_status=ready**; inspect ..." |
| (Busy, Failed) | no dispatch_status mention | "wait for **dispatch_status=ready**; inspect ..." |

## Validation

- `cargo test -p dcc-mcp-transport -- discovery::types` — 53/53 pass
- `cargo test -p dcc-mcp-cli` — all pass
- `cargo fmt --check` — clean