### PR TITLE
fix(cli): allow confirmed non-interactive installs

### DIFF
--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -153,9 +153,13 @@ impl InstallService {
     /// Steps are executed sequentially.  If any step fails, all prior steps
     /// are rolled back in reverse order.  Returns the full plan (with step
     /// results) on success.
-    pub fn execute(&self, request: InstallRequest) -> Result<InstallPlan, InstallError> {
+    pub fn execute(
+        &self,
+        request: InstallRequest,
+        skip_confirmation: bool,
+    ) -> Result<InstallPlan, InstallError> {
         let plan = self.plan(request)?;
-        self.execute_plan(&plan)
+        self.execute_plan(&plan, skip_confirmation)
     }
 
     fn load_entries(
@@ -184,7 +188,11 @@ impl InstallService {
         plan
     }
 
-    fn execute_plan(&self, plan: &InstallPlan) -> Result<InstallPlan, InstallError> {
+    fn execute_plan(
+        &self,
+        plan: &InstallPlan,
+        skip_confirmation: bool,
+    ) -> Result<InstallPlan, InstallError> {
         if !plan.install_policy.auto_install_enabled {
             if let Some(prompt) = &plan.install_policy.prompt {
                 eprintln!("{prompt}");
@@ -219,7 +227,7 @@ impl InstallService {
         eprintln!("╚══════════════════════════════════════════════╝");
         eprintln!();
 
-        if !ask_consent("Proceed with installation? [Y/n]")? {
+        if !skip_confirmation && !ask_consent("Proceed with installation? [Y/n]")? {
             return Err(InstallError::ConsentDenied);
         }
 
@@ -796,12 +804,15 @@ mod tests {
         );
 
         let plan = service
-            .execute(InstallRequest {
-                dcc_type: "maya".into(),
-                version: None,
-                catalog_path: None,
-                python: Some("/__nonexistent__/python".into()),
-            })
+            .execute(
+                InstallRequest {
+                    dcc_type: "maya".into(),
+                    version: None,
+                    catalog_path: None,
+                    python: Some("/__nonexistent__/python".into()),
+                },
+                true,
+            )
             .unwrap();
 
         assert!(!plan.install_policy.auto_install_enabled);

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -644,16 +644,6 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
     let output = output.unwrap_or_else(OutputFormat::auto_detect);
     let writer = OutputWriter::new(output);
 
-    if non_interactive && command_requires_interactive_input(&command) {
-        let envelope = ErrorEnvelope::new(
-            "INVALID_INPUT",
-            "--non-interactive cannot execute a command that requires confirmation",
-            ExitCode::InvalidInput,
-        );
-        writer.write_error(&envelope)?;
-        std::process::exit(ExitCode::InvalidInput.as_i32());
-    }
-
     // Deprecation warning for per-command timeout when global timeout is set.
     if global_timeout_secs.is_some() && command_has_per_timeout(&command) {
         let _ = writer.diagnostic(
@@ -984,7 +974,7 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                 python,
             };
             if execute {
-                to_json(service.execute(req)?)?
+                to_json(service.execute(req, non_interactive)?)?
             } else {
                 to_json(service.plan(req)?)?
             }
@@ -1118,10 +1108,6 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
         std::process::exit(exit_code.as_i32());
     }
     Ok(())
-}
-
-fn command_requires_interactive_input(command: &Command) -> bool {
-    matches!(command, Command::Install { execute: true, .. })
 }
 
 async fn ensure_gateway_for_command(

--- a/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
@@ -6,12 +6,14 @@ use tempfile::NamedTempFile;
 use support::*;
 
 #[test]
-fn non_interactive_install_execute_fails_without_reading_stdin() {
+fn non_interactive_install_execute_skips_confirmation_and_runs_plan() {
     let output = cli_command()
         .args([
             "install",
             "--dcc-type",
             "maya",
+            "--python",
+            "/__nonexistent__/python",
             "--execute",
             "--non-interactive",
             "--output",
@@ -21,16 +23,12 @@ fn non_interactive_install_execute_fails_without_reading_stdin() {
         .output()
         .unwrap();
 
-    assert_eq!(output.status.code(), Some(2));
+    assert_ne!(output.status.code(), Some(2));
     assert!(output.stdout.is_empty());
-    let error: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
-    assert_eq!(error["error"]["code"], "INVALID_INPUT");
-    assert!(
-        error["error"]["message"]
-            .as_str()
-            .unwrap()
-            .contains("requires confirmation")
-    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("failed to launch /__nonexistent__/python"));
+    assert!(!stderr.contains("requires confirmation"));
+    assert!(!stderr.contains("Proceed with installation?"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Treat explicit install --execute --non-interactive as confirmed.
- Keep the studio auto-install policy gate intact.
- Preserve the interactive Y/n prompt for normal execute mode.

## Local validation
- cargo fmt --check
- cargo test -p dcc-mcp-cli (110 unit tests plus CLI integration targets)
- Focused non-interactive install regression twice
- git diff --check