### PR TITLE
fix: expose registered server instance id

### DIFF
--- a/crates/dcc-mcp-http-py/src/server.rs
+++ b/crates/dcc-mcp-http-py/src/server.rs
@@ -4,6 +4,9 @@ use super::*;
 use std::collections::HashMap;
 use std::time::Duration;
 
+#[cfg(feature = "stub-gen")]
+use pyo3_stub_gen_derive::{gen_stub_pyclass, gen_stub_pymethods};
+
 /// Handle returned by `McpHttpServer.start()`.
 ///
 /// Example::
@@ -11,6 +14,7 @@ use std::time::Duration;
 ///     handle = server.start()
 ///     # ... later ...
 ///     handle.shutdown()
+#[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
 #[pyclass(name = "McpServerHandle", skip_from_py_object)]
 pub struct PyServerHandle {
     pub(crate) inner: Option<McpServerHandle>,
@@ -19,6 +23,8 @@ pub struct PyServerHandle {
     pub bind_addr: String,
     /// ``True`` if this process won the gateway port competition.
     pub is_gateway: bool,
+    /// Canonical string form of the UUID registered in `FileRegistry`.
+    pub instance_id: Option<String>,
     /// Shared live metadata — mirrors `McpHttpServer::live_meta` so Python
     /// can push scene/version/documents updates that flow into FileRegistry
     /// on the next heartbeat tick.
@@ -70,6 +76,7 @@ impl Drop for PyServerHandle {
     }
 }
 
+#[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
 #[pymethods]
 impl PyServerHandle {
     /// The actual port the server is listening on.
@@ -118,6 +125,15 @@ impl PyServerHandle {
     #[getter]
     fn is_gateway(&self) -> bool {
         self.is_gateway
+    }
+
+    /// The exact UUID registered in ``FileRegistry``, or ``None``.
+    ///
+    /// ``None`` means gateway registration was disabled or unavailable. The
+    /// value is cached on the handle and remains readable after ``shutdown()``.
+    #[getter]
+    fn instance_id(&self) -> Option<&str> {
+        self.instance_id.as_deref()
     }
 
     /// Update the live instance metadata in the gateway registry.

--- a/crates/dcc-mcp-http-py/src/skill_server.rs
+++ b/crates/dcc-mcp-http-py/src/skill_server.rs
@@ -209,6 +209,7 @@ impl PyMcpHttpServer {
         let port = handle.port;
         let bind_addr = handle.bind_addr.clone();
         let is_gateway = handle.is_gateway;
+        let instance_id = handle.instance_id.map(|id| id.to_string());
 
         Ok(PyServerHandle {
             inner: Some(handle),
@@ -216,6 +217,7 @@ impl PyMcpHttpServer {
             port,
             bind_addr,
             is_gateway,
+            instance_id,
             live_meta: self.live_meta.clone(),
             shutdown_on_drop: self.config.shutdown_on_drop(),
         })

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -9,6 +9,7 @@ use tokio::{net::TcpListener, sync::watch, task::JoinHandle};
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
+use uuid::Uuid;
 
 use crate::{
     config::McpHttpConfig,
@@ -74,6 +75,12 @@ pub struct McpServerHandle {
     /// `--no-default-features` (the `auto-gateway` feature is off and
     /// `gateway_port` becomes a no-op).
     pub is_gateway: bool,
+    /// Exact UUID used to register this service in `FileRegistry`.
+    ///
+    /// `None` means gateway registration was disabled or unavailable. No
+    /// fallback UUID is generated, so a present value always identifies the
+    /// same row exposed through gateway instance discovery.
+    pub instance_id: Option<Uuid>,
     // Keep the GatewayHandle alive so background tasks keep running.
     #[cfg(feature = "auto-gateway")]
     _gateway: Option<dcc_mcp_gateway::GatewayHandle>,
@@ -677,8 +684,16 @@ impl McpHttpServer {
             .map(|h| h.is_gateway)
             .unwrap_or(false);
 
+        #[cfg(feature = "auto-gateway")]
+        let instance_id = gateway_handle
+            .as_ref()
+            .map(|handle| handle.service_key.instance_id);
+
         #[cfg(not(feature = "auto-gateway"))]
         let is_gateway = false;
+
+        #[cfg(not(feature = "auto-gateway"))]
+        let instance_id = None;
 
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
@@ -710,6 +725,7 @@ impl McpHttpServer {
             port,
             bind_addr: actual_bind,
             is_gateway,
+            instance_id,
             #[cfg(feature = "auto-gateway")]
             _gateway: gateway_handle,
         })
@@ -726,6 +742,9 @@ pub fn start_in_runtime(
 ) -> HttpResult<McpServerHandle> {
     runtime.block_on(async { McpHttpServer::new(registry, config).start().await })
 }
+
+#[cfg(test)]
+mod tests;
 
 /// Build the [`JobManager`](crate::job::JobManager) for this server,
 /// attaching a SQLite-backed [`JobStorage`](crate::job_storage::JobStorage)

--- a/crates/dcc-mcp-http/src/server/tests.rs
+++ b/crates/dcc-mcp-http/src/server/tests.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+#[cfg(feature = "auto-gateway")]
+fn unused_local_port() -> u16 {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn instance_id_is_none_when_gateway_registration_is_disabled() {
+    let mut config = McpHttpConfig::default();
+    config.server.port = 0;
+    config.gateway.gateway_port = 0;
+
+    let handle = McpHttpServer::new(Arc::new(ToolRegistry::new()), config)
+        .start()
+        .await
+        .unwrap();
+
+    assert_eq!(handle.instance_id, None);
+    handle.shutdown().await;
+}
+
+#[cfg(feature = "auto-gateway")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn instance_id_matches_the_registered_service_key() {
+    use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+
+    let registry_dir = tempfile::tempdir().unwrap();
+    let mut config = McpHttpConfig::default();
+    config.server.port = 0;
+    config.gateway.gateway_port = unused_local_port();
+    config.gateway.registry_dir = Some(registry_dir.path().to_path_buf());
+    config.gateway.heartbeat_secs = 0;
+    config.gateway.admin_enabled = false;
+    config.instance.dcc_type = Some("maya".to_string());
+
+    let handle = McpHttpServer::new(Arc::new(ToolRegistry::new()), config)
+        .start()
+        .await
+        .unwrap();
+    let instance_id = handle
+        .instance_id
+        .expect("gateway registration should publish an instance UUID");
+
+    let registry = FileRegistry::new(registry_dir.path()).unwrap();
+    let entries = registry.list_instances("maya");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(instance_id, entries[0].instance_id);
+
+    handle.shutdown().await;
+}

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -79,6 +79,7 @@ from dcc_mcp_core import McpServerHandle  # preferred public handle name
 | `port` | `int` | Actual port server is bound to (useful when port=0) |
 | `bind_addr` | `str` | Bind address, e.g. `"127.0.0.1:8765"` |
 | `is_gateway` | `bool` | `True` if this process won the gateway port competition |
+| `instance_id` | `str \| None` | Exact UUID registered in `FileRegistry`; `None` when gateway registration is disabled or unavailable |
 
 ### Methods
 
@@ -101,11 +102,17 @@ server = McpHttpServer(registry, McpHttpConfig())
 handle = server.start()
 
 print(f"MCP HTTP server running at {handle.mcp_url()}")
-# The handle exposes the OS-assigned listener URL.
+print(f"Registered service: {handle.instance_id}")
+# The handle exposes the OS-assigned listener URL and canonical registry UUID.
 
 # Shutdown when done
 handle.shutdown()
 ```
+
+The raw handle keeps its cached `instance_id` after `shutdown()`. A
+`DccServerBase` exposes the same value through `server.instance_id` only while
+running: it is `None` before `start()`, after `stop()`, or whenever registration
+is disabled. Adapters must not manufacture a fallback UUID.
 
 ## McpHttpServer
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -438,7 +438,8 @@ dcc-mcp-ui-control (independent pure ui_control observation/action/wait/policy/a
 **Key Components**:
 - `McpHttpServer` — background-thread HTTP server (axum/Tokio).
 - `McpHttpConfig` — re-export of the `dcc-mcp-http-types::config` aggregate for compatibility; new Rust code can import it from `dcc-mcp-http-types` directly.
-- `McpServerHandle` — URL retrieval, `is_gateway` flag, and graceful shutdown.
+- `McpServerHandle` — URL retrieval, the exact registered `instance_id`,
+  `is_gateway` flag, and graceful shutdown.
 - `ResourceRegistry` and `PromptRegistry` — MCP `resources/*` and `prompts/*` implementation.
 - Gateway bootstrap — delegates dynamic gateway behavior to `dcc-mcp-gateway`.
 

--- a/docs/zh/api/http.md
+++ b/docs/zh/api/http.md
@@ -74,6 +74,7 @@ from dcc_mcp_core import McpServerHandle  # McpServerHandle 的别名
 | `port` | `int` | 服务器实际绑定的端口（当 port=0 时有用） |
 | `bind_addr` | `str` | 绑定地址，如 `"127.0.0.1:8765"` |
 | `is_gateway` | `bool` | 若本进程赢得网关端口竞争则为 `True` |
+| `instance_id` | `str \| None` | `FileRegistry` 中注册的精确 UUID；网关注册禁用或不可用时为 `None` |
 
 ### 方法
 
@@ -96,11 +97,16 @@ server = McpHttpServer(registry, McpHttpConfig())
 handle = server.start()
 
 print(f"MCP HTTP 服务器运行于 {handle.mcp_url()}")
-# handle 返回操作系统实际分配的监听地址。
+print(f"已注册服务：{handle.instance_id}")
+# handle 返回操作系统实际分配的监听地址和规范注册 UUID。
 
 # 完成后关闭
 handle.shutdown()
 ```
+
+原始 handle 在 `shutdown()` 后仍保留缓存的 `instance_id`。
+`DccServerBase` 仅在运行期间通过 `server.instance_id` 暴露同一个值：
+`start()` 前、`stop()` 后或注册禁用时均为 `None`。适配器不得自行生成备用 UUID。
 
 ## McpHttpServer
 

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -70,6 +70,7 @@ __all__ = [
     "InstanceStatus",
     "IpcChannelAdapter",
     "LoggingMiddleware",
+    "McpServerHandle",
     "ObjectTransform",
     "PromptArgument",
     "PromptDefinition",
@@ -1173,6 +1174,105 @@ class LoggingMiddleware:
 
         Args:
             log_params: If True, also log the action parameters (default: False).
+        """
+    def __repr__(self) -> builtins.str: ...
+
+@typing.final
+class McpServerHandle:
+    r"""
+    Handle returned by `McpHttpServer.start()`.
+
+    Example::
+
+        handle = server.start()
+        # ... later ...
+        handle.shutdown()
+    """
+    @property
+    def port(self) -> builtins.int:
+        r"""
+        The actual port the server is listening on.
+        """
+    @property
+    def bind_addr(self) -> builtins.str:
+        r"""
+        The bind address (e.g. ``127.0.0.1:8765``).
+        """
+    @property
+    def is_gateway(self) -> builtins.bool:
+        r"""
+        ``True`` if this process won the gateway port competition.
+        """
+    @property
+    def instance_id(self) -> typing.Optional[builtins.str]:
+        r"""
+        The exact UUID registered in ``FileRegistry``, or ``None``.
+
+        ``None`` means gateway registration was disabled or unavailable. The
+        value is cached on the handle and remains readable after ``shutdown()``.
+        """
+    def mcp_url(self) -> builtins.str:
+        r"""
+        The full MCP endpoint URL.
+        """
+    def shutdown(self) -> None:
+        r"""
+        Gracefully shut down the server.
+        """
+    def __enter__(self) -> McpServerHandle: ...
+    def __exit__(self, _exc_type: typing.Any, _exc: typing.Any, _tb: typing.Any) -> None: ...
+    def signal_shutdown(self) -> None:
+        r"""
+        Signal shutdown without blocking.
+        """
+    def update_scene(self, scene: typing.Optional[builtins.str] = None, version: typing.Optional[builtins.str] = None, documents: typing.Optional[typing.Sequence[builtins.str]] = None, display_name: typing.Optional[builtins.str] = None) -> None:
+        r"""
+        Update the live instance metadata in the gateway registry.
+
+        Works for both single-document DCCs (Maya, Blender — pass ``scene``
+        only) and multi-document DCCs (Photoshop, After Effects — also pass
+        ``documents`` with the full list of open files and optionally
+        ``display_name`` to label the instance).
+
+        Values are written into the shared live-metadata store and propagated
+        to ``FileRegistry`` on the next heartbeat tick (≤ 5 s).  After the
+        update, ``list_dcc_instances`` reflects the change so AI agents and
+        users can identify the correct instance without restarting.
+
+        Pass ``None`` to leave a field unchanged; pass ``""`` / ``[]`` to
+        clear it.
+
+        Examples::
+
+            # Maya — single active scene:
+            handle.update_scene("C:/projects/hero/rig.ma")
+
+            # Photoshop — active document + all open docs + instance label:
+            handle.update_scene(
+                scene="hero_comp.psd",
+                documents=["hero_comp.psd", "bg_plate.psd", "overlay.psd"],
+                display_name="PS-Marketing",
+            )
+
+            # Clear the document list (single-doc mode again):
+            handle.update_scene(documents=[])
+
+        Args:
+            scene: Active/focused scene or document path.
+                    ``None`` = no change, ``""`` = clear.
+            version: DCC application version string.
+                     ``None`` = no change, ``""`` = clear.
+            documents: Full list of open documents (multi-doc DCCs).
+                       ``None`` = no change, ``[]`` = clear list.
+            display_name: Human-readable instance label (e.g. ``"PS-Marketing"``).
+                          ``None`` = no change, ``""`` = clear.
+        """
+    def update_gateway_metadata(self, metadata: typing.Mapping[builtins.str, builtins.str]) -> None:
+        r"""
+        Merge arbitrary string metadata into the FileRegistry row.
+
+        Values propagate on the next heartbeat tick. Empty values clear the
+        matching key while preserving unrelated metadata.
         """
     def __repr__(self) -> builtins.str: ...
 

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -789,6 +789,11 @@ class DccServerBase:
         """The MCP endpoint URL, or ``None`` if not running."""
         return self._handle.mcp_url() if self._handle else None
 
+    @property
+    def instance_id(self) -> str | None:
+        """The registered service UUID, or ``None`` if not running/registered."""
+        return self._handle.instance_id if self._handle else None
+
     # --- gateway metadata update ------------------------------------------------
 
     def update_gateway_metadata(

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -150,6 +150,11 @@ does not replace a running server binary.
 9. Use `dcc_mcp_core.install_lifecycle.build_sidecar_command(...)` / `launch_sidecar(...)` for sidecar startup and readiness. Read `docs/guide/adapter-install-lifecycle.md` before changing host RPC, dispatch readiness, launch stdio, `watch_pid`, or `instance_id` handling.
    - The sidecar MCP listener is dispatch-only. A py37-lite factory can expose local skill metadata, but it cannot advertise or activate declarative skills through the gateway. Require a native py37 wheel for that path, or provide a separate discovery MCP URL; never report lite `load_skill` success without an executable catalog.
 10. Pass `instance_id` to sidecar launch helpers only when it is a real UUID for the DCC service. During early startup, omit it or pass `None`; `build_sidecar_command()` rejects cosmetic values such as `"unknown"` with `success=false` and `reason="invalid_instance_id"` so adapters do not spawn a child that can only fail with a CLI argument error.
+    After `DccServerBase.start()`, use `server.instance_id` when adapter UI or
+    sidecar wiring needs the canonical FileRegistry identity. It is the exact
+    registered UUID and is `None` before start, after stop, or when gateway
+    registration is disabled/unavailable; never inspect private handles or
+    generate a replacement UUID.
 11. Adapter supervisors that must stop the sidecar on plugin unload should call `launch_sidecar(..., return_process=True, detached=False)` instead of reimplementing `subprocess.Popen`; keep `return_process=False` for CLI/JSON paths because the process handle is not serializable.
 12. If the adapter cannot share the gateway `FileRegistry`, register remotely through `POST /v1/instances/register`, refresh with `/heartbeat`, and deregister on shutdown; the gateway will expose the row as `source: "http"` in `gateway://instances` / `GET /v1/instances`, preserve `instance_short` and `mcp_url`, and route it through the same `live_instances` contract.
 13. For same-LAN convenience discovery, build with `mdns` and pair adapter-side `--advertise-mdns` with gateway-side `--discover-mdns`; treat this as a multicast discovery hint only, keep auth/TLS policy explicit, and prefer HTTP registration or relay for routed/subnet-crossing production deployments.

--- a/tests/test_create_skill_manager.py
+++ b/tests/test_create_skill_manager.py
@@ -13,8 +13,12 @@ Covers:
 
 from __future__ import annotations
 
+import json
+from uuid import UUID
+
 import pytest
 
+from conftest import allocate_gateway_port
 from dcc_mcp_core import McpHttpConfig
 from dcc_mcp_core import McpHttpServer
 from dcc_mcp_core import create_skill_server
@@ -113,6 +117,42 @@ class TestCreateSkillManagerServerHandle:
         handle = server.start()
         handle.shutdown()
         handle.shutdown()  # Second shutdown must not raise
+
+    def test_instance_id_is_none_when_gateway_registration_is_disabled(self):
+        config = McpHttpConfig(port=0)
+        config.gateway_port = 0
+        server = create_skill_server("maya", config=config)
+
+        handle = server.start()
+        assert handle.instance_id is None
+        handle.shutdown()
+        assert handle.instance_id is None
+
+    def test_instance_id_matches_registry_and_survives_handle_shutdown(
+        self,
+        tmp_path,
+    ):
+        config = McpHttpConfig(port=0)
+        config.gateway_port = allocate_gateway_port()
+        config.registry_dir = str(tmp_path)
+        config.heartbeat_secs = 0
+        config.admin_enabled = False
+        config.dcc_type = "maya"
+        server = create_skill_server("maya", config=config)
+
+        handle = server.start()
+        instance_id = handle.instance_id
+        try:
+            assert instance_id is not None
+            assert instance_id == str(UUID(instance_id))
+            rows = json.loads((tmp_path / "services.json").read_text(encoding="utf-8"))
+            maya_rows = [row for row in rows if row["dcc_type"] == "maya"]
+            assert len(maya_rows) == 1
+            assert instance_id == maya_rows[0]["instance_id"]
+        finally:
+            handle.shutdown()
+
+        assert handle.instance_id == instance_id
 
 
 class TestCreateSkillManagerSkillMethods:

--- a/tests/test_dcc_adapter_base.py
+++ b/tests/test_dcc_adapter_base.py
@@ -416,6 +416,7 @@ class TestDccServerBase:
         server = self._make_server(tmp_path)
         assert not server.is_running
         assert server.mcp_url is None
+        assert server.instance_id is None
         assert not server.is_hot_reload_enabled
 
     def test_start_and_stop(self, tmp_path):
@@ -424,10 +425,12 @@ class TestDccServerBase:
         assert server.is_running
         assert handle is not None
         assert server.mcp_url is not None
+        assert server.instance_id == "fake-id-001"
 
         server.stop()
         assert not server.is_running
         assert server.mcp_url is None
+        assert server.instance_id is None
 
     def test_start_logs_server_version(self, tmp_path, caplog):
         server = self._make_server(tmp_path)


### PR DESCRIPTION
## Summary
- expose the exact FileRegistry UUID on Rust and Python server handles
- add DccServerBase.instance_id lifecycle semantics without fallback IDs
- add Rust/Python regressions, generated stubs, API docs, and adapter guidance

## Validation
- Rust handle tests: 2 passed
- PyO3 crate tests: 19 passed
- Python focused tests: 123 passed
- no-default-features check, owning-crate Clippy, Ruff, stub drift, and docs build passed
- live DCC host not exercised; the contract is covered through real McpHttpServer/FileRegistry registration