### PR TITLE
fix(cli): upgrade installed pip adapters

### DIFF
--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -380,6 +380,7 @@ fn pip_install_args(package: &str, extras: Option<&[String]>) -> Vec<String> {
         "-m".into(),
         "pip".into(),
         "install".into(),
+        "--upgrade".into(),
         pip_package_spec(package, extras),
     ]
 }
@@ -856,6 +857,7 @@ mod tests {
                 "-m".to_string(),
                 "pip".to_string(),
                 "install".to_string(),
+                "--upgrade".to_string(),
                 "dcc-mcp-maya[maya]".to_string(),
             ]
         );


### PR DESCRIPTION
## Summary
- pass `--upgrade` to CLI-managed pip adapter installs
- replace stale lower-version and editable adapter installs instead of treating them as satisfied
- preserve the existing package/extras and rollback contracts

## Validation
- `cargo fmt --all -- --check`
- focused pip argument regression twice
- `cargo test -p dcc-mcp-cli --lib` (110 passed)
- reproduced with an editable dcc-mcp-unity 0.6.3 install while 0.11.2 was current