### PR TITLE
feat(cli): wait for asynchronous job completion

### DIFF
--- a/crates/dcc-mcp-cli/src/application/control_plane.rs
+++ b/crates/dcc-mcp-cli/src/application/control_plane.rs
@@ -22,6 +22,8 @@ use crate::domain::rest::{
 use crate::infra::http::HttpGateway;
 
 const RELOAD_SKILLS_TOOL: &str = "dcc_admin__reload_skills";
+const JOB_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const TERMINAL_JOB_STATUSES: &[&str] = &["completed", "failed", "cancelled", "interrupted"];
 
 #[derive(Debug, Clone)]
 pub struct DccControlPlane {
@@ -156,6 +158,76 @@ impl DccControlPlane {
         Ok(attach_call_route(value, direct_local))
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub async fn call_and_wait(
+        &self,
+        tool_slug: String,
+        dcc_type: Option<String>,
+        instance_id: Option<String>,
+        arguments: Value,
+        meta: Option<Value>,
+        request_timeout: Duration,
+        wait_timeout: Duration,
+    ) -> anyhow::Result<Value> {
+        let status_tool = job_status_tool(&tool_slug, dcc_type.as_deref(), instance_id.as_deref())?;
+        let poll_meta = job_poll_meta(meta.clone());
+        let mut result = self
+            .call(
+                tool_slug,
+                dcc_type.clone(),
+                instance_id.clone(),
+                arguments,
+                meta,
+                request_timeout,
+            )
+            .await?;
+        let Some((job_id, mut status)) = job_identity(&result, 0)
+            .map(|(job_id, status)| (job_id.to_string(), status.to_string()))
+        else {
+            return Ok(result);
+        };
+        if is_terminal_job_status(&status) {
+            return Ok(result);
+        }
+
+        let started = tokio::time::Instant::now();
+        loop {
+            if started.elapsed() >= wait_timeout {
+                return Ok(json!({
+                    "success": false,
+                    "error": format!("timed out waiting for job {job_id} after {}s", wait_timeout.as_secs()),
+                    "job_id": job_id,
+                    "status": status,
+                    "wait_timed_out": true,
+                    "last_result": result,
+                }));
+            }
+            tokio::time::sleep(JOB_POLL_INTERVAL).await;
+            result = self
+                .call(
+                    status_tool.clone(),
+                    dcc_type.clone(),
+                    instance_id.clone(),
+                    json!({"job_id": job_id, "include_result": true}),
+                    poll_meta.clone(),
+                    request_timeout,
+                )
+                .await?;
+            let Some((reported_job_id, reported_status)) = job_identity(&result, 0) else {
+                anyhow::bail!("jobs_get_status returned no job envelope for {job_id}");
+            };
+            if reported_job_id != job_id {
+                anyhow::bail!(
+                    "jobs_get_status returned job {reported_job_id} while waiting for {job_id}"
+                );
+            }
+            status = reported_status.to_string();
+            if is_terminal_job_status(&status) {
+                return Ok(result);
+            }
+        }
+    }
+
     pub async fn call_batch(&self, body: Value, timeout: Duration) -> anyhow::Result<Value> {
         // Local mode owns and auto-starts the machine gateway, so batches use
         // its REST endpoint even though single calls can take the direct MCP path.
@@ -273,6 +345,63 @@ fn attach_call_route(mut value: Value, direct_local: bool) -> Value {
     value
 }
 
+fn job_status_tool(
+    tool_slug: &str,
+    dcc_type: Option<&str>,
+    instance_id: Option<&str>,
+) -> anyhow::Result<String> {
+    if dcc_type.is_some() && instance_id.is_some() {
+        return Ok("jobs_get_status".to_string());
+    }
+    let mut parts = tool_slug.splitn(3, '.');
+    let dcc = parts.next().unwrap_or_default();
+    let instance = parts.next().unwrap_or_default();
+    if dcc.is_empty() || instance.is_empty() || parts.next().is_none() {
+        anyhow::bail!("--wait requires a canonical DCC tool slug or direct instance selection");
+    }
+    Ok(format!("{dcc}.{instance}.jobs_get_status"))
+}
+
+fn job_identity(value: &Value, depth: u8) -> Option<(&str, &str)> {
+    if depth > 4 {
+        return None;
+    }
+    if let (Some(job_id), Some(status)) = (
+        value.get("job_id").and_then(Value::as_str),
+        value.get("status").and_then(Value::as_str),
+    ) {
+        return Some((job_id, status));
+    }
+    [
+        "output",
+        "result",
+        "structuredContent",
+        "structured_content",
+    ]
+    .iter()
+    .filter_map(|key| value.get(*key))
+    .find_map(|nested| job_identity(nested, depth + 1))
+}
+
+fn is_terminal_job_status(status: &str) -> bool {
+    TERMINAL_JOB_STATUSES.contains(&status)
+}
+
+fn job_poll_meta(mut meta: Option<Value>) -> Option<Value> {
+    let Some(Value::Object(root)) = meta.as_mut() else {
+        return meta;
+    };
+    root.remove("progressToken");
+    if let Some(Value::Object(dcc)) = root.get_mut("dcc") {
+        dcc.remove("async");
+        dcc.remove("wait_for_terminal");
+        if dcc.is_empty() {
+            root.remove("dcc");
+        }
+    }
+    meta.filter(|value| value.as_object().is_some_and(|object| !object.is_empty()))
+}
+
 fn attach_stats_coverage(mut value: Value, direct_local: bool) -> Value {
     if let Some(object) = value.as_object_mut() {
         object.insert(
@@ -315,8 +444,9 @@ fn select_remote_instances(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
 
-    use axum::extract::Query;
+    use axum::extract::{Query, State};
     use axum::routing::{get, post};
     use axum::{Json, Router};
     use tempfile::tempdir;
@@ -378,6 +508,91 @@ mod tests {
         assert_eq!(stats["stats_coverage"]["configured_route_recorded"], true);
         assert_eq!(stats["query"]["session_id"], "task-42");
 
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn wait_for_async_call_returns_terminal_result_without_requeueing_polls() {
+        async fn call(
+            State(requests): State<Arc<Mutex<Vec<Value>>>>,
+            Json(body): Json<Value>,
+        ) -> Json<Value> {
+            let slug = body["tool_slug"].as_str().unwrap_or_default().to_string();
+            let poll = {
+                let mut requests = requests.lock().unwrap();
+                let poll = requests
+                    .iter()
+                    .filter(|request| {
+                        request["tool_slug"]
+                            .as_str()
+                            .is_some_and(|tool| tool.ends_with(".jobs_get_status"))
+                    })
+                    .count();
+                requests.push(body);
+                poll
+            };
+            if slug.ends_with(".jobs_get_status") {
+                let status = if poll == 0 { "running" } else { "completed" };
+                return Json(json!({
+                    "structuredContent": {
+                        "job_id": "job-42",
+                        "status": status,
+                        "result": (status == "completed").then(|| json!({
+                            "success": true,
+                            "message": "done"
+                        }))
+                    }
+                }));
+            }
+            Json(json!({
+                "slug": slug,
+                "output": {"job_id": "job-42", "status": "pending"}
+            }))
+        }
+
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/v1/call", post(call))
+            .with_state(requests.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let registry = tempdir().unwrap();
+        let control = DccControlPlane::new(
+            GatewayTarget::Local,
+            Endpoint::new(format!("http://{addr}")),
+            registry.path().to_path_buf(),
+            true,
+        );
+
+        let result = control
+            .call_and_wait(
+                "unity.abc12345.run_tests".to_string(),
+                None,
+                None,
+                json!({}),
+                Some(json!({
+                    "agent_context": {"session_id": "task-42"},
+                    "lease_owner": "workflow-42",
+                    "dcc": {"async": true, "wait_for_terminal": true},
+                    "progressToken": "progress-9"
+                })),
+                Duration::from_secs(2),
+                Duration::from_secs(2),
+            )
+            .await
+            .unwrap();
+
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 3);
+        let poll_meta = &requests[1]["meta"];
+        assert_eq!(poll_meta["agent_context"]["session_id"], "task-42");
+        assert_eq!(poll_meta["lease_owner"], "workflow-42");
+        assert!(poll_meta["dcc"].get("async").is_none());
+        assert!(poll_meta["dcc"].get("wait_for_terminal").is_none());
+        assert!(poll_meta.get("progressToken").is_none());
+        assert_eq!(result["structuredContent"]["status"], "completed");
+        assert_eq!(result["structuredContent"]["result"]["message"], "done");
         server.abort();
     }
 

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -197,7 +197,7 @@ enum Command {
         /// Invoke an ordered gateway batch instead of one tool.
         #[arg(
             long,
-            conflicts_with_all = ["tool_slug", "dcc_type", "instance_id", "meta_json"]
+            conflicts_with_all = ["tool_slug", "dcc_type", "instance_id", "meta_json", "wait"]
         )]
         batch: bool,
         /// JSON array of batch call steps. Requires --batch.
@@ -216,6 +216,17 @@ enum Command {
         json_file: Option<PathBuf>,
         #[arg(long)]
         meta_json: Option<String>,
+        /// Poll an asynchronous job through the same DCC route until it reaches a terminal state.
+        #[arg(long, conflicts_with = "batch")]
+        wait: bool,
+        /// Maximum total time to wait for an asynchronous job.
+        #[arg(
+            long,
+            default_value = "600",
+            requires = "wait",
+            conflicts_with = "batch"
+        )]
+        wait_timeout_secs: u64,
         /// Per-request timeout for the tool call. Increase for renders and other long-running sync tools.
         #[arg(long, env = "DCC_MCP_CLI_CALL_TIMEOUT_SECS", default_value = "30")]
         timeout_secs: u64,
@@ -780,6 +791,8 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
             arguments_json,
             json_file,
             meta_json,
+            wait,
+            wait_timeout_secs,
             timeout_secs,
         } => {
             let effective_timeout = global_timeout_secs.unwrap_or(timeout_secs);
@@ -800,16 +813,31 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                     .map(|raw| parse_json_object(raw, "--meta-json"))
                     .transpose()?;
                 let meta = attach_agent_session_id(meta, agent_session_id.as_deref())?;
-                control
-                    .call(
-                        tool_slug,
-                        dcc_type,
-                        instance_id,
-                        arguments,
-                        meta,
-                        Duration::from_secs(effective_timeout.max(1)),
-                    )
-                    .await?
+                let request_timeout = Duration::from_secs(effective_timeout.max(1));
+                if wait {
+                    control
+                        .call_and_wait(
+                            tool_slug,
+                            dcc_type,
+                            instance_id,
+                            arguments,
+                            meta,
+                            request_timeout,
+                            Duration::from_secs(wait_timeout_secs.max(1)),
+                        )
+                        .await?
+                } else {
+                    control
+                        .call(
+                            tool_slug,
+                            dcc_type,
+                            instance_id,
+                            arguments,
+                            meta,
+                            request_timeout,
+                        )
+                        .await?
+                }
             };
             materialize_call_images(&mut result, &default_image_artifact_root());
             failed = !crate::application::local_control::call_result_succeeded(&result);

--- a/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
@@ -793,6 +793,8 @@ fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
                 arguments_json: "{}".to_string(),
                 json_file: None,
                 meta_json: None,
+                wait: false,
+                wait_timeout_secs: 600,
                 timeout_secs: 30,
             },
             &local,
@@ -936,6 +938,29 @@ fn call_parses_configurable_request_timeout() {
         panic!("expected call command");
     };
     assert_eq!(timeout_secs, 120);
+}
+
+#[test]
+fn call_contract_parses_wait_for_async_job() {
+    let args = Args::parse_from([
+        "dcc-mcp-cli",
+        "call",
+        "unity.abc12345.run_tests",
+        "--wait",
+        "--wait-timeout-secs",
+        "90",
+    ]);
+
+    let Command::Call {
+        wait,
+        wait_timeout_secs,
+        ..
+    } = args.command
+    else {
+        panic!("expected call command");
+    };
+    assert!(wait);
+    assert_eq!(wait_timeout_secs, 90);
 }
 
 #[test]

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -151,6 +151,7 @@ dcc-mcp-cli search --query "create sphere" --dcc-type maya --instance-id abc1234
 dcc-mcp-cli describe maya.abc12345.create_sphere
 dcc-mcp-cli load-skill workflow --dcc-type 3dsmax --instance-id 80321760
 dcc-mcp-cli call maya.abc12345.create_sphere --require-gateway --agent-session-id task-42 --json '{"radius":2}'
+dcc-mcp-cli call unity.abc12345.run_tests --require-gateway --wait --wait-timeout-secs 600 --json '{}'
 dcc-mcp-cli call maya_scene__get_session_info --dcc-type maya --instance-id abc12345 --json '{}'
 dcc-mcp-cli wait-ready --dcc-type maya --instance-id abc12345 --require skill_catalog,host_execution_bridge
 dcc-mcp-cli stop-instance --dcc-type maya --instance-id abc12345 --expected-owner release-smoke-test

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -387,10 +387,10 @@ python scripts/dcc_gateway.py call maya.a1b2c3d4.maya_primitives__create_sphere 
   --json '{"radius":2.0}'
 ```
 
-For `execution: async`, REST returns `output.status="pending"` plus `output.job_id`;
-do not retry HTTP 202. Poll `<same-instance>.jobs_get_status` through the gateway,
-never the adapter's private URL. Compact `ui-control` preserves `job_id`, `status`,
-`parent_job_id`, and `progress_token` for that canonical polling path.
+For asynchronous tools, add `--wait`; the CLI polls `jobs_get_status` through the
+same gateway/instance route and returns the terminal envelope. The default total
+wait is 600 seconds; override it with `--wait-timeout-secs`. Without `--wait`, REST
+returns `pending` plus `job_id`; manual gateway polling is only the fallback.
 
 Tool-specific fields (`code`, `file_path`, `radius`, and similar) belong inside
 the `--json` object. Do not pass them as top-level CLI flags unless the CLI adds

--- a/skills/dcc-mcp/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-mcp/references/CLI_CHEATSHEET.md
@@ -72,6 +72,7 @@ vx python scripts/dcc_gateway.py --ensure-cli list
 | `dcc-mcp-cli describe <slug>` | Inspect schema |
 | `dcc-mcp-cli call <slug> --require-gateway --agent-session-id task-42 --json '{"radius":2}'` | Invoke one tool through the measured gateway route with a stable task-scoped stats identifier |
 | `dcc-mcp-cli call <slug> --require-gateway --agent-session-id task-42 --json '{"radius":2}' --meta-json '{"lease_owner":"workflow-42"}'` | Invoke a measured tool call on an instance leased by this workflow |
+| `dcc-mcp-cli call <slug> --require-gateway --wait --wait-timeout-secs 600 --json '{}'` | Wait inside the CLI for an asynchronous job instead of spending agent calls on status polling |
 
 `dcc-types` reports the release catalog, not running instances. Entries include
 their canonical `dcc_type`, adapters, version/source data when available, and

--- a/tests/test_dcc_mcp_skill.py
+++ b/tests/test_dcc_mcp_skill.py
@@ -116,6 +116,12 @@ class TestDccMcpSkill:
         assert "review_skill_improvement" in body
         assert "do not use this skill" not in body
 
+    def test_async_calls_prefer_one_cli_wait_over_agent_polling(self) -> None:
+        body = (Path(DCC_MCP_SKILL_DIR) / "SKILL.md").read_text(encoding="utf-8")
+        assert "add `--wait`" in body
+        assert "`--wait-timeout-secs`" in body
+        assert "manual gateway polling is only the fallback" in body
+
     def test_openclaw_metadata_does_not_require_gateway_env(self) -> None:
         meta = dcc_mcp_core.parse_skill_md(DCC_MCP_SKILL_DIR)
         assert meta is not None


### PR DESCRIPTION
## Problem

`dcc-mcp-cli call` uses the REST control-plane route, so MCP `_meta.dcc.wait_for_terminal` does not apply there. Agents must repeatedly call `jobs_get_status`, adding avoidable tool calls and tokens while also having to preserve the original DCC instance route.

## Solution

- add opt-in `dcc-mcp-cli call --wait`
- poll the outer asynchronous job through the same DCC and instance route
- preserve `agent_context` and `lease_owner` on status calls
- remove async/wait/progress metadata from polling calls so they cannot enqueue recursively
- add `--wait-timeout-secs` with a structured timeout result
- keep existing no-wait behavior unchanged
- document the command and update the bundled `dcc-mcp` Skill guidance

This waits for the core/gateway job only. Adapters such as Unity may return their own persistent job handle, which still requires the adapter-specific inspection command.

## Validation

Run twice locally from a clean worktree based on `origin/main`:

- `cargo fmt --all -- --check`
- `cargo clippy -p dcc-mcp-cli --all-targets -- -D warnings`
- `cargo test -p dcc-mcp-cli --no-fail-fast` (110 unit, 1 auto-gateway, 25 CLI E2E, 6 install E2E, 23 marketplace E2E, doc tests)
- `python -m pytest tests/test_dcc_mcp_skill.py -q` (24 passed)
- `git diff --check`

Live Tuanjie/Unity proof:

- a single `call --wait` command completed the outer gateway job without an agent-issued `jobs_get_status`
- targeted Unity test `RealmFight.Tests.CombatWorldTests.BasicAttackUsesAnExplicitCooldown` passed (1/1)
- Unity result artifact SHA-256: `c69e0d3798077d27b86c9e556f32090dca0dabbe96381e24e21029cc1a445f6e`