### PR TITLE
fix(ui-control): allow exact Unity pane navigation

### DIFF
--- a/crates/dcc-mcp-computer-use/src/ui_control_host/policy.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/policy.rs
@@ -321,8 +321,15 @@ fn game_navigation_ancestry_is_safe(ancestry: &[&Value]) -> bool {
     let Some(root_process_id) = root.get("process_id").and_then(Value::as_u64) else {
         return false;
     };
+    let root_is_exact_native_window = root.get("control_type").and_then(Value::as_str)
+        == Some("ControlType.Window")
+        || (root.get("control_type").and_then(Value::as_str) == Some("ControlType.Pane")
+            && root
+                .get("native_window_handle")
+                .and_then(Value::as_u64)
+                .is_some_and(|handle| handle != 0));
     if root_process_id == 0
-        || root.get("control_type").and_then(Value::as_str) != Some("ControlType.Window")
+        || !root_is_exact_native_window
         || ancestry.iter().any(|control| {
             control.get("process_id").and_then(Value::as_u64) != Some(root_process_id)
                 || control.get("is_password").and_then(Value::as_bool) != Some(false)

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/tests/navigation.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/tests/navigation.rs
@@ -279,6 +279,38 @@ fn game_navigation_has_a_separate_bounded_descriptor() {
 }
 
 #[test]
+fn game_navigation_accepts_an_exact_native_unity_pane_root() {
+    let game_navigation = UiControlAction {
+        action: "game_navigation".to_owned(),
+        input_kind: UiControlInputKind::RawInput,
+        intent: UiControlIntent::Navigate,
+        keys: vec!["W".to_owned(), "D".to_owned()],
+        duration_ms: Some(500),
+        ..action(None, UiControlInputKind::RawInput)
+    };
+    let mut game = game_navigation_accessibility_state(
+        "42.game-root",
+        "42.game-root",
+        "ControlType.Pane",
+        42,
+        None,
+    );
+    game.root["control_type"] = json!("ControlType.Pane");
+    game.root["native_window_handle"] = json!(0x1234_u64);
+
+    assert_eq!(
+        classify_action(&game_navigation, Some(&game.root), None),
+        UiControlPolicyTier::TaskGrant
+    );
+
+    game.root["native_window_handle"] = Value::Null;
+    assert_eq!(
+        classify_action(&game_navigation, Some(&game.root), None),
+        UiControlPolicyTier::HardDeny
+    );
+}
+
+#[test]
 fn game_navigation_rejects_editable_or_unknown_intermediate_ancestors() {
     let game_navigation = UiControlAction {
         action: "game_navigation".to_owned(),


### PR DESCRIPTION
## Summary
- allow game_navigation on an exact top-level native ControlType.Pane
- keep null-HWND panes hard denied and preserve the existing PID, editable, password, value/text pattern, and authentication fences
- cover the Unity Player UIA root shape with a regression test

## Root cause
Packaged Unity/Tuanjie players expose their exact top-level UnityWndClass root as ControlType.Pane, not ControlType.Window. The policy therefore hard-denied game navigation even though UIA reported the adapter-bound PID and non-zero native HWND.

## Validation
- TDD red: game_navigation_accepts_an_exact_native_unity_pane_root returned HardDeny before the policy change
- focused test green after the change
- cargo fmt --all -- --check
- git diff --check
- full Windows library suite twice after final formatting: 171 passed, 0 failed on both runs
- live packaged Tuanjie/Unity game proof on exact PID 3172 / HWND 23334458:
  - W+D, J, K, L, Space, and Enter all completed with policy_tier=task_grant
  - visible pointer move and raw-coordinate click completed through the same scoped UI Control session
  - post-click snapshot recorded cause_action_id=action:fc136dee04334a32805a2525af5f8582
  - dynamic exact-window recording produced 40 frames with 6 distinct frame hashes and manifest SHA-256 5636a2398932121b8235ba345310b70cd164b93193700b645d24fbd2dd783abf
  - session stop returned cleanup_pending=false