### PR TITLE
fix(cli): pin requested adapter versions

### DIFF
--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -326,9 +326,15 @@ fn execute_action(action: &InstallStepAction) -> Result<Option<StepRollback>, In
     match action {
         InstallStepAction::PipInstall {
             package,
+            version,
             extras,
             python,
-        } => execute_pip_install(package, extras.as_deref(), python.as_deref()),
+        } => execute_pip_install(
+            package,
+            version.as_deref(),
+            extras.as_deref(),
+            python.as_deref(),
+        ),
         InstallStepAction::GitClone { url, ref_, dest } => {
             execute_git_clone(url, ref_.as_deref(), dest)
         }
@@ -349,12 +355,13 @@ fn execute_action(action: &InstallStepAction) -> Result<Option<StepRollback>, In
 
 fn execute_pip_install(
     package: &str,
+    version: Option<&str>,
     extras: Option<&[String]>,
     python: Option<&str>,
 ) -> Result<Option<StepRollback>, InstallError> {
     let python_cmd = python.unwrap_or("python");
     let mut cmd = Command::new(python_cmd);
-    cmd.args(pip_install_args(package, extras));
+    cmd.args(pip_install_args(package, version, extras));
 
     let status = cmd.status().map_err(|e| InstallError::StepFailed {
         step: format!("pip-install-{package}"),
@@ -375,21 +382,30 @@ fn execute_pip_install(
     }))
 }
 
-fn pip_package_spec(package: &str, extras: Option<&[String]>) -> String {
-    if extras.is_some_and(|values| !values.is_empty()) {
+fn pip_package_spec(package: &str, version: Option<&str>, extras: Option<&[String]>) -> String {
+    let package_with_extras = if extras.is_some_and(|values| !values.is_empty()) {
         format!("{}[{}]", package, extras.unwrap().join(","))
     } else {
         package.to_string()
+    };
+    if let Some(version) = version.filter(|value| !value.trim().is_empty()) {
+        format!("{package_with_extras}=={version}")
+    } else {
+        package_with_extras
     }
 }
 
-fn pip_install_args(package: &str, extras: Option<&[String]>) -> Vec<String> {
+fn pip_install_args(
+    package: &str,
+    version: Option<&str>,
+    extras: Option<&[String]>,
+) -> Vec<String> {
     vec![
         "-m".into(),
         "pip".into(),
         "install".into(),
         "--upgrade".into(),
-        pip_package_spec(package, extras),
+        pip_package_spec(package, version, extras),
     ]
 }
 
@@ -821,8 +837,12 @@ mod tests {
 
     #[test]
     fn pip_install_missing_python_reports_error() {
-        let result =
-            execute_pip_install("nonexistent-package", None, Some("/__nonexistent__/python"));
+        let result = execute_pip_install(
+            "nonexistent-package",
+            None,
+            None,
+            Some("/__nonexistent__/python"),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -863,13 +883,23 @@ mod tests {
     #[test]
     fn pip_install_uses_python_module_invocation() {
         assert_eq!(
-            pip_install_args("dcc-mcp-maya", Some(&["maya".to_string()])),
+            pip_install_args("dcc-mcp-maya", None, Some(&["maya".to_string()])),
             vec![
                 "-m".to_string(),
                 "pip".to_string(),
                 "install".to_string(),
                 "--upgrade".to_string(),
                 "dcc-mcp-maya[maya]".to_string(),
+            ]
+        );
+        assert_eq!(
+            pip_install_args("dcc-mcp-unity", Some("0.11.2"), None),
+            vec![
+                "-m".to_string(),
+                "pip".to_string(),
+                "install".to_string(),
+                "--upgrade".to_string(),
+                "dcc-mcp-unity==0.11.2".to_string(),
             ]
         );
         assert_eq!(

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -80,6 +80,9 @@ pub enum InstallStepAction {
     PipInstall {
         /// Pip package name (e.g. "dcc-mcp-maya").
         package: String,
+        /// Optional exact package version requested by the user.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<String>,
         /// Optional pip extras (e.g. ["maya"]).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         extras: Option<Vec<String>>,
@@ -170,9 +173,13 @@ impl InstallPlanner {
         let version = request.version.clone();
 
         let steps = match &adapter.install {
-            Some(install) => {
-                Self::build_executable_steps(&adapter, install, &dcc_type, request.python.clone())
-            }
+            Some(install) => Self::build_executable_steps(
+                &adapter,
+                install,
+                &dcc_type,
+                version.clone(),
+                request.python.clone(),
+            ),
             None => Self::build_info_steps(),
         };
 
@@ -193,6 +200,7 @@ impl InstallPlanner {
         entry: &CatalogEntry,
         install: &CatalogInstall,
         dcc_type: &str,
+        version: Option<String>,
         python_override: Option<String>,
     ) -> Vec<InstallStep> {
         let adapter_dir = default_adapter_dir().join(&entry.name);
@@ -206,6 +214,7 @@ impl InstallPlanner {
                         .pip_package
                         .clone()
                         .unwrap_or_else(|| entry.name.clone()),
+                    version,
                     extras: install.pip_extras.clone(),
                     python,
                 }
@@ -622,11 +631,13 @@ mod tests {
         ));
         if let Some(InstallStepAction::PipInstall {
             package,
+            version,
             extras,
             python,
         }) = &plan.steps[0].action
         {
             assert_eq!(package, "dcc-mcp-maya");
+            assert_eq!(version, &None);
             assert_eq!(extras.as_deref(), Some(&["maya".into()][..]));
             assert_eq!(python.as_deref(), Some("/usr/bin/mayapy"));
         } else {

--- a/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
@@ -82,6 +82,8 @@ fn install_uses_bundled_adapter_metadata_and_python_override() {
             "install",
             "--dcc-type",
             "maya",
+            "--version",
+            "0.11.2",
             "--python",
             "C:/Autodesk/Maya2026/bin/mayapy.exe",
         ],
@@ -95,6 +97,7 @@ fn install_uses_bundled_adapter_metadata_and_python_override() {
     assert_eq!(plan["steps"][0]["name"], "install-pip");
     assert_eq!(plan["steps"][0]["action"]["type"], "PipInstall");
     assert_eq!(plan["steps"][0]["action"]["package"], "dcc-mcp-maya");
+    assert_eq!(plan["steps"][0]["action"]["version"], "0.11.2");
     assert_eq!(
         plan["steps"][0]["action"]["python"],
         "C:/Autodesk/Maya2026/bin/mayapy.exe"


### PR DESCRIPTION
## Summary
- Carry the requested adapter version into PipInstall actions.
- Install exact package specs such as dcc-mcp-unity==0.11.2.
- Keep the base package name for verify and rollback operations.

## Local validation
- cargo fmt --check
- cargo test -p dcc-mcp-cli (110 unit tests plus all CLI integration targets)
- Focused planner, pip argv, and install-plan regressions
- Version-plan regression twice
- git diff --check