### PR TITLE
fix(skills): filter reserved metadata from subprocess scripts

### DIFF
--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -513,12 +513,15 @@ fn which_program(program: &str) -> bool {
 
 pub(crate) fn execute_script(
     script_path: &str,
-    params: serde_json::Value,
+    mut params: serde_json::Value,
     skill_dcc: Option<&str>,
 ) -> Result<serde_json::Value, String> {
     use std::io::Write;
     use std::process::{Command, Stdio};
 
+    if let Some(object) = params.as_object_mut() {
+        object.retain(|key, _| !key.starts_with('_'));
+    }
     let params_json = serde_json::to_string(&params).unwrap_or_else(|_| "{}".to_string());
 
     let path = std::path::Path::new(script_path);

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_real.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_real.rs
@@ -202,6 +202,29 @@ print(json.dumps({"success": True, "argv": argv}))
 }
 
 #[test]
+fn test_real_python_reserved_metadata_is_not_forwarded() {
+    if skip_real_exec("python") {
+        return;
+    }
+    let body = r#"
+import json, sys
+params = json.loads(sys.stdin.read() or "{}")
+assert params == {"visible": "value"}, params
+assert "--_meta" not in sys.argv[1:], sys.argv[1:]
+print(json.dumps({"success": True, "params": params}))
+"#;
+    let (_dir, script) = write_script("reserved_metadata.py", body);
+    let result = execute_script(
+        script.to_str().unwrap(),
+        serde_json::json!({"visible": "value", "_meta": {"session": "test"}}),
+        None,
+    )
+    .expect("reserved call metadata must stay at the execution boundary");
+
+    assert_eq!(result["params"], serde_json::json!({"visible": "value"}));
+}
+
+#[test]
 fn test_real_python_nonzero_exit_returns_error_with_stderr() {
     if skip_real_exec("python") {
         return;


### PR DESCRIPTION
## Root cause

Gateway calls add reserved `_meta` context. The in-process Python executor already strips reserved underscore-prefixed arguments, but the Rust subprocess executor serialized them into stdin/argv. Standalone Python Skills such as Tracy therefore received `_meta` in `**kwargs` and forwarded it to runtime APIs.

## Fix

Filter underscore-prefixed reserved arguments once in `execute_script` before subprocess serialization. This keeps script-language subprocess execution aligned with the in-process contract without adapter-specific guards.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dcc-mcp-skills --all-targets -- -D warnings`
- `cargo test -p dcc-mcp-skills` twice: 351 passed + 5 doctests passed each run
- Real subprocess regression: `_meta` absent from both JSON stdin and argv
- Local Windows wheel installed with Core/Server 0.19.80 + Tracy 0.2.5
- Gateway call with `--agent-session-id` completed Tracy capture (31.4 MB, 1,433 frames, 2,869 zones), CSV export, and CSV summary without Tracy wrapper filtering