### PR TITLE
feat(asset-skill): implement resolve/import/export/validate/catalog_status scripts

### DIFF
--- a/skills/asset/scripts/catalog_status.py
+++ b/skills/asset/scripts/catalog_status.py
@@ -8,8 +8,12 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from datetime import datetime, timezone
 from typing import Any
+
+
+_CREATION_FLAGS = subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
 
 
 def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
@@ -20,6 +24,7 @@ def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
             capture_output=True,
             text=True,
             timeout=timeout,
+            creationflags=_CREATION_FLAGS,
         )
         if result.returncode != 0:
             return None

--- a/skills/asset/scripts/catalog_status.py
+++ b/skills/asset/scripts/catalog_status.py
@@ -1,57 +1,115 @@
-"""catalog_status — Report asset catalog health and statistics."""
+"""catalog_status — Report asset catalog health and statistics.
+
+Composes dcc-mcp-cli calls to asset_source to enumerate catalogs and
+gather per-catalog statistics: total assets, type breakdown, storage,
+and health indicators.
+"""
 from __future__ import annotations
 
 import json
 import subprocess
+from datetime import datetime, timezone
 from typing import Any
 
 
+def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
+    """Run dcc-mcp-cli and return parsed JSON, or None on failure."""
+    try:
+        result = subprocess.run(
+            ["dcc-mcp-cli", *args, "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            return None
+        return json.loads(result.stdout)
+    except Exception:
+        return None
+
+
+def _query_catalog(name: str, query: str = "", limit: int = 1) -> dict[str, Any] | None:
+    """Query a specific catalog and return raw response."""
+    search_args: dict[str, Any] = {"query": query, "limit": limit}
+    if name and name != "all":
+        search_args["catalog"] = name
+    return _run_cli(
+        "call", "asset_source__search_assets",
+        "--json", json.dumps(search_args),
+        timeout=10,
+    )
+
+
+def _list_catalogs() -> list[str]:
+    """Discover available catalog names."""
+    # Try a dedicated catalog list endpoint first
+    data = _run_cli("call", "asset_source__list_catalogs", timeout=10)
+    if data:
+        return data.get("catalogs", data.get("names", []))
+
+    # Fallback: query the default catalog and see if per-catalog info is returned
+    data = _run_cli(
+        "call", "asset_source__search_assets",
+        "--json", json.dumps({"query": "", "limit": 1}),
+        timeout=10,
+    )
+    if data:
+        catalogs = data.get("catalogs", [])
+        if catalogs:
+            return [c.get("name", "default") for c in catalogs]
+    return ["default"]
+
+
 def catalog_status(catalog: str | None = None) -> dict[str, Any]:
-    """Report catalog health and statistics.
+    """Report asset catalog health and statistics.
+
+    Enumerates all available catalogs (or a specific one) and gathers
+    statistics: total assets, breakdown by type, storage usage, last
+    update timestamp, and health status.
 
     Args:
-        catalog: Named catalog. Defaults to all.
+        catalog: Specific catalog name. All catalogs when omitted.
 
     Returns:
-        Catalog health statistics.
+        Per-catalog statistics and health report.
     """
-    # Query the asset source for catalog status
-    catalogs: list[dict[str, Any]] = []
+    now_utc = datetime.now(timezone.utc).isoformat()
+    catalog_list = [catalog] if catalog else _list_catalogs()
 
-    try:
-        # Search with empty query to get catalog overview
-        result = subprocess.run(
-            ["dcc-mcp-cli", "call", "asset_source__search_assets",
-             "--json", json.dumps({"query": "", "limit": 1}), "--output", "json"],
-            capture_output=True, text=True, timeout=10,
-        )
-        if result.returncode == 0:
-            data = json.loads(result.stdout)
-            total = data.get("total", 0)
+    catalogs: list[dict[str, Any]] = []
+    overall_healthy = True
+    total_assets = 0
+
+    for cat_name in catalog_list:
+        data = _query_catalog(cat_name)
+        if data is None:
             catalogs.append({
-                "name": catalog or "default",
-                "total_assets": total,
-                "by_type": data.get("by_type", {}),
-                "storage_bytes": data.get("storage_bytes", 0),
-                "last_updated": data.get("last_updated", "unknown"),
-                "healthy": True,
-            })
-        else:
-            catalogs.append({
-                "name": catalog or "default",
+                "name": cat_name,
                 "total_assets": 0,
+                "by_type": {},
+                "storage_bytes": 0,
+                "last_updated": now_utc,
                 "healthy": False,
-                "error": result.stderr,
+                "error": "Catalog unreachable — check gateway and network.",
             })
-    except Exception as e:
+            overall_healthy = False
+            continue
+
+        cat_total = data.get("total", 0)
+        total_assets += cat_total
+
         catalogs.append({
-            "name": catalog or "default",
-            "total_assets": 0,
-            "healthy": False,
-            "error": str(e),
+            "name": cat_name,
+            "total_assets": cat_total,
+            "by_type": data.get("by_type", {}),
+            "storage_bytes": data.get("storage_bytes", data.get("storage", 0)),
+            "last_updated": data.get("last_updated", now_utc),
+            "healthy": True,
         })
 
     return {
         "success": True,
         "catalogs": catalogs,
+        "total_assets": total_assets,
+        "all_healthy": overall_healthy,
     }

--- a/skills/asset/scripts/export_asset.py
+++ b/skills/asset/scripts/export_asset.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from typing import Any
 
 
 # Supported export formats across common DCC hosts
 SUPPORTED_FORMATS = frozenset({"fbx", "usd", "usda", "usdc", "usdz", "abc", "obj", "gltf", "glb"})
+
+_CREATION_FLAGS = subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
 
 
 def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
@@ -26,6 +29,7 @@ def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
             capture_output=True,
             text=True,
             timeout=timeout,
+            creationflags=_CREATION_FLAGS,
         )
         if result.returncode != 0:
             return None

--- a/skills/asset/scripts/export_asset.py
+++ b/skills/asset/scripts/export_asset.py
@@ -1,32 +1,79 @@
-"""export_asset — Export selection/scene as a named asset in the catalog."""
+"""export_asset — Export DCC selection/scene as a named asset in the catalog.
+
+Composes dcc-mcp-cli list + search + call to:
+  1. Find a ready DCC instance
+  2. Discover the host-specific export tool
+  3. Execute the export
+  4. Report the result with file metadata
+"""
 from __future__ import annotations
 
 import json
 import os
 import subprocess
-import time
 from typing import Any
 
 
-def _get_first_instance(dcc_type: str | None = None) -> str | None:
-    """Get first ready instance matching dcc_type."""
+# Supported export formats across common DCC hosts
+SUPPORTED_FORMATS = frozenset({"fbx", "usd", "usda", "usdc", "usdz", "abc", "obj", "gltf", "glb"})
+
+
+def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
+    """Run dcc-mcp-cli and return parsed JSON, or None on failure."""
     try:
         result = subprocess.run(
-            ["dcc-mcp-cli", "list", "--output", "json"],
-            capture_output=True, text=True, timeout=10,
+            ["dcc-mcp-cli", *args, "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
         )
         if result.returncode != 0:
             return None
-        data = json.loads(result.stdout)
-        for inst in data.get("instances", []):
-            if dcc_type and inst.get("dcc_type") != dcc_type:
-                continue
-            if inst.get("direct_control", {}).get("ready"):
-                return inst.get("instance_short") or inst.get("instance_id")
-        if data.get("instances"):
-            return data["instances"][0].get("instance_short")
+        return json.loads(result.stdout)
     except Exception:
-        pass
+        return None
+
+
+def _find_ready_instance(dcc_type: str | None = None) -> str | None:
+    """Find the first dispatch-ready DCC instance, optionally filtered by type."""
+    inventory = _run_cli("list") or {}
+    instances = inventory.get("instances", [])
+    if not instances:
+        return None
+
+    for inst in instances:
+        if dcc_type and inst.get("dcc_type") != dcc_type:
+            continue
+        dc = inst.get("direct_control", {})
+        if dc.get("ready"):
+            return inst.get("instance_short") or inst.get("instance_id")
+
+    for inst in instances:
+        if dcc_type and inst.get("dcc_type") != dcc_type:
+            continue
+        return inst.get("instance_short") or inst.get("instance_id")
+
+    return None
+
+
+def _resolve_tool(query: str, dcc_type: str | None = None) -> str | None:
+    """Search for an export tool matching the query and return its slug."""
+    args = ["search", "--query", query, "--limit", "5"]
+    if dcc_type:
+        args.extend(["--dcc-type", dcc_type])
+    data = _run_cli(*args, timeout=15)
+    if not data:
+        return None
+
+    tools = data.get("tools", data.get("results", []))
+    if not tools:
+        return None
+
+    export_keywords = ("export", "save", "write", "publish")
+    for t in tools:
+        slug = t.get("slug", "")
+        if any(kw in slug.lower() for kw in export_keywords):
+            return slug
     return None
 
 
@@ -39,67 +86,117 @@ def export_asset(
     tags: list[str] | None = None,
     source_dcc: str | None = None,
 ) -> dict[str, Any]:
-    """Export selection/scene as a named asset.
+    """Export selection or full scene as a named asset in the catalog.
 
     Args:
         asset_name: Name for the exported asset.
-        asset_type: Asset type.
-        format: Export format.
-        selection_only: Export selection only.
-        output_dir: Output directory.
-        tags: Tags to attach.
-        source_dcc: Source DCC type.
+        asset_type: Asset type — 'model', 'material', 'texture', 'animation'.
+        format: Export format — 'fbx', 'usd', 'abc', 'obj', 'gltf'.
+        selection_only: Export only current selection (default True).
+        output_dir: Output directory. Uses catalog default when omitted.
+        tags: Tags to attach to the asset entry.
+        source_dcc: Source DCC type (auto-detected when omitted).
 
     Returns:
-        Export result.
+        Export result with file path, format, and size.
     """
+    # --- Validate format ---
+    fmt_lower = format.lower()
+    if fmt_lower not in SUPPORTED_FORMATS:
+        return {
+            "success": False,
+            "exported": False,
+            "asset_name": asset_name,
+            "error": "Unsupported format '{}'. Supported: {}.".format(
+                format, ", ".join(sorted(SUPPORTED_FORMATS))
+            ),
+        }
+
+    # --- Output directory ---
     output_dir = output_dir or os.path.join(os.getcwd(), "exports")
-    os.makedirs(output_dir, exist_ok=True)
-
-    output_path = os.path.join(output_dir, "{}.{}".format(asset_name, format))
-
-    instance = _get_first_instance(source_dcc)
-    if not instance:
-        return {"success": False, "exported": False, "error": "No ready DCC instance found."}
-
-    # Search for export tools
     try:
-        result = subprocess.run(
-            ["dcc-mcp-cli", "search", "--query", "export {}".format("selection" if selection_only else "scene"),
-             "--dcc-type", source_dcc or "", "--limit", "5", "--output", "json"],
-            capture_output=True, text=True, timeout=15,
-        )
-        tools = []
-        if result.returncode == 0:
-            data = json.loads(result.stdout)
-            tools = data.get("tools", data.get("results", []))
+        os.makedirs(output_dir, exist_ok=True)
+    except OSError as e:
+        return {
+            "success": False,
+            "exported": False,
+            "asset_name": asset_name,
+            "error": "Cannot create output directory '{}': {}.".format(output_dir, e),
+        }
 
-        if tools:
-            tool_slug = tools[0].get("slug", "")
-            export_args: dict[str, Any] = {
+    output_path = os.path.join(output_dir, "{}.{}".format(asset_name, fmt_lower))
+
+    # --- Find ready instance ---
+    instance = _find_ready_instance(source_dcc)
+    if not instance:
+        dcc_hint = " for {}".format(source_dcc) if source_dcc else ""
+        return {
+            "success": False,
+            "exported": False,
+            "asset_name": asset_name,
+            "error": "No dispatch-ready DCC instance found{}. Start a DCC adapter first.".format(dcc_hint),
+        }
+
+    # --- Find export tool ---
+    action = "selection" if selection_only else "scene"
+    queries = [
+        "export {}".format(action),
+        "export file",
+        "save {} as".format(action),
+    ]
+    tool_slug = None
+    for q in queries:
+        tool_slug = _resolve_tool(q, source_dcc)
+        if tool_slug:
+            break
+
+    if not tool_slug:
+        # Fallback: try a direct export call via tool name convention
+        dcc_part = source_dcc or "dcc"
+        tool_slug = "{}__export_file".format(dcc_part)
+
+    # --- Execute export ---
+    export_args: dict[str, Any] = {
+        "file_path": output_path,
+        "format": fmt_lower,
+    }
+    if selection_only:
+        export_args["selection_only"] = True
+    if asset_type:
+        export_args["asset_type"] = asset_type
+    if tags:
+        export_args["tags"] = tags
+
+    try:
+        data = _run_cli("call", tool_slug, "--json", json.dumps(export_args), timeout=60)
+        if data:
+            file_size = os.path.getsize(output_path) if os.path.isfile(output_path) else 0
+            return {
+                "success": True,
+                "exported": True,
+                "asset_name": asset_name,
                 "file_path": output_path,
-                "format": format,
+                "format": fmt_lower,
+                "file_size": file_size,
             }
-            call_result = subprocess.run(
-                ["dcc-mcp-cli", "call", tool_slug, "--json", json.dumps(export_args), "--output", "json"],
-                capture_output=True, text=True, timeout=60,
-            )
-            if call_result.returncode == 0:
-                file_size = os.path.getsize(output_path) if os.path.isfile(output_path) else 0
-                return {
-                    "success": True,
-                    "exported": True,
-                    "asset_name": asset_name,
-                    "file_path": output_path,
-                    "format": format,
-                    "file_size": file_size,
-                }
 
         return {
             "success": False,
             "exported": False,
             "asset_name": asset_name,
-            "error": "No export tool found for format '{}'.".format(format),
+            "error": "Export tool '{}' returned no data.".format(tool_slug),
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "exported": False,
+            "asset_name": asset_name,
+            "error": "Export timed out after 60s — scene may be too large or DCC unresponsive.",
         }
     except Exception as e:
-        return {"success": False, "exported": False, "asset_name": asset_name, "error": str(e)}
+        return {
+            "success": False,
+            "exported": False,
+            "asset_name": asset_name,
+            "error": str(e),
+        }

--- a/skills/asset/scripts/import_asset.py
+++ b/skills/asset/scripts/import_asset.py
@@ -11,8 +11,12 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import time
 from typing import Any
+
+
+_CREATION_FLAGS = subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
 
 
 def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
@@ -23,6 +27,7 @@ def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
             capture_output=True,
             text=True,
             timeout=timeout,
+            creationflags=_CREATION_FLAGS,
         )
         if result.returncode != 0:
             return None

--- a/skills/asset/scripts/import_asset.py
+++ b/skills/asset/scripts/import_asset.py
@@ -1,58 +1,82 @@
-"""import_asset — Import an AssetDescriptor into the active DCC scene."""
+"""import_asset — Import an AssetDescriptor into the active DCC scene.
+
+Composes dcc-mcp-cli list + search + call to orchestrate a cross-DCC import:
+  1. Validate the AssetDescriptor and select the target variant
+  2. Discover a ready DCC instance
+  3. Find the host-specific import tool
+  4. Execute the import and return scene objects
+"""
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import time
 from typing import Any
 
 
-def _get_first_instance(dcc_type: str | None = None) -> str | None:
-    """Get first ready instance matching dcc_type."""
+def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
+    """Run dcc-mcp-cli and return parsed JSON, or None on failure."""
     try:
         result = subprocess.run(
-            ["dcc-mcp-cli", "list", "--output", "json"],
-            capture_output=True, text=True, timeout=10,
+            ["dcc-mcp-cli", *args, "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
         )
         if result.returncode != 0:
             return None
-        data = json.loads(result.stdout)
-        for inst in data.get("instances", []):
-            if dcc_type and inst.get("dcc_type") != dcc_type:
-                continue
-            if inst.get("direct_control", {}).get("ready"):
-                return inst.get("instance_short") or inst.get("instance_id")
-        if data.get("instances"):
-            return data["instances"][0].get("instance_short")
+        return json.loads(result.stdout)
     except Exception:
-        pass
-    return None
+        return None
 
 
-def _search_import_tool(instance: str, dcc_type: str, asset_type: str) -> str | None:
-    """Find the best import tool for this asset type."""
-    queries = [
-        "import {}".format(asset_type),
-        "import file",
-        "import scene",
-    ]
-    for q in queries:
-        try:
-            result = subprocess.run(
-                ["dcc-mcp-cli", "search", "--query", q, "--dcc-type", dcc_type, "--limit", "5", "--output", "json"],
-                capture_output=True, text=True, timeout=10,
-            )
-            if result.returncode == 0:
-                data = json.loads(result.stdout)
-                tools = data.get("tools", data.get("results", []))
-                if tools:
-                    slug = tools[0].get("slug", "")
-                    # Verify tool looks like an import tool
-                    if any(kw in slug.lower() for kw in ["import", "load", "open"]):
-                        return slug.replace("." + instance + ".", ".{}.".format(instance))
-        except Exception:
+def _find_ready_instance(dcc_type: str | None = None) -> str | None:
+    """Find the first dispatch-ready DCC instance, optionally filtered by type."""
+    inventory = _run_cli("list") or {}
+    instances = inventory.get("instances", [])
+    if not instances:
+        return None
+
+    for inst in instances:
+        if dcc_type and inst.get("dcc_type") != dcc_type:
             continue
+        dc = inst.get("direct_control", {})
+        if dc.get("ready"):
+            return inst.get("instance_short") or inst.get("instance_id")
+
+    # Fallback: first instance of matching type
+    for inst in instances:
+        if dcc_type and inst.get("dcc_type") != dcc_type:
+            continue
+        return inst.get("instance_short") or inst.get("instance_id")
+
     return None
+
+
+def _resolve_tool(query: str, dcc_type: str | None = None) -> str | None:
+    """Search for a tool matching the query and return its slug."""
+    args = ["search", "--query", query, "--limit", "5"]
+    if dcc_type:
+        args.extend(["--dcc-type", dcc_type])
+    data = _run_cli(*args, timeout=15)
+    if not data:
+        return None
+
+    tools = data.get("tools", data.get("results", []))
+    if not tools:
+        return None
+
+    slug = tools[0].get("slug", "")
+    import_keywords = ("import", "load", "open", "file")
+    if not any(kw in slug.lower() for kw in import_keywords):
+        # Try the next tool
+        for t in tools[1:]:
+            s = t.get("slug", "")
+            if any(kw in s.lower() for kw in import_keywords):
+                return s
+        return None
+    return slug
 
 
 def import_asset(
@@ -61,85 +85,117 @@ def import_asset(
     variant_index: int = 0,
     import_options: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Import an asset into a DCC scene.
+    """Import a resolved AssetDescriptor into the active DCC scene.
 
     Args:
         descriptor: AssetDescriptor from resolve_asset.
-        target_dcc: Target DCC type.
-        variant_index: Variant to import.
-        import_options: DCC-specific options.
+        target_dcc: Target DCC type (auto-detected when omitted).
+        variant_index: Which variant to import (0 = first, default).
+        import_options: DCC-specific import options.
 
     Returns:
-        Import result.
+        Import result with scene objects and timing.
     """
     asset_name = descriptor.get("name", "unknown")
     variants = descriptor.get("variants", [])
+    asset_type = descriptor.get("asset_type", "")
 
-    if not variants or variant_index >= len(variants):
+    # --- Validate descriptor ---
+    if not variants:
         return {
             "success": False,
             "imported": False,
-            "error": "No valid variant found for import (variants={}, index={})".format(len(variants), variant_index),
+            "asset_name": asset_name,
+            "error": "No variants in AssetDescriptor. Run resolve_asset first to get file variants.",
+        }
+
+    if variant_index >= len(variants):
+        return {
+            "success": False,
+            "imported": False,
+            "asset_name": asset_name,
+            "error": "variant_index {} out of range ({} variants available).".format(
+                variant_index, len(variants)
+            ),
         }
 
     variant = variants[variant_index]
     file_path = variant.get("path", "")
     asset_format = variant.get("format", "unknown")
 
-    if not file_path or not os.path.exists(file_path):
+    if not file_path:
         return {
             "success": False,
             "imported": False,
+            "asset_name": asset_name,
+            "error": "Variant at index {} has no path.".format(variant_index),
+        }
+
+    if not os.path.exists(file_path):
+        return {
+            "success": False,
+            "imported": False,
+            "asset_name": asset_name,
+            "file_path": file_path,
             "error": "Asset file not found: {}".format(file_path),
         }
 
-    instance = _get_first_instance(target_dcc)
+    # --- Find ready instance ---
+    instance = _find_ready_instance(target_dcc)
     if not instance:
-        return {"success": False, "imported": False, "error": "No ready DCC instance found."}
+        dcc_hint = " for {}".format(target_dcc) if target_dcc else ""
+        return {
+            "success": False,
+            "imported": False,
+            "asset_name": asset_name,
+            "error": "No dispatch-ready DCC instance found{}. Start a DCC adapter first.".format(dcc_hint),
+        }
 
-    # Try to find and call the DCC's import tool
-    # Since we can't know the exact tool name, we use the workflow chain pattern
-    start_time = time.time()
+    # --- Find import tool ---
+    queries = [
+        "import {}".format(asset_type) if asset_type else "import file",
+        "import file",
+        "import scene",
+        "load file",
+    ]
+    tool_slug = None
+    for q in queries:
+        tool_slug = _resolve_tool(q, target_dcc)
+        if tool_slug:
+            break
 
-    # Build a generic import call — in practice this uses the DCC's tool
-    call_args: dict[str, Any] = {
-        "file_path": file_path,
-    }
+    if not tool_slug:
+        return {
+            "success": False,
+            "imported": False,
+            "asset_name": asset_name,
+            "file_path": file_path,
+            "format": asset_format,
+            "error": "No import tool found{} — check adapter install.".format(
+                " for {}".format(target_dcc) if target_dcc else ""
+            ),
+        }
+
+    # --- Execute import ---
+    call_args: dict[str, Any] = {"file_path": file_path}
     if import_options:
         call_args.update(import_options)
 
+    start_time = time.time()
     try:
-        # Use a multi-step call: search for import tool → call it
-        # For the demo implementation, we report the import parameters
-        result = subprocess.run(
-            ["dcc-mcp-cli", "search", "--query", "import file", "--dcc-type", target_dcc or "",
-             "--limit", "5", "--output", "json"],
-            capture_output=True, text=True, timeout=15,
-        )
-        tools = []
-        if result.returncode == 0:
-            data = json.loads(result.stdout)
-            tools = data.get("tools", data.get("results", []))
+        import_data = _run_cli("call", tool_slug, "--json", json.dumps(call_args), timeout=60)
+        duration_ms = (time.time() - start_time) * 1000
 
-        if tools:
-            # Found import tools — use the first one
-            tool_slug = tools[0].get("slug", "")
-            call_result = subprocess.run(
-                ["dcc-mcp-cli", "call", tool_slug, "--json", json.dumps(call_args), "--output", "json"],
-                capture_output=True, text=True, timeout=60,
-            )
-            if call_result.returncode == 0:
-                import_data = json.loads(call_result.stdout)
-                duration_ms = (time.time() - start_time) * 1000
-                return {
-                    "success": True,
-                    "imported": True,
-                    "asset_name": asset_name,
-                    "file_path": file_path,
-                    "format": asset_format,
-                    "scene_objects": import_data.get("scene_objects", import_data.get("objects", [])),
-                    "duration_ms": round(duration_ms, 1),
-                }
+        if import_data:
+            return {
+                "success": True,
+                "imported": True,
+                "asset_name": asset_name,
+                "file_path": file_path,
+                "format": asset_format,
+                "scene_objects": import_data.get("scene_objects", import_data.get("objects", [])),
+                "duration_ms": round(duration_ms, 1),
+            }
 
         return {
             "success": False,
@@ -147,12 +203,20 @@ def import_asset(
             "asset_name": asset_name,
             "file_path": file_path,
             "format": asset_format,
-            "error": "Import failed — no import tool found or call failed.",
+            "error": "Import tool '{}' returned no data.".format(tool_slug),
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "imported": False,
+            "asset_name": asset_name,
+            "error": "Import timed out after 60s — file may be too large or DCC unresponsive.",
         }
     except Exception as e:
         return {
             "success": False,
             "imported": False,
             "asset_name": asset_name,
+            "file_path": file_path,
             "error": str(e),
         }

--- a/skills/asset/scripts/resolve_asset.py
+++ b/skills/asset/scripts/resolve_asset.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from typing import Any
+
+
+_CREATION_FLAGS = subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
 
 
 def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
@@ -18,6 +22,7 @@ def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
             capture_output=True,
             text=True,
             timeout=timeout,
+            creationflags=_CREATION_FLAGS,
         )
         if result.returncode != 0:
             return None

--- a/skills/asset/scripts/resolve_asset.py
+++ b/skills/asset/scripts/resolve_asset.py
@@ -1,75 +1,126 @@
-"""resolve_asset — Resolve asset name to full AssetDescriptor with variants."""
+"""resolve_asset — Resolve an asset name to a full AssetDescriptor with variants.
+
+Composes asset_source__search_assets with variant filtering and format/LOD
+preference resolution.  Returns the full descriptor ready for import_asset.
+"""
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 from typing import Any
 
 
+def _run_cli(*args: str, timeout: int = 15) -> dict[str, Any] | None:
+    """Run dcc-mcp-cli and return parsed JSON, or None on failure."""
+    try:
+        result = subprocess.run(
+            ["dcc-mcp-cli", *args, "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            return None
+        return json.loads(result.stdout)
+    except Exception:
+        return None
+
+
+def _filter_variants(
+    variants: list[dict[str, Any]],
+    preferred_format: str | None,
+    preferred_lod: str | None,
+) -> list[dict[str, Any]]:
+    """Sort variants so format/LOD-preferring entries come first.
+
+    Does not remove non-matching variants — callers still have the full set,
+    but the preferred ones are first so variant_index=0 picks correctly.
+    """
+    if not preferred_format and not preferred_lod:
+        return variants
+
+    def _score(v: dict[str, Any]) -> int:
+        s = 0
+        if preferred_format and v.get("format") == preferred_format:
+            s += 2
+        if preferred_lod and v.get("lod") == preferred_lod:
+            s += 1
+        return -s  # Higher score sorts first
+
+    return sorted(variants, key=_score)
+
+
 def resolve_asset(
     asset_name: str,
-    format: str | None = None,
-    lod: str | None = None,
+    preferred_format: str | None = None,
+    preferred_lod: str | None = None,
 ) -> dict[str, Any]:
     """Resolve an asset name to a full AssetDescriptor.
 
+    Searches the catalog for the asset, finds the exact match, filters
+    variants by format/LOD preference, and returns a complete descriptor
+    ready for import.
+
     Args:
-        asset_name: Exact asset name from search_assets.
-        format: Preferred format (e.g. 'fbx', 'usd').
-        lod: Level of detail: proxy, low, medium, high.
+        asset_name: Exact asset name from search_assets result.
+        preferred_format: Preferred format (e.g. 'fbx', 'usd', 'abc').
+            First available variant when omitted.
+        preferred_lod: Preferred LOD — 'proxy', 'low', 'medium', 'high'.
+            Closest available when omitted.
 
     Returns:
-        Full AssetDescriptor ready for import.
+        Full AssetDescriptor with resolved variants, attribution, and metadata.
     """
-    # First search to find the asset
     search_args: dict[str, Any] = {"query": asset_name, "limit": 5}
-    try:
-        result = subprocess.run(
-            ["dcc-mcp-cli", "call", "asset_source__search_assets",
-             "--json", json.dumps(search_args), "--output", "json"],
-            capture_output=True, text=True, timeout=15,
-        )
-        if result.returncode != 0:
-            return {"success": False, "resolved": False, "error": "Search failed: {}".format(result.stderr)}
 
-        data = json.loads(result.stdout)
-        results = data.get("results", data.get("assets", []))
-        if not results:
-            return {"success": True, "resolved": False, "error": "Asset '{}' not found.".format(asset_name)}
-
-        # Find exact match
-        descriptor = None
-        for r in results:
-            if r.get("name") == asset_name:
-                descriptor = r
-                break
-        if not descriptor:
-            descriptor = results[0]  # Fallback to first result
-
-        # Filter variants by format/LOD preference
-        variants = descriptor.get("variants", [])
-        if variants:
-            if format:
-                variants = [v for v in variants if v.get("format") == format] + \
-                          [v for v in variants if v.get("format") != format]
-            if lod:
-                variants = [v for v in variants if v.get("lod") == lod] + \
-                          [v for v in variants if v.get("lod") != lod]
-
-        resolved = {
-            "name": descriptor.get("name", asset_name),
-            "asset_type": descriptor.get("asset_type", "unknown"),
-            "display_name": descriptor.get("display_name", asset_name),
-            "variants": variants,
-            "attribution": descriptor.get("attribution", {}),
-            "metadata": descriptor.get("metadata", {}),
+    data = _run_cli(
+        "call", "asset_source__search_assets",
+        "--json", json.dumps(search_args),
+        timeout=15,
+    )
+    if data is None:
+        return {
+            "success": False,
+            "resolved": False,
+            "descriptor": None,
+            "error": "Catalog search failed — asset_source not reachable. Check gateway health with verify_gateway.",
         }
 
+    results = data.get("results", data.get("assets", []))
+    if not results:
         return {
             "success": True,
-            "resolved": bool(variants),
-            "descriptor": resolved,
+            "resolved": False,
+            "descriptor": None,
+            "error": "Asset '{}' not found in any catalog. Try search_assets first to discover available names.".format(
+                asset_name
+            ),
         }
-    except Exception as e:
-        return {"success": False, "resolved": False, "error": str(e)}
+
+    # Prefer exact-match name, fall back to first result
+    descriptor = None
+    for r in results:
+        if r.get("name") == asset_name:
+            descriptor = r
+            break
+    if descriptor is None:
+        descriptor = results[0]
+
+    # Filter and sort variants by preference
+    variants = descriptor.get("variants", [])
+    variants = _filter_variants(variants, preferred_format, preferred_lod)
+
+    resolved = {
+        "name": descriptor.get("name", asset_name),
+        "asset_type": descriptor.get("asset_type", "unknown"),
+        "display_name": descriptor.get("display_name", asset_name),
+        "variants": variants,
+        "attribution": descriptor.get("attribution", {}),
+        "metadata": descriptor.get("metadata", {}),
+    }
+
+    return {
+        "success": True,
+        "resolved": len(variants) > 0,
+        "descriptor": resolved,
+    }

--- a/skills/asset/scripts/search_assets.py
+++ b/skills/asset/scripts/search_assets.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from typing import Any
+
+
+_CREATION_FLAGS = subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
 
 
 def search_assets(
@@ -36,6 +40,7 @@ def search_assets(
             ["dcc-mcp-cli", "call", "asset_source__search_assets",
              "--json", json.dumps(search_args), "--output", "json"],
             capture_output=True, text=True, timeout=15,
+            creationflags=_CREATION_FLAGS,
         )
         if result.returncode == 0:
             data = json.loads(result.stdout)

--- a/skills/asset/scripts/validate_asset.py
+++ b/skills/asset/scripts/validate_asset.py
@@ -1,20 +1,29 @@
-"""validate_asset — Validate asset file integrity, format, and metadata."""
+"""validate_asset — Validate asset file integrity, format, and metadata.
+
+Performs layered validation:
+  1. File existence and size sanity checks
+  2. Format detection from extension
+  3. Optional referenced-file resolution (textures, dependencies)
+  4. Structured issue reporting with severity levels
+
+Supports common DCC formats: FBX, USD, ABC, OBJ, GLTF, Maya ASCII/Binary,
+Blender, and image textures (PNG, JPG, EXR, TGA, TIF).
+"""
 from __future__ import annotations
 
-import json
 import os
-import subprocess
 from typing import Any
 
 
-# Format → expected extension mapping
+# Format → expected extension(s) mapping
 FORMAT_EXTENSIONS: dict[str, list[str]] = {
     "fbx": [".fbx"],
     "usd": [".usd", ".usda", ".usdc", ".usdz"],
     "abc": [".abc"],
     "obj": [".obj"],
     "gltf": [".gltf", ".glb"],
-    "ma": [".ma", ".mb"],
+    "ma": [".ma"],
+    "mb": [".mb"],
     "blend": [".blend"],
     "png": [".png"],
     "jpg": [".jpg", ".jpeg"],
@@ -23,6 +32,10 @@ FORMAT_EXTENSIONS: dict[str, list[str]] = {
     "tif": [".tif", ".tiff"],
 }
 
+# File size sanity thresholds (bytes)
+MIN_REASONABLE_SIZE = 100      # Smaller than this is suspicious
+MAX_REASONABLE_SIZE = 2**34   # 16 GiB — larger is suspicious
+
 
 def _detect_format(file_path: str) -> str | None:
     """Detect format from file extension."""
@@ -30,7 +43,53 @@ def _detect_format(file_path: str) -> str | None:
     for fmt, exts in FORMAT_EXTENSIONS.items():
         if ext in exts:
             return fmt
+    if ext:
+        # Unknown extension — return it as-is for caller awareness
+        return ext.lstrip(".")
     return None
+
+
+def _scan_texture_refs(file_path: str, fmt: str) -> list[dict[str, Any]]:
+    """Scan for referenced texture files.
+
+    For text-based formats (Maya ASCII, USD ASCII, OBJ), parses the file
+    and checks referenced texture paths.  For binary formats, returns empty.
+    """
+    referenced: list[dict[str, Any]] = []
+    text_formats = {"ma", "usda", "obj"}
+
+    if fmt not in text_formats:
+        return referenced
+
+    base_dir = os.path.dirname(file_path) or "."
+    texture_exts = {".png", ".jpg", ".jpeg", ".exr", ".tga", ".tif", ".tiff", ".bmp", ".dds"}
+
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as fh:
+            content = fh.read(65536)  # Read first 64 KiB — texture refs are near the top
+    except Exception:
+        return referenced
+
+    # Simple path-fragment scanning — look for tokens that look like file paths
+    # with texture extensions near the file path string
+    for line in content.split("\n"):
+        for tex_ext in texture_exts:
+            if tex_ext in line.lower():
+                # Extract a plausible file path
+                for token in line.split():
+                    clean = token.strip('";\',')
+                    if clean.lower().endswith(tex_ext) and len(clean) > 4:
+                        ref_path = clean
+                        if not os.path.isabs(ref_path):
+                            ref_path = os.path.normpath(os.path.join(base_dir, ref_path))
+                        referenced.append({
+                            "path": ref_path,
+                            "exists": os.path.isfile(ref_path),
+                            "type": "texture",
+                        })
+                        break
+
+    return referenced
 
 
 def validate_asset(
@@ -40,25 +99,21 @@ def validate_asset(
 ) -> dict[str, Any]:
     """Validate an asset file.
 
+    Checks file existence, size sanity, format integrity, and optionally
+    resolves referenced texture files to detect broken links.
+
     Args:
-        file_path: Asset file path.
-        format: Expected format. Auto-detected when omitted.
-        check_textures: Also validate referenced textures.
+        file_path: Asset file path to validate.
+        format: Expected format. Auto-detected from extension when omitted.
+        check_textures: Also validate referenced texture files (default False).
 
     Returns:
-        Validation report.
+        Validation report with issues array and optional referenced_files.
     """
-    issues: list[dict[str, str]] = []
-    checks: dict[str, Any] = {
-        "file_exists": False,
-        "format_match": None,
-        "file_size_bytes": 0,
-    }
+    issues: list[dict[str, Any]] = []
 
-    # File existence
+    # --- File existence ---
     if not os.path.isfile(file_path):
-        checks["file_exists"] = False
-        issues.append({"severity": "error", "message": "File not found: {}".format(file_path), "check": "file_exists"})
         return {
             "success": True,
             "valid": False,
@@ -66,38 +121,71 @@ def validate_asset(
             "format": format or "unknown",
             "file_exists": False,
             "file_size": 0,
-            "issues": issues,
+            "issues": [
+                {
+                    "severity": "error",
+                    "message": "File not found: {}".format(file_path),
+                    "check": "file_exists",
+                }
+            ],
             "referenced_files": [],
         }
-    checks["file_exists"] = True
 
-    # File size
+    # --- File size ---
     file_size = os.path.getsize(file_path)
-    checks["file_size_bytes"] = file_size
     if file_size == 0:
-        issues.append({"severity": "error", "message": "File is empty (0 bytes).", "check": "file_size"})
-    elif file_size < 100:
-        issues.append({"severity": "warning", "message": "File is very small ({} bytes).".format(file_size), "check": "file_size"})
-
-    # Format detection and matching
-    detected = _detect_format(file_path)
-    if not detected:
-        issues.append({"severity": "warning", "message": "Unknown file format for extension.", "check": "format_match"})
-    elif format and detected != format:
-        checks["format_match"] = False
         issues.append({
             "severity": "error",
-            "message": "Format mismatch: expected '{}', detected '{}'.".format(format, detected),
+            "message": "File is empty (0 bytes). Likely a failed or interrupted export.",
+            "check": "file_size",
+        })
+    elif file_size < MIN_REASONABLE_SIZE:
+        issues.append({
+            "severity": "warning",
+            "message": "File is very small ({} bytes). May be corrupted or truncated.".format(file_size),
+            "check": "file_size",
+        })
+    elif file_size > MAX_REASONABLE_SIZE:
+        issues.append({
+            "severity": "warning",
+            "message": "File is unusually large ({:.1f} GiB). Verify before import.".format(
+                file_size / (1024 ** 3)
+            ),
+            "check": "file_size",
+        })
+
+    # --- Format detection ---
+    detected = _detect_format(file_path)
+    if format and detected and format != detected:
+        issues.append({
+            "severity": "error",
+            "message": "Format mismatch: expected '{}' but file extension indicates '{}'.".format(
+                format, detected
+            ),
             "check": "format_match",
         })
-    else:
-        checks["format_match"] = True
+    elif not detected:
+        issues.append({
+            "severity": "warning",
+            "message": "Unknown file format — extension not recognized. Supported: {}.".format(
+                ", ".join(sorted(FORMAT_EXTENSIONS.keys()))
+            ),
+            "check": "format_match",
+        })
 
-    # Referenced files (basic texture check)
+    resolved_format = format or detected or "unknown"
+
+    # --- Texture references ---
     referenced: list[dict[str, Any]] = []
-    if check_textures and detected in ("ma", "mb", "blend", "usd"):
-        # This would parse the file for texture references — simplified here
-        pass
+    if check_textures:
+        referenced = _scan_texture_refs(file_path, resolved_format)
+        missing = [r for r in referenced if not r["exists"]]
+        for m in missing:
+            issues.append({
+                "severity": "warning",
+                "message": "Referenced texture not found: {}".format(m["path"]),
+                "check": "texture_refs",
+            })
 
     valid = not any(i["severity"] == "error" for i in issues)
 
@@ -105,8 +193,8 @@ def validate_asset(
         "success": True,
         "valid": valid,
         "file_path": file_path,
-        "format": format or detected or "unknown",
-        "file_exists": checks["file_exists"],
+        "format": resolved_format,
+        "file_exists": True,
         "file_size": file_size,
         "issues": issues,
         "referenced_files": referenced,

--- a/skills/asset/tools.yaml
+++ b/skills/asset/tools.yaml
@@ -78,17 +78,18 @@ tools:
           type: string
           minLength: 1
           description: "Exact asset name from search_assets result."
-        format:
+        preferred_format:
           type: string
           description: "Preferred format (e.g. fbx, usd, abc, obj, gltf). First available when omitted."
-        lod:
+        preferred_lod:
           type: string
-          description: "Level of detail: proxy, low, medium, high. Medium when omitted."
+          description: "Level of detail: proxy, low, medium, high. Closest available when omitted."
     output_schema:
       type: object
       required: [success]
       properties:
         success: { type: boolean }
+        resolved: { type: boolean }
         descriptor:
           type: object
           properties:
@@ -127,11 +128,11 @@ tools:
     call_examples:
       - arguments:
           asset_name: "table_01"
-          format: "fbx"
+          preferred_format: "fbx"
         note: "Resolve table_01 with FBX variant preferred"
       - arguments:
           asset_name: "hero_character"
-          lod: "high"
+          preferred_lod: "high"
         note: "Resolve character with high-detail LOD"
 
   - name: import_asset
@@ -348,6 +349,8 @@ tools:
       required: [success]
       properties:
         success: { type: boolean }
+        total_assets: { type: integer }
+        all_healthy: { type: boolean }
         catalogs:
           type: array
           items:


### PR DESCRIPTION
## Summary

Complete the 5 pending asset domain skill scripts from PIP-2941:

| Script | Changes |
|--------|---------|
| `resolve_asset.py` | Rename `format`→`preferred_format`, `lod`→`preferred_lod`; add `_run_cli()` helper, variant scoring, better error messages |
| `import_asset.py` | **Fix missing `import os`** (NameError); add `_run_cli()`/`_find_ready_instance()`/`_resolve_tool()` helpers, timeout handling |
| `export_asset.py` | Add `_run_cli()`/`_find_ready_instance()`/`_resolve_tool()` helpers, format validation, better error handling |
| `validate_asset.py` | Add `_scan_texture_refs()` for Maya ASCII/USD ASCII/OBJ; improved format detection, size thresholds; remove unused imports |
| `catalog_status.py` | Add `_run_cli()` helper, multi-catalog discovery (`_list_catalogs()`), aggregate stats (`total_assets`, `all_healthy`) |
| `tools.yaml` | Sync param names and output schemas with implementations |

## Quality

- All scripts follow the same `_run_cli()` helper pattern as `verify` skill
- Python 3.7+ compatible (`from __future__ import annotations`)
- All 40 contract tests pass (`test_asset_import_contract.py`)
- All 6 scripts pass `py_compile` syntax check

Refs: PIP-2941, PIP-2896