### PR TITLE
fix(catalog): report current Unity adapter version

### DIFF
--- a/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
@@ -196,6 +196,18 @@ fn install_bundled_catalog_covers_non_maya_first_party_adapters() {
 }
 
 #[test]
+fn bundled_catalog_reports_current_unity_adapter_version() {
+    let plan = run_json_with_env_removed(
+        &["install", "--dcc-type", "unity"],
+        &[],
+        &["DCC_MCP_CATALOG_PATH", "DCC_MCP_INSTALL_PYTHON"],
+    );
+
+    assert_eq!(plan["adapter"]["name"], "dcc-mcp-unity");
+    assert_eq!(plan["adapter"]["version"], "0.11.2");
+}
+
+#[test]
 fn install_prefers_adapter_over_same_dcc_skill_pack() {
     let plan = run_json_with_env_removed(
         &["install", "--dcc-type", "photoshop"],

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -238,7 +238,7 @@ entries:
     dcc: ["unity"]
     url: "https://github.com/dcc-mcp/dcc-mcp-unity"
     tags: ["adapter", "unity", "official", "pip", "game-engine", "upm"]
-    version: "0.3.0"
+    version: "0.11.2"
     min_core_version: "0.19.45"
     maintainer: "dcc-mcp"
     install:

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -41,7 +41,7 @@ submit a PR updating this matrix before the release PR merges.
 | Substance 3D Designer | [dcc-mcp-substance3d-designer](https://github.com/dcc-mcp/dcc-mcp-substance3d-designer) | 0.3.0 | >=0.19.45,<1.0.0 | — | Host bridge | — |
 | Substance 3D Painter | [dcc-mcp-substance3d-painter](https://github.com/dcc-mcp/dcc-mcp-substance3d-painter) | 0.1.3 | >=0.19.3,<1.0.0 | — | Host bridge | — |
 | Godot | [dcc-mcp-godot](https://github.com/dcc-mcp/dcc-mcp-godot) | 0.4.0 | >=0.19.45,<1.0.0 | 4.x | EditorPlugin + runtime bridge | 2026-07 |
-| Unity | [dcc-mcp-unity](https://github.com/dcc-mcp/dcc-mcp-unity) | 0.3.0 | >=0.19.45,<1.0.0 | 2018.4.36f1+ | EditorApplication.update + WebSocket bridge | — |
+| Unity | [dcc-mcp-unity](https://github.com/dcc-mcp/dcc-mcp-unity) | 0.11.2 | >=0.19.45,<1.0.0 | 2018.4.36f1+ | EditorApplication.update + WebSocket bridge | — |
 | OpenUSD | [dcc-mcp-openusd](https://github.com/dcc-mcp/dcc-mcp-openusd) | 0.8.1 | >=0.19.45,<1.0.0 | — | Headless USD stage adapter | 2026-07 |
 | Custom Studio Tool | _(your repo here)_ | _your version_ | _your pin_ | _your min_ | _your pattern_ | _date_ |
 


### PR DESCRIPTION
## Summary
- Update the bundled Unity adapter entry from 0.3.0 to the released 0.11.2.
- Keep the adapter compatibility matrix synchronized.
- Add a CLI regression for the bundled catalog projection.

## Local validation
- dcc-mcp-catalog tests 31/31 twice
- cargo test -p dcc-mcp-cli
- Focused Unity catalog regression repeatedly
- git diff --check

Verified against dcc-mcp-unity GitHub Release v0.11.2 and PyPI 0.11.2.