### PR TITLE
feat(skills): add asset domain skill with 5 pipeline scripts

### DIFF
--- a/skills/asset/SKILL.md
+++ b/skills/asset/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: asset
+description: >-
+  Gateway skill for cross-DCC asset operations — resolve asset descriptors,
+  import/export to-from DCC hosts, validate file integrity, and inspect
+  catalog status. Sits above asset-source for resolution and delegates to
+  DCC-specific import/export skills at runtime.
+license: MIT
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: python
+    layer: domain
+    version: "1.0.0"
+    tags: [pipeline, asset-import, asset-export, validation, catalog]
+    search-hint: >-
+      resolve asset, import asset, export asset, validate asset file,
+      catalog status, asset statistics, cross-dcc asset pipeline
+    search-aliases: [asset resolve, asset import, asset export, asset validate, catalog stats, asset pipeline]
+    intent: "Resolve, import, export, and validate assets across DCC hosts using the shared AssetDescriptor contract."
+    recall-context:
+      app_type: python
+      domain: asset
+      workflow_stage: pipeline
+      task_category: orchestration
+    preconditions:
+      - asset-source skill loaded for resolution
+    side-effects:
+      creates: true
+      modifies: true
+      file_output: true
+      targets: [dcc_scene, asset_catalog]
+    produces: [asset_descriptor, import_result, export_result, validation_report, catalog_stats]
+    requires: [asset-source]
+    tools: tools.yaml
+---
+
+# asset
+
+Gateway skill for cross-DCC asset pipeline operations. Builds on top of
+`asset-source` for resolution and delegates import/export to DCC-specific
+skills discovered at runtime.
+
+## Architecture
+
+```
+asset-source (resolution)
+       │
+       ▼
+   asset (this skill)
+       │
+       ├── resolve_asset ───► full AssetDescriptor
+       ├── import_asset ───► host import tools
+       ├── export_asset ───► host export tools
+       ├── validate_asset ─► file integrity report
+       └── catalog_status ─► catalog statistics
+```
+
+## Tools
+
+| Tool | Category | Description |
+|------|----------|-------------|
+| `resolve_asset` | Query | Resolve an asset_id or query into a full AssetDescriptor |
+| `import_asset` | Action | Import a resolved asset into a DCC host scene |
+| `export_asset` | Action | Export from a DCC host and register in the catalog |
+| `validate_asset` | Inspection | Check file integrity (format, size, referenced textures) |
+| `catalog_status` | Query | Report catalog statistics by format, tag, or attribution |
+
+## Gateway flow
+
+```
+search_skills("import asset") → load_skill("asset") → call("resolve_asset", {asset_id: "props/table-round"})
+→ AssetDescriptor → call("import_asset", {descriptor: ..., dcc: "blender"})
+→ ImportToSceneResult
+```
+
+## Prerequisites
+
+- `asset-source` skill must be loaded for `resolve_asset` to function.
+- DCC host skills (e.g. `blender-import-to-scene`) are discovered at runtime
+  via the gateway's tool search; they are not hard dependencies.

--- a/skills/asset/scripts/catalog_status.py
+++ b/skills/asset/scripts/catalog_status.py
@@ -1,0 +1,208 @@
+"""Report catalog statistics and health.
+
+Aggregates statistics from the asset-source catalog:
+- Total asset count
+- Breakdown by file format
+- Tag frequency distribution
+- Attribution coverage (how many assets have license/author info)
+- Format health (how many assets per format)
+
+Useful for catalog health checks, gap analysis, and overview.
+"""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_catalog():
+    """Return the full catalog as a list of AssetDescriptor dicts.
+
+    Tries the gateway path first, then falls back to local catalog.
+    """
+    # Try gateway tool dispatch first
+    try:
+        from dcc_mcp_core.skills_helper import call_tool as _call
+        from dcc_mcp_core.skills_helper import search_tools as _search
+
+        tools = _search("search_assets")
+        if tools and isinstance(tools, list):
+            for entry in tools:
+                tool_slug = entry.get("tool_slug") or entry.get("name", "")
+                if "search_assets" in tool_slug:
+                    # Search with empty wildcard to get all results
+                    response = _call(tool_slug, {
+                        "query": "",
+                        "limit": 50,
+                    })
+                    if response.get("success") and response.get("context", {}).get("results"):
+                        return response["context"]["results"]
+    except (ImportError, Exception):
+        pass
+
+    # Fallback: local catalog
+    try:
+        from skills.asset_source.scripts.search_assets import _DEMO_CATALOG
+        return [desc.to_dict() for desc in _DEMO_CATALOG]
+    except ImportError:
+        pass
+
+    return []
+
+
+def _compute_format_stats(catalog, format_filter=None):
+    """Compute breakdown by file format."""
+    counts = {}
+    for item in catalog:
+        variants = item.get("variants", [])
+        for v in variants:
+            fmt = v.get("format", "unknown")
+            if format_filter and fmt != format_filter:
+                continue
+            counts[fmt] = counts.get(fmt, 0) + 1
+    return counts
+
+
+def _compute_tag_stats(catalog, tag_filter=None):
+    """Compute tag frequency distribution."""
+    counts = {}
+    for item in catalog:
+        tags = item.get("tags", [])
+        for tag in tags:
+            if tag_filter and tag != tag_filter:
+                continue
+            counts[tag] = counts.get(tag, 0) + 1
+    # Sort by frequency descending
+    return dict(sorted(counts.items(), key=lambda x: x[1], reverse=True))
+
+
+def _compute_attribution_coverage(catalog):
+    """Compute attribution metadata coverage."""
+    total = len(catalog)
+    if total == 0:
+        return {
+            "total": 0,
+            "with_attribution": 0,
+            "with_license": 0,
+            "with_author": 0,
+            "with_title": 0,
+            "coverage_pct": 0.0,
+        }
+
+    with_attr = 0
+    with_license = 0
+    with_author = 0
+    with_title = 0
+
+    for item in catalog:
+        attr = item.get("attribution")
+        if attr:
+            with_attr += 1
+            if attr.get("license_spdx") or attr.get("license_text"):
+                with_license += 1
+            if attr.get("author"):
+                with_author += 1
+            if attr.get("title"):
+                with_title += 1
+
+    return {
+        "total": total,
+        "with_attribution": with_attr,
+        "with_license": with_license,
+        "with_author": with_author,
+        "with_title": with_title,
+        "coverage_pct": round(with_attr * 100.0 / total, 1) if total > 0 else 0.0,
+    }
+
+
+def _compute_unit_stats(catalog):
+    """Compute breakdown by unit system."""
+    counts = {}
+    for item in catalog:
+        unit = item.get("unit_hint", "unitless")
+        counts[unit] = counts.get(unit, 0) + 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Tool entry point
+# ---------------------------------------------------------------------------
+
+
+@skill_entry
+def main(format_filter=None, tag_filter=None, include_empty=False, **kwargs):
+    """Report catalog statistics.
+
+    Args:
+        format_filter: Optional format to restrict statistics to.
+        tag_filter: Optional tag to restrict statistics to.
+        include_empty: Include entries with zero counts.
+
+    Returns:
+        Skill result dict with catalog statistics in context.
+
+    """
+    catalog = _fetch_catalog()
+    total = len(catalog)
+
+    if total == 0:
+        return skill_error(
+            "Catalog is empty",
+            "No assets found in the catalog",
+            prompt="Populate the catalog first or check the asset-source configuration.",
+        )
+
+    # Compute all breakdowns
+    format_stats = _compute_format_stats(catalog, format_filter)
+    tag_stats = _compute_tag_stats(catalog, tag_filter)
+    attr_coverage = _compute_attribution_coverage(catalog)
+    unit_stats = _compute_unit_stats(catalog)
+
+    # Filter out zeros unless include_empty is set
+    if not include_empty:
+        format_stats = {k: v for k, v in format_stats.items() if v > 0}
+        tag_stats = {k: v for k, v in tag_stats.items() if v > 0}
+        unit_stats = {k: v for k, v in unit_stats.items() if v > 0}
+
+    # Determine unique format count
+    unique_formats = len(format_stats)
+    top_format = max(format_stats.items(), key=lambda x: x[1]) if format_stats else ("none", 0)
+
+    # Asset IDs for reference
+    asset_ids = [item.get("asset_id", "") for item in catalog]
+
+    filter_desc = []
+    if format_filter:
+        filter_desc.append("format=%s" % format_filter)
+    if tag_filter:
+        filter_desc.append("tag=%s" % tag_filter)
+    filter_str = (" (filtered: %s)" % ", ".join(filter_desc)) if filter_desc else ""
+
+    return skill_success(
+        "Catalog has %d asset(s)%s across %d format(s)" % (
+            total, filter_str, unique_formats,
+        ),
+        prompt=(
+            "Use resolve_asset to look up individual assets, or "
+            "asset-source search_assets to search by keyword."
+        ),
+        total=total,
+        unique_formats=unique_formats,
+        top_format=top_format[0],
+        top_format_count=top_format[1],
+        format_breakdown=format_stats,
+        tag_breakdown=tag_stats,
+        unit_breakdown=unit_stats,
+        attribution_coverage=attr_coverage,
+        asset_ids=asset_ids,
+    )
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+    run_main(main)

--- a/skills/asset/scripts/export_asset.py
+++ b/skills/asset/scripts/export_asset.py
@@ -1,0 +1,348 @@
+"""Export selected nodes from a DCC host scene to a file.
+
+Discovers the host export tool at runtime via gateway tool search and
+delegates the actual export. After export, registers the result in the
+asset catalog via the asset-source skill.
+
+Export flow:
+1. Discover host export tools (by dcc name or auto-detect)
+2. Call the discovered export tool with node list + output path
+3. On success, build an AssetDescriptor from the output
+4. Register in catalog (if gateway is available)
+5. Return the descriptor
+"""
+
+from __future__ import annotations
+
+import os as _os
+import sys as _sys
+from pathlib import Path as _Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
+from dcc_mcp_core.asset_import import (
+    AssetDescriptor,
+    AssetFileVariant,
+    AssetFormat,
+    AssetAttribution,
+)
+
+
+# ---------------------------------------------------------------------------
+# Format helpers
+# ---------------------------------------------------------------------------
+
+_FORMAT_EXTENSIONS = {
+    "fbx": AssetFormat.FBX,
+    "obj": AssetFormat.OBJ,
+    "usd": AssetFormat.USD,
+    "usdz": AssetFormat.USDZ,
+    "gltf": AssetFormat.GLTF,
+    "glb": AssetFormat.GLB,
+    "abc": AssetFormat.ABC,
+    "blend": AssetFormat.BLEND,
+}
+
+_FORMAT_MIMES = {
+    "fbx": "model/fbx",
+    "obj": "model/obj",
+    "usd": "model/vnd.usd+zip",
+    "usdz": "model/vnd.usdz+zip",
+    "gltf": "model/gltf+json",
+    "glb": "model/gltf-binary",
+    "abc": "application/x-alembic",
+    "blend": "application/x-blender",
+}
+
+
+def _infer_format(output_path, explicit_format=None):
+    """Infer format from file extension, with explicit override."""
+    if explicit_format:
+        return explicit_format.lower()
+    ext = output_path.rsplit(".", 1)[-1].lower() if "." in output_path else ""
+    return _FORMAT_EXTENSIONS.get(ext, AssetFormat.UNKNOWN)
+
+
+def _infer_mime(fmt):
+    """Return MIME type for a format string."""
+    return _FORMAT_MIMES.get(fmt, "application/octet-stream")
+
+
+def _generate_asset_id(output_path, explicit_id=None):
+    """Generate a catalog asset_id from the output path."""
+    if explicit_id:
+        return explicit_id
+    path = _Path(output_path)
+    name = path.stem
+    # Use the parent directory's last component as category prefix
+    category = path.parent.name
+    if category and category not in (".", "..", ""):
+        return "exports/%s/%s" % (category, name)
+    return "exports/%s" % name
+
+
+# ---------------------------------------------------------------------------
+# Tool discovery helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_export_tools(dcc=None):
+    """Search gateway for available export tools."""
+    export_tools = []
+    try:
+        from dcc_mcp_core.skills_helper import search_tools as _search
+
+        raw = _search("export from scene")
+        if not isinstance(raw, list):
+            return export_tools
+
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            tool_slug = entry.get("tool_slug") or entry.get("name", "")
+            if "export" not in tool_slug.lower():
+                continue
+            if dcc and dcc.lower() not in tool_slug.lower():
+                continue
+            export_tools.append({
+                "tool_slug": tool_slug,
+                "dcc_type": entry.get("dcc_type", "unknown"),
+                "display_name": entry.get("display_name", tool_slug),
+            })
+    except (ImportError, Exception):
+        pass
+    return export_tools
+
+
+def _find_export_tools_fallback(dcc=None):
+    """Fallback: list known export tool naming conventions."""
+    known = {
+        "maya": ["maya_geometry__export_selected", "maya_pipeline__export_selected"],
+        "blender": ["blender_export__export_selected"],
+        "houdini": ["houdini_geometry__export_selected"],
+        "unreal": ["unreal_pipeline__export_selected"],
+    }
+
+    result = []
+    targets = [dcc.lower()] if dcc else known.keys()
+    for target in targets:
+        for tool_slug in known.get(target, []):
+            result.append({
+                "tool_slug": tool_slug,
+                "dcc_type": target,
+                "display_name": tool_slug,
+            })
+    return result
+
+
+def _call_export_tool(tool_slug, params):
+    """Call a discovered export tool."""
+    try:
+        from dcc_mcp_core.skills_helper import call_tool as _call
+        return _call(tool_slug, params)
+    except (ImportError, Exception):
+        pass
+
+    # Subprocess fallback
+    import subprocess
+    import json
+
+    try:
+        creationflags = 0
+        if _sys.platform == "win32":
+            creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+        cmd = [
+            _sys.executable,
+            "-c",
+            "import json, sys; "
+            "from dcc_mcp_core.skills_helper import call_tool; "
+            "result = call_tool(%s, %s); "
+            "print(json.dumps(result))"
+            % (json.dumps(tool_slug), json.dumps(params)),
+        ]
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            creationflags=creationflags,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            return json.loads(proc.stdout)
+        return {
+            "success": False,
+            "message": "Export tool call failed: %s" % (proc.stderr or "unknown error"),
+        }
+    except Exception as exc:
+        return {"success": False, "message": "Export tool error: %s" % str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# Catalog registration
+# ---------------------------------------------------------------------------
+
+
+def _register_asset(descriptor_dict):
+    """Register an exported asset in the catalog via asset-source."""
+    try:
+        from dcc_mcp_core.skills_helper import call_tool as _call
+        from dcc_mcp_core.skills_helper import search_tools as _search
+
+        tools = _search("asset source register")
+        for entry in (tools if isinstance(tools, list) else []):
+            tool_slug = entry.get("tool_slug") or entry.get("name", "")
+            if "register" in tool_slug:
+                result = _call(tool_slug, {"descriptor": descriptor_dict})
+                return result.get("success", False)
+    except (ImportError, Exception):
+        pass
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tool entry point
+# ---------------------------------------------------------------------------
+
+
+@skill_entry
+def main(output_path, node_names, format=None, dcc=None,
+         asset_id=None, tags=None, **kwargs):
+    """Export nodes from a DCC host scene to a file.
+
+    Args:
+        output_path: Target file path for the exported asset.
+        node_names: List of node names or paths to export.
+        format: Export format hint. Inferred from extension if omitted.
+        dcc: Source DCC host. Auto-detected if omitted.
+        asset_id: Catalog asset_id. Auto-generated from filename if omitted.
+        tags: Optional list of tags for catalog registration.
+
+    Returns:
+        Skill result dict with the exported AssetDescriptor in context.
+
+    """
+    output_path = output_path.strip()
+    if not output_path:
+        return skill_error("Empty output_path", "output_path must not be empty")
+
+    if not node_names:
+        return skill_error("Empty node_names", "At least one node name is required")
+
+    fmt = _infer_format(output_path, format)
+    if fmt == AssetFormat.UNKNOWN:
+        return skill_error(
+            "Unknown export format",
+            "Cannot determine format from '%s'" % output_path,
+            prompt="Specify --format explicitly (e.g. 'fbx', 'usd', 'obj').",
+            output_path=output_path,
+        )
+
+    # Discover export tools
+    export_tools = _find_export_tools(dcc)
+    if not export_tools:
+        export_tools = _find_export_tools_fallback(dcc)
+
+    if not export_tools:
+        dcc_hint = " for '%s'" % dcc if dcc else ""
+        return skill_error(
+            "No export tools found%s" % dcc_hint,
+            "No DCC export tools discovered",
+            prompt=(
+                "Load a DCC export skill first or ensure a DCC gateway "
+                "instance is running."
+            ),
+            dcc=dcc,
+            output_path=output_path,
+        )
+
+    # Build export params
+    export_params = {
+        "output_path": output_path,
+        "node_names": node_names,
+        "format": fmt,
+    }
+
+    # Try each available export tool
+    results = []
+    for tool_info in export_tools:
+        tool_slug = tool_info["tool_slug"]
+        response = _call_export_tool(tool_slug, export_params)
+        results.append({
+            "tool": tool_slug,
+            "dcc": tool_info["dcc_type"],
+            "success": response.get("success", False),
+            "message": response.get("message", ""),
+            "context": response.get("context", {}),
+        })
+
+    succeeded = [r for r in results if r["success"]]
+
+    if not succeeded:
+        return skill_error(
+            "Export failed: tried %d tool(s)" % len(results),
+            "All export attempts failed",
+            prompt="Check DCC instances are running and export skills are loaded.",
+            output_path=output_path,
+            nodes=node_names,
+            attempts=results,
+        )
+
+    first = succeeded[0]
+    generated_id = _generate_asset_id(output_path, asset_id)
+    mime = _infer_mime(fmt)
+
+    # Build the exported asset descriptor
+    variant = AssetFileVariant(
+        local_path=output_path,
+        format=fmt,
+        preferred=True,
+        mime=mime,
+    )
+
+    # Check file size
+    file_size = None
+    try:
+        file_size = _Path(output_path).stat().st_size
+    except OSError:
+        pass
+
+    tags_list = list(tags) if tags else []
+
+    desc = AssetDescriptor(
+        asset_id=generated_id,
+        variants=[variant],
+        unit_hint="unitless",
+        meters_per_unit=1.0,
+        up_axis="y",
+        tags=tags_list,
+        extra={
+            "exported_from": first["dcc"],
+            "export_tool": first["tool"],
+            "node_count": len(node_names),
+        },
+    )
+    desc_dict = desc.to_dict()
+
+    # Attempt catalog registration
+    registered = _register_asset(desc_dict)
+
+    return skill_success(
+        "Exported %d node(s) to '%s' via %s" % (
+            len(node_names), output_path, first["dcc"],
+        ),
+        prompt="Pass the descriptor to import_asset to re-import later.",
+        descriptor=desc_dict,
+        asset_id=generated_id,
+        output_path=output_path,
+        file_size=file_size,
+        format=fmt,
+        dcc=first["dcc"],
+        node_count=len(node_names),
+        registered=registered,
+        all_results=results,
+    )
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+    run_main(main)

--- a/skills/asset/scripts/import_asset.py
+++ b/skills/asset/scripts/import_asset.py
@@ -1,0 +1,252 @@
+"""Import a resolved AssetDescriptor into a DCC host scene.
+
+Discovers the appropriate DCC-specific import tool at runtime via gateway
+tool search and delegates the actual import. The descriptor is expected
+to be a full AssetDescriptor dict from resolve_asset or asset-source.
+
+Import flow:
+1. Validate the descriptor
+2. Discover host import tools (by dcc name or auto-detect)
+3. Build ImportToSceneRequest
+4. Call the discovered import tool
+5. Return ImportToSceneResult
+"""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success, skill_warning
+from dcc_mcp_core.asset_import import (
+    AssetDescriptor,
+    ImportToSceneRequest,
+    MaterialMode,
+    PlacementHint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tool discovery helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_import_tools(dcc=None):
+    """Search gateway for available import-to-scene tools.
+
+    Returns a list of dicts with tool_slug, dcc_type, and display_name.
+    """
+    import_tools = []
+    try:
+        from dcc_mcp_core.skills_helper import search_tools as _search
+
+        raw = _search("import to scene")
+        if not isinstance(raw, list):
+            return import_tools
+
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            tool_slug = entry.get("tool_slug") or entry.get("name", "")
+            if "import" not in tool_slug.lower():
+                continue
+            if dcc and dcc.lower() not in tool_slug.lower():
+                continue
+            import_tools.append({
+                "tool_slug": tool_slug,
+                "dcc_type": entry.get("dcc_type", "unknown"),
+                "display_name": entry.get("display_name", tool_slug),
+            })
+    except (ImportError, Exception):
+        pass
+    return import_tools
+
+
+def _find_import_tools_fallback(dcc=None):
+    """Fallback: list known import tool naming conventions."""
+    known = {
+        "maya": ["maya_geometry__import_to_scene", "maya_pipeline__import_to_scene"],
+        "blender": ["blender_import__import_to_scene"],
+        "houdini": ["houdini_geometry__import_to_scene"],
+        "unreal": ["unreal_pipeline__import_to_scene"],
+    }
+
+    result = []
+    targets = [dcc.lower()] if dcc else known.keys()
+    for target in targets:
+        for tool_slug in known.get(target, []):
+            result.append({
+                "tool_slug": tool_slug,
+                "dcc_type": target,
+                "display_name": tool_slug,
+            })
+    return result
+
+
+def _call_import_tool(tool_slug, request_dict):
+    """Call a discovered import tool with the import request."""
+    try:
+        from dcc_mcp_core.skills_helper import call_tool as _call
+        return _call(tool_slug, request_dict)
+    except (ImportError, Exception):
+        pass
+
+    # Direct subprocess fallback
+    import subprocess
+    import json
+    import sys
+    import os
+
+    try:
+        creationflags = 0
+        if sys.platform == "win32":
+            creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+        cmd = [
+            sys.executable,
+            "-c",
+            "import json, sys; "
+            "from dcc_mcp_core.skills_helper import call_tool; "
+            "result = call_tool(%s, %s); "
+            "print(json.dumps(result))"
+            % (json.dumps(tool_slug), json.dumps(request_dict)),
+        ]
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            creationflags=creationflags,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            return json.loads(proc.stdout)
+        return {
+            "success": False,
+            "message": "Import tool call failed: %s" % (proc.stderr or "unknown error"),
+        }
+    except Exception as exc:
+        return {"success": False, "message": "Import tool error: %s" % str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# Tool entry point
+# ---------------------------------------------------------------------------
+
+
+@skill_entry
+def main(descriptor, dcc=None, material_mode="as_authored",
+         target_collection=None, skip_existing=False, placement=None, **kwargs):
+    """Import a resolved asset descriptor into a DCC host scene.
+
+    Args:
+        descriptor: AssetDescriptor dict from resolve_asset or asset-source.
+        dcc: Target DCC host name. Auto-detected if omitted.
+        material_mode: Material import strategy (as_authored, default_gray, skip).
+        target_collection: Optional collection/layer name.
+        skip_existing: Skip import if asset_id already present.
+        placement: Optional placement hint dict with translate/rotate/scale/parent_name.
+
+    Returns:
+        Skill result dict with ImportToSceneResult in context.
+
+    """
+    # Validate descriptor
+    try:
+        asset_desc = AssetDescriptor.from_dict(descriptor)
+        asset_desc.validate()
+    except Exception as exc:
+        return skill_error(
+            "Invalid asset descriptor",
+            str(exc),
+            prompt="Pass a valid descriptor from resolve_asset or asset-source.",
+        )
+
+    # Discover import tools
+    import_tools = _find_import_tools(dcc)
+    if not import_tools:
+        import_tools = _find_import_tools_fallback(dcc)
+
+    if not import_tools:
+        dcc_hint = " for '%s'" % dcc if dcc else ""
+        return skill_error(
+            "No import tools found%s" % dcc_hint,
+            "No DCC import-to-scene tools discovered",
+            prompt=(
+                "Load a DCC import skill first (e.g. blender-import-to-scene, "
+                "maya-geometry) or ensure a DCC gateway instance is running."
+            ),
+            dcc=dcc,
+            descriptor_id=asset_desc.asset_id,
+        )
+
+    # Build import request
+    placement_hint = PlacementHint.from_dict(placement) if placement else None
+    request = ImportToSceneRequest(
+        descriptor=asset_desc,
+        material_mode=material_mode,
+        placement=placement_hint,
+        target_collection=target_collection,
+        skip_existing=skip_existing,
+    )
+    request_dict = request.to_dict()
+
+    # Try each available import tool
+    results = []
+    for tool_info in import_tools:
+        tool_slug = tool_info["tool_slug"]
+        response = _call_import_tool(tool_slug, request_dict)
+        results.append({
+            "tool": tool_slug,
+            "dcc": tool_info["dcc_type"],
+            "success": response.get("success", False),
+            "message": response.get("message", ""),
+            "context": response.get("context", {}),
+        })
+
+    succeeded = [r for r in results if r["success"]]
+    failed = [r for r in results if not r["success"]]
+
+    if succeeded:
+        first = succeeded[0]
+        imported_nodes = first.get("context", {}).get("imported_nodes", [])
+        warnings = first.get("context", {}).get("warnings", [])
+
+        msg = "Imported '%s' into %s: %d node(s)" % (
+            asset_desc.asset_id,
+            first["dcc"],
+            len(imported_nodes),
+        )
+
+        warn_count = len(warnings)
+        if warn_count > 0:
+            return skill_warning(
+                msg,
+                warning="%d non-fatal warning(s) during import" % warn_count,
+                prompt="Check imported nodes in the viewport.",
+                imported_nodes=imported_nodes,
+                warnings=warnings,
+                tool=first["tool"],
+                dcc=first["dcc"],
+                all_results=results,
+            )
+
+        return skill_success(
+            msg,
+            prompt="Check imported nodes in the viewport.",
+            imported_nodes=imported_nodes,
+            warnings=warnings,
+            tool=first["tool"],
+            dcc=first["dcc"],
+            all_results=results,
+        )
+
+    # All tools failed
+    return skill_error(
+        "Import failed for '%s': tried %d tool(s)" % (asset_desc.asset_id, len(results)),
+        "All import attempts failed",
+        prompt="Check DCC instances are running and import skills are loaded.",
+        asset_id=asset_desc.asset_id,
+        attempts=results,
+    )
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+    run_main(main)

--- a/skills/asset/scripts/resolve_asset.py
+++ b/skills/asset/scripts/resolve_asset.py
@@ -1,0 +1,193 @@
+"""Resolve an asset by asset_id or search query into a full AssetDescriptor.
+
+Delegates to the asset-source skill for catalog lookup. Returns the
+descriptor with all variants and attribution metadata, ready for import.
+
+If the asset_id is a direct catalog match it is returned immediately;
+otherwise a fuzzy search is performed and the best match returned.
+"""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
+from dcc_mcp_core.asset_import import AssetDescriptor, AssetFileVariant, AssetFormat
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_from_extension(path):
+    """Infer AssetFormat from a file extension."""
+    ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+    mapping = {
+        "obj": AssetFormat.OBJ,
+        "fbx": AssetFormat.FBX,
+        "gltf": AssetFormat.GLTF,
+        "glb": AssetFormat.GLB,
+        "usd": AssetFormat.USD,
+        "usdz": AssetFormat.USDZ,
+        "abc": AssetFormat.ABC,
+        "blend": AssetFormat.BLEND,
+    }
+    return mapping.get(ext, AssetFormat.UNKNOWN)
+
+
+def _build_descriptor_from_result(item, prefer_format=None):
+    """Build an AssetDescriptor from an asset-source search result dict."""
+    variants_raw = item.get("variants", [])
+    variants = []
+    for v in variants_raw:
+        variant = AssetFileVariant.from_dict(v)
+        variants.append(variant)
+
+    attribution_raw = item.get("attribution")
+    from dcc_mcp_core.asset_import import AssetAttribution
+    attribution = AssetAttribution.from_dict(attribution_raw) if attribution_raw else None
+
+    # Reorder variants so preferred format comes first
+    if prefer_format and len(variants) > 1:
+        preferred = [v for v in variants if v.format == prefer_format]
+        others = [v for v in variants if v.format != prefer_format]
+        variants = preferred + others
+
+    desc = AssetDescriptor(
+        asset_id=item.get("asset_id", "unknown"),
+        variants=variants,
+        attribution=attribution,
+        preview=item.get("preview"),
+        unit_hint=item.get("unit_hint", "unitless"),
+        meters_per_unit=float(item.get("meters_per_unit", 1.0)),
+        up_axis=item.get("up_axis", "y"),
+        scale_hint=float(item["scale_hint"]) if item.get("scale_hint") is not None else None,
+        source_bbox=item.get("source_bbox"),
+        tags=list(item.get("tags", [])),
+        extra=dict(item.get("extra", {})),
+    )
+    return desc
+
+
+def _resolve_from_catalog(asset_id, prefer_format=None):
+    """Query the asset-source skill's search_assets and return best match.
+
+    Uses the gateway's tool search/call pattern via skills_helper.
+    When running inside a DCC-MCP gateway, this will route through the
+    gateway's dynamic capability surface. In standalone mode, falls back
+    to the local catalog.
+    """
+    # Try gateway tool dispatch path first
+    try:
+        from dcc_mcp_core.skills_helper import search_skills as _search
+
+        # Search for available DCC instances and the asset-source skill
+        results = _search("asset-source search_assets")
+        if results and len(results) > 0:
+            # Call via gateway when available
+            for entry in results:
+                tool_slug = entry.get("tool_slug") or entry.get("name")
+                if tool_slug and "search_assets" in tool_slug:
+                    from dcc_mcp_core.skills_helper import call_tool as _call
+                    response = _call(tool_slug, {"query": asset_id, "limit": 1})
+                    if response.get("success") and response.get("context", {}).get("results"):
+                        first = response["context"]["results"][0]
+                        return _build_descriptor_from_result(first, prefer_format)
+    except (ImportError, Exception):
+        pass
+
+    # Fallback: import local catalog directly
+    return _resolve_from_local_catalog(asset_id, prefer_format)
+
+
+def _resolve_from_local_catalog(asset_id, prefer_format=None):
+    """Direct catalog lookup fallback when gateway is unavailable."""
+    try:
+        from skills.asset_source.scripts.search_assets import _DEMO_CATALOG
+        from skills.asset_source.scripts.search_assets import _match_score
+
+        query = asset_id.strip()
+        scored = [(desc, _match_score(desc, query)) for desc in _DEMO_CATALOG]
+        scored = [(desc, score) for desc, score in scored if score > 0]
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        if not scored:
+            return None
+
+        best_desc, best_score = scored[0]
+        desc_dict = best_desc.to_dict()
+
+        if prefer_format:
+            variants = desc_dict.get("variants", [])
+            preferred = [v for v in variants if v.get("format") == prefer_format]
+            others = [v for v in variants if v.get("format") != prefer_format]
+            desc_dict["variants"] = preferred + others
+
+        return _build_descriptor_from_result(desc_dict, prefer_format)
+    except ImportError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tool entry point
+# ---------------------------------------------------------------------------
+
+
+@skill_entry
+def main(asset_id, prefer_format=None, **kwargs):
+    """Resolve an asset by asset_id or search query.
+
+    Args:
+        asset_id: Asset identifier (e.g. 'props/table-round') or search query.
+        prefer_format: Optional preferred file format filter.
+
+    Returns:
+        Skill result dict with the resolved AssetDescriptor in context.
+
+    """
+    asset_id = asset_id.strip()
+    if not asset_id:
+        return skill_error("Empty asset_id", "asset_id must not be empty")
+
+    descriptor = _resolve_from_catalog(asset_id, prefer_format)
+
+    if descriptor is None:
+        return skill_error(
+            "Asset not found",
+            "No matching asset for '%s'" % asset_id,
+            prompt="Try a different asset_id or check the catalog with catalog_status.",
+            query=asset_id,
+        )
+
+    try:
+        descriptor.validate()
+    except Exception as exc:
+        return skill_error(
+            "Asset descriptor validation failed",
+            str(exc),
+            query=asset_id,
+        )
+
+    desc_dict = descriptor.to_dict()
+    variant_count = len(desc_dict.get("variants", []))
+    preferred_path = ""
+    for v in desc_dict.get("variants", []):
+        if v.get("preferred"):
+            preferred_path = v.get("local_path", "")
+            break
+    if not preferred_path and variant_count > 0:
+        preferred_path = desc_dict["variants"][0].get("local_path", "")
+
+    return skill_success(
+        "Resolved asset '%s': %d variant(s)" % (descriptor.asset_id, variant_count),
+        prompt="Pass the descriptor to import_asset to import into a DCC host.",
+        descriptor=desc_dict,
+        asset_id=descriptor.asset_id,
+        variant_count=variant_count,
+        preferred_path=preferred_path,
+        query=asset_id,
+    )
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+    run_main(main)

--- a/skills/asset/scripts/validate_asset.py
+++ b/skills/asset/scripts/validate_asset.py
@@ -1,0 +1,306 @@
+"""Validate asset file integrity.
+
+Performs a series of checks on an asset file:
+- File exists and is readable
+- Non-zero size within expected bounds
+- Format is recognised (by extension or explicit hint)
+- Optionally checks referenced texture paths for existence
+- Reports warnings for unusual file sizes or missing references
+
+This is a read-only, filesystem-level check. It does not open or parse
+the asset file content — only validates file-level properties.
+"""
+
+from __future__ import annotations
+
+import os as _os
+import sys as _sys
+from pathlib import Path as _Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success, skill_warning
+
+
+# ---------------------------------------------------------------------------
+# Format constants
+# ---------------------------------------------------------------------------
+
+_RECOGNISED_EXTENSIONS = {
+    ".obj", ".fbx", ".gltf", ".glb", ".usd", ".usda", ".usdc", ".usdz",
+    ".abc", ".blend", ".ma", ".mb", ".hip", ".hipnc", ".max", ".c4d",
+    ".uasset", ".png", ".jpg", ".jpeg", ".tga", ".exr", ".tif", ".tiff",
+    ".hdr", ".bmp", ".psd", ".ai", ".svg",
+}
+
+# Known texture reference patterns in text-based formats
+_TEXTURE_REF_PATTERNS = {
+    ".obj": ["map_Kd", "map_Ka", "map_Ks", "map_Bump", "map_d", "disp"],
+    ".usd": ["@", ".png", ".jpg", ".exr", ".tga"],
+    ".usda": ["@", ".png", ".jpg", ".exr", ".tga"],
+}
+
+# Reasonable size thresholds (bytes)
+_MIN_FILE_SIZE = 1
+_DEFAULT_MAX_FILE_SIZE = 2 * 1024 * 1024 * 1024  # 2 GB
+_WARN_SIZE_LOW = 1024  # 1 KB — suspiciously small
+_WARN_SIZE_HIGH = 500 * 1024 * 1024  # 500 MB — suspiciously large
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_file_existence(file_path):
+    """Check that the file exists and is readable. Returns (ok, error_message)."""
+    path = _Path(file_path)
+    if not path.exists():
+        return False, "File does not exist: %s" % file_path
+    if not path.is_file():
+        return False, "Path is not a file: %s" % file_path
+    try:
+        with open(str(path), "rb") as f:
+            f.read(1)
+    except (OSError, IOError) as exc:
+        return False, "File is not readable: %s" % str(exc)
+    return True, None
+
+
+def _check_file_size(file_path, max_size_bytes=None):
+    """Check file size. Returns (ok, actual_size, warnings, error_message)."""
+    try:
+        size = _Path(file_path).stat().st_size
+    except OSError as exc:
+        return False, None, [], "Cannot stat file: %s" % str(exc)
+
+    warnings = []
+
+    if size < _MIN_FILE_SIZE:
+        return False, size, [], "File is empty (0 bytes)"
+
+    if max_size_bytes is not None and size > max_size_bytes:
+        return False, size, [], (
+            "File size %d bytes exceeds maximum %d bytes" % (size, max_size_bytes)
+        )
+
+    if size < _WARN_SIZE_LOW:
+        warnings.append(
+            "File size (%d bytes) is suspiciously small for an asset file" % size
+        )
+
+    if size > _WARN_SIZE_HIGH:
+        warnings.append(
+            "File size (%.1f MB) is unusually large" % (size / (1024.0 * 1024.0))
+        )
+
+    return True, size, warnings, None
+
+
+def _check_format(file_path, expected_format=None):
+    """Check that the file extension is recognised. Returns (ok, format_str, message)."""
+    ext = _Path(file_path).suffix.lower()
+    if not ext:
+        return False, "unknown", "File has no extension"
+
+    if expected_format:
+        # Normalize: strip leading dot and lowercase
+        expected = expected_format.lower().lstrip(".")
+        actual = ext.lstrip(".")
+        if actual != expected:
+            return False, actual, (
+                "Format mismatch: expected '%s', got '%s' (extension '%s')"
+                % (expected, actual, ext)
+            )
+
+    if ext not in _RECOGNISED_EXTENSIONS:
+        return True, ext, "Unrecognised extension '%s' — may still be valid" % ext
+
+    return True, ext, "Recognised format: '%s'" % ext.lstrip(".")
+
+
+def _find_texture_refs(file_path, fmt):
+    """Scan a text-based file for texture path references."""
+
+    def _resolve_texture_path(base_dir, ref):
+        """Try to resolve a texture reference to an actual file."""
+        # Try absolute path
+        if _os.path.isabs(ref):
+            if _Path(ref).exists():
+                return ref
+            return None
+
+        # Try relative to asset file directory
+        candidate = _Path(base_dir) / ref
+        if candidate.exists():
+            return str(candidate)
+
+        # Try common texture subdirectories
+        for sub in ["textures", "tex", "maps", "sourceimages"]:
+            candidate = _Path(base_dir) / sub / _Path(ref).name
+            if candidate.exists():
+                return str(candidate)
+
+        return None
+
+    if not fmt or fmt not in _TEXTURE_REF_PATTERNS:
+        return [], []
+
+    base_dir = _Path(file_path).parent
+    found = []
+    missing = []
+
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read(32768)  # Read first 32 KB only
+    except (OSError, IOError):
+        return [], []
+
+    lines = content.split("\n")
+
+    if fmt == ".obj":
+        for line in lines:
+            line = line.strip()
+            if any(line.startswith(p) for p in _TEXTURE_REF_PATTERNS[".obj"]):
+                parts = line.split()
+                if len(parts) >= 2:
+                    ref = parts[-1]
+                    resolved = _resolve_texture_path(base_dir, ref)
+                    if resolved:
+                        found.append(resolved)
+                    else:
+                        missing.append(ref)
+
+    elif fmt in (".usd", ".usda"):
+        for line in lines:
+            line = line.strip()
+            if "@" in line:
+                # Extract paths between @ delimiters
+                import re
+                matches = re.findall(r"@([^@]+)@", line)
+                for ref in matches:
+                    ref = ref.strip()
+                    if ref:
+                        resolved = _resolve_texture_path(base_dir, ref)
+                        if resolved:
+                            found.append(resolved)
+                        else:
+                            missing.append(ref)
+
+    return found, missing
+
+
+# ---------------------------------------------------------------------------
+# Tool entry point
+# ---------------------------------------------------------------------------
+
+
+@skill_entry
+def main(file_path, format=None, check_textures=False,
+         max_size_bytes=None, **kwargs):
+    """Validate asset file integrity.
+
+    Args:
+        file_path: Path to the asset file to validate.
+        format: Expected format. Inferred from extension if omitted.
+        check_textures: Whether to scan for and check referenced textures.
+        max_size_bytes: Maximum allowed file size. Defaults to 2 GB.
+
+    Returns:
+        Skill result dict with validation report in context.
+
+    """
+    file_path = file_path.strip()
+    if not file_path:
+        return skill_error("Empty file_path", "file_path must not be empty")
+
+    # Phase 1: Existence
+    ok, err = _check_file_existence(file_path)
+    if not ok:
+        return skill_error(
+            "File existence check failed",
+            err,
+            file_path=file_path,
+        )
+
+    # Phase 2: Size
+    ok, actual_size, size_warnings, err = _check_file_size(file_path, max_size_bytes)
+    if not ok:
+        return skill_error(
+            "File size check failed",
+            err,
+            file_path=file_path,
+            file_size=actual_size,
+        )
+
+    # Phase 3: Format
+    ext = _Path(file_path).suffix.lower()
+    ok, detected_fmt, fmt_msg = _check_format(file_path, format)
+    if not ok:
+        return skill_error(
+            "Format check failed",
+            fmt_msg,
+            file_path=file_path,
+            expected_format=format,
+            detected_extension=ext,
+        )
+
+    # Phase 4: Texture references (optional)
+    all_warnings = list(size_warnings)
+    texture_refs_found = []
+    texture_refs_missing = []
+
+    if check_textures:
+        found, missing = _find_texture_refs(file_path, ext)
+        texture_refs_found = found
+        texture_refs_missing = missing
+        if missing:
+            all_warnings.append(
+                "%d referenced texture(s) not found" % len(missing)
+            )
+
+    # Build result
+    checks = {
+        "exists": True,
+        "size_ok": True,
+        "format_ok": True,
+        "extensions_recognised": ext in _RECOGNISED_EXTENSIONS,
+    }
+    if texture_refs_found or texture_refs_missing:
+        checks["textures_resolved"] = len(texture_refs_found)
+        checks["textures_missing"] = len(texture_refs_missing)
+
+    valid = len(all_warnings) == 0
+
+    context = {
+        "file_path": file_path,
+        "file_size": actual_size,
+        "file_size_mb": round(actual_size / (1024.0 * 1024.0), 2) if actual_size else None,
+        "format": detected_fmt.lstrip("."),
+        "checks": checks,
+        "texture_refs_found": texture_refs_found[:20],
+        "texture_refs_missing": texture_refs_missing[:20],
+    }
+
+    if all_warnings:
+        return skill_warning(
+            "Validation completed with %d warning(s) for '%s'" % (
+                len(all_warnings), _Path(file_path).name,
+            ),
+            warning="; ".join(all_warnings),
+            prompt="Review warnings and fix issues before import.",
+            **context
+        )
+
+    return skill_success(
+        "Validation passed for '%s' (%s, %.1f MB)" % (
+            _Path(file_path).name,
+            detected_fmt.lstrip("."),
+            actual_size / (1024.0 * 1024.0),
+        ),
+        prompt="File is valid. Proceed with import or further processing.",
+        **context
+    )
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+    run_main(main)

--- a/skills/asset/tools.yaml
+++ b/skills/asset/tools.yaml
@@ -1,0 +1,281 @@
+tools:
+  - name: resolve_asset
+    description: >-
+      Resolve an asset by asset_id or search query and return a full
+      AssetDescriptor including all variants and attribution metadata.
+      Delegates to the asset-source skill for catalog lookup.
+    source_file: scripts/resolve_asset.py
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [asset_id]
+      properties:
+        asset_id:
+          type: string
+          minLength: 1
+          description: "Asset identifier (e.g. 'props/table-round') or search query."
+        prefer_format:
+          type: string
+          description: "Preferred file format filter (e.g. 'fbx', 'usd')."
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+    call_examples:
+      - arguments:
+          asset_id: "props/table-round"
+        note: "Resolve a specific asset by its catalog ID"
+      - arguments:
+          asset_id: "chair"
+          prefer_format: "fbx"
+        note: "Search for chair assets, prefer FBX format"
+
+  - name: import_asset
+    description: >-
+      Import a resolved AssetDescriptor into a DCC host scene. Discovers
+      the appropriate host import tool at runtime via gateway tool search
+      and delegates the actual import to that DCC-specific skill.
+    source_file: scripts/import_asset.py
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [descriptor]
+      properties:
+        descriptor:
+          type: object
+          description: "AssetDescriptor dict from resolve_asset or asset-source search."
+        dcc:
+          type: string
+          description: "Target DCC host (e.g. 'maya', 'blender', 'houdini'). Auto-detected if omitted."
+        material_mode:
+          type: string
+          enum: [as_authored, default_gray, skip]
+          default: as_authored
+          description: "Material import strategy."
+        target_collection:
+          type: string
+          description: "Optional collection/layer name to place the asset into."
+        skip_existing:
+          type: boolean
+          default: false
+          description: "Skip import if asset_id already present in scene."
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+      open_world_hint: true
+    call_examples:
+      - arguments:
+          descriptor:
+            asset_id: "props/table-round"
+            variants:
+              - local_path: "/data/assets/props/table_round.obj"
+                format: "obj"
+                preferred: true
+          dcc: "maya"
+        note: "Import a table asset into Maya"
+
+  - name: export_asset
+    description: >-
+      Export selected objects from a DCC host scene to a file and register
+      the result in the asset catalog. Discovers the host export tool at
+      runtime and delegates the actual export.
+    source_file: scripts/export_asset.py
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [output_path, node_names]
+      properties:
+        output_path:
+          type: string
+          minLength: 1
+          description: "Target file path for the exported asset."
+        node_names:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          description: "Node names or paths to export from the scene."
+        format:
+          type: string
+          description: "Export format hint (e.g. 'fbx', 'usd', 'obj'). Inferred from extension if omitted."
+        dcc:
+          type: string
+          description: "Source DCC host. Auto-detected if omitted."
+        asset_id:
+          type: string
+          description: "Catalog asset_id to register under. Auto-generated from filename if omitted."
+        tags:
+          type: array
+          items:
+            type: string
+          description: "Tags for catalog registration."
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+      open_world_hint: true
+    call_examples:
+      - arguments:
+          output_path: "/data/exports/chair_v2.fbx"
+          node_names: ["chair_grp"]
+          dcc: "maya"
+        note: "Export chair_grp from Maya as FBX"
+
+  - name: validate_asset
+    description: >-
+      Validate asset file integrity — check that the file exists, has a
+      non-zero size within expected bounds, its format is recognised, and
+      referenced textures (if any) are resolvable.
+    source_file: scripts/validate_asset.py
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [file_path]
+      properties:
+        file_path:
+          type: string
+          minLength: 1
+          description: "Path to the asset file to validate."
+        format:
+          type: string
+          description: "Expected format (e.g. 'fbx', 'usd'). Inferred from extension if omitted."
+        check_textures:
+          type: boolean
+          default: false
+          description: "Whether to check referenced texture paths for existence."
+        max_size_bytes:
+          type: integer
+          description: "Maximum allowed file size in bytes."
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+    call_examples:
+      - arguments:
+          file_path: "/data/assets/props/chair_modern.fbx"
+        note: "Validate a single FBX asset file"
+      - arguments:
+          file_path: "/data/assets/sets/corridor.usd"
+          check_textures: true
+        note: "Validate a USD asset and check referenced textures"
+
+  - name: catalog_status
+    description: >-
+      Return catalog statistics — total asset count, breakdown by file
+      format, tag frequency, and attribution coverage. Useful for health
+      checks and catalog overview.
+    source_file: scripts/catalog_status.py
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        format_filter:
+          type: string
+          description: "Optional format to filter statistics by (e.g. 'fbx', 'usd')."
+        tag_filter:
+          type: string
+          description: "Optional tag to filter by (e.g. 'furniture', 'character')."
+        include_empty:
+          type: boolean
+          default: false
+          description: "Include entries with zero counts in breakdowns."
+      required: []
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+    call_examples:
+      - arguments: {}
+        note: "Get full catalog statistics"
+      - arguments:
+          tag_filter: "furniture"
+        note: "Get statistics only for furniture-tagged assets"


### PR DESCRIPTION
## Summary

Adds the `asset` domain skill as a gateway for cross-DCC asset pipeline operations.

### New files

- **`skills/asset/SKILL.md`** — skill metadata and architecture docs
- **`skills/asset/tools.yaml`** — 5 tool declarations with input/output schemas
- **`skills/asset/scripts/resolve_asset.py`** — resolve asset_id into full AssetDescriptor via asset-source
- **`skills/asset/scripts/import_asset.py`** — discover host import tools and delegate import
- **`skills/asset/scripts/export_asset.py`** — discover host export tools, execute export, register to catalog
- **`skills/asset/scripts/validate_asset.py`** — file integrity checks (existence, size, format, textures)
- **`skills/asset/scripts/catalog_status.py`** — catalog statistics (format, tag, attribution coverage)

### Design

- Python 3.7+ compatible (%-formatting, no f-strings, no walrus operator)
- Uses `dcc_mcp_core.skills_helper` for HTTP/JSON (lazy imports)
- `affinity: any` — pure filesystem/metadata operations
- `CREATE_NO_WINDOW` flag in subprocess calls
- Follows asset-source and dcc-mcp skill patterns