### PR TITLE
fix(ui-control): allow explicit resume after escape

### DIFF
--- a/crates/dcc-mcp-computer-use/src/ui_control_host.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host.rs
@@ -351,11 +351,11 @@ impl UiControlHost {
             Ok(runtime) => runtime,
             Err(failure) => return failure.into_response(),
         };
-        if let Err(failure) = runtime.start_visible_notice() {
-            if failure.code != UiControlHostErrorCode::UserInterrupted {
-                runtime.stop();
-                return failure.into_response();
-            }
+        if let Err(failure) = runtime.start_visible_notice()
+            && failure.code != UiControlHostErrorCode::UserInterrupted
+        {
+            runtime.stop();
+            return failure.into_response();
         }
         let target = runtime.target().clone();
 

--- a/crates/dcc-mcp-computer-use/src/ui_control_host.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host.rs
@@ -352,8 +352,10 @@ impl UiControlHost {
             Err(failure) => return failure.into_response(),
         };
         if let Err(failure) = runtime.start_visible_notice() {
-            runtime.stop();
-            return failure.into_response();
+            if failure.code != UiControlHostErrorCode::UserInterrupted {
+                runtime.stop();
+                return failure.into_response();
+            }
         }
         let target = runtime.target().clone();
 
@@ -507,6 +509,9 @@ impl UiControlHost {
             UiControlWindowOperation::Show => "show_window",
             UiControlWindowOperation::Activate => "activate_window",
         };
+        if let Err(failure) = session.runtime.start_visible_notice() {
+            return failure.into_response();
+        }
         match session.runtime.change_window_state(operation) {
             Ok(state) => {
                 audit_event(

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/tests.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/tests.rs
@@ -108,6 +108,12 @@ impl HostRuntimeSession for FakeSession {
     }
 
     fn start_visible_notice(&mut self) -> Result<(), HostFailure> {
+        if self.user_interrupted {
+            return Err(HostFailure::new(
+                UiControlHostErrorCode::UserInterrupted,
+                "the operator pressed physical Escape",
+            ));
+        }
         self.notice_started = true;
         Ok(())
     }
@@ -228,6 +234,7 @@ impl HostRuntimeSession for FakeSession {
 
     fn resume_after_approval(&mut self) -> Result<(), HostFailure> {
         self.resume_calls.fetch_add(1, Ordering::SeqCst);
+        self.user_interrupted = false;
         Ok(())
     }
 
@@ -476,6 +483,20 @@ fn explicit_resume_clears_user_interrupt_without_another_confirmation() {
         else {
             panic!("session not opened: {opened:?}");
         };
+        if user_interrupted {
+            assert!(matches!(
+                host.change_window_state(
+                    "resume",
+                    "grant-1",
+                    &window_capability,
+                    UiControlWindowOperation::Activate,
+                ),
+                UiControlHostResponse::Error {
+                    code: UiControlHostErrorCode::UserInterrupted,
+                    ..
+                }
+            ));
+        }
         let resumed = host.resume_session("resume", "grant-1", &window_capability);
         assert!(matches!(
             resumed,
@@ -485,6 +506,10 @@ fn explicit_resume_clears_user_interrupt_without_another_confirmation() {
             resume_calls.load(Ordering::SeqCst),
             usize::from(user_interrupted)
         );
+        assert!(matches!(
+            host.snapshot("resume", "grant-1", &window_capability, 5, 250),
+            UiControlHostResponse::Snapshot { .. }
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary
- keep an exact-target UI Control session dormant when physical Escape is latched
- return its opaque window capability so an explicitly approved `ResumeSession` can clear the latch
- keep mutating window transitions blocked until the visible-control notice starts

## Local validation
- red test reproduced `UserInterrupted` before capability issuance
- `cargo test -p dcc-mcp-computer-use explicit_resume_clears_user_interrupt_without_another_confirmation`
- `cargo test -p dcc-mcp-computer-use` (170/170, twice)
- `cargo fmt --all -- --check`
- `git diff --check`