### PR TITLE
fix: harden capture diagnostics and release coverage

### DIFF
--- a/crates/dcc-mcp-capture/src/backend/windows.rs
+++ b/crates/dcc-mcp-capture/src/backend/windows.rs
@@ -13,6 +13,19 @@ use crate::error::{CaptureError, CaptureResult};
 use crate::types::CaptureFormat;
 use crate::types::{CaptureBackendKind, CaptureConfig, CaptureFrame};
 
+const E_ACCESSDENIED_HRESULT: i32 = 0x8007_0005_u32 as i32;
+
+fn map_duplicate_output_error(code: i32, native_error: String) -> CaptureError {
+    if code == E_ACCESSDENIED_HRESULT {
+        CaptureError::DesktopUnavailable {
+            backend: CaptureBackendKind::DxgiDesktopDuplication.to_string(),
+            native_error,
+        }
+    } else {
+        CaptureError::Platform(format!("DuplicateOutput: {native_error}"))
+    }
+}
+
 // ── DxgiBackend ────────────────────────────────────────────────────────────
 
 /// Windows DXGI Desktop Duplication capture backend.
@@ -164,7 +177,7 @@ fn capture_dxgi(config: &CaptureConfig) -> CaptureResult<CaptureFrame> {
     let duplication = unsafe {
         output1
             .DuplicateOutput(&device)
-            .map_err(|e| CaptureError::Platform(format!("DuplicateOutput: {e}")))?
+            .map_err(|error| map_duplicate_output_error(error.code().0, error.to_string()))?
     };
 
     // Get display mode dimensions.
@@ -343,5 +356,30 @@ mod tests {
     fn test_dxgi_backend_kind() {
         let b = DxgiBackend::new();
         assert_eq!(b.backend_kind(), CaptureBackendKind::DxgiDesktopDuplication);
+    }
+
+    #[test]
+    fn duplicate_output_access_denied_maps_to_desktop_unavailable() {
+        let error = map_duplicate_output_error(
+            E_ACCESSDENIED_HRESULT,
+            "Access is denied (0x80070005)".to_owned(),
+        );
+
+        assert!(matches!(
+            error,
+            CaptureError::DesktopUnavailable {
+                ref backend,
+                ref native_error,
+            } if backend == "DXGI Desktop Duplication" && native_error.contains("0x80070005")
+        ));
+    }
+
+    #[test]
+    fn duplicate_output_other_errors_remain_platform_errors() {
+        let error = map_duplicate_output_error(0x887A_0001_u32 as i32, "invalid call".to_owned());
+        assert!(matches!(
+            error,
+            CaptureError::Platform(message) if message == "DuplicateOutput: invalid call"
+        ));
     }
 }

--- a/crates/dcc-mcp-capture/src/backend/windows.rs
+++ b/crates/dcc-mcp-capture/src/backend/windows.rs
@@ -13,8 +13,10 @@ use crate::error::{CaptureError, CaptureResult};
 use crate::types::CaptureFormat;
 use crate::types::{CaptureBackendKind, CaptureConfig, CaptureFrame};
 
+#[cfg(any(target_os = "windows", test))]
 const E_ACCESSDENIED_HRESULT: i32 = 0x8007_0005_u32 as i32;
 
+#[cfg(any(target_os = "windows", test))]
 fn map_duplicate_output_error(code: i32, native_error: String) -> CaptureError {
     if code == E_ACCESSDENIED_HRESULT {
         CaptureError::DesktopUnavailable {

--- a/crates/dcc-mcp-capture/src/error.rs
+++ b/crates/dcc-mcp-capture/src/error.rs
@@ -14,6 +14,15 @@ pub enum CaptureError {
     #[error("platform error: {0}")]
     Platform(String),
 
+    /// The interactive desktop cannot currently be captured.
+    #[error("desktop_unavailable: backend={backend}; native_error={native_error}")]
+    DesktopUnavailable {
+        /// Capture backend that reported the unavailable desktop.
+        backend: String,
+        /// Original platform error retained for diagnosis.
+        native_error: String,
+    },
+
     /// The target window or process could not be found.
     #[error("target not found: {0}")]
     TargetNotFound(String),
@@ -74,6 +83,19 @@ mod tests {
     fn test_error_display_timeout() {
         let e = CaptureError::Timeout(5000);
         assert!(e.to_string().contains("5000"));
+    }
+
+    #[test]
+    fn desktop_unavailable_preserves_backend_and_native_error() {
+        let error = CaptureError::DesktopUnavailable {
+            backend: "DXGI Desktop Duplication".to_owned(),
+            native_error: "Access is denied (0x80070005)".to_owned(),
+        };
+
+        let message = error.to_string();
+        assert!(message.starts_with("desktop_unavailable:"));
+        assert!(message.contains("DXGI Desktop Duplication"));
+        assert!(message.contains("0x80070005"));
     }
 
     #[test]

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows.rs
@@ -1118,6 +1118,7 @@ fn map_recording_capture_error(error: CaptureError) -> HostFailure {
         CaptureError::Cancelled => UiControlHostErrorCode::UserInterrupted,
         CaptureError::TargetNotFound(_) => UiControlHostErrorCode::InvalidTarget,
         CaptureError::BackendNotSupported(_) => UiControlHostErrorCode::BackendUnavailable,
+        CaptureError::DesktopUnavailable { .. } => UiControlHostErrorCode::DesktopUnavailable,
         _ => UiControlHostErrorCode::CaptureFailed,
     };
     HostFailure::new(code, error.to_string())

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows/tests.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows/tests.rs
@@ -481,3 +481,14 @@ fn file_and_directory_symlinks_report_created_and_unchanged_when_permitted() {
         UiControlEnsureOutcome::Unchanged
     );
 }
+
+#[test]
+fn recording_maps_capture_desktop_unavailable_without_downgrading_it() {
+    let failure = map_recording_capture_error(CaptureError::DesktopUnavailable {
+        backend: "DXGI Desktop Duplication".to_owned(),
+        native_error: "Access is denied (0x80070005)".to_owned(),
+    });
+
+    assert_eq!(failure.code, UiControlHostErrorCode::DesktopUnavailable);
+    assert!(failure.message.contains("0x80070005"));
+}

--- a/docs/api/capture.md
+++ b/docs/api/capture.md
@@ -21,7 +21,7 @@ capturer = Capturer.new_auto()
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `new_auto()` | `Capturer` | Create capturer with best available backend (full-screen / display) |
-| `new_window_auto()` | `Capturer` | Create capturer configured for single-window capture (HWND PrintWindow on Windows; Mock elsewhere) |
+| `new_window_auto()` | `Capturer` | Create capturer configured for single-window capture (Windows.Graphics.Capture with bounded GDI fallback on Windows; Mock elsewhere) |
 | `new_mock(width=1920, height=1080)` | `Capturer` | Create capturer with mock backend (for testing/CI) |
 | `capture_window_png(pid, *, timeout_ms=1000)` | `bytes \| None` | One-shot helper: resolve the main window of `pid`, capture it, return PNG-encoded bytes. Returns `None` on any failure (window not found, backend error, …) instead of raising |
 | `capture_region_png(pid, x, y, w, h, *, timeout_ms=1000)` | `bytes \| None` | One-shot helper: capture window of `pid` and CPU-crop to the rectangle `(x, y, w, h)` (window-local pixels). Zero-width / zero-height regions short-circuit to `None` without touching the backend |
@@ -197,6 +197,12 @@ try:
 except RuntimeError as e:
     print(f"Capture failed: {e}")
 ```
+
+DXGI `DuplicateOutput` access-denied failures use the stable
+`desktop_unavailable:` prefix and retain both the backend and native error
+(including `0x80070005`). The bundled `dcc_diagnostics__screenshot` tool
+projects that prefix as `error_kind=desktop_unavailable` instead of silently
+switching to another capture path.
 
 ## Platform-Specific Notes
 

--- a/python/dcc_mcp_core/dcc_server.py
+++ b/python/dcc_mcp_core/dcc_server.py
@@ -273,6 +273,7 @@ def _handle_take_screenshot(params_json: str) -> str:
     pid = params.get("process_id") or _instance_context.get("dcc_pid")
     title = params.get("window_title") or _instance_context.get("dcc_window_title")
 
+    cap = None
     try:
         if full_screen:
             cap = _get_full_capturer()
@@ -290,6 +291,18 @@ def _handle_take_screenshot(params_json: str) -> str:
                         hwnd = resolver()
                     except Exception as exc:
                         logger.debug("take_screenshot: resolver failed: %s", exc)
+            if not hwnd and (pid or title):
+                try:
+                    from dcc_mcp_core import CaptureTarget
+                    from dcc_mcp_core import WindowFinder
+
+                    target = CaptureTarget.process_id(pid) if pid else CaptureTarget.window_title(title)
+                    window = WindowFinder().find(target)
+                    if window is not None:
+                        hwnd = window.handle
+                        title = window.title
+                except Exception as exc:
+                    logger.debug("take_screenshot: window discovery failed: %s", exc)
             cap = _get_window_capturer()
             frame = cap.capture_window(
                 process_id=pid,
@@ -299,6 +312,27 @@ def _handle_take_screenshot(params_json: str) -> str:
                 jpeg_quality=quality,
                 scale=scale,
                 timeout_ms=timeout_ms,
+            )
+        capture_backend = cap.backend_name()
+        fallback_from = "Windows.Graphics.Capture" if not full_screen and capture_backend == "GDI PrintWindow" else None
+        capture_health = getattr(
+            frame,
+            "capture_health",
+            "degraded" if fallback_from else "unverified",
+        )
+        if capture_health == "unusable":
+            return json_dumps(
+                {
+                    "success": False,
+                    "message": "Capture backend reported an unusable frame",
+                    "error_kind": "unusable_capture",
+                    "capture_backend": capture_backend,
+                    "fallback_from": fallback_from,
+                    "capture_health": capture_health,
+                    "window_handle": hwnd,
+                    "window_title": frame.window_title,
+                    "source": "dcc-ipc",
+                }
             )
         payload = {
             "success": True,
@@ -311,15 +345,25 @@ def _handle_take_screenshot(params_json: str) -> str:
             "image_base64": base64.b64encode(frame.data).decode("ascii"),
             "window_rect": list(frame.window_rect) if frame.window_rect else None,
             "window_title": frame.window_title,
+            "window_handle": hwnd,
+            "capture_backend": capture_backend,
+            "fallback_from": fallback_from,
+            "capture_health": capture_health,
             "timestamp_ms": int(time.time() * 1000),
             "source": "dcc-ipc",
         }
     except Exception as exc:
         logger.warning("take_screenshot handler error: %s", exc)
+        message = str(exc)
+        error_kind = message.partition(":")[0] if message.startswith("desktop_unavailable:") else "capture_failed"
         payload = {
             "success": False,
-            "message": str(exc),
+            "message": message,
             "error": type(exc).__name__,
+            "error_kind": error_kind,
+            "native_error": message,
+            "capture_backend": cap.backend_name() if cap is not None else None,
+            "window_handle": hwnd,
             "source": "dcc-ipc",
         }
     return json_dumps(payload)

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/SKILL.md
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/SKILL.md
@@ -57,9 +57,17 @@ When a DCC tool fails with a vague error, call tools in this order:
 Capture the current screen or a specific window as a PNG/JPEG image.
 Backed by the `dcc_mcp_core.Capturer` class which uses:
 
-- **Windows**: DXGI Desktop Duplication API (<16ms per frame)
+- **Windows display**: DXGI Desktop Duplication API
+- **Windows window**: Windows.Graphics.Capture with bounded GDI fallback
 - **Linux**: X11 XShmGetImage
 - **Fallback**: Mock synthetic backend (headless/CI)
+
+Successful DCC-window results include `window_handle`, `window_title`,
+`capture_backend`, `fallback_from`, and `capture_health`. Treat
+`capture_health=unverified` as pixels without semantic content validation and
+`degraded` as a backend fallback. `unusable_capture` and
+`desktop_unavailable` are structured failures; do not retry them through
+another desktop or input path.
 
 ### `dcc_diagnostics__audit_log`
 

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/screenshot.py
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/screenshot.py
@@ -55,6 +55,8 @@ def main(
     format: str = "png",
     scale: float = 1.0,
     jpeg_quality: int = 85,
+    process_id: int | None = None,
+    window_handle: int | None = None,
     window_title: str | None = None,
     save_path: str | None = None,
     timeout_ms: int = 5000,
@@ -69,10 +71,31 @@ def main(
             "scale": scale,
             "timeout_ms": timeout_ms,
             "full_screen": full_screen,
+            "process_id": process_id,
+            "window_handle": window_handle,
             "window_title": window_title,
         }
     )
-    if ipc_payload is not None and ipc_payload.get("success"):
+    if ipc_payload is not None and not ipc_payload.get("success"):
+        return {
+            "success": False,
+            "message": ipc_payload.get("message", "DCC screenshot capture failed"),
+            "error": ipc_payload.get("error"),
+            "error_kind": ipc_payload.get("error_kind", "capture_failed"),
+            "context": {
+                k: ipc_payload.get(k)
+                for k in (
+                    "capture_backend",
+                    "capture_health",
+                    "fallback_from",
+                    "native_error",
+                    "window_handle",
+                    "window_title",
+                )
+            },
+        }
+
+    if ipc_payload is not None:
         saved_path = None
         if save_path:
             try:
@@ -101,6 +124,10 @@ def main(
                         "timestamp_ms",
                         "window_rect",
                         "window_title",
+                        "window_handle",
+                        "capture_backend",
+                        "fallback_from",
+                        "capture_health",
                         "image_base64",
                     )
                 },
@@ -115,21 +142,66 @@ def main(
         return {"success": False, "message": "dcc_mcp_core not available. Install the package first."}
 
     try:
-        capturer = Capturer.new_auto()
-    except Exception:
+        capturer = (
+            Capturer.new_auto()
+            if full_screen or not (process_id or window_handle or window_title)
+            else Capturer.new_window_auto()
+        )
+    except Exception as exc:
+        message = str(exc)
+        if message.startswith("desktop_unavailable:"):
+            return {
+                "success": False,
+                "message": f"Capture failed: {message}",
+                "error_kind": "desktop_unavailable",
+                "context": {"native_error": message},
+            }
         # Fall back to mock backend in headless environments
         capturer = Capturer.new_mock(1920, 1080)
 
     try:
-        frame = capturer.capture(
-            format=format,
-            jpeg_quality=jpeg_quality,
-            scale=scale,
-            timeout_ms=timeout_ms,
-            window_title=window_title,
-        )
+        if not full_screen and (process_id or window_handle or window_title):
+            frame = capturer.capture_window(
+                process_id=process_id,
+                window_handle=window_handle,
+                window_title=window_title,
+                format=format,
+                jpeg_quality=jpeg_quality,
+                scale=scale,
+                timeout_ms=timeout_ms,
+            )
+        else:
+            frame = capturer.capture(
+                format=format,
+                jpeg_quality=jpeg_quality,
+                scale=scale,
+                timeout_ms=timeout_ms,
+            )
     except Exception as exc:
-        return {"success": False, "message": f"Capture failed: {exc}"}
+        message = str(exc)
+        error_kind = message.partition(":")[0] if message.startswith("desktop_unavailable:") else "capture_failed"
+        return {
+            "success": False,
+            "message": f"Capture failed: {message}",
+            "error_kind": error_kind,
+            "context": {
+                "capture_backend": capturer.backend_name(),
+                "native_error": message,
+            },
+        }
+
+    capture_backend = capturer.backend_name()
+    capture_health = getattr(frame, "capture_health", "unverified")
+    if capture_health == "unusable":
+        return {
+            "success": False,
+            "message": "Capture backend reported an unusable frame",
+            "error_kind": "unusable_capture",
+            "context": {
+                "capture_backend": capture_backend,
+                "capture_health": capture_health,
+            },
+        }
 
     # Optionally save to disk
     saved_path = None
@@ -160,6 +232,8 @@ def main(
             "byte_len": frame.byte_len(),
             "timestamp_ms": frame.timestamp_ms,
             "dpi_scale": frame.dpi_scale,
+            "capture_backend": capture_backend,
+            "capture_health": capture_health,
             "saved_path": saved_path,
             "image_base64": b64_data,
         },
@@ -174,6 +248,8 @@ def _main_cli() -> int:
     parser.add_argument("--format", default="png", choices=["png", "jpeg", "raw_bgra"])
     parser.add_argument("--scale", type=float, default=1.0)
     parser.add_argument("--jpeg-quality", type=int, default=85, dest="jpeg_quality")
+    parser.add_argument("--process-id", type=int, default=None, dest="process_id")
+    parser.add_argument("--window-handle", type=int, default=None, dest="window_handle")
     parser.add_argument("--window-title", default=None, dest="window_title")
     parser.add_argument("--save-path", default=None, dest="save_path")
     parser.add_argument("--timeout-ms", type=int, default=5000, dest="timeout_ms")
@@ -184,6 +260,8 @@ def _main_cli() -> int:
         format=args.format,
         scale=args.scale,
         jpeg_quality=args.jpeg_quality,
+        process_id=args.process_id,
+        window_handle=args.window_handle,
         window_title=args.window_title,
         save_path=args.save_path,
         timeout_ms=args.timeout_ms,

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/tools.yaml
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/tools.yaml
@@ -18,7 +18,19 @@ tools:
           default: 85
         window_title:
           type: string
-          description: "Capture only the window whose title contains this substring. If omitted, captures the full screen."
+          description: "Capture the window whose title contains this substring."
+        process_id:
+          type: integer
+          minimum: 1
+          description: "Capture the primary visible window owned by this process."
+        window_handle:
+          type: integer
+          minimum: 1
+          description: "Capture this exact native window handle. Overrides process_id and window_title."
+        full_screen:
+          type: boolean
+          default: false
+          description: "Capture the full primary display instead of the owning DCC window."
         save_path:
           type: string
           description: "If provided, save the image to this file path in addition to returning base64."

--- a/tests/test_dcc_server_take_screenshot.py
+++ b/tests/test_dcc_server_take_screenshot.py
@@ -148,3 +148,87 @@ def test_take_screenshot_window_rect_none_for_full_screen():
     # Full-screen / mock captures report no window metadata.
     assert data["window_rect"] is None
     assert data["window_title"] is None
+
+
+class _Frame:
+    data = b"png"
+    width = 2
+    height = 2
+    format = "png"
+    mime_type = "image/png"
+    window_rect = (0, 0, 2, 2)
+    window_title = "Houdini FX"
+
+    def byte_len(self) -> int:
+        return len(self.data)
+
+
+class _WindowCapturer:
+    def __init__(self, *, health: str = "unverified") -> None:
+        self.health = health
+        self.arguments = None
+
+    def capture_window(self, **kwargs):
+        self.arguments = kwargs
+        frame = _Frame()
+        frame.capture_health = self.health
+        return frame
+
+    def backend_name(self) -> str:
+        return "GDI PrintWindow"
+
+
+def test_take_screenshot_exposes_exact_window_and_fallback_metadata(monkeypatch):
+    import dcc_mcp_core.dcc_server as mod
+
+    capturer = _WindowCapturer(health="degraded")
+    monkeypatch.setattr(mod, "_get_window_capturer", lambda: capturer)
+
+    result = mod._handle_take_screenshot(json.dumps({"window_handle": 0x1234, "process_id": 42}))
+    data = json.loads(result)
+
+    assert data["success"] is True
+    assert data["window_handle"] == 0x1234
+    assert data["window_title"] == "Houdini FX"
+    assert data["capture_backend"] == "GDI PrintWindow"
+    assert data["fallback_from"] == "Windows.Graphics.Capture"
+    assert data["capture_health"] == "degraded"
+    assert capturer.arguments["window_handle"] == 0x1234
+
+
+def test_take_screenshot_rejects_backend_marked_unusable_frame(monkeypatch):
+    import dcc_mcp_core.dcc_server as mod
+
+    monkeypatch.setattr(
+        mod,
+        "_get_window_capturer",
+        lambda: _WindowCapturer(health="unusable"),
+    )
+
+    data = json.loads(mod._handle_take_screenshot(json.dumps({"window_handle": 0x1234})))
+
+    assert data["success"] is False
+    assert data["error_kind"] == "unusable_capture"
+    assert data["capture_health"] == "unusable"
+
+
+def test_take_screenshot_preserves_desktop_unavailable_error(monkeypatch):
+    import dcc_mcp_core.dcc_server as mod
+
+    class _UnavailableCapturer:
+        def capture(self, **_kwargs):
+            raise RuntimeError(
+                "desktop_unavailable: backend=DXGI Desktop Duplication; native_error=Access is denied (0x80070005)"
+            )
+
+        def backend_name(self) -> str:
+            return "DXGI Desktop Duplication"
+
+    monkeypatch.setattr(mod, "_get_full_capturer", _UnavailableCapturer)
+
+    data = json.loads(mod._handle_take_screenshot('{"full_screen": true}'))
+
+    assert data["success"] is False
+    assert data["error_kind"] == "desktop_unavailable"
+    assert data["capture_backend"] == "DXGI Desktop Duplication"
+    assert data["native_error"].endswith("0x80070005)")

--- a/tests/test_diagnostics_screenshot_skill.py
+++ b/tests/test_diagnostics_screenshot_skill.py
@@ -53,11 +53,21 @@ class _Capturer:
         return _Capturer()
 
     @staticmethod
+    def new_window_auto() -> _Capturer:
+        return _Capturer()
+
+    @staticmethod
     def new_mock(_width: int, _height: int) -> _Capturer:
         return _Capturer()
 
     def capture(self, **_kwargs: Any) -> _Frame:
         return _Frame()
+
+    def capture_window(self, **_kwargs: Any) -> _Frame:
+        return _Frame()
+
+    def backend_name(self) -> str:
+        return "Mock"
 
 
 def test_screenshot_main_returns_dict_for_inprocess_executor(monkeypatch) -> None:
@@ -99,3 +109,69 @@ def test_screenshot_main_returns_ipc_payload_dict(monkeypatch, tmp_path: Path) -
     assert result["context"]["source"] == "dcc-ipc"
     assert result["context"]["saved_path"] == str(out)
     assert out.read_bytes() == image_bytes
+
+
+def test_screenshot_main_preserves_structured_ipc_capture_failure(monkeypatch) -> None:
+    module = _load_screenshot_module()
+    monkeypatch.setattr(
+        module,
+        "_try_ipc_capture",
+        lambda _params: {
+            "success": False,
+            "message": (
+                "desktop_unavailable: backend=DXGI Desktop Duplication; native_error=Access is denied (0x80070005)"
+            ),
+            "error_kind": "desktop_unavailable",
+            "capture_backend": "DXGI Desktop Duplication",
+            "native_error": "Access is denied (0x80070005)",
+        },
+    )
+
+    result = module.main()
+
+    assert result["success"] is False
+    assert result["error_kind"] == "desktop_unavailable"
+    assert result["context"]["capture_backend"] == "DXGI Desktop Duplication"
+    assert result["context"]["native_error"].endswith("0x80070005)")
+
+
+def test_screenshot_main_does_not_mock_desktop_unavailable(monkeypatch) -> None:
+    class _UnavailableCapturer(_Capturer):
+        @staticmethod
+        def new_auto() -> _Capturer:
+            raise RuntimeError(
+                "desktop_unavailable: backend=DXGI Desktop Duplication; native_error=Access is denied (0x80070005)"
+            )
+
+    module = _load_screenshot_module()
+    monkeypatch.setattr(module, "_try_ipc_capture", lambda _params: None)
+    monkeypatch.setattr(dcc_mcp_core, "Capturer", _UnavailableCapturer)
+
+    result = module.main()
+
+    assert result["success"] is False
+    assert result["error_kind"] == "desktop_unavailable"
+
+
+def test_screenshot_main_forwards_exact_window_target_to_ipc(monkeypatch) -> None:
+    module = _load_screenshot_module()
+    observed = {}
+
+    def _capture(params):
+        observed.update(params)
+        return {
+            "success": True,
+            "image_base64": base64.b64encode(b"png").decode("ascii"),
+            "window_handle": 0x1234,
+            "capture_backend": "Windows.Graphics.Capture",
+            "capture_health": "unverified",
+        }
+
+    monkeypatch.setattr(module, "_try_ipc_capture", _capture)
+
+    result = module.main(process_id=42, window_handle=0x1234, window_title="Houdini")
+
+    assert observed["process_id"] == 42
+    assert observed["window_handle"] == 0x1234
+    assert observed["window_title"] == "Houdini"
+    assert result["context"]["window_handle"] == 0x1234

--- a/tests/test_release_cli_bundle.py
+++ b/tests/test_release_cli_bundle.py
@@ -1,0 +1,45 @@
+"""Release CLI bundle packaging tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import zipfile
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "release" / "build_cli_bundle.py"
+
+
+def _build_bundle(tmp_path: Path, binary_name: str) -> zipfile.ZipFile:
+    cli = tmp_path / binary_name
+    cli.write_bytes(b"cli")
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--version",
+            "0.19.64",
+            "--platform",
+            "windows-x86_64" if cli.suffix == ".exe" else "linux-x86_64",
+            "--cli-bin",
+            str(cli),
+            "--out-dir",
+            str(tmp_path),
+        ],
+        check=True,
+    )
+
+    return zipfile.ZipFile(next(tmp_path.glob("dcc-mcp-cli-*.zip")))
+
+
+def test_build_cli_bundle_packages_unsuffixed_unix_binary(tmp_path: Path) -> None:
+    with _build_bundle(tmp_path, "dcc-mcp-cli-linux-x86_64") as bundle:
+        assert bundle.namelist() == ["dcc-mcp-cli"]
+        assert bundle.read("dcc-mcp-cli") == b"cli"
+
+
+def test_build_cli_bundle_preserves_windows_exe_name(tmp_path: Path) -> None:
+    with _build_bundle(tmp_path, "dcc-mcp-cli-windows-x86_64.exe") as bundle:
+        assert bundle.namelist() == ["dcc-mcp-cli.exe"]
+        assert bundle.read("dcc-mcp-cli.exe") == b"cli"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -127,7 +127,7 @@ def test_release_workflow_keeps_github_release_safety_net_after_pypi_jobs() -> N
     assert "needs.publish-github-release-assets.result" in run
 
 
-def test_release_workflow_builds_deployable_server_zip_per_platform() -> None:
+def test_release_workflow_builds_deployable_zips_per_platform() -> None:
     jobs = _release_jobs()
     build = jobs["build-binaries"]
     includes = build["strategy"]["matrix"]["include"]
@@ -145,6 +145,13 @@ def test_release_workflow_builds_deployable_server_zip_per_platform() -> None:
     assert '--server-bin "${{ matrix.artifact_name }}"' in run
     assert '--cli-bin "${{ matrix.cli_artifact_name }}"' in run
     assert "--ui-control-host target/release/dcc-mcp-ui-control-host.exe" in run
+
+    cli_bundle = next(step for step in build["steps"] if step.get("id") == "cli-bundle")
+    cli_run = cli_bundle["run"]
+    assert "scripts/release/build_cli_bundle.py" in cli_run
+    assert '--version "${{ needs.release-please.outputs.version }}"' in cli_run
+    assert '--platform "${{ matrix.platform }}"' in cli_run
+    assert '--cli-bin "${{ matrix.cli_artifact_name }}"' in cli_run
 
     host_build = next(step for step in build["steps"] if step.get("name") == "Build and stage Windows UI Control host")
     assert host_build["if"] == "matrix.os == 'windows-latest'"
@@ -175,12 +182,15 @@ def test_release_workflow_builds_deployable_server_zip_per_platform() -> None:
         if step.get("uses") == "actions/upload-artifact@v4" and step["with"]["name"] == "server-binary-${{ matrix.os }}"
     )
     assert "${{ steps.server-bundle.outputs.bundle_path }}" in raw_upload["with"]["path"]
+    assert "${{ steps.cli-bundle.outputs.cli_bundle_path }}" in raw_upload["with"]["path"]
 
     release_upload = next(step for step in build["steps"] if step.get("uses") == "softprops/action-gh-release@v3")
     assert "${{ steps.server-bundle.outputs.bundle_path }}" in release_upload["with"]["files"]
+    assert "${{ steps.cli-bundle.outputs.cli_bundle_path }}" in release_upload["with"]["files"]
 
     notify = next(step for step in jobs["publish"]["steps"] if step["name"] == "Notify Multica release-ready autopilot")
     assert r"^dcc-mcp-server-[0-9A-Za-z.+-]+-(linux-x86_64|windows-x86_64|macos-universal2)\.zip$" in notify["run"]
+    assert r"^dcc-mcp-cli-[0-9A-Za-z.+-]+-(linux-x86_64|windows-x86_64|macos-universal2)\.zip$" in notify["run"]
 
 
 def test_release_workflow_skips_host_version_probe_for_01964_backfill() -> None:


### PR DESCRIPTION
## Summary
- cover standalone `dcc-mcp-cli` ZIP build and release contracts
- expose exact window, backend, fallback, and capture-health diagnostics
- preserve DXGI access-denied failures as `desktop_unavailable` instead of mock or generic capture errors

## Validation
- `vx cargo test -p dcc-mcp-capture`
- `vx cargo clippy -p dcc-mcp-capture --all-targets -- -D warnings`
- `vx cargo test -p dcc-mcp-computer-use`
- targeted Python diagnostics/server tests
- `vx pytest --noconftest tests/test_release_cli_bundle.py -q`
- Ruff, Cargo fmt, and Python support contract checks
- branch wheel built on Windows and exercised against live Houdini 21 and a real remote-workstation lock

Live Houdini evidence: the installed older runtime returned a misleading successful 145x39 minimized-window PNG; the branch build rejected the unavailable target instead of returning that image. Branch full-screen DXGI capture also succeeded at 3120x2080 and exposed backend/health metadata.

Live locked-desktop evidence: the remote workstation was locked with `LockWorkStation`; three capture attempts all returned `success=false`, `error_kind=desktop_unavailable`, backend `DXGI Desktop Duplication`, and retained native error `0x80070005`. No image payload was returned.

Closes #1947