### PR TITLE
perf: streamline capability discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,8 @@ Natural DCC intent is enough to trigger the default `dcc-mcp` skill. If a user
 asks to create, edit, inspect, animate, render, composite, or export something
 in Maya, Blender, Houdini, Photoshop, 3ds Max, Nuke, Unreal, Substance 3D, or
 another supported host, load `dcc-mcp` first even when the user never says
-“MCP”. Inventory, search, describe, and call the structured DCC tool before
-falling back to raw scripting or scoped Computer Use.
+“MCP”. Inventory, run one narrow search, and follow the returned `next_step`
+before falling back to raw scripting or scoped Computer Use.
 
 **Why?** Skills provide:
 - ✅ Structured results with validation
@@ -27,7 +27,8 @@ falling back to raw scripting or scoped Computer Use.
 - ✅ Progressive loading (load only what you need)
 - ✅ Audit logs and traceability
 
-**Don't** call Maya/Blender/Python scripts directly — use `search_skills()` → `load_skill()` → call the tool.
+**Don't** call Maya/Blender/Python scripts directly — search once, follow the
+returned load/describe/call step, then invoke the typed tool.
 
 ## 🚀 Agent Entry Strategy: CLI+REST (default) vs IDE MCP
 
@@ -43,7 +44,7 @@ falling back to raw scripting or scoped Computer Use.
 | GUI artist using DCC plugin directly | **IDE MCP** | DCC's built-in MCP plugin exposes tools directly to the IDE |
 
 **Core principle:**
-- **AI agents** start with `dcc-mcp` skill + `dcc-mcp-cli` CLI. The CLI handles gateway lifecycle (ensure, health, start) and exposes `search → describe → call` via shell.
+- **AI agents** start with `dcc-mcp` skill + `dcc-mcp-cli` CLI. The CLI handles gateway lifecycle (ensure, health, start); `search` returns the exact next load, describe, or call step.
 - **Human IDE users** continue using MCP configuration. The gateway serves both paths simultaneously.
 - **CLI-first does not deprecate MCP** — the gateway always exposes both MCP and REST side by side.
 
@@ -141,7 +142,7 @@ falling back to raw scripting or scoped Computer Use.
 Gateway CLI+REST (agent default — use dcc-mcp skill + dcc-mcp-cli):
 Support check (only when unclear): `dcc-mcp-cli dcc-types` lists canonical adapter-backed identifiers from the release catalog without starting a gateway; use `list` for live sessions.
 1. Discover: `dcc-mcp-cli search --query "keyword" --dcc-type maya` or `POST /v1/search` → get `tool_slug`; names/summaries are tokenized, so underscores are optional (`create_sphere` and `sphere` both work).
-2. Inspect: `dcc-mcp-cli describe <slug>` or `POST /v1/describe` → read schema + annotations.
+2. Follow `next_step`: a no-schema hit calls directly only when search also carries safety hints; otherwise perform the returned targeted `load_skill` or `describe`. A correlated load may inline `compact_schema` with safety/execution hints and point straight to `call`.
 3. Execute: `dcc-mcp-cli call <slug> --json '{"radius": 2.0}'` or `POST /v1/call`.
 4. Batch execute: `dcc-mcp-cli call --batch --steps '<json-array>'` or `POST /v1/call_batch` for ordered batches (max 25).
 5. Package as a skill: fork or extend `dcc-mcp` to reuse `dcc-mcp-cli` calls as structured MCP tools.
@@ -157,7 +158,7 @@ Support check (only when unclear): `dcc-mcp-cli dcc-types` lists canonical adapt
 
 IDE MCP (for human IDE users — Cursor, Claude Desktop, VS Code):
 1. Discover: MCP `search(query="keyword", dcc_type="maya")` → get `tool_slug`.
-2. Inspect: MCP `describe(tool_slug=...)` → read schema + annotations.
+2. Follow the hit's `next_step`; describe only when requested, and pass correlated load arguments unchanged.
 3. Execute through MCP: `call(tool_slug, arguments)` or REST `POST /v1/call` / `POST /v1/call_batch` (max 25).
 4. Hidden MCP compatibility routes still accept older `search_tools` / `describe_tool` / `call_tool` / `call_tools` names.
 
@@ -169,7 +170,7 @@ Per-DCC MCP server (legacy / direct DCC connection):
 5. Debug on failure: use dcc_diagnostics__screenshot or audit_log
 
 Gateway instance discovery:
-1. Usually skip instance discovery and go straight to `search` / `POST /v1/search` → `describe` / `POST /v1/describe` → `POST /v1/call` (or `/v1/call_batch` when invoking several slugs in order).
+1. Usually skip instance discovery and go straight to `search` / `POST /v1/search`, then follow its returned `next_step` to targeted load, optional describe, or call.
 2. When you need a concrete DCC session or direct MCP URL, call resources/read with uri="gateway://instances"; rows always include `mcp_url`, `instance_short`, `source`, `source_meta`, and a normalized `dispatch` object (`reported`, `status`, `ready`, failure metadata), and the list payload includes `by_source` counts.
 3. For one instance, read gateway://instances/{instance_id}; full UUID, `instance_short`, or any unique ≥4-char UUID prefix works across gateway tools and tool slugs.
 4. Instance rows may come from the local FileRegistry (`source: "file"`), HTTP registration (`source: "http"`), relay-backed tunnels (`source: "relay"`), or optional mDNS/DNS-SD LAN discovery (`source: "mdns"`); HTTP rows win conflicts, then relay, then mDNS, then file rows.

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -34,7 +34,7 @@ automation.
 
 | If you are... | Use this path | How to start |
 |---------------|---------------|--------------|
-| An AI agent in OpenClaw, Hermes, Codex CLI, or any headless agent runtime | **CLI+REST** ← **this is you** | Load `dcc-mcp` skill → call `dcc-mcp-cli search/describe/call` |
+| An AI agent in OpenClaw, Hermes, Codex CLI, or any headless agent runtime | **CLI+REST** ← **this is you** | Load `dcc-mcp` skill → search once → follow `next_step` |
 | An AI agent in Cursor / Claude Desktop / VS Code with MCP enabled | **Either works**, prefer CLI+REST | CLI+REST via `dcc-mcp` is preferred; IDE MCP is available as fallback |
 | Running a CI/CD or automation script | **CLI+REST** | `dcc-mcp-cli` with structured output and exit codes |
 | Troubleshooting DCC connectivity | **CLI+REST** | `dcc-mcp-cli health/list/smoke` |
@@ -289,10 +289,16 @@ before loading it. If you intentionally call `tools/list`, follow every
 If your MCP connection is the multi-DCC gateway, do not expect backend actions to appear directly in `tools/list`. The gateway surface is intentionally fixed and bounded; use the dynamic-capability workflow instead:
 
 ```python
-# Gateway MCP four-tool workflow
+# Gateway MCP workflow: follow the selected hit, do not describe unconditionally
 hits = search(kind="tool", query="create sphere", dcc_type="maya", limit=5)
-info = describe(tool_slug=hits["hits"][0]["tool_slug"])
-result = call(tool_slug=info["record"]["tool_slug"], arguments={"radius": 2.0})
+step = hits["hits"][0]["next_step"]
+if step["action"] == "load_skill":
+    step = load_skill(**step["arguments"])["next_step"]
+if step["action"] == "describe":
+    step = describe(**step["arguments"])["next_step"]
+assert step["action"] == "call"
+call_args = {**step["arguments"], "arguments": {"radius": 2.0}}
+result = call(**call_args)
 
 # Ordered MCP batch flow (max 25 calls)
 batch = call(
@@ -304,7 +310,7 @@ batch = call(
 )
 ```
 
-Use `search(kind="skill", ...)` to find unloaded skills, then `load_skill(skill_name="...", instance_id="...")` when a search hit's `next_step` asks for activation. Gateway `tools/list` advertises exactly `search`, `describe`, `load_skill`, and `call`. Hidden MCP compatibility routes still accept older `search_tools` / `describe_tool` / `call_tool` / `call_tools` names, but new agent workflows should use the four canonical tools.
+Use `search(kind="skill", ...)` to find unloaded skills, then pass the search hit's `next_step.arguments` unchanged when activation is requested. This preserves target instance, tool group, and correlation metadata. Gateway `tools/list` advertises exactly `search`, `describe`, `load_skill`, and `call`. Hidden MCP compatibility routes still accept older `search_tools` / `describe_tool` / `call_tool` / `call_tools` names, but new agent workflows should use the four canonical tools.
 
 Wrapper payloads accept only `tool_slug`, `arguments`, and optional `meta`. Put backend-specific inputs such as `code`, `script`, `file_path`, or `radius` inside `arguments`, never at the wrapper top level. `dcc-mcp-wire` normalizes missing / `null` / empty-string arguments to `{}` and rejects non-object roots; Python host wrappers can call `dcc_mcp_core.host.normalize_tool_arguments()` / `normalize_tool_meta()`.
 
@@ -333,11 +339,11 @@ to the execution tool. The tool returns FileRef/path/hash/TTL/session metadata
 and never echoes raw source. Gateway traces and admin audit rows redact
 script-source input fields by default and keep the descriptor metadata instead.
 
-Pure HTTP clients use the same REST endpoints directly: `POST /v1/search`, `POST /v1/describe`, `POST /v1/call`, and gateway `POST /v1/call_batch`. Gateway REST returns compact TOON by default; send `Accept: application/json` or body `response_format: "json"` when a legacy JSON client needs compatibility. See `docs/guide/gateway.md` and `docs/guide/rest-api-surface.md`.
+Pure HTTP clients use the same REST endpoints directly: `POST /v1/search`, targeted `POST /v1/load_skill` or `POST /v1/describe` only when requested, `POST /v1/call`, and gateway `POST /v1/call_batch`. Gateway REST returns compact TOON by default; send `Accept: application/json` or body `response_format: "json"` when a legacy JSON client needs compatibility. See `docs/guide/gateway.md` and `docs/guide/rest-api-surface.md`.
 
 ### Gateway workflow guide (`gateway://docs/agent-workflows`)
 
-**`resources/read`** with **`uri=gateway://docs/agent-workflows`** is the **platform-agnostic** copy bundled with the gateway: MCP **tools** vs **`resources/list`/`read`** / **`prompts`**, using **`describe`** (schema, **affinity**, execution mode, timeouts), fewer redundant round-trips, optional **`call({calls:[...]})`** / **`POST /v1/call_batch`** (≤25 ordered steps), and reading **host-published help** URIs exactly as listed—never inventing schemes. Re-fetch in very long sessions if the contract might have fallen out of context.
+Use **`resources/read uri=gateway://docs/agent-workflows`** only when the workflow contract is unclear; do not fetch it before routine DCC work. It covers MCP tools vs resources/prompts, conditional `describe`, optional batches, and exact host-published help URIs.
 
 ### Gateway Instance Discovery
 
@@ -458,7 +464,7 @@ MemoryRecorder(store).install(hooks)  # wires 6 lifecycle events
 
 | Task | Use this API |
 |------|---------------|
-| **Control DCC via CLI (agent default)** | Load `dcc-mcp` skill → `dcc-mcp-cli search/describe/call` |
+| **Control DCC via CLI (agent default)** | Load `dcc-mcp` skill → search once → follow `next_step` |
 | **Expose DCC tools over MCP** | `DccServerOptions.from_env(...)` → `DccServerBase(opts)` → `start()` |
 | **Zero-code tool registration** | agentskills.io `SKILL.md` + `metadata.dcc-mcp.tools` pointing at sibling `tools.yaml` + `scripts/` |
 | **Return structured results** | `success_result()` / `error_result()` |
@@ -561,7 +567,7 @@ If you are uncertain whether a change affects py37 compatibility, ask. Never ass
 
 ## 💡 Pro Tips for AI Agents
 
-1. **CLI+REST is your default path** — load `dcc-mcp` skill and use `dcc-mcp-cli search/describe/call`. Only fall back to MCP when running inside an IDE.
+1. **CLI+REST is your default path** — load `dcc-mcp`, search once, and follow `next_step`. Only fall back to MCP when running inside an IDE.
 2. **Always search before assuming** — use `dcc-mcp-cli search --query "..." --dcc-type ...` or `search_skills()` to discover relevant tools
 3. **Read tool annotations** — respect safety hints (`read_only`, `destructive`)
 4. **Follow next-tools chains** — they guide you through complex workflows

--- a/crates/dcc-mcp-actions/src/registry/mod.rs
+++ b/crates/dcc-mcp-actions/src/registry/mod.rs
@@ -360,6 +360,34 @@ impl ToolRegistry {
         changed
     }
 
+    /// Set ``enabled`` for one skill's actions in the named group.
+    ///
+    /// Group names are only required to be unique within a skill, so callers
+    /// targeting a discovered skill must not use [`Self::set_group_enabled`].
+    pub fn set_skill_group_enabled(&self, skill_name: &str, group: &str, enabled: bool) -> usize {
+        let mut changed = 0;
+        for mut entry in self.actions.iter_mut() {
+            if entry.value().skill_name.as_deref() == Some(skill_name)
+                && entry.value().group == group
+                && entry.value().enabled != enabled
+            {
+                entry.value_mut().enabled = enabled;
+                changed += 1;
+            }
+        }
+        for dcc_map in self.dcc_actions.iter() {
+            for mut entry in dcc_map.value().iter_mut() {
+                if entry.value().skill_name.as_deref() == Some(skill_name)
+                    && entry.value().group == group
+                    && entry.value().enabled != enabled
+                {
+                    entry.value_mut().enabled = enabled;
+                }
+            }
+        }
+        changed
+    }
+
     /// Enable or disable a single action by name.
     ///
     /// Returns ``true`` if the action existed.

--- a/crates/dcc-mcp-cli/src/application/local_control.rs
+++ b/crates/dcc-mcp-cli/src/application/local_control.rs
@@ -48,6 +48,7 @@ pub async fn search_local(registry_dir: PathBuf, request: SearchRequest) -> anyh
                     "query": query,
                     "dcc": entry.dcc_type,
                     "limit": limit,
+                    "include_disabled": true,
                 }),
                 None,
             )
@@ -93,34 +94,41 @@ pub async fn describe_local(registry_dir: PathBuf, tool_slug: String) -> anyhow:
     let route = resolve_tool_route(&registry_dir, &tool_slug, None, None)?;
     let gateway = HttpGateway::default();
     let mcp_url = local_instance::mcp_url(&route.entry);
-    let tools = list_mcp_tools(&gateway, &mcp_url).await?;
-    let tool = if let Some(tool) = tools.into_iter().find(|tool| {
-        tool.get("name")
-            .and_then(Value::as_str)
-            .is_some_and(|name| name == route.backend_tool)
-    }) {
-        tool
-    } else {
-        let endpoint = Endpoint::from_mcp_url(mcp_url);
-        let described = gateway
-            .post_json(
-                &endpoint.path("/v1/describe"),
-                &json!({"tool_slug": route.backend_tool, "include_schema": true}),
-            )
-            .await
-            .with_context(|| {
-                format!(
-                    "tool '{}' was not found in tools/list and the local describe fallback failed",
-                    route.backend_tool
-                )
-            })?;
-        json!({
+    let endpoint = Endpoint::from_mcp_url(&mcp_url);
+    let tool = match gateway
+        .post_json(
+            &endpoint.path("/v1/describe"),
+            &json!({"tool_slug": route.backend_tool, "include_schema": true}),
+        )
+        .await
+    {
+        Ok(described) => json!({
             "name": route.backend_tool,
             "description": described.get("description").cloned().unwrap_or(Value::Null),
             "inputSchema": described.get("input_schema").cloned().unwrap_or_else(|| json!({"type": "object"})),
             "annotations": described.get("annotations").cloned().unwrap_or_else(|| json!({})),
             "_meta": described.get("metadata").cloned().unwrap_or(Value::Null),
-        })
+        }),
+        Err(describe_error) => list_mcp_tools(&gateway, &mcp_url)
+            .await
+            .with_context(|| {
+                format!(
+                    "local describe failed for '{}' and tools/list fallback also failed: {describe_error}",
+                    route.backend_tool
+                )
+            })?
+            .into_iter()
+            .find(|tool| {
+                tool.get("name")
+                    .and_then(Value::as_str)
+                    .is_some_and(|name| name == route.backend_tool)
+            })
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "tool '{}' was not found after local describe failed: {describe_error}",
+                    route.backend_tool
+                )
+            })?,
     };
 
     Ok(json!({
@@ -132,36 +140,126 @@ pub async fn describe_local(registry_dir: PathBuf, tool_slug: String) -> anyhow:
 }
 
 pub async fn load_skill_local(registry_dir: PathBuf, body: Value) -> anyhow::Result<Value> {
-    let (dcc_type, instance_id, backend_body) = split_load_skill_request(body)?;
+    let LocalLoadSkillRequest {
+        dcc_type,
+        instance_id,
+        target_tool_slug,
+        mut backend_body,
+    } = split_load_skill_request(body)?;
     let entry = local_instance::select_one_routable_entry(
         &registry_dir,
         dcc_type.as_deref(),
         instance_id.as_deref(),
     )?;
     let gateway = HttpGateway::default();
-    let result = mcp_call_tool(
-        &gateway,
-        &local_instance::mcp_url(&entry),
-        "load_skill",
-        backend_body,
-        None,
-    )
-    .await
-    .with_context(|| {
-        format!(
-            "loading skill on local {} instance {}",
-            entry.dcc_type,
-            local_instance::instance_short(&entry)
-        )
-    })?;
+    let mcp_url = local_instance::mcp_url(&entry);
+    let tool_group = backend_body
+        .get("tool_group")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|group| !group.is_empty())
+        .map(str::to_string);
+    let skill_name = backend_body
+        .get("skill_name")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    if tool_group.is_some()
+        && backend_body.get("activate_groups").is_none()
+        && let Some(object) = backend_body.as_object_mut()
+    {
+        object.insert("activate_groups".to_string(), Value::Bool(false));
+    }
+    let result = mcp_call_tool(&gateway, &mcp_url, "load_skill", backend_body, None)
+        .await
+        .with_context(|| {
+            format!(
+                "loading skill on local {} instance {}",
+                entry.dcc_type,
+                local_instance::instance_short(&entry)
+            )
+        })?;
+    if !call_result_succeeded(&result) {
+        anyhow::bail!("loading skill failed: {result}");
+    }
     let mut payload = call_result_payload(&result).unwrap_or(result);
+    if payload.get("loaded").and_then(Value::as_bool) == Some(false) {
+        anyhow::bail!("loading skill failed: {payload}");
+    }
+    if let Some(group) = tool_group.as_deref()
+        && !payload
+            .get("activated_groups")
+            .and_then(Value::as_array)
+            .is_some_and(|groups| groups.iter().any(|value| value.as_str() == Some(group)))
+    {
+        let mut arguments = json!({"group_name": group});
+        if let Some(skill_name) = skill_name.as_deref()
+            && let Some(object) = arguments.as_object_mut()
+        {
+            object.insert("skill_name".to_string(), json!(skill_name));
+        }
+        let activation = mcp_call_tool(&gateway, &mcp_url, "activate_tool_group", arguments, None)
+            .await
+            .with_context(|| {
+                format!(
+                    "activating tool group '{group}' on local {} instance {}",
+                    entry.dcc_type,
+                    local_instance::instance_short(&entry)
+                )
+            })?;
+        if !call_result_succeeded(&activation) {
+            anyhow::bail!("activating tool group '{group}' failed: {activation}");
+        }
+        if let Some(groups) = payload
+            .as_object_mut()
+            .map(|object| {
+                object
+                    .entry("activated_groups")
+                    .or_insert_with(|| json!([]))
+            })
+            .and_then(Value::as_array_mut)
+        {
+            groups.push(json!(group));
+        }
+    }
     attach_local_context(&mut payload, &entry, None, "local_mcp");
+    let target_tool_slug = target_tool_slug.or_else(|| {
+        payload
+            .get("registered_tools")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .find(|name| !name.trim().is_empty())
+            .or_else(|| {
+                payload
+                    .get("tools")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+                    .find(|name| !name.trim().is_empty())
+            })
+            .map(|name| local_instance::local_tool_slug(&entry, name))
+    });
+    if let Some(target_tool_slug) = target_tool_slug {
+        attach_local_post_load_hint(
+            &mut payload,
+            &entry,
+            &target_tool_slug,
+            skill_name.as_deref(),
+        );
+    }
     Ok(payload)
 }
 
-fn split_load_skill_request(
-    body: Value,
-) -> anyhow::Result<(Option<String>, Option<String>, Value)> {
+struct LocalLoadSkillRequest {
+    dcc_type: Option<String>,
+    instance_id: Option<String>,
+    target_tool_slug: Option<String>,
+    backend_body: Value,
+}
+
+fn split_load_skill_request(body: Value) -> anyhow::Result<LocalLoadSkillRequest> {
     let Value::Object(mut object) = body else {
         anyhow::bail!("load-skill local request body must be a JSON object");
     };
@@ -175,12 +273,177 @@ fn split_load_skill_request(
         .get("instance_id")
         .and_then(Value::as_str)
         .map(str::to_string);
+    let target_tool_slug = object
+        .get("target_tool_slug")
+        .and_then(Value::as_str)
+        .map(str::to_string);
 
     object.remove("dcc_type");
     object.remove("dcc");
     object.remove("instance_id");
+    object.remove("target_tool_slug");
+    object.remove("meta");
+    object.remove("_meta");
+    if target_tool_slug.is_some()
+        && ["tool_group", "group", "group_name"].iter().any(|key| {
+            object
+                .get(*key)
+                .and_then(Value::as_str)
+                .is_some_and(|group| !group.trim().is_empty())
+        })
+    {
+        object.insert("strict_tool_group".to_string(), Value::Bool(true));
+    }
 
-    Ok((dcc_type, instance_id, Value::Object(object)))
+    Ok(LocalLoadSkillRequest {
+        dcc_type,
+        instance_id,
+        target_tool_slug,
+        backend_body: Value::Object(object),
+    })
+}
+
+fn attach_local_post_load_hint(
+    payload: &mut Value,
+    entry: &ServiceEntry,
+    target_tool_slug: &str,
+    requested_skill_name: Option<&str>,
+) {
+    if payload.get("loaded").and_then(Value::as_bool) != Some(true) {
+        return;
+    }
+    let requested_backend_tool = parse_local_tool_slug(target_tool_slug).backend_tool;
+    let backend_tool =
+        resolve_loaded_backend_tool(payload, &requested_backend_tool, requested_skill_name);
+    let target_tool_slug = local_instance::local_tool_slug(entry, &backend_tool);
+    let selected_tool = payload
+        .get("tools")
+        .and_then(Value::as_array)
+        .and_then(|tools| {
+            tools.iter().find(|tool| {
+                tool.get("name")
+                    .and_then(Value::as_str)
+                    .is_some_and(|name| name == backend_tool)
+            })
+        });
+    let input_schema = selected_tool
+        .and_then(|tool| tool.get("inputSchema").or_else(|| tool.get("input_schema")))
+        .filter(|schema| schema.is_object())
+        .cloned();
+    let annotations = selected_tool
+        .and_then(|tool| tool.get("annotations"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let metadata = selected_tool
+        .and_then(|tool| tool.get("metadata"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let Some(object) = payload.as_object_mut() else {
+        return;
+    };
+    let next_step = if let Some(input_schema) = input_schema {
+        let complete_for_call = simple_object_schema(&input_schema);
+        let safe_to_call = complete_for_call && has_safety_hints(&annotations);
+        let required = input_schema
+            .get("required")
+            .cloned()
+            .unwrap_or_else(|| json!([]));
+        let properties = input_schema
+            .get("properties")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let property_keys: Vec<String> = properties
+            .as_object()
+            .map(|properties| properties.keys().cloned().collect())
+            .unwrap_or_default();
+        object.insert(
+            "compact_schema".to_string(),
+            json!({
+                "tool_slug": &target_tool_slug,
+                "has_schema": schema_has_constraints(&input_schema),
+                "complete_for_call": complete_for_call,
+                "required": required,
+                "property_keys": property_keys,
+                "properties": properties,
+                "annotations": annotations,
+                "metadata": metadata,
+            }),
+        );
+        if safe_to_call {
+            json!({
+                "action": "call",
+                "arguments": {"tool_slug": &target_tool_slug, "arguments": {}},
+                "schema_source": "load_skill.compact_schema",
+            })
+        } else {
+            json!({
+                "action": "describe",
+                "arguments": {"tool_slug": &target_tool_slug},
+            })
+        }
+    } else {
+        json!({
+            "action": "describe",
+            "arguments": {"tool_slug": &target_tool_slug},
+        })
+    };
+    object.insert("next_step".to_string(), next_step);
+}
+
+fn resolve_loaded_backend_tool(
+    payload: &Value,
+    requested_backend_tool: &str,
+    requested_skill_name: Option<&str>,
+) -> String {
+    let mut candidates: Vec<&str> = payload
+        .get("tools")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+        .chain(
+            payload
+                .get("registered_tools")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str),
+        )
+        .collect();
+    candidates.sort_unstable();
+    candidates.dedup();
+
+    if candidates.contains(&requested_backend_tool) {
+        return requested_backend_tool.to_string();
+    }
+
+    let skill_name = requested_skill_name.or_else(|| {
+        payload
+            .get("skill_name")
+            .and_then(Value::as_str)
+            .filter(|name| !name.trim().is_empty())
+    });
+    let Some(skill_name) = skill_name else {
+        return requested_backend_tool.to_string();
+    };
+    let canonical_prefix = format!("{}__", skill_name.replace('-', "_"));
+    let requested_action = requested_backend_tool
+        .strip_prefix(&canonical_prefix)
+        .unwrap_or(requested_backend_tool)
+        .replace('-', "_");
+    let mut matches = candidates.into_iter().filter(|candidate| {
+        candidate
+            .strip_prefix(&canonical_prefix)
+            .is_some_and(|action| action == requested_action)
+    });
+    let Some(canonical) = matches.next() else {
+        return requested_backend_tool.to_string();
+    };
+    if matches.next().is_some() {
+        return requested_backend_tool.to_string();
+    }
+    canonical.to_string()
 }
 
 pub async fn call_local(
@@ -658,20 +921,156 @@ fn extend_tool_hits(hits: &mut Vec<Value>, entry: &ServiceEntry, payload: &Value
         let Some(name) = tool.get("name").and_then(Value::as_str) else {
             continue;
         };
+        let tool_slug = local_instance::local_tool_slug(entry, name);
+        let has_schema = tool
+            .get("has_schema")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        let enabled = tool.get("enabled").and_then(Value::as_bool).unwrap_or(true);
+        let group = tool
+            .get("group")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|group| !group.is_empty());
+        let skill_name = tool
+            .get("skill_name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|skill| !skill.is_empty());
+        let annotations = tool.get("annotations").cloned().unwrap_or(Value::Null);
+        let next_step = if !enabled {
+            match (skill_name, group) {
+                (Some(skill_name), Some(group)) => json!({
+                    "action": "load_skill",
+                    "arguments": {
+                        "skill_name": skill_name,
+                        "dcc": entry.dcc_type,
+                        "dcc_type": entry.dcc_type,
+                        "instance_id": entry.instance_id.to_string(),
+                        "tool_group": group,
+                        "group_action": "activate",
+                        "target_tool_slug": tool_slug,
+                    }
+                }),
+                _ => json!({"action": "describe", "arguments": {"tool_slug": tool_slug}}),
+            }
+        } else if has_schema || !has_safety_hints(&annotations) {
+            json!({"action": "describe", "arguments": {"tool_slug": tool_slug}})
+        } else {
+            json!({
+                "action": "call",
+                "arguments": {"tool_slug": tool_slug, "arguments": {}}
+            })
+        };
         hits.push(json!({
             "kind": "tool",
-            "slug": local_instance::local_tool_slug(entry, name),
+            "slug": tool_slug,
             "backend_tool": name,
             "instance_id": entry.instance_id.to_string(),
             "instance_short": local_instance::instance_short(entry),
             "dcc": entry.dcc_type,
             "dcc_type": entry.dcc_type,
             "summary": tool.get("description").cloned().unwrap_or(Value::Null),
+            "has_schema": has_schema,
+            "enabled": enabled,
+            "skill_name": skill_name,
+            "tool_group": group,
+            "annotations": annotations,
+            "metadata": tool.get("metadata").cloned().unwrap_or(Value::Null),
             "loaded": true,
+            "next_step": next_step,
             "scope": "local",
             "source": "local_mcp",
             "mcp_url": local_instance::mcp_url(entry),
         }));
+    }
+}
+
+fn has_safety_hints(annotations: &Value) -> bool {
+    annotations.as_object().is_some_and(|annotations| {
+        [
+            ("readOnlyHint", "read_only_hint"),
+            ("destructiveHint", "destructive_hint"),
+            ("idempotentHint", "idempotent_hint"),
+            ("openWorldHint", "open_world_hint"),
+        ]
+        .iter()
+        .all(|(camel, snake)| {
+            annotations
+                .get(*camel)
+                .or_else(|| annotations.get(*snake))
+                .and_then(Value::as_bool)
+                .is_some()
+        })
+    })
+}
+
+fn simple_object_schema(schema: &Value) -> bool {
+    let Some(object) = schema.as_object() else {
+        return false;
+    };
+    if object.get("type").and_then(Value::as_str) != Some("object")
+        || object.keys().any(|key| {
+            !matches!(
+                key.as_str(),
+                "type"
+                    | "properties"
+                    | "required"
+                    | "title"
+                    | "description"
+                    | "$schema"
+                    | "additionalProperties"
+            )
+        })
+    {
+        return false;
+    }
+    !schema_contains_complex_keyword(schema)
+}
+
+fn schema_has_constraints(schema: &Value) -> bool {
+    let Some(object) = schema.as_object() else {
+        return !schema.is_null();
+    };
+    object.iter().any(|(key, value)| match key.as_str() {
+        "type" => value.as_str() != Some("object"),
+        "properties" => value
+            .as_object()
+            .is_none_or(|properties| !properties.is_empty()),
+        "required" => value.as_array().is_none_or(|required| !required.is_empty()),
+        "title" | "description" | "$schema" => false,
+        _ => true,
+    })
+}
+
+fn schema_contains_complex_keyword(schema: &Value) -> bool {
+    const COMPLEX: &[&str] = &[
+        "$ref",
+        "$dynamicRef",
+        "$defs",
+        "definitions",
+        "oneOf",
+        "anyOf",
+        "allOf",
+        "not",
+        "if",
+        "then",
+        "else",
+        "unevaluatedProperties",
+        "patternProperties",
+        "propertyNames",
+        "dependentRequired",
+        "dependentSchemas",
+        "dependencies",
+    ];
+    match schema {
+        Value::Object(object) => object.iter().any(|(key, value)| {
+            (key == "additionalProperties" && value != &Value::Bool(false))
+                || COMPLEX.contains(&key.as_str())
+                || schema_contains_complex_keyword(value)
+        }),
+        Value::Array(items) => items.iter().any(schema_contains_complex_keyword),
+        _ => false,
     }
 }
 
@@ -690,16 +1089,33 @@ fn extend_skill_hits(hits: &mut Vec<Value>, entry: &ServiceEntry, payload: &Valu
             .get("matching_tools")
             .and_then(Value::as_array)
             .and_then(|tools| tools.iter().filter_map(Value::as_str).next());
+        let target_tool_slug = target_tool.map(|tool| local_instance::local_tool_slug(entry, tool));
+        let mut load_arguments = json!({
+            "skill_name": skill_name,
+            "dcc": entry.dcc_type,
+            "dcc_type": entry.dcc_type,
+            "instance_id": entry.instance_id.to_string(),
+        });
+        if let Some(target_tool_slug) = &target_tool_slug {
+            load_arguments["target_tool_slug"] = json!(target_tool_slug);
+        }
+        if let Some(tool_group) = skill.get("tool_group").and_then(Value::as_str) {
+            load_arguments["tool_group"] = json!(tool_group);
+        }
         hits.push(json!({
             "kind": "skill_candidate",
             "skill_name": skill_name,
-            "slug": target_tool.map(|tool| local_instance::local_tool_slug(entry, tool)),
-            "target_tool_slug": target_tool.map(|tool| local_instance::local_tool_slug(entry, tool)),
+            "slug": target_tool_slug,
+            "target_tool_slug": target_tool_slug,
             "matching_tools": skill.get("matching_tools").cloned().unwrap_or_else(|| json!([])),
             "requires_load_skill": true,
             "load_hint": {
                 "tool": "load_skill",
-                "arguments": { "skill_name": skill_name },
+                "arguments": load_arguments,
+            },
+            "next_step": {
+                "action": "load_skill",
+                "arguments": load_arguments,
             },
             "instance_id": entry.instance_id.to_string(),
             "instance_short": local_instance::instance_short(entry),
@@ -833,24 +1249,175 @@ mod tests {
 
     #[test]
     fn load_skill_request_strips_local_routing_fields() {
-        let (dcc_type, instance_id, backend_body) = split_load_skill_request(json!({
+        let request = split_load_skill_request(json!({
             "skill_name": "workflow",
             "dcc_type": "maya",
             "dcc": "maya-legacy",
             "instance_id": "abc12345",
+            "target_tool_slug": "maya.abc12345.workflow__run",
+            "meta": {"search_id": "search-1"},
+            "_meta": {"response_format": "json"},
+            "tool_group": "execution",
             "activate_groups": false
         }))
         .unwrap();
 
-        assert_eq!(dcc_type.as_deref(), Some("maya"));
-        assert_eq!(instance_id.as_deref(), Some("abc12345"));
+        assert_eq!(request.dcc_type.as_deref(), Some("maya"));
+        assert_eq!(request.instance_id.as_deref(), Some("abc12345"));
         assert_eq!(
-            backend_body,
+            request.target_tool_slug.as_deref(),
+            Some("maya.abc12345.workflow__run")
+        );
+        assert_eq!(
+            request.backend_body,
             json!({
                 "skill_name": "workflow",
-                "activate_groups": false
+                "tool_group": "execution",
+                "activate_groups": false,
+                "strict_tool_group": true
             })
         );
+    }
+
+    #[test]
+    fn correlated_ungrouped_tool_does_not_request_strict_group_loading() {
+        let request = split_load_skill_request(json!({
+            "skill_name": "workflow",
+            "target_tool_slug": "maya.abc12345.workflow__run"
+        }))
+        .unwrap();
+
+        assert!(request.target_tool_slug.is_some());
+        assert!(request.backend_body.get("strict_tool_group").is_none());
+    }
+
+    #[test]
+    fn local_post_load_hint_resolves_bare_declaration_to_canonical_action() {
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 18080);
+        let mut payload = json!({
+            "loaded": true,
+            "skill_name": "workflow",
+            "registered_tools": ["workflow__run"],
+            "tools": [{
+                "name": "workflow__run",
+                "inputSchema": {"type": "object", "properties": {}}
+            }]
+        });
+
+        attach_local_post_load_hint(
+            &mut payload,
+            &entry,
+            "blender.deadbeef.run",
+            Some("workflow"),
+        );
+
+        assert_eq!(
+            payload["next_step"]["arguments"]["tool_slug"],
+            local_instance::local_tool_slug(&entry, "workflow__run")
+        );
+    }
+
+    #[test]
+    fn local_no_arg_tool_requires_safety_hints_before_direct_call() {
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 18080);
+        let mut hits = Vec::new();
+        extend_tool_hits(
+            &mut hits,
+            &entry,
+            &json!({
+                "tools": [{
+                    "name": "dangerous_reset",
+                    "description": "Reset the scene",
+                    "has_schema": false,
+                    "annotations": {"destructive_hint": true}
+                }]
+            }),
+        );
+        assert_eq!(hits[0]["next_step"]["action"], "describe");
+
+        hits.clear();
+        extend_tool_hits(
+            &mut hits,
+            &entry,
+            &json!({
+                "tools": [{
+                    "name": "dangerous_reset",
+                    "description": "Reset the scene",
+                    "has_schema": false,
+                    "annotations": {
+                        "read_only_hint": false,
+                        "destructive_hint": true,
+                        "idempotent_hint": false,
+                        "open_world_hint": false
+                    }
+                }]
+            }),
+        );
+        assert_eq!(hits[0]["next_step"]["action"], "call");
+        assert_eq!(hits[0]["annotations"]["destructive_hint"], true);
+    }
+
+    #[test]
+    fn local_strict_object_schema_can_call_without_describe() {
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 18080);
+        let mut payload = json!({
+            "loaded": true,
+            "tools": [{
+                "name": "workflow__run",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                    "additionalProperties": false
+                },
+                "annotations": {
+                    "read_only_hint": true,
+                    "destructive_hint": false,
+                    "idempotent_hint": true,
+                    "open_world_hint": false
+                }
+            }]
+        });
+
+        attach_local_post_load_hint(&mut payload, &entry, "workflow__run", Some("workflow"));
+
+        assert_eq!(payload["next_step"]["action"], "call", "{payload}");
+        assert_eq!(payload["compact_schema"]["complete_for_call"], true);
+        assert_eq!(payload["compact_schema"]["has_schema"], true);
+    }
+
+    #[test]
+    fn local_complex_schema_requires_describe_even_with_safety_hints() {
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 18080);
+        for schema in [
+            json!({"type": "object", "oneOf": []}),
+            json!({"type": "object", "anyOf": []}),
+            json!({"type": "object", "allOf": []}),
+            json!({"type": "object", "$ref": "#/$defs/input", "$defs": {}}),
+            json!({"type": "object", "additionalProperties": true}),
+            json!({"type": "object", "additionalProperties": {"type": "string"}}),
+            json!({"type": "object", "patternProperties": {}}),
+            json!({"type": "object", "dependentRequired": {}}),
+            json!({"type": "object", "if": {}, "then": {}}),
+        ] {
+            let mut payload = json!({
+                "loaded": true,
+                "tools": [{
+                    "name": "workflow__run",
+                    "inputSchema": schema,
+                    "annotations": {
+                        "read_only_hint": true,
+                        "destructive_hint": false,
+                        "idempotent_hint": true,
+                        "open_world_hint": false
+                    }
+                }]
+            });
+            attach_local_post_load_hint(&mut payload, &entry, "workflow__run", Some("workflow"));
+            assert_eq!(payload["next_step"]["action"], "describe", "{payload}");
+            assert_eq!(payload["compact_schema"]["complete_for_call"], false);
+            assert_eq!(payload["compact_schema"]["has_schema"], true);
+        }
     }
 
     #[test]

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -440,50 +440,167 @@ fn local_profile_controls_registered_instance_through_direct_mcp() {
     assert_eq!(search["hits"][0]["instance_id"], instance_id);
     let slug = search["hits"][0]["slug"].as_str().unwrap();
     assert!(slug.starts_with(&format!("maya.{instance_short}.")));
+    assert_eq!(search["hits"][0]["has_schema"], false);
+    assert_eq!(search["hits"][0]["next_step"]["action"], "call");
 
     let describe = run_json_with_env(&["describe", slug], &envs);
     assert_eq!(describe["source"], "local_mcp");
     assert_eq!(describe["record"]["tool_slug"], slug);
     assert_eq!(describe["tool"]["name"], "maya_scene__get_session_info");
 
-    let loaded = run_json_with_env(
+    let stderr = run_failure_with_env(
         &[
             "load-skill",
-            "workflow",
-            "--dcc-type",
-            "maya",
-            "--instance-id",
-            &instance_short,
+            "--json",
+            &serde_json::to_string(&serde_json::json!({
+                "skill_name": "broken",
+                "dcc_type": "maya",
+                "instance_id": instance_id,
+                "tool_group": "execution"
+            }))
+            .unwrap(),
         ],
         &envs,
     );
+    assert!(stderr.contains("skill load failed"), "stderr: {stderr}");
+    assert_eq!(fixture.activate_group_calls(), 0);
+
+    for (skill_name, expected_error) in [
+        ("broken-domain", "skill domain failure"),
+        ("not-loaded", "skill not loaded"),
+    ] {
+        let stderr = run_failure_with_env(
+            &[
+                "load-skill",
+                "--json",
+                &serde_json::to_string(&serde_json::json!({
+                    "skill_name": skill_name,
+                    "dcc_type": "maya",
+                    "instance_id": instance_id,
+                    "tool_group": "execution"
+                }))
+                .unwrap(),
+            ],
+            &envs,
+        );
+        assert!(stderr.contains(expected_error), "stderr: {stderr}");
+        assert_eq!(fixture.activate_group_calls(), 0);
+    }
+
+    let load_step = &search["hits"][1]["next_step"];
+    assert_eq!(load_step["action"], "load_skill");
+    assert_eq!(load_step["arguments"]["dcc_type"], "maya");
+    assert_eq!(load_step["arguments"]["instance_id"], instance_id);
+    assert_eq!(load_step["arguments"]["tool_group"], "execution");
+    let load_json = serde_json::to_string(&load_step["arguments"]).unwrap();
+    let loaded = run_json_with_env(&["load-skill", "--json", &load_json], &envs);
     assert_eq!(loaded["source"], "local_mcp");
     assert_eq!(loaded["loaded"], true);
+    assert_eq!(loaded["activate_groups"], false);
+    assert_eq!(loaded["strict_tool_group"], true);
+    assert_eq!(loaded["activated_groups"], serde_json::json!(["execution"]));
+    assert_eq!(fixture.activate_group_calls(), 1);
     assert_eq!(loaded["registered_tools"][0], "workflow__run");
+    let canonical_tool_slug = loaded["compact_schema"]["tool_slug"].as_str().unwrap();
+    assert_ne!(
+        canonical_tool_slug,
+        load_step["arguments"]["target_tool_slug"].as_str().unwrap(),
+        "load response must replace the declarative bare action with the registered callable"
+    );
+    assert!(canonical_tool_slug.ends_with(".workflow__run"));
+    assert_eq!(
+        loaded["compact_schema"]["required"],
+        serde_json::json!(["name"])
+    );
+    assert_eq!(loaded["next_step"]["action"], "call");
+    assert_eq!(
+        loaded["next_step"]["schema_source"],
+        "load_skill.compact_schema"
+    );
 
-    let call = run_json_with_env(&["call", slug, "--json", r#"{"detail":true}"#], &envs);
+    let mut call_arguments = loaded["next_step"]["arguments"].clone();
+    call_arguments["arguments"] = serde_json::json!({"name": "demo"});
+    let target_tool_slug = call_arguments["tool_slug"].as_str().unwrap();
+    let backend_arguments = serde_json::to_string(&call_arguments["arguments"]).unwrap();
+    let call = run_json_with_env(
+        &["call", target_tool_slug, "--json", &backend_arguments],
+        &envs,
+    );
     assert_eq!(call["source"], "local_mcp");
     assert_eq!(call["control_route"], "local_mcp_direct");
     assert_eq!(call["gateway_stats_recorded"], false);
     assert_eq!(call["success"], true);
-    assert_eq!(call["tool_slug"], slug);
+    assert_eq!(call["tool_slug"], target_tool_slug);
+    assert_eq!(call["backend_tool"], "workflow__run");
     assert_eq!(call["result"]["isError"], false);
 
-    let direct_call = run_json_with_env(
+    let skill_only = run_json_with_env(
+        &["search", "--query", "skill-only", "--dcc-type", "maya"],
+        &envs,
+    );
+    assert_eq!(skill_only["total"], 1);
+    assert_eq!(
+        skill_only["hits"][0]["matching_tools"],
+        serde_json::json!([])
+    );
+    let skill_only_load = &skill_only["hits"][0]["next_step"];
+    assert_eq!(skill_only_load["action"], "load_skill");
+    assert!(
+        skill_only_load["arguments"]
+            .get("target_tool_slug")
+            .is_none()
+    );
+    let loaded = run_json_with_env(
         &[
-            "call",
-            "workflow__run",
-            "--dcc-type",
-            "maya",
-            "--instance-id",
-            &instance_short,
+            "load-skill",
             "--json",
-            r#"{"name":"demo"}"#,
+            &serde_json::to_string(&skill_only_load["arguments"]).unwrap(),
         ],
         &envs,
     );
-    assert_eq!(direct_call["success"], true);
-    assert_eq!(direct_call["backend_tool"], "workflow__run");
+    assert_eq!(loaded["next_step"]["action"], "call");
+    assert!(
+        loaded["next_step"]["arguments"]["tool_slug"]
+            .as_str()
+            .unwrap()
+            .ends_with(".workflow__run")
+    );
+
+    let inactive = run_json_with_env(
+        &["search", "--query", "inactive", "--dcc-type", "maya"],
+        &envs,
+    );
+    assert_eq!(inactive["total"], 1);
+    let inactive_step = &inactive["hits"][0]["next_step"];
+    assert_eq!(inactive["hits"][0]["enabled"], false);
+    assert_eq!(inactive_step["action"], "load_skill");
+    assert_eq!(inactive_step["arguments"]["skill_name"], "workflow");
+    assert_eq!(inactive_step["arguments"]["tool_group"], "execution");
+    assert_eq!(
+        inactive_step["arguments"]["target_tool_slug"],
+        inactive["hits"][0]["slug"]
+    );
+
+    let inactive_load = run_json_with_env(
+        &[
+            "load-skill",
+            "--json",
+            &serde_json::to_string(&inactive_step["arguments"]).unwrap(),
+        ],
+        &envs,
+    );
+    assert_eq!(fixture.activate_group_calls(), 2);
+    assert_eq!(
+        inactive_load["activated_groups"],
+        serde_json::json!(["execution"])
+    );
+    assert_eq!(inactive_load["next_step"]["action"], "call");
+    assert!(
+        inactive_load["next_step"]["arguments"]["tool_slug"]
+            .as_str()
+            .unwrap()
+            .ends_with(".workflow__run")
+    );
 
     let reload = run_json_with_env(
         &[
@@ -660,7 +777,7 @@ fn local_search_without_query_lists_tools_for_dcc_filter() {
 }
 
 #[test]
-fn local_describe_uses_rest_for_loaded_tool_missing_from_tools_list() {
+fn local_describe_prefers_exact_rest_lookup() {
     let fixture = spawn_local_mcp_fixture();
     let registry = TempDir::new().unwrap();
     let file_registry = FileRegistry::new(registry.path()).unwrap();
@@ -689,6 +806,11 @@ fn local_describe_uses_rest_for_loaded_tool_missing_from_tools_list() {
     assert_eq!(describe["source"], "local_mcp");
     assert_eq!(describe["tool"]["name"], "dynamic__run");
     assert_eq!(describe["tool"]["inputSchema"]["required"][0], "name");
+    assert_eq!(
+        fixture.tools_list_calls(),
+        0,
+        "exact local describe must not enumerate the full tools/list"
+    );
 }
 
 #[test]

--- a/crates/dcc-mcp-cli/tests/support/mod.rs
+++ b/crates/dcc-mcp-cli/tests/support/mod.rs
@@ -3,7 +3,7 @@
 use std::process::Command;
 
 use axum::Router;
-use axum::extract::{Json, Path, Query};
+use axum::extract::{Json, Path, Query, State};
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -31,6 +31,8 @@ pub(crate) struct LocalMcpFixture {
     pub(crate) base_url: String,
     pub(crate) shutdown: Option<oneshot::Sender<()>>,
     pub(crate) thread: Option<std::thread::JoinHandle<()>>,
+    pub(crate) tools_list_calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    pub(crate) activate_group_calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl LocalMcpFixture {
@@ -40,6 +42,16 @@ impl LocalMcpFixture {
 
     pub(crate) fn safe_stop_url(&self) -> String {
         format!("{}/safe-stop", self.base_url)
+    }
+
+    pub(crate) fn tools_list_calls(&self) -> usize {
+        self.tools_list_calls
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    pub(crate) fn activate_group_calls(&self) -> usize {
+        self.activate_group_calls
+            .load(std::sync::atomic::Ordering::SeqCst)
     }
 }
 
@@ -545,10 +557,18 @@ pub(crate) fn spawn_gateway_fixture() -> GatewayFixture {
 }
 
 pub(crate) fn spawn_local_mcp_fixture() -> LocalMcpFixture {
+    let tools_list_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let activate_group_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let app = Router::new()
         .route(
             "/mcp",
-            post(|headers: HeaderMap, Json(body): Json<Value>| async move {
+            post(
+                |State((tools_list_calls, activate_group_calls)): State<(
+                    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+                    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+                )>,
+                 headers: HeaderMap,
+                 Json(body): Json<Value>| async move {
                 let accept = headers
                     .get(header::ACCEPT)
                     .and_then(|value| value.to_str().ok())
@@ -566,37 +586,40 @@ pub(crate) fn spawn_local_mcp_fixture() -> LocalMcpFixture {
 
                 let method = body.get("method").and_then(Value::as_str).unwrap_or("");
                 match method {
-                    "tools/list" => (
-                        StatusCode::OK,
-                        Json(json!({
-                            "jsonrpc": "2.0",
-                            "id": body.get("id").cloned().unwrap_or(json!(null)),
-                            "result": {
-                                "tools": [
-                                    {
-                                        "name": "search_tools",
-                                        "description": "Search local tools",
-                                        "inputSchema": {"type": "object"}
-                                    },
-                                    {
-                                        "name": "load_skill",
-                                        "description": "Load local skill",
-                                        "inputSchema": {"type": "object"}
-                                    },
-                                    {
-                                        "name": "maya_scene__get_session_info",
-                                        "description": "Read scene session info",
-                                        "inputSchema": {"type": "object", "properties": {}}
-                                    },
-                                    {
-                                        "name": "workflow__run",
-                                        "description": "Run workflow",
-                                        "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}}
-                                    }
-                                ]
-                            }
-                        })),
-                    ),
+                    "tools/list" => {
+                        tools_list_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        (
+                            StatusCode::OK,
+                            Json(json!({
+                                "jsonrpc": "2.0",
+                                "id": body.get("id").cloned().unwrap_or(json!(null)),
+                                "result": {
+                                    "tools": [
+                                        {
+                                            "name": "search_tools",
+                                            "description": "Search local tools",
+                                            "inputSchema": {"type": "object"}
+                                        },
+                                        {
+                                            "name": "load_skill",
+                                            "description": "Load local skill",
+                                            "inputSchema": {"type": "object"}
+                                        },
+                                        {
+                                            "name": "maya_scene__get_session_info",
+                                            "description": "Read scene session info",
+                                            "inputSchema": {"type": "object", "properties": {}}
+                                        },
+                                        {
+                                            "name": "workflow__run",
+                                            "description": "Run workflow",
+                                            "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}}
+                                        }
+                                    ]
+                                }
+                            })),
+                        )
+                    }
                     "tools/call" => {
                         let params = body.get("params").cloned().unwrap_or_else(|| json!({}));
                         let name = params.get("name").and_then(Value::as_str).unwrap_or("");
@@ -623,7 +646,65 @@ pub(crate) fn spawn_local_mcp_fixture() -> LocalMcpFixture {
                                         })),
                                     );
                                 }
-                                json!({
+                                if arguments.get("include_disabled") != Some(&json!(true)) {
+                                    return (
+                                        StatusCode::OK,
+                                        Json(json!({
+                                            "jsonrpc": "2.0",
+                                            "id": body.get("id").cloned().unwrap_or(json!(null)),
+                                            "error": {
+                                                "code": -32602,
+                                                "message": "local search must include inactive-group tools"
+                                            }
+                                        })),
+                                    );
+                                }
+                                if query == "skill-only" {
+                                    json!({
+                                        "total": 1,
+                                        "query": query,
+                                        "tools": [],
+                                        "skill_candidates": [{
+                                            "kind": "skill_candidate",
+                                            "skill_name": "workflow",
+                                            "description": "Workflow tools",
+                                            "tags": ["workflow"],
+                                            "dcc": "maya",
+                                            "scope": "repo",
+                                            "tool_count": 1,
+                                            "matching_tools": [],
+                                            "requires_load_skill": true,
+                                            "load_hint": {
+                                                "tool": "load_skill",
+                                                "arguments": {"skill_name": "workflow"}
+                                            }
+                                        }]
+                                    })
+                                } else if query == "inactive" {
+                                    json!({
+                                        "total": 1,
+                                        "query": query,
+                                        "tools": [{
+                                            "kind": "tool",
+                                            "name": "workflow__run",
+                                            "description": "Run workflow",
+                                            "category": "workflow",
+                                            "group": "execution",
+                                            "enabled": false,
+                                            "has_schema": true,
+                                            "dcc": "maya",
+                                            "skill_name": "workflow",
+                                            "annotations": {
+                                                "read_only_hint": false,
+                                                "destructive_hint": false,
+                                                "idempotent_hint": false,
+                                                "open_world_hint": false
+                                            }
+                                        }],
+                                        "skill_candidates": []
+                                    })
+                                } else {
+                                    json!({
                                     "total": 2,
                                     "query": query,
                                     "tools": [{
@@ -633,8 +714,22 @@ pub(crate) fn spawn_local_mcp_fixture() -> LocalMcpFixture {
                                         "category": "scene",
                                         "group": "",
                                         "enabled": true,
+                                        "has_schema": false,
                                         "dcc": "maya",
-                                        "skill_name": "maya-scene"
+                                        "skill_name": "maya-scene",
+                                        "annotations": {
+                                            "read_only_hint": true,
+                                            "destructive_hint": false,
+                                            "idempotent_hint": true,
+                                            "open_world_hint": false
+                                        },
+                                        "metadata": {
+                                            "dcc": {
+                                                "affinity": "any",
+                                                "execution": "sync",
+                                                "jobStrategy": "monolithic"
+                                            }
+                                        }
                                     }],
                                     "skill_candidates": [{
                                         "kind": "skill_candidate",
@@ -644,19 +739,27 @@ pub(crate) fn spawn_local_mcp_fixture() -> LocalMcpFixture {
                                         "dcc": "maya",
                                         "scope": "repo",
                                         "tool_count": 1,
-                                        "matching_tools": ["workflow__run"],
+                                        "matching_tools": ["run"],
+                                        "tool_group": "execution",
                                         "requires_load_skill": true,
                                         "load_hint": {
                                             "tool": "load_skill",
-                                            "arguments": {"skill_name": "workflow"}
+                                            "arguments": {
+                                                "skill_name": "workflow",
+                                                "tool_group": "execution"
+                                            }
                                         }
                                     }]
-                                })
+                                    })
+                                }
                             }
                             "load_skill" => {
                                 if arguments.get("dcc_type").is_some()
                                     || arguments.get("dcc").is_some()
                                     || arguments.get("instance_id").is_some()
+                                    || arguments.get("target_tool_slug").is_some()
+                                    || arguments.get("meta").is_some()
+                                    || arguments.get("_meta").is_some()
                                 {
                                     return (
                                         StatusCode::OK,
@@ -665,20 +768,85 @@ pub(crate) fn spawn_local_mcp_fixture() -> LocalMcpFixture {
                                             "id": body.get("id").cloned().unwrap_or(json!(null)),
                                             "error": {
                                                 "code": -32602,
-                                                "message": "load_skill received local routing fields"
+                                                "message": "load_skill received local or gateway routing fields"
                                             }
                                         })),
                                     );
                                 }
+                                if arguments.get("tool_group").is_some()
+                                    && arguments.get("activate_groups") != Some(&json!(false))
+                                {
+                                    return (
+                                        StatusCode::OK,
+                                        Json(json!({
+                                            "jsonrpc": "2.0",
+                                            "id": body.get("id").cloned().unwrap_or(json!(null)),
+                                            "error": {
+                                                "code": -32602,
+                                                "message": "targeted load_skill must default activate_groups=false"
+                                            }
+                                        })),
+                                    );
+                                }
+                                if arguments.get("skill_name") == Some(&json!("broken")) {
+                                    return (
+                                        StatusCode::OK,
+                                        Json(json!({
+                                            "jsonrpc": "2.0",
+                                            "id": body.get("id").cloned().unwrap_or(json!(null)),
+                                            "result": {
+                                                "isError": true,
+                                                "content": [{"type": "text", "text": "skill load failed"}]
+                                            }
+                                        })),
+                                    );
+                                }
+                                match arguments.get("skill_name").and_then(Value::as_str) {
+                                    Some("broken-domain") => json!({
+                                        "success": false,
+                                        "message": "skill domain failure"
+                                    }),
+                                    Some("not-loaded") => json!({
+                                        "loaded": false,
+                                        "message": "skill not loaded"
+                                    }),
+                                    _ => json!({
+                                        "loaded": true,
+                                        "skill_name": arguments.get("skill_name").cloned().unwrap_or(Value::Null),
+                                        "activate_groups": arguments.get("activate_groups").cloned().unwrap_or(Value::Null),
+                                        "strict_tool_group": arguments.get("strict_tool_group").cloned().unwrap_or(Value::Null),
+                                        "registered_tools": ["workflow__run"],
+                                        "tool_count": 1,
+                                        "tools": [{
+                                            "name": "workflow__run",
+                                            "annotations": {
+                                                "read_only_hint": false,
+                                                "destructive_hint": false,
+                                                "idempotent_hint": false,
+                                                "open_world_hint": false
+                                            },
+                                            "metadata": {
+                                                "dcc": {
+                                                    "affinity": "any",
+                                                    "execution": "sync",
+                                                    "jobStrategy": "monolithic"
+                                                }
+                                            },
+                                            "inputSchema": {
+                                                "type": "object",
+                                                "properties": {"name": {"type": "string"}},
+                                                "required": ["name"]
+                                            }
+                                        }]
+                                    }),
+                                }
+                            }
+                            "activate_tool_group" => {
+                                activate_group_calls
+                                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                                 json!({
-                                    "loaded": true,
-                                    "skill_name": arguments.get("skill_name").cloned().unwrap_or(Value::Null),
-                                    "registered_tools": ["workflow__run"],
-                                    "tool_count": 1,
-                                    "tools": [{
-                                        "name": "workflow__run",
-                                        "inputSchema": {"type": "object"}
-                                    }]
+                                    "success": true,
+                                    "group": arguments.get("group_name").cloned().unwrap_or(Value::Null),
                                 })
                             }
                             "dcc_admin__reload_skills" => json!({
@@ -779,7 +947,8 @@ pub(crate) fn spawn_local_mcp_fixture() -> LocalMcpFixture {
                     "session": body.get("session").cloned().unwrap_or(Value::Null)
                 }))
             }),
-        );
+        )
+        .with_state((tools_list_calls.clone(), activate_group_calls.clone()));
 
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
@@ -803,6 +972,8 @@ pub(crate) fn spawn_local_mcp_fixture() -> LocalMcpFixture {
         base_url: format!("http://{addr}"),
         shutdown: Some(shutdown_tx),
         thread: Some(thread),
+        tools_list_calls,
+        activate_group_calls,
     }
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
@@ -29,7 +29,6 @@ mod tests;
 
 pub use call::route_tools_call;
 pub use fingerprint::compute_tools_fingerprint;
-pub(crate) use fingerprint::compute_tools_fingerprint_with_own;
 pub(crate) use helpers::{
     find_instance_by_prefix, inject_instance_metadata, live_backends, resolve_target,
     targets_for_fanout, to_text_result,

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -50,12 +50,29 @@ pub(crate) async fn skill_mgmt_dispatch(
                     // Strip gateway-only routing keys before forwarding.
                     let mut forward_args = args.clone();
                     if let Some(obj) = forward_args.as_object_mut() {
+                        let correlated_target = tool == "load_skill"
+                            && obj
+                                .get("target_tool_slug")
+                                .and_then(Value::as_str)
+                                .is_some_and(|slug| !slug.trim().is_empty())
+                            && ["tool_group", "group", "group_name"].iter().any(|key| {
+                                obj.get(*key)
+                                    .and_then(Value::as_str)
+                                    .is_some_and(|group| !group.trim().is_empty())
+                            });
                         obj.remove("instance_id");
                         obj.remove("meta");
                         obj.remove("_meta");
                         obj.remove("target_tool_slug");
+                        obj.remove("group_action");
+                        if correlated_target {
+                            obj.insert("strict_tool_group".to_string(), Value::Bool(true));
+                        }
                         if tool == "load_skill" && !obj.contains_key("activate_groups") {
-                            obj.insert("activate_groups".to_string(), Value::Bool(true));
+                            let targeted_group = ["tool_group", "group", "group_name"]
+                                .iter()
+                                .any(|key| obj.get(*key).and_then(Value::as_str).is_some());
+                            obj.insert("activate_groups".to_string(), Value::Bool(!targeted_group));
                         }
                         if let Some(group_name) = obj.get("group_name").cloned()
                             && !obj.contains_key("group")
@@ -76,6 +93,8 @@ pub(crate) async fn skill_mgmt_dispatch(
                         }
                     };
                     let params = json!({"name": tool, "arguments": forward_args});
+                    let mutation_gate = gs.capability_index.refresh_gate(entry.instance_id);
+                    let _mutation_guard = mutation_gate.lock().await;
                     match call_backend(
                         &gs.http_client,
                         &url,
@@ -125,8 +144,10 @@ pub(crate) async fn skill_mgmt_dispatch(
                                     );
                                 }
 
-                                crate::gateway::capability_service::refresh_all_live_backends(
+                                let discovery_url = entry_discovery_mcp_url(&entry);
+                                crate::gateway::capability_service::refresh_live_backend_locked(
                                     gs,
+                                    &entry,
                                     crate::gateway::capability::RefreshReason::ToolsListChanged,
                                 )
                                 .await;
@@ -134,41 +155,31 @@ pub(crate) async fn skill_mgmt_dispatch(
                                 // Layer 2: Retry refresh with backoff if tools
                                 // didn't appear in the index after the first
                                 // refresh (timing resilience, issue #1659).
-                                if !skill_names.is_empty() {
-                                    let discovery_url = entry_discovery_mcp_url(&entry);
-                                    if !discovery_url.is_empty() {
-                                        let max_retries = 2;
-                                        for attempt in 0..max_retries {
-                                            let slugs = new_tool_slugs_for_skill(
-                                                gs,
-                                                entry.instance_id,
-                                                Some(&skill_names[0]),
-                                            );
-                                            if !slugs.is_empty() {
-                                                break;
-                                            }
-                                            tokio::time::sleep(std::time::Duration::from_millis(
-                                                200,
-                                            ))
-                                            .await;
-                                            crate::gateway::capability::refresh_instance(
-                                                &gs.capability_index,
-                                                &gs.http_client,
-                                                &discovery_url,
-                                                entry.instance_id,
-                                                &entry.dcc_type,
-                                                gs.backend_timeout,
-                                                crate::gateway::capability::RefreshReason::ToolsListChanged,
-                                                Some(&gs.instance_diagnostics),
-                                            )
-                                            .await;
-                                            tracing::info!(
-                                                instance = %entry.instance_id,
-                                                skill = %skill_names[0],
-                                                retry = attempt + 1,
-                                                "load_skill: retried refresh after backoff",
-                                            );
+                                if !skill_names.is_empty() && !discovery_url.is_empty() {
+                                    let max_retries = 2;
+                                    for attempt in 0..max_retries {
+                                        let slugs = new_tool_slugs_for_skill(
+                                            gs,
+                                            entry.instance_id,
+                                            Some(&skill_names[0]),
+                                        );
+                                        if !slugs.is_empty() {
+                                            break;
                                         }
+                                        tokio::time::sleep(std::time::Duration::from_millis(200))
+                                            .await;
+                                        crate::gateway::capability_service::refresh_live_backend_locked(
+                                            gs,
+                                            &entry,
+                                            crate::gateway::capability::RefreshReason::ToolsListChanged,
+                                        )
+                                        .await;
+                                        tracing::info!(
+                                            instance = %entry.instance_id,
+                                            skill = %skill_names[0],
+                                            retry = attempt + 1,
+                                            "load_skill: retried refresh after backoff",
+                                        );
                                     }
                                 }
 
@@ -205,7 +216,14 @@ pub(crate) async fn skill_mgmt_dispatch(
         }
         _ => {
             // Fan-out aggregation.
-            let mut targets = targets_for_fanout(gs, dcc_filter).await;
+            let mut targets = if target_instance.is_some() {
+                match resolve_target(gs, target_instance, dcc_filter).await {
+                    Ok(entry) => vec![entry],
+                    Err(message) => return (message, true),
+                }
+            } else {
+                targets_for_fanout(gs, dcc_filter).await
+            };
             if targets.is_empty() {
                 return (
                     "No live DCC instances. Start dcc-mcp-server (or your DCC adapter) so the gateway can fan out skill tools. \
@@ -734,8 +752,7 @@ async fn decorate_load_skill_success(
     let target_tool_slug = request_args
         .get("target_tool_slug")
         .and_then(Value::as_str)
-        .filter(|slug| tool_slugs.iter().any(|candidate| candidate == *slug))
-        .map(str::to_string);
+        .and_then(|slug| resolve_loaded_target_slug(slug, &tool_slugs, requested_skill.as_deref()));
     obj.insert("new_tool_slugs".to_string(), json!(tool_slugs));
     obj.insert(
         "index_generation".to_string(),
@@ -744,13 +761,11 @@ async fn decorate_load_skill_success(
         )),
     );
 
-    if !obj.contains_key("activated_groups") {
-        let active_groups = obj
-            .get("active_groups")
-            .cloned()
-            .unwrap_or_else(|| json!([]));
-        obj.insert("activated_groups".to_string(), active_groups);
-    }
+    // `active_groups` from older backends is global and cannot prove that a
+    // same-named group is active for the requested skill.  Keep the scoped
+    // field empty so `tool_load_skill` performs its idempotent fallback.
+    obj.entry("activated_groups".to_string())
+        .or_insert_with(|| json!([]));
 
     let selected_tool_slug = target_tool_slug.or_else(|| {
         obj.get("new_tool_slugs")
@@ -806,6 +821,36 @@ fn new_tool_slugs_for_skill(
     slugs
 }
 
+fn resolve_loaded_target_slug(
+    requested_slug: &str,
+    loaded_tool_slugs: &[String],
+    skill_name: Option<&str>,
+) -> Option<String> {
+    if let Some(exact) = loaded_tool_slugs
+        .iter()
+        .find(|candidate| candidate.as_str() == requested_slug)
+    {
+        return Some(exact.clone());
+    }
+
+    let skill_name = skill_name?;
+    let requested_action = crate::gateway::capability::parse_slug(requested_slug)
+        .map(|(_, _, action)| action)
+        .unwrap_or(requested_slug);
+    let requested_bare =
+        dcc_mcp_gateway_core::naming::extract_bare_tool_name(skill_name, requested_action)
+            .replace('-', "_");
+    let mut matches = loaded_tool_slugs.iter().filter(|candidate| {
+        crate::gateway::capability::parse_slug(candidate).is_some_and(|(_, _, action)| {
+            dcc_mcp_gateway_core::naming::extract_bare_tool_name(skill_name, action)
+                .replace('-', "_")
+                == requested_bare
+        })
+    });
+    let canonical = matches.next()?.clone();
+    matches.next().is_none().then_some(canonical)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn suggested_post_load_next_step(
     gs: &GatewayState,
@@ -818,7 +863,7 @@ fn suggested_post_load_next_step(
     compact_schema: Option<&Value>,
 ) -> Value {
     if let Some(tool_slug) = first_tool_slug {
-        if compact_schema.is_some() {
+        if compact_schema.is_some_and(compact_schema_has_safety_hints) {
             let mut arguments = json!({ "tool_slug": tool_slug, "arguments": {} });
             attach_search_meta(&mut arguments, search_id, index_generation);
             let mut mcp_arguments = arguments.clone();
@@ -845,6 +890,7 @@ fn suggested_post_load_next_step(
         if let Ok(record) =
             crate::gateway::capability_service::describe_service(&gs.capability_index, tool_slug)
             && !record.has_schema
+            && crate::gateway::capability_service::capability_has_safety_hints(&record)
         {
             let mut arguments = json!({ "tool_slug": tool_slug, "arguments": {} });
             attach_search_meta(&mut arguments, search_id, index_generation);
@@ -965,10 +1011,128 @@ fn compact_schema_payload(
     json!({
         "tool_slug": tool_slug,
         "has_schema": record.has_schema,
+        "complete_for_call": simple_object_schema(input_schema),
         "required": required,
         "property_keys": property_keys,
         "properties": properties,
+        "annotations": record.annotations,
+        "metadata": record.metadata,
     })
+}
+
+fn compact_schema_has_safety_hints(schema: &Value) -> bool {
+    schema.get("complete_for_call").and_then(Value::as_bool) == Some(true)
+        && schema
+            .get("annotations")
+            .and_then(Value::as_object)
+            .is_some_and(|annotations| {
+                [
+                    "readOnlyHint",
+                    "destructiveHint",
+                    "idempotentHint",
+                    "openWorldHint",
+                ]
+                .iter()
+                .all(|key| annotations.get(*key).and_then(Value::as_bool).is_some())
+            })
+}
+
+fn simple_object_schema(schema: &Value) -> bool {
+    let Some(object) = schema.as_object() else {
+        return false;
+    };
+    if object.get("type").and_then(Value::as_str) != Some("object")
+        || object.keys().any(|key| {
+            !matches!(
+                key.as_str(),
+                "type"
+                    | "properties"
+                    | "required"
+                    | "title"
+                    | "description"
+                    | "$schema"
+                    | "additionalProperties"
+            )
+        })
+    {
+        return false;
+    }
+    !schema_contains_complex_keyword(schema)
+}
+
+fn schema_contains_complex_keyword(schema: &Value) -> bool {
+    const COMPLEX: &[&str] = &[
+        "$ref",
+        "$dynamicRef",
+        "$defs",
+        "definitions",
+        "oneOf",
+        "anyOf",
+        "allOf",
+        "not",
+        "if",
+        "then",
+        "else",
+        "unevaluatedProperties",
+        "patternProperties",
+        "propertyNames",
+        "dependentRequired",
+        "dependentSchemas",
+        "dependencies",
+    ];
+    match schema {
+        Value::Object(object) => object.iter().any(|(key, value)| {
+            (key == "additionalProperties" && value != &Value::Bool(false))
+                || COMPLEX.contains(&key.as_str())
+                || schema_contains_complex_keyword(value)
+        }),
+        Value::Array(items) => items.iter().any(schema_contains_complex_keyword),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod compact_schema_tests {
+    use super::*;
+
+    #[test]
+    fn only_complete_simple_object_schemas_are_call_ready() {
+        assert!(simple_object_schema(&json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+            "additionalProperties": false
+        })));
+
+        for schema in [
+            json!({"type": "object", "oneOf": []}),
+            json!({"type": "object", "anyOf": []}),
+            json!({"type": "object", "allOf": []}),
+            json!({"type": "object", "$ref": "#/$defs/input", "$defs": {}}),
+            json!({"type": "object", "additionalProperties": true}),
+            json!({"type": "object", "additionalProperties": {"type": "string"}}),
+            json!({"type": "object", "patternProperties": {}}),
+            json!({"type": "object", "dependentRequired": {}}),
+            json!({"type": "object", "if": {}, "then": {}}),
+        ] {
+            assert!(!simple_object_schema(&schema), "schema: {schema}");
+        }
+    }
+
+    #[test]
+    fn compact_schema_requires_all_boolean_safety_hints() {
+        let mut schema = json!({
+            "complete_for_call": true,
+            "annotations": {
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "openWorldHint": false
+            }
+        });
+        assert!(!compact_schema_has_safety_hints(&schema));
+        schema["annotations"]["idempotentHint"] = json!(true);
+        assert!(compact_schema_has_safety_hints(&schema));
+    }
 }
 
 fn attach_search_meta(

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests/gateway_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests/gateway_tests.rs
@@ -247,8 +247,10 @@ async fn gateway_mcp_initialize_advertises_prompts_capability() {
 }
 
 #[tokio::test]
-async fn gateway_mcp_four_tool_workflow_covers_search_describe_load_and_call() {
-    let (backend_port, stop_backend) = spawn_canonical_workflow_backend().await;
+async fn gateway_mcp_executes_search_load_call_before_optional_describe() {
+    use std::sync::atomic::Ordering;
+
+    let (backend_port, stop_backend, backend_mcp_calls) = spawn_canonical_workflow_backend().await;
     let dir = tempfile::tempdir().unwrap();
     let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
         dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
@@ -316,6 +318,97 @@ async fn gateway_mcp_four_tool_workflow_covers_search_describe_load_and_call() {
         .as_str()
         .expect("search returns a tool_slug")
         .to_string();
+    assert_eq!(search_payload["hits"][0]["loaded"], false);
+    assert_eq!(
+        search_payload["hits"][0]["next_step"]["action"],
+        "load_skill"
+    );
+    let load_arguments = search_payload["hits"][0]["next_step"]["arguments"].clone();
+    assert_eq!(load_arguments["tool_group"], "inspection");
+    assert_eq!(load_arguments["target_tool_slug"], tool_slug);
+
+    let correlated_load = post_mcp_json(
+        &client,
+        &url,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 40,
+            "method": "tools/call",
+            "params": {
+                "name": "load_skill",
+                "arguments": load_arguments
+            }
+        }),
+    )
+    .await;
+    assert_eq!(
+        correlated_load["result"]["isError"], false,
+        "{correlated_load}"
+    );
+    let correlated_payload = mcp_call_text_json(&correlated_load);
+    assert_eq!(correlated_payload["compact_schema"]["tool_slug"], tool_slug);
+    assert_eq!(
+        correlated_payload["compact_schema"]["required"],
+        json!(["radius"])
+    );
+    assert_eq!(
+        correlated_payload["compact_schema"]["properties"]["radius"]["type"],
+        "number"
+    );
+    assert_eq!(correlated_payload["next_step"]["action"], "call");
+    assert_eq!(
+        correlated_payload["next_step"]["schema_source"],
+        "load_skill.compact_schema"
+    );
+    assert!(
+        correlated_payload["received_arguments"]
+            .get("target_tool_slug")
+            .is_none(),
+        "gateway-only target_tool_slug must not be forwarded to the backend"
+    );
+    assert_eq!(
+        correlated_payload["received_arguments"]["strict_tool_group"],
+        true
+    );
+    assert_eq!(
+        correlated_payload["received_arguments"]["activate_groups"],
+        false
+    );
+    assert_eq!(
+        correlated_payload["received_arguments"]["tool_group"],
+        "inspection"
+    );
+    assert_eq!(
+        backend_mcp_calls.load(Ordering::SeqCst),
+        1,
+        "targeted load must activate its group in the same backend request"
+    );
+
+    let mut call_arguments = correlated_payload["next_step"]["arguments"].clone();
+    call_arguments["arguments"] = json!({"radius": 2.0});
+    let single = post_mcp_json(
+        &client,
+        &url,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {
+                "name": "call",
+                "arguments": call_arguments
+            }
+        }),
+    )
+    .await;
+    assert_eq!(single["result"]["isError"], false);
+    let single_payload = mcp_call_text_json(&single);
+    assert_eq!(single_payload["isError"], false);
+    assert!(
+        single_payload["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("radius")
+    );
 
     let describe = post_mcp_json(
         &client,
@@ -373,51 +466,6 @@ async fn gateway_mcp_four_tool_workflow_covers_search_describe_load_and_call() {
     assert_eq!(load_payload["next_step"]["mcp"]["tool"], "describe");
     assert_eq!(load_payload["next_step"]["rest"]["path"], "/v1/describe");
 
-    let correlated_load = post_mcp_json(
-        &client,
-        &url,
-        json!({
-            "jsonrpc": "2.0",
-            "id": 40,
-            "method": "tools/call",
-            "params": {
-                "name": "load_skill",
-                "arguments": {
-                    "skill_name": "maya-primitives",
-                    "dcc_type": "maya",
-                    "target_tool_slug": tool_slug.clone(),
-                    "meta": {
-                        "search_id": search_payload["search_id"],
-                        "index_generation": search_payload["index_generation"]
-                    }
-                }
-            }
-        }),
-    )
-    .await;
-    assert_eq!(correlated_load["result"]["isError"], false);
-    let correlated_payload = mcp_call_text_json(&correlated_load);
-    assert_eq!(correlated_payload["compact_schema"]["tool_slug"], tool_slug);
-    assert_eq!(
-        correlated_payload["compact_schema"]["required"],
-        json!(["radius"])
-    );
-    assert_eq!(
-        correlated_payload["compact_schema"]["properties"]["radius"]["type"],
-        "number"
-    );
-    assert_eq!(correlated_payload["next_step"]["action"], "call");
-    assert_eq!(
-        correlated_payload["next_step"]["schema_source"],
-        "load_skill.compact_schema"
-    );
-    assert!(
-        correlated_payload["received_arguments"]
-            .get("target_tool_slug")
-            .is_none(),
-        "gateway-only target_tool_slug must not be forwarded to the backend"
-    );
-
     let load_lazy = post_mcp_json(
         &client,
         &url,
@@ -441,30 +489,6 @@ async fn gateway_mcp_four_tool_workflow_covers_search_describe_load_and_call() {
     assert_eq!(
         load_lazy_payload["received_arguments"]["activate_groups"],
         false
-    );
-
-    let single = post_mcp_json(
-        &client,
-        &url,
-        json!({
-            "jsonrpc": "2.0",
-            "id": 6,
-            "method": "tools/call",
-            "params": {
-                "name": "call",
-                "arguments": {"tool_slug": tool_slug.clone(), "arguments": {"radius": 2.0}}
-            }
-        }),
-    )
-    .await;
-    assert_eq!(single["result"]["isError"], false);
-    let single_payload = mcp_call_text_json(&single);
-    assert_eq!(single_payload["isError"], false);
-    assert!(
-        single_payload["content"][0]["text"]
-            .as_str()
-            .unwrap()
-            .contains("radius")
     );
 
     let batch = post_mcp_json(

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests/helpers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests/helpers.rs
@@ -133,7 +133,13 @@ pub(crate) async fn make_gateway_state(
     }
 }
 
-pub(crate) async fn spawn_canonical_workflow_backend() -> (u16, tokio::sync::oneshot::Sender<()>) {
+pub(crate) async fn spawn_canonical_workflow_backend() -> (
+    u16,
+    tokio::sync::oneshot::Sender<()>,
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+) {
+    let mcp_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let loaded = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let app = axum::Router::new()
         .route(
             "/health",
@@ -141,28 +147,41 @@ pub(crate) async fn spawn_canonical_workflow_backend() -> (u16, tokio::sync::one
         )
         .route(
             "/v1/search",
-            axum::routing::post(|| async {
-                axum::Json(json!({
-                    "total": 1,
-                    "hits": [{
-                        "action": "create_sphere",
-                        "skill": "maya-primitives",
-                        "summary": "Create a polygon sphere in the current scene.",
-                        "loaded": true,
-                        "has_schema": true,
-                        "annotations": {
-                            "readOnlyHint": false,
-                            "destructiveHint": false,
-                            "openWorldHint": true
-                        },
-                        "metadata": {
-                            "dcc": {
-                                "affinity": "main",
-                                "execution": "in-process"
-                            }
-                        }
-                    }]
-                }))
+            axum::routing::post({
+                let loaded = loaded.clone();
+                move || {
+                    let loaded = loaded.clone();
+                    async move {
+                        axum::Json(json!({
+                            "total": 1,
+                            "hits": [{
+                                "action": "create_sphere",
+                                "skill": "maya-primitives",
+                                "summary": "Create a polygon sphere in the current scene.",
+                                "loaded": loaded.load(std::sync::atomic::Ordering::SeqCst),
+                                "has_schema": true,
+                                "annotations": {
+                                    "readOnlyHint": false,
+                                    "destructiveHint": false,
+                                    "idempotentHint": false,
+                                    "openWorldHint": true
+                                },
+                                "metadata": {
+                                    "dcc": {
+                                        "affinity": "main",
+                                        "execution": "in-process"
+                                    }
+                                },
+                                "available_groups": [{
+                                    "name": "inspection",
+                                    "tools": ["create_sphere"],
+                                    "default_active": false,
+                                    "active": loaded.load(std::sync::atomic::Ordering::SeqCst)
+                                }]
+                            }]
+                        }))
+                    }
+                }
             }),
         )
         .route(
@@ -191,6 +210,7 @@ pub(crate) async fn spawn_canonical_workflow_backend() -> (u16, tokio::sync::one
                     "annotations": {
                         "readOnlyHint": false,
                         "destructiveHint": false,
+                        "idempotentHint": false,
                         "openWorldHint": true
                     },
                     "metadata": {
@@ -220,42 +240,57 @@ pub(crate) async fn spawn_canonical_workflow_backend() -> (u16, tokio::sync::one
         )
         .route(
             "/mcp",
-            axum::routing::post(|axum::Json(body): axum::Json<Value>| async move {
-                let id = body.get("id").cloned().unwrap_or(Value::Null);
-                let name = body
-                    .get("params")
-                    .and_then(|params| params.get("name"))
-                    .and_then(Value::as_str)
-                    .unwrap_or("");
-                let result = if name == "load_skill" {
-                    let received_arguments = body
-                        .get("params")
-                        .and_then(|params| params.get("arguments"))
-                        .cloned()
-                        .unwrap_or_else(|| json!({}));
-                    json!({
-                        "content": [{
-                            "type": "text",
-                            "text": serde_json::to_string_pretty(&json!({
-                                "loaded": true,
-                                "skill_name": "maya-primitives",
-                                "dcc_type": "maya",
-                                "activated_groups": ["core"],
-                                "received_arguments": received_arguments,
-                            })).unwrap()
-                        }],
-                        "isError": false
-                    })
-                } else {
-                    json!({
-                        "content": [{
-                            "type": "text",
-                            "text": format!("unexpected backend MCP tool: {name}")
-                        }],
-                        "isError": true
-                    })
-                };
-                axum::Json(json!({"jsonrpc": "2.0", "id": id, "result": result}))
+            axum::routing::post({
+                let mcp_calls = mcp_calls.clone();
+                let loaded = loaded.clone();
+                move |axum::Json(body): axum::Json<Value>| {
+                    let mcp_calls = mcp_calls.clone();
+                    let loaded = loaded.clone();
+                    async move {
+                        mcp_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        let id = body.get("id").cloned().unwrap_or(Value::Null);
+                        let name = body
+                            .get("params")
+                            .and_then(|params| params.get("name"))
+                            .and_then(Value::as_str)
+                            .unwrap_or("");
+                        let result = if name == "load_skill" {
+                            loaded.store(true, std::sync::atomic::Ordering::SeqCst);
+                            let received_arguments = body
+                                .get("params")
+                                .and_then(|params| params.get("arguments"))
+                                .cloned()
+                                .unwrap_or_else(|| json!({}));
+                            let activated_group = received_arguments
+                                .get("tool_group")
+                                .and_then(Value::as_str)
+                                .unwrap_or("core");
+                            json!({
+                                "content": [{
+                                    "type": "text",
+                                    "text": serde_json::to_string_pretty(&json!({
+                                        "loaded": true,
+                                        "skill_name": "maya-primitives",
+                                        "dcc_type": "maya",
+                                        "activated_groups": [activated_group],
+                                        "registered_tools": ["create_sphere"],
+                                        "received_arguments": received_arguments,
+                                    })).unwrap()
+                                }],
+                                "isError": false
+                            })
+                        } else {
+                            json!({
+                                "content": [{
+                                    "type": "text",
+                                    "text": format!("unexpected backend MCP tool: {name}")
+                                }],
+                                "isError": true
+                            })
+                        };
+                        axum::Json(json!({"jsonrpc": "2.0", "id": id, "result": result}))
+                    }
+                }
             }),
         );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -270,7 +305,7 @@ pub(crate) async fn spawn_canonical_workflow_backend() -> (u16, tokio::sync::one
             .ok();
     });
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    (port, tx)
+    (port, tx, mcp_calls)
 }
 
 pub(crate) async fn post_mcp_json(client: &reqwest::Client, url: &str, body: Value) -> Value {

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests/tool_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests/tool_tests.rs
@@ -4,6 +4,177 @@ use crate::gateway::aggregator::*;
 use serde_json::{Value, json};
 use uuid::Uuid;
 
+async fn spawn_latency_search_backend(
+    action: &'static str,
+    calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    slow: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> (u16, tokio::sync::oneshot::Sender<()>) {
+    use std::sync::atomic::Ordering;
+
+    let app = axum::Router::new()
+        .route(
+            "/health",
+            axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
+        )
+        .route(
+            "/v1/search",
+            axum::routing::post(move || {
+                let calls = calls.clone();
+                let slow = slow.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    if slow.load(Ordering::SeqCst) {
+                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    }
+                    axum::Json(json!({
+                        "total": 1,
+                        "hits": [{
+                            "skill": "latency-test",
+                            "action": action,
+                            "summary": action,
+                            "loaded": true,
+                            "has_schema": false
+                        }]
+                    }))
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .ok();
+    });
+    (port, shutdown_tx)
+}
+
+async fn spawn_skill_search_backend(
+    skill_name: &'static str,
+) -> (
+    u16,
+    tokio::sync::oneshot::Sender<()>,
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let skill_calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let calls = skill_calls.clone();
+    let app = axum::Router::new()
+        .route(
+            "/health",
+            axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
+        )
+        .route(
+            "/v1/search",
+            axum::routing::post(move || async move {
+                axum::Json(json!({
+                    "total": 1,
+                    "hits": [{
+                        "skill": skill_name,
+                        "action": format!("{skill_name}_tool"),
+                        "summary": skill_name,
+                        "loaded": true,
+                        "has_schema": false
+                    }]
+                }))
+            }),
+        )
+        .route(
+            "/mcp",
+            axum::routing::post(move |axum::Json(body): axum::Json<Value>| {
+                let calls = calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    let id = body.get("id").cloned().unwrap_or(Value::Null);
+                    axum::Json(json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {
+                            "content": [{
+                                "type": "text",
+                                "text": serde_json::to_string(&json!({
+                                    "skills": [{
+                                        "name": skill_name,
+                                        "description": skill_name,
+                                        "loaded": false,
+                                    }],
+                                    "total": 1,
+                                })).unwrap()
+                            }],
+                            "isError": false,
+                        }
+                    }))
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .ok();
+    });
+    (port, shutdown_tx, skill_calls)
+}
+
+#[tokio::test]
+async fn unified_skill_search_honors_the_instance_filter() {
+    use std::sync::atomic::Ordering;
+
+    let (first_port, stop_first, first_calls) = spawn_skill_search_backend("skill-a").await;
+    let (second_port, stop_second, second_calls) = spawn_skill_search_backend("skill-b").await;
+    let (gs, _dir, ids) =
+        gateway_state_with_instances(&[("maya", first_port), ("maya", second_port)]).await;
+
+    for kind in ["skill", "all"] {
+        let text = crate::gateway::tools::tool_search(
+            &gs,
+            &json!({
+                "kind": kind,
+                "query": "skill",
+                "dcc_type": "maya",
+                "instance_id": ids[0].to_string(),
+            }),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let payload: Value = serde_json::from_str(&text).unwrap();
+        let skills = if kind == "all" {
+            &payload["skills"]["skills"]
+        } else {
+            &payload["skills"]
+        };
+        assert_eq!(skills.as_array().unwrap().len(), 1, "{payload:#}");
+        if kind == "all" {
+            assert_eq!(
+                skills[0]["next_step"]["arguments"]["skill_name"], "skill-a",
+                "{payload:#}"
+            );
+        } else {
+            assert_eq!(skills[0]["name"], "skill-a", "{payload:#}");
+        }
+        assert!(!text.contains("skill-b"), "{text}");
+    }
+
+    assert_eq!(first_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(second_calls.load(Ordering::SeqCst), 0);
+    let _ = stop_first.send(());
+    let _ = stop_second.send(());
+}
+
 #[test]
 fn skill_management_tool_defs_cover_all_six_tools() {
     let defs = skill_management_tool_defs();
@@ -232,6 +403,635 @@ async fn load_skill_backend_payload_failure_is_not_decorated_as_loaded() {
 }
 
 #[tokio::test]
+async fn load_skill_refreshes_only_its_target_instance() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let (target_port, stop_target, _) = spawn_canonical_workflow_backend().await;
+    let sibling_searches = std::sync::Arc::new(AtomicUsize::new(0));
+    let sibling_app = axum::Router::new()
+        .route(
+            "/health",
+            axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
+        )
+        .route(
+            "/v1/search",
+            axum::routing::post({
+                let sibling_searches = sibling_searches.clone();
+                move || {
+                    let sibling_searches = sibling_searches.clone();
+                    async move {
+                        sibling_searches.fetch_add(1, Ordering::SeqCst);
+                        axum::Json(json!({"total": 0, "hits": []}))
+                    }
+                }
+            }),
+        );
+    let sibling_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let sibling_port = sibling_listener.local_addr().unwrap().port();
+    let (stop_sibling, sibling_shutdown) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(sibling_listener, sibling_app)
+            .with_graceful_shutdown(async {
+                let _ = sibling_shutdown.await;
+            })
+            .await
+            .ok();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let (gs, _dir, ids) =
+        gateway_state_with_instances(&[("maya", target_port), ("maya", sibling_port)]).await;
+    crate::gateway::capability_service::refresh_all_live_backends(
+        &gs,
+        crate::gateway::capability::RefreshReason::Periodic,
+    )
+    .await;
+    let checkpoint_before = gs.capability_index.refresh_checkpoint.lock().await.clone();
+    assert!(checkpoint_before.is_some());
+    sibling_searches.store(0, Ordering::SeqCst);
+    let (text, is_error) = skill_mgmt_dispatch(
+        &gs,
+        "load_skill",
+        &json!({
+            "skill_name": "maya-primitives",
+            "dcc_type": "maya",
+            "instance_id": ids[0].to_string(),
+        }),
+    )
+    .await;
+
+    assert!(!is_error, "{text}");
+    assert_eq!(
+        sibling_searches.load(Ordering::SeqCst),
+        0,
+        "loading one Maya instance must not refresh its sibling Maya backend"
+    );
+    assert_eq!(
+        *gs.capability_index.refresh_checkpoint.lock().await,
+        checkpoint_before
+    );
+    let _ = stop_target.send(());
+    let _ = stop_sibling.send(());
+}
+
+#[tokio::test]
+async fn periodic_capability_refreshes_share_one_backend_fetch() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let calls_for_route = calls.clone();
+    let app = axum::Router::new().route(
+        "/v1/search",
+        axum::routing::post(move || {
+            let calls = calls_for_route.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                axum::Json(json!({
+                    "total": 1,
+                    "hits": [{
+                        "skill": "maya-scene",
+                        "action": "maya_scene__get_selection",
+                        "summary": "Get the current selection",
+                        "loaded": true,
+                        "has_schema": false
+                    }]
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .ok();
+    });
+
+    let (gs, _dir, _) = gateway_state_with_instances(&[("maya", port)]).await;
+    let first = crate::gateway::capability_service::refresh_all_live_backends(
+        &gs,
+        crate::gateway::capability::RefreshReason::Periodic,
+    );
+    let second = crate::gateway::capability_service::refresh_all_live_backends(
+        &gs,
+        crate::gateway::capability::RefreshReason::Periodic,
+    );
+    tokio::join!(first, second);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    crate::gateway::capability_service::refresh_all_live_backends(
+        &gs,
+        crate::gateway::capability::RefreshReason::Periodic,
+    )
+    .await;
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    crate::gateway::capability_service::refresh_all_live_backends_now(
+        &gs,
+        crate::gateway::capability::RefreshReason::Periodic,
+    )
+    .await;
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+    crate::gateway::capability_service::refresh_all_live_backends(
+        &gs,
+        crate::gateway::capability::RefreshReason::ToolsListChanged,
+    )
+    .await;
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+    let _ = shutdown_tx.send(());
+}
+
+#[tokio::test]
+async fn targeted_search_does_not_refresh_unrelated_slow_dcc() {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    let houdini_calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let maya_calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let (houdini_port, stop_houdini) = spawn_latency_search_backend(
+        "houdini_fast_tool",
+        houdini_calls.clone(),
+        std::sync::Arc::new(AtomicBool::new(false)),
+    )
+    .await;
+    let (maya_port, stop_maya) = spawn_latency_search_backend(
+        "maya_slow_tool",
+        maya_calls.clone(),
+        std::sync::Arc::new(AtomicBool::new(true)),
+    )
+    .await;
+    let (gs, _dir, _) =
+        gateway_state_with_instances(&[("houdini", houdini_port), ("maya", maya_port)]).await;
+    let query = json!({"query": "fast tool", "dcc_type": "houdini"});
+
+    let first = crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None);
+    let second = crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None);
+    let (first, second) = tokio::join!(first, second);
+    let first = first.unwrap();
+    let second = second.unwrap();
+
+    assert!(first.contains("houdini_fast_tool"), "{first}");
+    assert!(second.contains("houdini_fast_tool"), "{second}");
+    assert_eq!(
+        houdini_calls.load(Ordering::SeqCst),
+        1,
+        "concurrent cold searches should share one backend refresh"
+    );
+    assert_eq!(
+        maya_calls.load(Ordering::SeqCst),
+        0,
+        "a targeted Houdini search must not touch an unrelated Maya backend"
+    );
+    let _ = stop_houdini.send(());
+    let _ = stop_maya.send(());
+}
+
+#[tokio::test]
+async fn missing_slug_describe_refreshes_only_its_owning_dcc() {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    let houdini_calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let maya_calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let (houdini_port, stop_houdini) = spawn_latency_search_backend(
+        "houdini_describe_tool",
+        houdini_calls.clone(),
+        std::sync::Arc::new(AtomicBool::new(false)),
+    )
+    .await;
+    let (maya_port, stop_maya) = spawn_latency_search_backend(
+        "maya_unrelated_tool",
+        maya_calls.clone(),
+        std::sync::Arc::new(AtomicBool::new(false)),
+    )
+    .await;
+    let (gs, _dir, ids) =
+        gateway_state_with_instances(&[("houdini", houdini_port), ("maya", maya_port)]).await;
+    let missing_slug =
+        crate::gateway::capability::tool_slug("houdini", &ids[0], "houdini_describe_tool");
+
+    crate::gateway::capability_service::refresh_for_describe(&gs, &missing_slug).await;
+
+    assert_eq!(houdini_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        maya_calls.load(Ordering::SeqCst),
+        0,
+        "a valid missing Houdini slug must not refresh unrelated Maya discovery"
+    );
+    let _ = stop_houdini.send(());
+    let _ = stop_maya.send(());
+}
+
+#[tokio::test]
+async fn cached_search_rebinds_followup_correlation_and_telemetry() {
+    let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let (port, stop) = spawn_latency_search_backend(
+        "cached_correlation_tool",
+        calls,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .await;
+    let (gs, _dir, _) = gateway_state_with_instances(&[("houdini", port)]).await;
+    let query = json!({"query": "cached correlation", "dcc_type": "houdini"});
+
+    let first: Value = serde_json::from_str(
+        &crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let second: Value = serde_json::from_str(
+        &crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(second["search_cache_hit"], true);
+    assert_ne!(first["search_id"], second["search_id"]);
+    let search_id = second["search_id"].as_str().unwrap();
+    let hit = &second["hits"][0];
+    assert_eq!(
+        hit["next_step"]["arguments"]["meta"]["search_id"],
+        search_id
+    );
+    assert_eq!(
+        hit["next_step"]["mcp"]["arguments"]["meta"]["search_id"],
+        search_id
+    );
+    assert_eq!(hit["next_step"]["mcp"]["_meta"]["search_id"], search_id);
+    assert_eq!(
+        hit["next_step"]["rest"]["body"]["meta"]["search_id"],
+        search_id
+    );
+    assert!(
+        gs.search_telemetry
+            .selected_hit(search_id, hit["tool_slug"].as_str(), None)
+            .is_some()
+    );
+
+    let _ = stop.send(());
+}
+
+#[tokio::test]
+async fn warm_search_serves_cached_snapshot_while_backend_revalidates() {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    let calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let slow = std::sync::Arc::new(AtomicBool::new(false));
+    let (port, stop) =
+        spawn_latency_search_backend("cached_houdini_tool", calls.clone(), slow.clone()).await;
+    let maya_calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let (maya_port, stop_maya) = spawn_latency_search_backend(
+        "maya_cold_tool",
+        maya_calls.clone(),
+        std::sync::Arc::new(AtomicBool::new(false)),
+    )
+    .await;
+    let (gs, _dir, ids) =
+        gateway_state_with_instances(&[("houdini", port), ("maya", maya_port)]).await;
+    let query = json!({"query": "cached houdini", "dcc_type": "houdini"});
+
+    let cold = crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+        .await
+        .unwrap();
+    assert!(cold.contains("cached_houdini_tool"), "{cold}");
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    slow.store(true, Ordering::SeqCst);
+    gs.capability_index.expire_search_refresh_for_test(ids[0]);
+    let warm = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None),
+    )
+    .await
+    .expect("warm search must not wait for a slow backend")
+    .unwrap();
+
+    assert!(warm.contains("cached_houdini_tool"), "{warm}");
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while calls.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("stale snapshot should trigger background revalidation");
+
+    let maya_query = json!({"query": "cold tool", "dcc_type": "maya"});
+    let maya = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        crate::gateway::tools::tool_search_tools(&gs, &maya_query, None, None, None),
+    )
+    .await
+    .expect("slow Houdini revalidation must not block a cold Maya search")
+    .unwrap();
+    assert!(maya.contains("maya_cold_tool"), "{maya}");
+    assert_eq!(maya_calls.load(Ordering::SeqCst), 1);
+    let _ = stop.send(());
+    let _ = stop_maya.send(());
+}
+
+#[tokio::test]
+async fn warm_search_does_not_queue_refresh_behind_a_busy_instance_gate() {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    let calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let (port, stop) = spawn_latency_search_backend(
+        "busy_gate_tool",
+        calls.clone(),
+        std::sync::Arc::new(AtomicBool::new(false)),
+    )
+    .await;
+    let (gs, _dir, ids) = gateway_state_with_instances(&[("houdini", port)]).await;
+    let query = json!({"query": "busy gate", "dcc_type": "houdini"});
+
+    crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    gs.capability_index.expire_search_refresh_for_test(ids[0]);
+
+    let gate = gs.capability_index.refresh_gate(ids[0]);
+    let guard = gate.lock().await;
+    crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+        .await
+        .unwrap();
+    tokio::task::yield_now().await;
+    drop(guard);
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "stale-while-revalidate must skip a busy gate instead of queuing work"
+    );
+    let _ = stop.send(());
+}
+
+#[tokio::test]
+async fn concurrent_warm_searches_start_only_one_background_refresh() {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    let calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let slow = std::sync::Arc::new(AtomicBool::new(false));
+    let (port, stop) =
+        spawn_latency_search_backend("warm_concurrency_tool", calls.clone(), slow.clone()).await;
+    let (gs, _dir, ids) = gateway_state_with_instances(&[("houdini", port)]).await;
+    let query = json!({"query": "warm concurrency", "dcc_type": "houdini"});
+
+    crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    slow.store(true, Ordering::SeqCst);
+    gs.capability_index.expire_search_refresh_for_test(ids[0]);
+    let searches =
+        (0..32).map(|_| crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None));
+    let results = futures::future::join_all(searches).await;
+    assert!(results.into_iter().all(|result| result.is_ok()));
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while calls.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("one background refresh should start");
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "one cold refresh plus one shared stale refresh is expected"
+    );
+    let _ = stop.send(());
+}
+
+#[tokio::test]
+async fn skill_mutation_waits_for_inflight_stale_refresh_before_calling_backend() {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    let loaded = std::sync::Arc::new(AtomicBool::new(false));
+    let search_calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let stale_started = std::sync::Arc::new(tokio::sync::Notify::new());
+    let release_stale = std::sync::Arc::new(tokio::sync::Notify::new());
+    let load_called = std::sync::Arc::new(tokio::sync::Notify::new());
+
+    let loaded_for_search = loaded.clone();
+    let search_calls_for_route = search_calls.clone();
+    let stale_started_for_route = stale_started.clone();
+    let release_stale_for_route = release_stale.clone();
+    let loaded_for_call = loaded.clone();
+    let load_called_for_route = load_called.clone();
+    let app = axum::Router::new()
+        .route(
+            "/health",
+            axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
+        )
+        .route(
+            "/v1/search",
+            axum::routing::post(move || {
+                let loaded = loaded_for_search.clone();
+                let calls = search_calls_for_route.clone();
+                let stale_started = stale_started_for_route.clone();
+                let release_stale = release_stale_for_route.clone();
+                async move {
+                    let request_number = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                    if request_number == 2 {
+                        stale_started.notify_one();
+                        release_stale.notified().await;
+                    }
+                    let action = if request_number >= 3 && loaded.load(Ordering::SeqCst) {
+                        "new_loaded_tool"
+                    } else {
+                        "old_snapshot_tool"
+                    };
+                    axum::Json(json!({
+                        "total": 1,
+                        "hits": [{
+                            "skill": "gate-test",
+                            "action": action,
+                            "summary": action,
+                            "loaded": true,
+                            "has_schema": false
+                        }]
+                    }))
+                }
+            }),
+        )
+        .route(
+            "/mcp",
+            axum::routing::post(move |axum::Json(body): axum::Json<Value>| {
+                let loaded = loaded_for_call.clone();
+                let load_called = load_called_for_route.clone();
+                async move {
+                    loaded.store(true, Ordering::SeqCst);
+                    load_called.notify_one();
+                    let id = body.get("id").cloned().unwrap_or(Value::Null);
+                    axum::Json(json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {
+                            "content": [{
+                                "type": "text",
+                                "text": serde_json::to_string(&json!({
+                                    "loaded": true,
+                                    "skill_name": "gate-test",
+                                    "registered_tools": ["new_loaded_tool"]
+                                })).unwrap()
+                            }],
+                            "isError": false
+                        }
+                    }))
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (stop, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = stop_rx.await;
+            })
+            .await
+            .ok();
+    });
+
+    let (gs, _dir, ids) = gateway_state_with_instances(&[("houdini", port)]).await;
+    let query = json!({"query": "snapshot tool", "dcc_type": "houdini"});
+    crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+        .await
+        .unwrap();
+    gs.capability_index.expire_search_refresh_for_test(ids[0]);
+
+    let stale_started_wait = stale_started.notified();
+    crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+        .await
+        .unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(1), stale_started_wait)
+        .await
+        .expect("stale refresh should hold the instance gate");
+
+    let mutation_state = gs.clone();
+    let mutation = tokio::spawn(async move {
+        skill_mgmt_dispatch(
+            &mutation_state,
+            "load_skill",
+            &json!({
+                "skill_name": "gate-test",
+                "dcc_type": "houdini",
+                "instance_id": ids[0].to_string(),
+            }),
+        )
+        .await
+    });
+    let called_while_stale = tokio::time::timeout(
+        std::time::Duration::from_millis(100),
+        load_called.notified(),
+    )
+    .await
+    .is_ok();
+
+    release_stale.notify_one();
+    let (text, is_error) = mutation.await.unwrap();
+    assert!(
+        !is_error,
+        "load_skill should succeed after stale refresh: {text}"
+    );
+    assert!(
+        !called_while_stale,
+        "skill mutation must share the instance gate with stale refresh"
+    );
+    assert!(
+        gs.capability_index
+            .snapshot()
+            .records
+            .iter()
+            .any(|record| record.backend_tool == "new_loaded_tool"),
+        "post-mutation refresh must leave the new capability indexed"
+    );
+    let _ = stop.send(());
+}
+
+#[tokio::test]
+async fn search_evicts_cached_rows_for_instances_no_longer_live() {
+    let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let (port, stop) = spawn_latency_search_backend(
+        "offline_houdini_tool",
+        calls,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .await;
+    let (gs, _dir, ids) = gateway_state_with_instances(&[("houdini", port)]).await;
+    let query = json!({"query": "offline tool", "dcc_type": "houdini"});
+
+    let cold = crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+        .await
+        .unwrap();
+    assert!(cold.contains("offline_houdini_tool"), "{cold}");
+
+    {
+        let registry = gs.registry.read().await;
+        let entry = registry
+            .list_all()
+            .into_iter()
+            .find(|entry| entry.instance_id == ids[0])
+            .unwrap();
+        registry.deregister(&entry.key()).unwrap();
+    }
+    let after = crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+        .await
+        .unwrap();
+    assert!(!after.contains("offline_houdini_tool"), "{after}");
+    assert!(gs.capability_index.fingerprint_for(ids[0]).is_none());
+    let _ = stop.send(());
+}
+
+#[tokio::test]
+async fn targeted_search_evicts_cached_rows_for_unreachable_instances() {
+    use dcc_mcp_transport::discovery::types::ServiceStatus;
+
+    let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let (port, stop) = spawn_latency_search_backend(
+        "unreachable_houdini_tool",
+        calls,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .await;
+    let (gs, _dir, ids) = gateway_state_with_instances(&[("houdini", port)]).await;
+    let query = json!({"query": "unreachable tool", "dcc_type": "houdini"});
+
+    let cold = crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+        .await
+        .unwrap();
+    assert!(cold.contains("unreachable_houdini_tool"), "{cold}");
+
+    {
+        let registry = gs.registry.read().await;
+        let mut entry = registry
+            .list_all()
+            .into_iter()
+            .find(|entry| entry.instance_id == ids[0])
+            .unwrap();
+        registry.deregister(&entry.key()).unwrap();
+        entry.status = ServiceStatus::Unreachable;
+        registry.register(entry).unwrap();
+    }
+
+    let after = crate::gateway::tools::tool_search_tools(&gs, &query, None, None, None)
+        .await
+        .unwrap();
+    assert!(!after.contains("unreachable_houdini_tool"), "{after}");
+    assert!(gs.capability_index.fingerprint_for(ids[0]).is_none());
+    let _ = stop.send(());
+}
+
+#[tokio::test]
 async fn load_skill_for_sidecar_row_uses_discovery_endpoint() {
     let loaded = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let discovery_load_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -248,17 +1048,71 @@ async fn load_skill_for_sidecar_row_uses_discovery_endpoint() {
             axum::routing::post(move || {
                 let loaded = loaded_for_search.load(std::sync::atomic::Ordering::SeqCst);
                 async move {
-                    axum::Json(json!({
-                        "total": 1,
-                        "hits": [{
+                    let hits = if loaded {
+                        json!([
+                            {
+                                "skill": "maya-primitives",
+                                "action": "maya_primitives__create_cube",
+                                "summary": "Create a cube",
+                                "loaded": true,
+                                "has_schema": true
+                            },
+                            {
+                                "skill": "maya-primitives",
+                                "action": "maya_primitives__create_sphere",
+                                "summary": "Create a sphere",
+                                "loaded": true,
+                                "has_schema": true
+                            }
+                        ])
+                    } else {
+                        json!([{
                             "skill": "maya-primitives",
-                            "action": "maya_primitives__create_sphere",
+                            "action": "create_sphere",
                             "summary": "Create a sphere",
-                            "loaded": loaded,
+                            "loaded": false,
                             "has_schema": true
-                        }]
+                        }])
+                    };
+                    axum::Json(json!({
+                        "total": hits.as_array().map_or(0, Vec::len),
+                        "hits": hits
                     }))
                 }
+            }),
+        )
+        .route(
+            "/v1/describe",
+            axum::routing::post(|axum::Json(body): axum::Json<Value>| async move {
+                let action = body
+                    .get("tool_slug")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                axum::Json(json!({
+                    "entry": {
+                        "slug": format!("maya.maya-primitives.{action}"),
+                        "skill": "maya-primitives",
+                        "action": action,
+                        "dcc": "maya",
+                        "summary": "Create a primitive",
+                        "loaded": true,
+                        "has_schema": true,
+                        "scope": "repo"
+                    },
+                    "description": "Create a primitive",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"radius": {"type": "number"}},
+                        "required": ["radius"]
+                    },
+                    "annotations": {
+                        "readOnlyHint": false,
+                        "destructiveHint": false,
+                        "idempotentHint": false,
+                        "openWorldHint": false
+                    },
+                    "metadata": {"dcc": {"execution": "sync"}}
+                }))
             }),
         )
         .route(
@@ -285,7 +1139,10 @@ async fn load_skill_for_sidecar_row_uses_discovery_endpoint() {
                                         "loaded": true,
                                         "skill_name": "maya-primitives",
                                         "dcc_type": "maya",
-                                        "registered_tools": ["maya_primitives__create_sphere"]
+                                        "registered_tools": [
+                                            "maya_primitives__create_cube",
+                                            "maya_primitives__create_sphere"
+                                        ]
                                     })).unwrap()
                                 }],
                                 "isError": false
@@ -333,19 +1190,27 @@ async fn load_skill_for_sidecar_row_uses_discovery_endpoint() {
                         .pointer("/params/name")
                         .and_then(Value::as_str)
                         .unwrap_or_default();
+                    let payload = if name == "maya_primitives__create_sphere" {
+                        json!({
+                            "success": true,
+                            "created": "sphere"
+                        })
+                    } else {
+                        json!({
+                            "success": false,
+                            "message": format!("Unknown sidecar action: {name}"),
+                            "error": "unknown-action"
+                        })
+                    };
                     axum::Json(json!({
                         "jsonrpc": "2.0",
                         "id": id,
                         "result": {
                             "content": [{
                                 "type": "text",
-                                "text": serde_json::to_string(&json!({
-                                    "success": false,
-                                    "message": format!("Unknown sidecar action: {name}"),
-                                    "error": "unknown-action"
-                                })).unwrap()
+                                "text": serde_json::to_string(&payload).unwrap()
                             }],
-                            "isError": false
+                            "isError": payload["success"] == false
                         }
                     }))
                 }
@@ -397,28 +1262,20 @@ async fn load_skill_for_sidecar_row_uses_discovery_endpoint() {
         crate::gateway::capability::RefreshReason::Periodic,
     )
     .await;
-    let unloaded_query = crate::gateway::capability_service::parse_search_payload(&json!({
+    let search_args = json!({
         "query": "sphere",
         "dcc_type": "maya",
         "instance_id": instance_id.to_string(),
-    }));
-    let unloaded_hits =
-        crate::gateway::capability_service::search_service(&gs.capability_index, &unloaded_query);
-    assert_eq!(unloaded_hits.len(), 1);
-    assert!(
-        !unloaded_hits[0].record.loaded,
-        "pre-load search must surface the unloaded skill hint"
-    );
-    let (text, is_error) = skill_mgmt_dispatch(
-        &gs,
-        "load_skill",
-        &json!({
-            "skill_name": "maya-primitives",
-            "dcc_type": "maya",
-            "instance_id": instance_id.to_string(),
-        }),
-    )
-    .await;
+    });
+    let search_text = crate::gateway::tools::tool_search_tools(&gs, &search_args, None, None, None)
+        .await
+        .unwrap();
+    let search_payload: Value = serde_json::from_str(&search_text).unwrap();
+    let load_args = search_payload["hits"][0]["next_step"]["arguments"].clone();
+    let searched_target = load_args["target_tool_slug"].as_str().unwrap().to_string();
+    assert!(searched_target.ends_with(".create_sphere"));
+
+    let (text, is_error) = crate::gateway::tools::tool_load_skill(&gs, &load_args).await;
     assert!(!is_error, "load_skill must use discovery endpoint: {text}");
     assert_eq!(
         discovery_load_calls.load(std::sync::atomic::Ordering::SeqCst),
@@ -429,19 +1286,36 @@ async fn load_skill_for_sidecar_row_uses_discovery_endpoint() {
         0,
         "skill lifecycle calls must not hit the sidecar dispatch endpoint"
     );
-    let loaded_query = crate::gateway::capability_service::parse_search_payload(&json!({
-        "query": "sphere",
-        "dcc_type": "maya",
-        "instance_id": instance_id.to_string(),
-        "loaded_only": true,
-    }));
-    let loaded_hits =
-        crate::gateway::capability_service::search_service(&gs.capability_index, &loaded_query);
-    assert!(
-        loaded_hits.iter().any(|hit| {
-            hit.record.loaded && hit.record.backend_tool == "maya_primitives__create_sphere"
-        }),
-        "post-load refresh must surface the callable skill tool"
+    let load_payload: Value = serde_json::from_str(&text).unwrap();
+    let canonical_target = load_payload["next_step"]["arguments"]["tool_slug"]
+        .as_str()
+        .unwrap();
+    assert_ne!(canonical_target, searched_target);
+    assert!(canonical_target.ends_with(".maya_primitives__create_sphere"));
+    assert_eq!(
+        load_payload["compact_schema"]["tool_slug"],
+        canonical_target
+    );
+    assert_eq!(
+        load_payload["compact_schema"]["required"],
+        json!(["radius"])
+    );
+
+    let call_result = crate::gateway::capability_service::call_service(
+        &gs,
+        canonical_target,
+        json!({"radius": 2.0}),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("canonical post-load target must be callable");
+    assert!(call_result.to_string().contains("sphere"), "{call_result}");
+    assert_eq!(
+        sidecar_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "post-load call must route only the resolved canonical action"
     );
     let _ = stop_discovery_tx.send(());
     let _ = stop_sidecar_tx.send(());
@@ -643,13 +1517,15 @@ async fn load_skill_preserves_existing_index_when_v1_search_fails() {
 }
 
 #[tokio::test]
-async fn load_skill_for_dispatch_only_sidecar_without_discovery_url() {
+async fn rest_targeted_load_scopes_legacy_group_fallback_to_the_requested_skill() {
     // Regression test for issue #1664:
     // A dispatch-only sidecar registered with `role = "per-dcc-sidecar"` and
     // **no** `discovery_mcp_url` must still accept `load_skill` calls through
     // its `/mcp` endpoint.
     let load_skill_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let calls = load_skill_calls.clone();
+    let group_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let load_calls = load_skill_calls.clone();
+    let activate_calls = group_calls.clone();
     let app = axum::Router::new()
         .route(
             "/health",
@@ -658,7 +1534,8 @@ async fn load_skill_for_dispatch_only_sidecar_without_discovery_url() {
         .route(
             "/mcp",
             axum::routing::post(move |axum::Json(body): axum::Json<Value>| {
-                let calls = calls.clone();
+                let load_calls = load_calls.clone();
+                let activate_calls = activate_calls.clone();
                 async move {
                     let id = body.get("id").cloned().unwrap_or(Value::Null);
                     let name = body
@@ -666,7 +1543,19 @@ async fn load_skill_for_dispatch_only_sidecar_without_discovery_url() {
                         .and_then(Value::as_str)
                         .unwrap_or_default();
                     if name == "load_skill" {
-                        calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        load_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    } else if name == "activate_tool_group" {
+                        activate_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        assert_eq!(
+                            body.pointer("/params/arguments/skill_name")
+                                .and_then(Value::as_str),
+                            Some("maya-mgear")
+                        );
+                        assert_eq!(
+                            body.pointer("/params/arguments/group_name")
+                                .and_then(Value::as_str),
+                            Some("inspection")
+                        );
                     }
                     axum::Json(json!({
                         "jsonrpc": "2.0",
@@ -678,6 +1567,12 @@ async fn load_skill_for_dispatch_only_sidecar_without_discovery_url() {
                                     "loaded": true,
                                     "skill_name": "maya-mgear",
                                     "dcc_type": "maya",
+                                    // Legacy backends report active groups globally. Here
+                                    // `inspection` belongs to the already-loaded sibling
+                                    // skill, not the requested `maya-mgear` skill.
+                                    "already_loaded": ["maya-scene"],
+                                    "newly_loaded": ["maya-mgear"],
+                                    "active_groups": ["inspection"],
                                     "registered_tools": [
                                         "maya_mgear__inspect",
                                         "maya_mgear__list_joints",
@@ -727,25 +1622,37 @@ async fn load_skill_for_dispatch_only_sidecar_without_discovery_url() {
     };
     let gs = make_gateway_state(registry).await;
 
-    let (text, is_error) = skill_mgmt_dispatch(
-        &gs,
-        "load_skill",
-        &json!({
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        axum::http::header::ACCEPT,
+        "application/json".parse().unwrap(),
+    );
+    let response = crate::gateway::handlers::handle_v1_load_skill(
+        axum::extract::State(gs.clone()),
+        headers,
+        axum::Json(json!({
             "skill_name": "maya-mgear",
             "dcc_type": "maya",
             "instance_id": instance_id.to_string(),
-        }),
+            "tool_group": "inspection",
+        })),
     )
     .await;
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let payload: Value = serde_json::from_slice(&body).unwrap();
 
-    assert!(
-        !is_error,
-        "load_skill must succeed for dispatch-only sidecar without discovery_mcp_url: {text}"
-    );
     assert_eq!(
         load_skill_calls.load(std::sync::atomic::Ordering::SeqCst),
         1,
         "load_skill must be routed to the sidecar's /mcp endpoint"
+    );
+    assert_eq!(
+        group_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "legacy sidecars must receive one activate_tool_group fallback"
     );
 
     let snap = gs.capability_index.snapshot();
@@ -762,7 +1669,7 @@ async fn load_skill_for_dispatch_only_sidecar_without_discovery_url() {
         "maya_mgear__list_joints must be indexed after load_skill"
     );
 
-    let payload: Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(payload["activated_groups"], json!(["inspection"]));
     let slugs = payload["new_tool_slugs"].as_array().unwrap();
     assert!(
         slugs.iter().any(|s| s

--- a/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
@@ -23,8 +23,12 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
+use dashmap::DashMap;
 use parking_lot::RwLock;
+use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use super::record::CapabilityRecord;
@@ -44,6 +48,28 @@ pub struct CapabilityIndex {
     /// `HashMap::iter` resort on every snapshot build — the index is
     /// small enough that the log-n insert cost is noise.
     inner: RwLock<InnerState>,
+    /// Process-unique identity plus a monotonic content revision.
+    ///
+    /// This keeps cache validation O(1): callers do not need to clone and hash
+    /// the full index merely to learn whether its content changed.
+    generation_seed: Uuid,
+    revision: AtomicU64,
+    /// Serialises backend refreshes and remembers the last completed live set.
+    ///
+    /// On-demand discovery calls use this checkpoint to share one fresh index
+    /// snapshot instead of each re-fetching every backend catalog.
+    pub(crate) refresh_checkpoint: Mutex<Option<(Instant, Vec<Uuid>)>>,
+    /// Serialises refreshes of the same backend without coupling unrelated DCCs.
+    ///
+    /// ponytail: gates live for the gateway lifetime; prune only if
+    /// high-churn instance registration makes this map measurably large.
+    refresh_gates: DashMap<Uuid, Arc<Mutex<()>>>,
+    /// Last completed discovery refresh per backend.
+    ///
+    /// Search uses this independently from the full-live-set checkpoint so a
+    /// targeted query can reuse its own backend snapshot without waiting for
+    /// unrelated DCCs.
+    search_refresh_completed: RwLock<HashMap<Uuid, Instant>>,
 }
 
 #[derive(Default)]
@@ -65,7 +91,19 @@ impl CapabilityIndex {
     pub fn new() -> Self {
         Self {
             inner: RwLock::new(InnerState::default()),
+            generation_seed: Uuid::new_v4(),
+            revision: AtomicU64::new(0),
+            refresh_checkpoint: Mutex::new(None),
+            refresh_gates: DashMap::new(),
+            search_refresh_completed: RwLock::new(HashMap::new()),
         }
+    }
+
+    pub(crate) fn refresh_gate(&self, instance_id: Uuid) -> Arc<Mutex<()>> {
+        self.refresh_gates
+            .entry(instance_id)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
     }
 
     /// Replace every record owned by `instance_id` with `records`,
@@ -85,12 +123,22 @@ impl CapabilityIndex {
     ) -> Option<InstanceFingerprint> {
         let mut guard = self.inner.write();
         if records.is_empty() {
-            return guard
+            let previous = guard
                 .per_instance
                 .remove(&instance_id)
                 .map(|s| s.fingerprint);
+            if previous.is_some() {
+                self.bump_revision();
+            }
+            return previous;
         }
-        guard
+        if let Some(current) = guard.per_instance.get(&instance_id)
+            && current.fingerprint == fingerprint
+            && current.records.as_ref() == records.as_slice()
+        {
+            return Some(current.fingerprint);
+        }
+        let previous = guard
             .per_instance
             .insert(
                 instance_id,
@@ -99,14 +147,63 @@ impl CapabilityIndex {
                     fingerprint,
                 },
             )
-            .map(|s| s.fingerprint)
+            .map(|s| s.fingerprint);
+        self.bump_revision();
+        previous
     }
 
     /// Drop every record belonging to `instance_id`. Returns `true`
     /// if the instance was present.
     pub fn remove_instance(&self, instance_id: Uuid) -> bool {
         let mut guard = self.inner.write();
-        guard.per_instance.remove(&instance_id).is_some()
+        let removed = guard.per_instance.remove(&instance_id).is_some();
+        if removed {
+            self.bump_revision();
+        }
+        drop(guard);
+        self.search_refresh_completed.write().remove(&instance_id);
+        removed
+    }
+
+    /// Return indexed instance ids without cloning or sorting capability rows.
+    pub(crate) fn instance_ids(&self) -> Vec<Uuid> {
+        self.inner.read().per_instance.keys().copied().collect()
+    }
+
+    pub(crate) fn search_refresh_is_recent(
+        &self,
+        instance_id: Uuid,
+        max_age: std::time::Duration,
+    ) -> bool {
+        self.search_refresh_completed
+            .read()
+            .get(&instance_id)
+            .is_some_and(|completed_at| completed_at.elapsed() < max_age)
+    }
+
+    pub(crate) fn search_refresh_was_attempted(&self, instance_id: Uuid) -> bool {
+        self.search_refresh_completed
+            .read()
+            .contains_key(&instance_id)
+    }
+
+    pub(crate) fn mark_search_refresh_completed(
+        &self,
+        instance_ids: impl IntoIterator<Item = Uuid>,
+    ) {
+        let completed_at = Instant::now();
+        let mut guard = self.search_refresh_completed.write();
+        for instance_id in instance_ids {
+            guard.insert(instance_id, completed_at);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn expire_search_refresh_for_test(&self, instance_id: Uuid) {
+        self.search_refresh_completed.write().insert(
+            instance_id,
+            Instant::now() - std::time::Duration::from_secs(60),
+        );
     }
 
     /// Take an owned snapshot of the whole index. Intended for REST /
@@ -118,6 +215,27 @@ impl CapabilityIndex {
     /// that aren't connected yet.
     pub fn snapshot(&self) -> IndexSnapshot {
         let guard = self.inner.read();
+        Self::snapshot_locked(&guard)
+    }
+
+    /// Return a coherent owned snapshot and its generation.
+    ///
+    /// The read guard remains held until both values are captured, so search
+    /// results produced from the snapshot can be cached under exactly the
+    /// generation that produced them.
+    pub fn snapshot_with_generation(&self) -> (IndexSnapshot, String) {
+        let guard = self.inner.read();
+        let snapshot = Self::snapshot_locked(&guard);
+        let generation = self.generation_string(self.revision.load(Ordering::Acquire));
+        (snapshot, generation)
+    }
+
+    /// Return the current opaque generation without cloning index records.
+    pub fn generation(&self) -> String {
+        self.generation_string(self.revision.load(Ordering::Acquire))
+    }
+
+    fn snapshot_locked(guard: &InnerState) -> IndexSnapshot {
         let loaded_count: usize = guard.per_instance.values().map(|s| s.records.len()).sum();
         let unloaded_count = guard.unloaded.len();
         let mut records: Vec<CapabilityRecord> = Vec::with_capacity(loaded_count + unloaded_count);
@@ -137,6 +255,14 @@ impl CapabilityIndex {
             records: Arc::from(records),
             fingerprints,
         }
+    }
+
+    fn bump_revision(&self) {
+        self.revision.fetch_add(1, Ordering::Release);
+    }
+
+    fn generation_string(&self, revision: u64) -> String {
+        format!("{}:{revision:016x}", self.generation_seed.simple())
     }
 
     /// Return the fingerprint previously stored for `instance_id`, if
@@ -181,7 +307,11 @@ impl CapabilityIndex {
         // to re-sort them separately.
         let mut sorted = records;
         sorted.sort_by(|a, b| a.tool_slug.cmp(&b.tool_slug));
+        if guard.unloaded.as_ref() == sorted.as_slice() {
+            return;
+        }
         guard.unloaded = Arc::from(sorted);
+        self.bump_revision();
     }
 
     /// Number of unloaded skill records currently indexed; diagnostics-only.
@@ -233,6 +363,55 @@ mod unit_tests {
         assert!(idx.snapshot().is_empty());
         assert_eq!(idx.total_records(), 0);
         assert_eq!(idx.instance_count(), 0);
+    }
+
+    #[test]
+    fn generation_changes_only_when_index_content_changes() {
+        let idx = CapabilityIndex::new();
+        let iid = Uuid::from_u128(1);
+        let record = rec("maya", iid, "create_sphere", true);
+
+        let initial = idx.generation();
+        let (snapshot, snapshot_generation) = idx.snapshot_with_generation();
+        assert!(snapshot.is_empty());
+        assert_eq!(snapshot_generation, initial);
+
+        idx.upsert_instance(iid, vec![record.clone()], InstanceFingerprint(1));
+        let after_insert = idx.generation();
+        assert_ne!(after_insert, initial);
+
+        idx.upsert_instance(iid, vec![record], InstanceFingerprint(1));
+        assert_eq!(idx.generation(), after_insert);
+
+        assert!(!idx.remove_instance(Uuid::from_u128(2)));
+        assert_eq!(idx.generation(), after_insert);
+
+        assert!(idx.remove_instance(iid));
+        let after_remove = idx.generation();
+        assert_ne!(after_remove, after_insert);
+
+        idx.set_unloaded_records(Vec::new());
+        assert_eq!(idx.generation(), after_remove);
+        let unloaded = CapabilityRecord::from_skill_tool(
+            "maya-geometry",
+            "create_cube",
+            "Create a cube",
+            "maya",
+            None,
+        );
+        idx.set_unloaded_records(vec![unloaded.clone()]);
+        let after_unloaded_insert = idx.generation();
+        assert_ne!(after_unloaded_insert, after_remove);
+        idx.set_unloaded_records(vec![unloaded]);
+        assert_eq!(idx.generation(), after_unloaded_insert);
+    }
+
+    #[test]
+    fn generation_is_unique_per_index_within_the_process() {
+        let first = CapabilityIndex::new();
+        let second = CapabilityIndex::new();
+
+        assert_ne!(first.generation(), second.generation());
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -19,6 +19,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 use dcc_mcp_gateway_core::policy::{GatewayPolicy, GatewayPolicyDenial, GatewayPolicyOperation};
@@ -37,12 +38,12 @@ use super::backend_client::{
     forward_tools_call, try_describe_tool,
 };
 use super::capability::{
-    CapabilityIndex, CapabilityRecord, RANKER_VERSION, RefreshReason, SearchHit, SearchMode,
-    SearchQuery, backend_job_status_tool, is_backend_job_tool, parse_slug, refresh_instance,
-    remove_instance, search,
+    CapabilityIndex, CapabilityRecord, IndexSnapshot, RANKER_VERSION, RefreshReason, SearchHit,
+    SearchMode, SearchQuery, backend_job_status_tool, is_backend_job_tool, parse_slug,
+    refresh_instance, remove_instance, search,
 };
 use super::request_meta::meta_with_agent_context;
-use super::state::GatewayState;
+use super::state::{GatewayState, ResolveInstanceError};
 use dcc_mcp_gateway_core::naming::instance_short;
 
 /// Metadata attached to one gateway search response for follow-up correlation.
@@ -180,7 +181,21 @@ pub fn search_service_hits_for_policy(
     query: &SearchQuery,
     policy: &GatewayPolicy,
 ) -> Vec<SearchHit> {
-    search_service(index, query)
+    let snapshot = index.snapshot();
+    search_snapshot_hits_for_policy(&snapshot, query, policy)
+}
+
+/// Search one immutable index snapshot after applying gateway policy filters.
+///
+/// Callers that also publish an index generation should obtain both values via
+/// [`CapabilityIndex::snapshot_with_generation`] so cached hits and response
+/// metadata describe the same coherent view.
+pub fn search_snapshot_hits_for_policy(
+    snapshot: &IndexSnapshot,
+    query: &SearchQuery,
+    policy: &GatewayPolicy,
+) -> Vec<SearchHit> {
+    search(snapshot, query)
         .into_iter()
         .filter(|hit| {
             policy
@@ -251,39 +266,50 @@ pub fn search_hit_to_value_with_context(
         } else if let Some(group_name) = hit.record.disabled_by_group() {
             // Tool is loaded but its progressive group is inactive.
             value["disabled_by_group"] = json!(group_name);
-            // Provide an activate_tool_group next_step (MCP only —
-            // activate_tool_group is a gateway meta-tool, not a
-            // capability-indexed action, so there is no REST /v1/call
-            // route for it).
+            // Reuse the public load_skill contract to activate the group so
+            // the same next step works through both gateway MCP and REST.
             if let Some(skill_name) = &hit.record.skill_name {
                 let mut arguments = json!({
                     "skill_name": skill_name,
                     "dcc": &hit.record.dcc_type,
                     "dcc_type": &hit.record.dcc_type,
                     "tool_group": group_name,
+                    "group_action": "activate",
                     "instance_id": hit.record.instance_id.to_string(),
+                    "target_tool_slug": &hit.record.tool_slug,
                 });
                 attach_search_meta(&mut arguments, context);
                 value["next_step"] = json!({
-                    "action": "activate_tool_group",
+                    "action": "load_skill",
                     "arguments": arguments.clone(),
                     "mcp": {
-                        "tool": "activate_tool_group",
-                        "arguments": {
-                            "skill_name": skill_name,
-                            "group": group_name,
-                        },
+                        "tool": "load_skill",
+                        "arguments": arguments.clone(),
                         "_meta": search_meta(context),
+                    },
+                    "rest": {
+                        "method": "POST",
+                        "path": "/v1/load_skill",
+                        "body": arguments,
                     },
                 });
             }
-        } else if hit.record.has_schema {
+        } else if hit.record.has_schema || !capability_has_safety_hints(&hit.record) {
             value["next_step"] = describe_next_step(&hit.record.tool_slug, context);
         } else {
             value["next_step"] = call_next_step(&hit.record.tool_slug, context);
         }
     }
     value
+}
+
+pub(crate) fn capability_has_safety_hints(record: &CapabilityRecord) -> bool {
+    record.annotations.as_ref().is_some_and(|annotations| {
+        annotations.read_only_hint.is_some()
+            && annotations.destructive_hint.is_some()
+            && annotations.idempotent_hint.is_some()
+            && annotations.open_world_hint.is_some()
+    })
 }
 
 pub fn describe_next_step(slug: &str, context: Option<&SearchResponseContext>) -> Value {
@@ -353,32 +379,7 @@ fn search_meta(context: Option<&SearchResponseContext>) -> Option<Value> {
 /// The value is intentionally opaque. Clients can compare it for equality to
 /// detect that a cached `tool_slug` came from an older search view.
 pub fn index_generation(index: &CapabilityIndex) -> String {
-    index_snapshot_generation(&index.snapshot())
-}
-
-fn index_snapshot_generation(snapshot: &super::capability::IndexSnapshot) -> String {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut hasher = DefaultHasher::new();
-    let mut fingerprints: Vec<_> = snapshot.fingerprints.iter().collect();
-    fingerprints.sort_by_key(|(id, _)| id.to_string());
-    for (id, fp) in fingerprints {
-        id.hash(&mut hasher);
-        fp.0.hash(&mut hasher);
-    }
-    for record in snapshot.records.iter() {
-        record.tool_slug.hash(&mut hasher);
-        record.loaded.hash(&mut hasher);
-        record.has_schema.hash(&mut hasher);
-        record.tool_group.hash(&mut hasher);
-        for group in &record.available_groups {
-            group.name.hash(&mut hasher);
-            group.default_active.hash(&mut hasher);
-            group.active.hash(&mut hasher);
-        }
-    }
-    format!("{:016x}", hasher.finish())
+    index.generation()
 }
 
 /// Resolve `slug` to its record. Returns a structured error when the
@@ -742,19 +743,327 @@ pub fn parse_search_payload(payload: &Value) -> SearchQuery {
     query
 }
 
+/// Parse a search request before any backend discovery work and resolve the
+/// REST/MCP short instance-id form against the live registry.
+pub async fn parse_and_resolve_search_payload(
+    gs: &GatewayState,
+    payload: &Value,
+) -> Result<SearchQuery, ResolveInstanceError> {
+    let mut query = parse_search_payload(payload);
+    if query.instance_id.is_none()
+        && let Some(raw_instance_id) = payload
+            .get("instance_id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    {
+        let registry = gs.registry.read().await;
+        let entry =
+            gs.resolve_instance(&registry, Some(raw_instance_id), query.dcc_type.as_deref())?;
+        query.instance_id = Some(entry.instance_id);
+    }
+    Ok(query)
+}
+
+const SEARCH_REFRESH_WINDOW: Duration = Duration::from_secs(10);
+const CAPABILITY_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn refresh_instance_bounded(
+    gs: &GatewayState,
+    url: &str,
+    instance_id: Uuid,
+    dcc_type: &str,
+    reason: RefreshReason,
+) -> bool {
+    match tokio::time::timeout(
+        CAPABILITY_DISCOVERY_TIMEOUT,
+        refresh_instance(
+            &gs.capability_index,
+            &gs.http_client,
+            url,
+            instance_id,
+            dcc_type,
+            gs.backend_timeout.min(CAPABILITY_DISCOVERY_TIMEOUT),
+            reason,
+            Some(&gs.instance_diagnostics),
+        ),
+    )
+    .await
+    {
+        Ok(updated) => updated,
+        Err(_) => {
+            tracing::warn!(
+                instance = %instance_id,
+                dcc = dcc_type,
+                timeout_secs = CAPABILITY_DISCOVERY_TIMEOUT.as_secs(),
+                "capability discovery refresh timed out; preserving existing index"
+            );
+            false
+        }
+    }
+}
+
+/// Refresh only the backends that can contribute rows to `query`.
+///
+/// Missing snapshots are populated synchronously so a cold search remains
+/// correct. Existing snapshots are served immediately; when stale, their
+/// refresh runs in the background (stale-while-revalidate).
+pub async fn refresh_search_backends(gs: &GatewayState, query: &SearchQuery) {
+    let reg = gs.registry.read().await;
+    let reachable_instances: Vec<_> = gs
+        .live_instances(&reg)
+        .into_iter()
+        .filter(|entry| {
+            !matches!(
+                entry.status,
+                dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
+            )
+        })
+        .collect();
+    let live_ids: std::collections::HashSet<_> = reachable_instances
+        .iter()
+        .map(|entry| entry.instance_id)
+        .collect();
+    let instances: Vec<_> = reachable_instances
+        .into_iter()
+        .filter(|entry| search_query_matches_instance(query, entry))
+        .collect();
+    drop(reg);
+
+    remove_missing_capability_instances(gs, &live_ids).await;
+
+    if instances.is_empty() {
+        return;
+    }
+
+    let has_cold_instance = instances.iter().any(|entry| {
+        gs.capability_index
+            .fingerprint_for(entry.instance_id)
+            .is_none()
+            && !gs
+                .capability_index
+                .search_refresh_was_attempted(entry.instance_id)
+    });
+    if has_cold_instance {
+        refresh_search_instances(gs, instances, SearchRefreshMode::Cold).await;
+        return;
+    }
+
+    if instances.iter().any(|entry| {
+        !gs.capability_index
+            .search_refresh_is_recent(entry.instance_id, SEARCH_REFRESH_WINDOW)
+    }) {
+        let state = gs.clone();
+        tokio::spawn(async move {
+            refresh_search_instances(&state, instances, SearchRefreshMode::Stale).await;
+        });
+    }
+}
+
+#[derive(Clone, Copy)]
+enum SearchRefreshMode {
+    Cold,
+    Stale,
+}
+
+async fn refresh_search_instances(
+    gs: &GatewayState,
+    instances: Vec<ServiceEntry>,
+    mode: SearchRefreshMode,
+) {
+    let refreshes = instances.into_iter().map(|entry| {
+        let gate = gs.capability_index.refresh_gate(entry.instance_id);
+        async move {
+            let _refresh_guard = match mode {
+                SearchRefreshMode::Cold => gate.lock().await,
+                SearchRefreshMode::Stale => {
+                    let Ok(guard) = gate.try_lock() else {
+                        tracing::trace!(
+                            instance = %entry.instance_id,
+                            "capability index: skipped queued stale refresh"
+                        );
+                        return;
+                    };
+                    guard
+                }
+            };
+            let needs_refresh = match mode {
+                SearchRefreshMode::Cold => {
+                    gs.capability_index
+                        .fingerprint_for(entry.instance_id)
+                        .is_none()
+                        && !gs
+                            .capability_index
+                            .search_refresh_was_attempted(entry.instance_id)
+                }
+                SearchRefreshMode::Stale => !gs
+                    .capability_index
+                    .search_refresh_is_recent(entry.instance_id, SEARCH_REFRESH_WINDOW),
+            };
+            if !needs_refresh {
+                return;
+            }
+
+            let url = entry_discovery_mcp_url(&entry);
+            if !url.is_empty() {
+                refresh_instance_bounded(
+                    gs,
+                    &url,
+                    entry.instance_id,
+                    &entry.dcc_type,
+                    RefreshReason::Periodic,
+                )
+                .await;
+            }
+            // Failed fetches are deliberately throttled too; forced slug
+            // recovery still bypasses this search freshness window.
+            gs.capability_index
+                .mark_search_refresh_completed([entry.instance_id]);
+        }
+    });
+    futures::future::join_all(refreshes).await;
+}
+
+async fn remove_missing_capability_instances(
+    gs: &GatewayState,
+    live_ids: &std::collections::HashSet<Uuid>,
+) {
+    let stale_ids: Vec<_> = gs
+        .capability_index
+        .instance_ids()
+        .into_iter()
+        .filter(|instance_id| !live_ids.contains(instance_id))
+        .collect();
+    for instance_id in stale_ids {
+        let gate = gs.capability_index.refresh_gate(instance_id);
+        let _refresh_guard = gate.lock().await;
+        let reg = gs.registry.read().await;
+        let still_missing = !gs.live_instances(&reg).iter().any(|entry| {
+            entry.instance_id == instance_id
+                && !matches!(
+                    entry.status,
+                    dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
+                )
+        });
+        drop(reg);
+        if still_missing {
+            remove_instance(&gs.capability_index, instance_id);
+        }
+    }
+}
+
+fn search_query_matches_instance(query: &SearchQuery, entry: &ServiceEntry) -> bool {
+    if query
+        .instance_id
+        .is_some_and(|instance_id| instance_id != entry.instance_id)
+    {
+        return false;
+    }
+    let dcc_matches = query
+        .dcc_type
+        .as_deref()
+        .map(str::trim)
+        .filter(|dcc| !dcc.is_empty())
+        .is_some_and(|dcc| entry.dcc_type.eq_ignore_ascii_case(dcc))
+        || query
+            .dcc_types
+            .iter()
+            .map(|dcc| dcc.trim())
+            .filter(|dcc| !dcc.is_empty())
+            .any(|dcc| entry.dcc_type.eq_ignore_ascii_case(dcc));
+    let has_dcc_filter = query
+        .dcc_type
+        .as_deref()
+        .is_some_and(|dcc| !dcc.trim().is_empty())
+        || query.dcc_types.iter().any(|dcc| !dcc.trim().is_empty());
+    !has_dcc_filter || dcc_matches
+}
+
 /// Refresh the capability index for every currently-live backend.
 ///
 /// Called on-demand by the REST / MCP dynamic-capability entry
 /// points so the first agent query after startup (or after a skill
 /// load/unload) always sees fresh data without waiting for the
-/// periodic watcher. Each backend's slice is short-circuited on an
-/// unchanged fingerprint, so the extra `tools/list` round-trips are
-/// free in the steady state.
+/// periodic watcher. Periodic callers with the same live instance set share a
+/// recent snapshot, avoiding repeated full-catalog network requests during one
+/// discovery workflow. Lifecycle-triggered refreshes always bypass that window.
 ///
 /// Evicts records owned by instances that have disappeared from the
 /// live registry — this is how `instance-offline` errors stay rare
 /// after a backend crashes.
 pub async fn refresh_all_live_backends(gs: &GatewayState, reason: RefreshReason) {
+    refresh_all_live_backends_inner(gs, reason, true).await;
+}
+
+/// Refresh every live backend without reusing a recent periodic checkpoint.
+///
+/// Unknown-slug recovery uses this path because the missing capability may
+/// have appeared after the last otherwise-fresh snapshot.
+pub async fn refresh_all_live_backends_now(gs: &GatewayState, reason: RefreshReason) {
+    refresh_all_live_backends_inner(gs, reason, false).await;
+}
+
+/// Refresh discovery before describing a slug that is absent from the index.
+///
+/// A well-formed slug carries its owning DCC and instance prefix, so refresh
+/// only that backend. Malformed, stale, or ambiguous ownership falls back to a
+/// full refresh because no narrower route is trustworthy.
+pub async fn refresh_for_describe(gs: &GatewayState, slug: &str) {
+    if describe_service(&gs.capability_index, slug).is_ok() {
+        return;
+    }
+
+    let owner = if let Some((dcc_type, instance_hint, _)) = parse_slug(slug) {
+        let registry = gs.registry.read().await;
+        gs.resolve_instance(&registry, Some(instance_hint), Some(dcc_type))
+            .ok()
+    } else {
+        None
+    };
+
+    if let Some(entry) = owner {
+        refresh_live_backend_now(gs, &entry, RefreshReason::Periodic).await;
+    } else {
+        refresh_all_live_backends_now(gs, RefreshReason::Periodic).await;
+    }
+}
+
+/// Refresh one backend after a known capability mutation.
+///
+/// This shares the full-refresh lock so an older periodic snapshot cannot
+/// overwrite the just-mutated instance.
+pub async fn refresh_live_backend_now(
+    gs: &GatewayState,
+    entry: &ServiceEntry,
+    reason: RefreshReason,
+) {
+    let gate = gs.capability_index.refresh_gate(entry.instance_id);
+    let _refresh_guard = gate.lock().await;
+    refresh_live_backend_locked(gs, entry, reason).await;
+}
+
+/// Refresh one backend while the caller holds its per-instance refresh gate.
+///
+/// Skill lifecycle mutations use this helper so the backend call, optimistic
+/// index update, and authoritative refresh form one serialized transaction.
+pub(crate) async fn refresh_live_backend_locked(
+    gs: &GatewayState,
+    entry: &ServiceEntry,
+    reason: RefreshReason,
+) {
+    let url = entry_discovery_mcp_url(entry);
+    if !url.is_empty() {
+        refresh_instance_bounded(gs, &url, entry.instance_id, &entry.dcc_type, reason).await;
+        gs.capability_index
+            .mark_search_refresh_completed([entry.instance_id]);
+    }
+}
+
+async fn refresh_all_live_backends_inner(
+    gs: &GatewayState,
+    reason: RefreshReason,
+    reuse_recent_periodic: bool,
+) {
     let reg = gs.registry.read().await;
     let instances: Vec<_> = gs
         .live_instances(&reg)
@@ -768,38 +1077,49 @@ pub async fn refresh_all_live_backends(gs: &GatewayState, reason: RefreshReason)
         .collect();
     drop(reg);
 
+    let mut instance_ids: Vec<_> = instances.iter().map(|entry| entry.instance_id).collect();
+    instance_ids.sort_unstable();
+    let mut checkpoint = gs.capability_index.refresh_checkpoint.lock().await;
+    const REFRESH_COALESCE_WINDOW: Duration = Duration::from_secs(10);
+    if reuse_recent_periodic
+        && reason == RefreshReason::Periodic
+        && checkpoint
+            .as_ref()
+            .is_some_and(|(completed_at, refreshed_ids)| {
+                refreshed_ids == &instance_ids && completed_at.elapsed() < REFRESH_COALESCE_WINDOW
+            })
+    {
+        tracing::trace!(
+            instances = instance_ids.len(),
+            "capability index: reused recent refresh"
+        );
+        return;
+    }
+
     // Remove records owned by instances that left between refreshes.
     let current: std::collections::HashSet<uuid::Uuid> =
         instances.iter().map(|e| e.instance_id).collect();
-    let snap = gs.capability_index.snapshot();
-    for iid in snap.fingerprints.keys() {
-        if !current.contains(iid) {
-            remove_instance(&gs.capability_index, *iid);
-        }
-    }
+    remove_missing_capability_instances(gs, &current).await;
 
     // Refresh every live instance in parallel. Errors are logged and
     // swallowed — a single flaky backend must not break the others.
     let refreshes = instances.iter().map(|entry| {
+        let gate = gs.capability_index.refresh_gate(entry.instance_id);
         let url = entry_discovery_mcp_url(entry);
         async move {
+            let _refresh_guard = gate.lock().await;
             if url.is_empty() {
                 return;
             }
-            refresh_instance(
-                &gs.capability_index,
-                &gs.http_client,
-                &url,
-                entry.instance_id,
-                &entry.dcc_type,
-                gs.backend_timeout,
-                reason,
-                Some(&gs.instance_diagnostics),
-            )
-            .await;
+            refresh_instance_bounded(gs, &url, entry.instance_id, &entry.dcc_type, reason).await;
         }
     });
     futures::future::join_all(refreshes).await;
+    gs.capability_index
+        .mark_search_refresh_completed(instance_ids.iter().copied());
+    // This is also a short retry throttle after failures; forced recovery
+    // paths bypass it when a concrete slug is missing.
+    *checkpoint = Some((Instant::now(), instance_ids));
 }
 
 /// Convert a [`ServiceError`] into the gateway's existing
@@ -1498,7 +1818,7 @@ mod unit_tests {
     }
 
     #[test]
-    fn progressive_group_inactive_generates_activate_next_step() {
+    fn progressive_group_inactive_generates_public_load_next_step() {
         let rec = make_group_record(
             "maya.abcdef01.create_sphere",
             Some("maya-modeling"),
@@ -1518,19 +1838,32 @@ mod unit_tests {
             score: 10,
             match_reasons: vec![],
         };
-        let row = search_hit_to_value(hit);
+        let context = SearchResponseContext::new("search-1".into(), "generation-1".into());
+        let row = search_hit_to_value_with_context(hit, Some(&context));
 
         assert_eq!(row["callable"], false);
         assert_eq!(row["load_state"], "loaded");
         assert_eq!(row["disabled_by_group"], "modeling");
-        assert_eq!(row["next_step"]["action"], "activate_tool_group");
+        assert_eq!(row["next_step"]["action"], "load_skill");
         assert_eq!(row["next_step"]["arguments"]["skill_name"], "maya-modeling");
         assert_eq!(row["next_step"]["arguments"]["tool_group"], "modeling");
-        assert_eq!(row["next_step"]["mcp"]["tool"], "activate_tool_group");
-        assert_eq!(row["next_step"]["mcp"]["arguments"]["group"], "modeling");
-        // REST block must NOT be present for activate_tool_group
-        // (gateway meta-tool, not a capability-indexed action).
-        assert!(row["next_step"].get("rest").is_none());
+        assert_eq!(row["next_step"]["arguments"]["group_action"], "activate");
+        assert_eq!(
+            row["next_step"]["arguments"]["target_tool_slug"],
+            "maya.abcdef01.create_sphere"
+        );
+        assert_eq!(row["next_step"]["mcp"]["tool"], "load_skill");
+        assert_eq!(row["next_step"]["mcp"]["_meta"]["search_id"], "search-1");
+        assert_eq!(
+            row["next_step"]["mcp"]["arguments"],
+            row["next_step"]["arguments"]
+        );
+        assert_eq!(row["next_step"]["rest"]["method"], "POST");
+        assert_eq!(row["next_step"]["rest"]["path"], "/v1/load_skill");
+        assert_eq!(
+            row["next_step"]["rest"]["body"],
+            row["next_step"]["arguments"]
+        );
     }
 
     #[test]
@@ -1665,6 +1998,16 @@ mod unit_tests {
             true,
             None, // no group
             vec![],
+        )
+        .with_surface_metadata(
+            Some(crate::gateway::capability::CapabilityAnnotations {
+                title: None,
+                read_only_hint: Some(false),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(false),
+                open_world_hint: Some(false),
+            }),
+            None,
         );
         let hit = SearchHit {
             record: rec,
@@ -1681,6 +2024,35 @@ mod unit_tests {
         assert_eq!(row["next_step"]["arguments"]["arguments"], json!({}));
         assert_eq!(row["next_step"]["rest"]["path"], "/v1/call");
         assert_eq!(row["next_step"]["mcp"]["tool"], "call");
+    }
+
+    #[test]
+    fn loaded_no_arg_tool_without_complete_safety_hints_requires_describe() {
+        let rec = make_group_record(
+            "maya.abcdef01.reset_scene",
+            Some("maya-scene"),
+            true,
+            None,
+            vec![],
+        )
+        .with_surface_metadata(
+            Some(crate::gateway::capability::CapabilityAnnotations {
+                title: None,
+                read_only_hint: Some(false),
+                destructive_hint: None,
+                idempotent_hint: None,
+                open_world_hint: None,
+            }),
+            None,
+        );
+        let row = search_hit_to_value(SearchHit {
+            record: rec,
+            rank: 1,
+            score: 10,
+            match_reasons: vec![],
+        });
+
+        assert_eq!(row["next_step"]["action"], "describe");
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -447,7 +447,7 @@ async fn handle_initialize(
                  1. Optional: resources/read uri=gateway://instances to inspect live DCCs\n\
                  1b. Optional: resources/read uri=gateway://docs/agent-workflows (MCP+REST patterns, path /v1/dcc/.../call, re-list instances after DCC restart)\n\
                  2. search(kind=\"skill\", ...) then load_skill(skill_name=..., instance_id=... when needed)\n\
-                 3. search(kind=\"tool\", ...) -> describe(tool_slug=...) -> call(tool_slug=..., arguments={...}); never put code/python/mel at the call top level\n\
+                 3. Run one narrow search(kind=\"tool\", ...), then follow the selected hit's next_step. Describe only when requested; schema-free hits can call directly, and correlated load may return compact_schema plus next_step=call. Never put code/python/mel at the call top level\n\
                  4. Optional: call({calls:[{tool_slug, arguments}, ...], stop_on_error?}) for ordered batches (max 25)\n\
                  5. Compact-capable clients should request compact TOON payloads on high-token calls with params._meta.response_format=\"toon\" or params._meta.compact=true; use params._meta.response_format=\"json\" to opt out. JSON-RPC jsonrpc/id/result/error stay JSON.\n\
                  \n\

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -11,8 +11,8 @@ use crate::gateway::capability::search_cache::SearchCacheKey;
 use crate::gateway::capability::{RefreshReason, tool_slug};
 use crate::gateway::capability_service::{
     SearchResponseContext, ServiceError, describe_tool_full, index_generation,
-    parse_search_payload, refresh_all_live_backends, search_hit_to_value_with_context,
-    search_service_hits_for_policy, service_error_to_json,
+    parse_and_resolve_search_payload, refresh_all_live_backends, refresh_search_backends,
+    search_hit_to_value_with_context, search_snapshot_hits_for_policy, service_error_to_json,
 };
 use crate::gateway::response_codec::{compact_call_batch_payload, compact_describe_payload};
 use crate::gateway::search_telemetry::{SearchTelemetryInput, search_id_from_payload};
@@ -546,28 +546,11 @@ pub async fn handle_v1_search(
         Some(&body),
         body.get("meta").or_else(|| body.get("_meta")),
     );
-    // Refresh-on-demand so the first call after startup or a skill
-    // load sees fresh capabilities without waiting for a watcher tick.
-    refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
-    let mut query = parse_search_payload(&body);
-    if query.instance_id.is_none()
-        && let Some(raw_instance_id) = body
-            .get("instance_id")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-    {
-        let registry = gs.registry.read().await;
-        match gs.resolve_instance(&registry, Some(raw_instance_id), query.dcc_type.as_deref()) {
-            Ok(entry) => {
-                query.instance_id = Some(entry.instance_id);
-            }
-            Err(err) => {
-                drop(registry);
-                return resolve_instance_negotiated_response(&headers, &body, err);
-            }
-        }
-    }
+    let query = match parse_and_resolve_search_payload(&gs, &body).await {
+        Ok(query) => query,
+        Err(err) => return resolve_instance_negotiated_response(&headers, &body, err),
+    };
+    refresh_search_backends(&gs, &query).await;
 
     // Shared helper: hybrid→fuzzy downgrade + semantic diagnostic.
     // MCP and REST must produce byte-identical search responses for
@@ -580,43 +563,40 @@ pub async fn handle_v1_search(
 
     // --- LRU cache check (PIP-2471) ---
     let cache_key = SearchCacheKey::from_query(&query);
-    let index_gen = index_generation(&gs.capability_index);
-    if let Some(cached_body) = gs
+    let index_gen = gs.capability_index.generation();
+    let cached_hits = gs
         .search_cache
         .get_with_index_gen(&cache_key, Some(&index_gen))
-    {
-        let hits: Vec<Value> = serde_json::from_slice(&cached_body).unwrap_or_else(|e| {
-            tracing::warn!(?e, "search cache entry corrupt, falling back to recompute");
-            Vec::new()
+        .and_then(|cached_body| {
+            let hits = serde_json::from_slice(&cached_body).unwrap_or_else(|e| {
+                tracing::warn!(?e, "search cache entry corrupt, falling back to recompute");
+                Vec::new()
+            });
+            (!hits.is_empty()).then_some(hits)
         });
-        if hits.is_empty() {
-            // Cache miss due to corruption — fall through to recompute.
-        } else {
-            let index_generation = index_generation(&gs.capability_index);
-            let search_context = SearchResponseContext::new(
-                crate::gateway::search_telemetry::SearchTelemetryStore::new_search_id(),
-                index_generation,
-            );
-            let metadata = RestResponseMetadata::from_trace_context(&trace_context)
-                .with_index_generation(search_context.index_generation.clone())
-                .with_search(
-                    search_context.search_id.clone(),
-                    search_context.ranker_version.to_string(),
-                )
-                .with_search_cache_hit(true);
-            return search_response_with_metadata(&headers, &body, hits, &metadata, Some(semantic));
-        }
-    }
     // --- end cache check ---
 
-    let index_generation = index_generation(&gs.capability_index);
+    let (hits, index_generation, search_cache_hit) = match cached_hits {
+        Some(hits) => (hits, index_gen, true),
+        None => {
+            let (snapshot, generation) = gs.capability_index.snapshot_with_generation();
+            let hits = search_snapshot_hits_for_policy(&snapshot, &query, &gs.policy);
+            (hits, generation, false)
+        }
+    };
     let search_context = SearchResponseContext::new(
         crate::gateway::search_telemetry::SearchTelemetryStore::new_search_id(),
         index_generation,
     );
-    let hits = search_service_hits_for_policy(&gs.capability_index, &query, &gs.policy);
     let telemetry_hits = search_hits_for_telemetry(&hits);
     let total = hits.len();
+    if !search_cache_hit && let Ok(body_bytes) = serde_json::to_vec(&hits) {
+        gs.search_cache.put(
+            cache_key,
+            body_bytes,
+            search_context.index_generation.clone(),
+        );
+    }
     let hits: Vec<Value> = hits
         .into_iter()
         .map(|hit| search_hit_to_value_with_context(hit, Some(&search_context)))
@@ -667,15 +647,11 @@ pub async fn handle_v1_search(
             search_context.search_id.clone(),
             search_context.ranker_version.to_string(),
         );
-    // --- LRU cache store (PIP-2471) ---
-    if let Ok(body_bytes) = serde_json::to_vec(&hits) {
-        gs.search_cache.put(
-            cache_key,
-            body_bytes,
-            search_context.index_generation.clone(),
-        );
-    }
-    // --- end cache store ---
+    let metadata = if search_cache_hit {
+        metadata.with_search_cache_hit(true)
+    } else {
+        metadata
+    };
 
     search_response_with_metadata(&headers, &body, hits, &metadata, Some(semantic))
 }
@@ -713,7 +689,11 @@ async fn skill_lifecycle_response(
     );
     let search_id = search_id_from_payload(&body);
     let skill_name = skill_name_from_payload(&body);
-    let (text, is_error) = crate::gateway::aggregator::skill_mgmt_dispatch(gs, tool, &body).await;
+    let (text, is_error) = if tool == "load_skill" {
+        crate::gateway::tools::tool_load_skill(gs, &body).await
+    } else {
+        crate::gateway::aggregator::skill_mgmt_dispatch(gs, tool, &body).await
+    };
     if tool == "load_skill" {
         record_search_followup(
             gs,
@@ -846,7 +826,13 @@ pub async fn handle_v1_describe(
             true,
         );
     };
-    refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
+    refresh_before_describe(
+        &gs,
+        slug,
+        &body,
+        body.get("meta").or_else(|| body.get("_meta")),
+    )
+    .await;
     let metadata = RestResponseMetadata::from_trace_context(&trace_context)
         .with_index_generation(index_generation(&gs.capability_index));
 
@@ -870,8 +856,8 @@ pub async fn handle_v1_describe_path(
 ) -> Response {
     let trace_context = TraceContext::from_headers(&headers);
     let agent_context = AgentContext::from_request_parts_with_server_network(&headers, None, None);
-    refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
     let body = json!({});
+    refresh_before_describe(&gs, &slug, &body, None).await;
     let metadata = RestResponseMetadata::from_trace_context(&trace_context)
         .with_index_generation(index_generation(&gs.capability_index));
     describe_slug_response(
@@ -884,6 +870,17 @@ pub async fn handle_v1_describe_path(
         agent_context.as_ref(),
     )
     .await
+}
+
+async fn refresh_before_describe(
+    gs: &GatewayState,
+    slug: &str,
+    args: &Value,
+    meta: Option<&Value>,
+) {
+    if crate::gateway::tools::describe_needs_refresh(gs, slug, args, meta) {
+        crate::gateway::capability_service::refresh_for_describe(gs, slug).await;
+    }
 }
 
 async fn describe_slug_response(
@@ -1024,7 +1021,6 @@ pub async fn handle_v1_dcc_instance_describe(
         );
     }
 
-    refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
     let metadata = RestResponseMetadata::from_trace_context(&trace_context)
         .with_index_generation(index_generation(&gs.capability_index));
 
@@ -1056,6 +1052,9 @@ pub async fn handle_v1_dcc_instance_describe(
     }
 
     let slug = tool_slug(&entry.dcc_type, &entry.instance_id, backend_tool);
+    refresh_before_describe(&gs, &slug, &body, None).await;
+    let metadata = RestResponseMetadata::from_trace_context(&trace_context)
+        .with_index_generation(index_generation(&gs.capability_index));
     describe_slug_response(
         &gs,
         &headers,

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_batch_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_batch_tests.rs
@@ -1,6 +1,7 @@
 use serde_json::{Value, json};
+use tower::ServiceExt;
 
-use super::rest_impl_tests::test_gateway_state;
+use super::rest_impl_tests::{response_json, test_gateway_state};
 
 /// Spawn a fake backend that responds to /v1/describe and /v1/call.
 async fn spawn_echo_backend() -> (u16, tokio::sync::oneshot::Sender<()>) {
@@ -135,6 +136,75 @@ async fn gateway_rest_v1_call_batch_refreshes_a_cold_live_instance_index() {
 
     let _ = shutdown_tx.send(());
     let _ = server.await;
+    let _ = stop_backend.send(());
+}
+
+#[tokio::test]
+async fn gateway_rest_forces_refresh_when_a_live_slug_is_missing_from_a_fresh_index() {
+    let (backend_port, stop_backend) = spawn_echo_backend().await;
+    let dir = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
+        dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+    ));
+    let instance_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+    {
+        let r = registry.read().await;
+        let mut entry = dcc_mcp_transport::discovery::types::ServiceEntry::new(
+            "maya",
+            "127.0.0.1",
+            backend_port,
+        );
+        entry.instance_id = instance_id;
+        r.register(entry).unwrap();
+    }
+
+    let mut gs = test_gateway_state("1.2.3");
+    gs.registry = registry;
+    crate::gateway::capability_service::refresh_all_live_backends(
+        &gs,
+        crate::gateway::capability::RefreshReason::Periodic,
+    )
+    .await;
+    let index = gs.capability_index.clone();
+    assert!(index.remove_instance(instance_id));
+
+    let app = crate::gateway::router::build_gateway_router(gs);
+    let slug = format!("maya.{instance_id}.echo");
+    let call = app
+        .clone()
+        .oneshot(
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/v1/call")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(
+                    json!({"tool_slug": slug, "arguments": {}}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, body) = response_json(call).await;
+    assert!(status.is_success(), "{body:#}");
+    assert_eq!(body["isError"], false, "{body:#}");
+
+    assert!(index.remove_instance(instance_id));
+    let describe = app
+        .oneshot(
+            axum::http::Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/v1/dcc/maya/instances/{instance_id}/describe?backend_tool=echo"
+                ))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, body) = response_json(describe).await;
+    assert!(status.is_success(), "{body:#}");
+    assert_eq!(body["record"]["backend_tool"], "echo", "{body:#}");
+
     let _ = stop_backend.send(());
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_trace.rs
@@ -7,7 +7,7 @@ use crate::gateway::admin::trace::{
 use crate::gateway::agent_telemetry::{AgentWorkflowEvent, policy_reason_from_value};
 use crate::gateway::capability::{RefreshReason, parse_slug};
 use crate::gateway::capability_service::{
-    ServiceError, call_service, refresh_all_live_backends, service_error_to_json,
+    ServiceError, call_service, refresh_all_live_backends_now, service_error_to_json,
 };
 use crate::gateway::middleware::{CallContext, CallResult};
 use crate::gateway::response_codec::compact_call_batch_payload;
@@ -164,8 +164,8 @@ pub(super) async fn call_service_with_admin_trace(
         ctx.agent_context.as_ref(),
     )
     .await;
-    if matches!(&result, Err(err) if err.kind == "unknown-slug") {
-        refresh_all_live_backends(gs, RefreshReason::Periodic).await;
+    if matches!(&result, Err(err) if crate::gateway::tools::call_error_needs_refresh(err)) {
+        refresh_all_live_backends_now(gs, RefreshReason::Periodic).await;
         result = call_service(
             gs,
             slug,

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
@@ -9,7 +9,7 @@
 ## Use MCP the way the gateway expects
 
 1. **`tools/list`** — Small, stable set: exactly **`search`**, **`describe`**, **`load_skill`**, and **`call`**. Treat it as an **index of gateway verbs**, not the full catalog of every backend action.
-2. **Discover backend work** — `search(kind="tool")` returns compact hits with an executable `next_step`. Follow it: hits with `has_schema=false` can go straight to **`call`** with `{}` arguments; hits with schema still use **`describe`** (read schema, descriptions, safety hints, **`affinity`**, **`execution`**, timeouts) before **`call`**. On REST, use `/v1/search`, `/v1/describe`, `/v1/call` (or the path-style `POST /v1/dcc/{dcc}/instances/{id}/call` from **REST clients** below). Skipping `describe` for schema-bearing tools wastes retries and breaks validation. Preserve the returned `next_step.arguments.meta.search_id` (or the same object as MCP `_meta`) on `describe`, `load_skill`, and `call`; this lets the gateway measure selected rank and hit rate without storing full prompts.
+2. **Discover backend work** — `search(kind="tool")` returns compact hits with an executable `next_step`. Follow it: no-schema hits go straight to **`call`** with `{}` only when compact safety hints are already present; otherwise use **`describe`** to read schema, safety hints, **`affinity`**, **`execution`**, and timeouts before **`call`**. On REST, use `/v1/search`, `/v1/describe`, `/v1/call` (or the path-style `POST /v1/dcc/{dcc}/instances/{id}/call` from **REST clients** below). Preserve the returned `next_step.arguments.meta.search_id` (or the same object as MCP `_meta`) on `describe`, `load_skill`, and `call`; this lets the gateway measure selected rank and hit rate without storing full prompts.
 3. **Chaining** — **`call({calls:[...]})`** / **`POST /v1/call_batch`** runs up to **25** ordered calls when you have several **different** validated steps. Prefer fewer, well-formed calls over chatty micro-steps.
 4. **Skills vs tools** — `search(kind="skill")` / `load_skill` load packaged workflows on a host; `search(kind="tool")` resolves a **`tool_slug`** for the dynamic surface. Keep names straight; use `describe` before calling an unfamiliar schema-bearing slug. Unloaded hits carry `load_state`, `available_groups` when known, and `next_step` with both MCP and REST call shapes.
 5. **Progressive groups** — gateway `load_skill` activates declared groups by default (`activate_groups=true` when omitted). Pass `activate_groups=false` for lazy loading, or `load_skill(..., tool_group="...")` when you only want one group.
@@ -284,7 +284,7 @@ links without exposing hidden reasoning or raw prompts.
 
 ## Efficiency (without a separate “bulk” playbook)
 
-- One **`describe`** per new schema-bearing slug; cache the schema mentally for the rest of the task. If `search` says `has_schema=false`, use the returned `call` next_step directly.
+- One **`describe`** per returned describe step; cache the schema mentally for the rest of the task. A no-schema hit calls directly only when search already surfaced its safety hints.
 - After a correlated `load_skill`, prefer the returned `compact_schema` when present instead of immediately calling `describe` again.
 - One **`search(kind="tool")`** with a tight `query` and correct **`dcc_type`** / **`instance_id`** when the user names a host or you see multiple live rows in `gateway://instances`.
 - Prefer **structured arguments** (paths, flags, IDs) in a single **`call`** when the schema supports it, instead of many tiny speculative calls.

--- a/crates/dcc-mcp-gateway/src/gateway/rest_openapi.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/rest_openapi.rs
@@ -234,10 +234,10 @@ pub(crate) fn build_gateway_openapi_document(server_version: &str) -> Value {
         post_operation_with_params(
             &["skills"],
             "Load a backend skill",
-            "Loads a skill on a selected backend instance. Gateway load_skill defaults to lazy group activation.",
+            "Loads a skill on a selected backend instance. Pass tool_group to activate only that group; otherwise declared groups remain enabled by default.",
             vec![accept_response_format_header()],
             request_body_ref("LoadSkillRequest"),
-            gateway_response_ref("SkillLifecycleResponse"),
+            gateway_response_ref("GatewayLoadSkillResponse"),
         ),
     );
     paths.insert(
@@ -501,6 +501,80 @@ fn annotate_response_format_controls(schemas: &mut Map<String, Value>) {
 
 fn gateway_schemas() -> Vec<(&'static str, Value)> {
     vec![
+        (
+            "LoadSkillRequest",
+            json!({
+                "type": "object",
+                "anyOf": [
+                    {"required": ["skill_name"]},
+                    {"required": ["skill_names"]},
+                    {"required": ["tool_group"]},
+                    {"required": ["group_name"]}
+                ],
+                "properties": {
+                    "skill_name": {"type": "string"},
+                    "skill_names": {"type": "array", "items": {"type": "string"}},
+                    "activate_groups": {"type": "boolean", "default": true},
+                    "tool_group": {"type": "string", "description": "Activate only this progressive group while loading the target skill."},
+                    "group_name": {"type": "string", "description": "Alias of tool_group."},
+                    "group_action": {"type": "string", "enum": ["activate", "deactivate"], "default": "activate"},
+                    "instance_id": {"type": "string", "description": "Target instance UUID or unique prefix."},
+                    "dcc": {"type": "string", "description": "DCC type filter."},
+                    "dcc_type": {"type": "string", "description": "Alias of dcc."},
+                    "target_tool_slug": {"type": "string", "description": "Correlated search hit used to inline compact_schema."},
+                    "meta": {"type": "object", "additionalProperties": true}
+                },
+                "additionalProperties": false,
+            }),
+        ),
+        (
+            "GatewayLoadSkillResponse",
+            json!({
+                "oneOf": [
+                    {"$ref": "#/components/schemas/GatewaySkillLoadResponse"},
+                    {"$ref": "#/components/schemas/GatewayGroupActionResponse"}
+                ]
+            }),
+        ),
+        (
+            "GatewaySkillLoadResponse",
+            json!({
+                "type": "object",
+                "required": ["loaded", "dcc_type", "instance_id", "instance_short", "new_tool_slugs", "next_step"],
+                "properties": {
+                    "loaded": {"type": "boolean"},
+                    "skill_name": {"type": "string"},
+                    "dcc_type": {"type": "string"},
+                    "instance_id": {"type": "string", "format": "uuid"},
+                    "instance_short": {"type": "string"},
+                    "activated_groups": {"type": "array", "items": {"type": "string"}},
+                    "new_tool_slugs": {"type": "array", "items": {"type": "string"}},
+                    "compact_schema": {
+                        "type": "object",
+                        "description": "Bounded target schema plus safety and execution hints for a correlated load.",
+                        "additionalProperties": true
+                    },
+                    "next_step": {"$ref": "#/components/schemas/ProgressiveNextStep"},
+                    "index_generation": {"type": "string"}
+                },
+                "additionalProperties": true,
+            }),
+        ),
+        (
+            "GatewayGroupActionResponse",
+            json!({
+                "type": "object",
+                "required": ["success", "group", "changed", "active_groups"],
+                "properties": {
+                    "success": {"type": "boolean"},
+                    "group": {"type": "string"},
+                    "changed": {"type": "integer", "minimum": 0},
+                    "active_groups": {"type": "array", "items": {"type": "string"}},
+                    "index_generation": {"type": "string"}
+                },
+                "additionalProperties": true,
+            }),
+        ),
         (
             "GatewayHealth",
             json!({
@@ -1226,6 +1300,9 @@ mod tests {
             "SearchRequest",
             "SearchResponse",
             "LoadSkillRequest",
+            "GatewayLoadSkillResponse",
+            "GatewaySkillLoadResponse",
+            "GatewayGroupActionResponse",
             "UnloadSkillRequest",
             "SkillLifecycleResponse",
             "DescribeRequest",
@@ -1242,6 +1319,79 @@ mod tests {
                 "gateway OpenAPI schema set missing {schema}"
             );
         }
+    }
+
+    #[test]
+    fn gateway_openapi_documents_correlated_targeted_skill_load() {
+        let doc = build_gateway_openapi_document("1.2.3");
+        let schema = &doc["components"]["schemas"]["LoadSkillRequest"];
+
+        for property in [
+            "skill_name",
+            "skill_names",
+            "activate_groups",
+            "tool_group",
+            "group_name",
+            "group_action",
+            "instance_id",
+            "dcc_type",
+            "target_tool_slug",
+            "meta",
+        ] {
+            assert!(
+                schema["properties"].get(property).is_some(),
+                "missing LoadSkillRequest.{property}"
+            );
+        }
+        assert_eq!(schema["additionalProperties"], false);
+        assert!(schema["anyOf"].as_array().is_some_and(|choices| {
+            choices
+                .iter()
+                .any(|choice| choice["required"] == json!(["skill_names"]))
+        }));
+
+        let response = &doc["components"]["schemas"]["GatewaySkillLoadResponse"];
+        for property in [
+            "activated_groups",
+            "new_tool_slugs",
+            "compact_schema",
+            "next_step",
+            "instance_id",
+        ] {
+            assert!(
+                response["properties"].get(property).is_some(),
+                "missing GatewaySkillLoadResponse.{property}"
+            );
+        }
+        assert_eq!(
+            doc["components"]["schemas"]["GatewayLoadSkillResponse"]["oneOf"],
+            json!([
+                {"$ref": "#/components/schemas/GatewaySkillLoadResponse"},
+                {"$ref": "#/components/schemas/GatewayGroupActionResponse"}
+            ])
+        );
+        let group_response = &doc["components"]["schemas"]["GatewayGroupActionResponse"];
+        assert_eq!(
+            group_response["required"],
+            json!(["success", "group", "changed", "active_groups"])
+        );
+        for property in [
+            "success",
+            "group",
+            "changed",
+            "active_groups",
+            "index_generation",
+        ] {
+            assert!(
+                group_response["properties"].get(property).is_some(),
+                "missing GatewayGroupActionResponse.{property}"
+            );
+        }
+        assert_eq!(
+            doc["paths"]["/v1/load_skill"]["post"]["responses"]["200"]["content"]["application/json"]
+                ["schema"]["$ref"],
+            "#/components/schemas/GatewayLoadSkillResponse"
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -10,8 +10,7 @@ pub(crate) use probe::self_probe_listener;
 
 /// Outcome of [`start_gateway_tasks`] for the ambient (shared-runtime) path.
 pub(crate) struct GatewayTasks {
-    /// AbortHandle for the combined supervisor task (cleanup + watcher +
-    /// tools watcher + serve).
+    /// AbortHandle for the combined supervisor task (cleanup + watchers + serve).
     pub(crate) abort: AbortHandle,
     /// JoinHandle for the combined supervisor task. Retained by
     /// `GatewayHandle` so the task is not silently detached — this is the
@@ -384,14 +383,14 @@ pub(crate) async fn start_gateway_tasks(
     let yield_tx = Arc::new(yield_tx);
 
     // ── SSE broadcast channel ──────────────────────────────────────────────
-    // All MCP notifications (resources/list_changed, tools/list_changed) are
-    // sent here. Capacity 128 is generous; watchers fire at most every 2-3 s.
+    // All MCP list-change notifications are sent here. Capacity 128 is
+    // generous; watchers fire at most every 2-3 s.
     let (events_tx, _) = broadcast::channel::<String>(128);
     let events_tx = Arc::new(events_tx);
 
     // ── Shared HTTP client for backend fan-out (JSON-RPC calls) ───────────
-    // Reused by both the tools-list watcher task and the facade /mcp handler
-    // via GatewayState so connection pooling is shared across all consumers.
+    // Reused by watcher tasks and the facade /mcp handler via GatewayState so
+    // connection pooling is shared across all consumers.
     // A 30-second timeout is appropriate for regular request/response calls.
     let http_client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(5))
@@ -605,63 +604,6 @@ pub(crate) async fn start_gateway_tasks(
                     }))
                     .unwrap_or_default();
                     let _ = events_tx_watch.send(notif);
-                }
-                last_fingerprint = fingerprint;
-            }
-        }
-    });
-
-    // ── Aggregated tools/list_changed watcher (every 3 s) ─────────────────
-    // Polls every live backend's `tools/list`, computes a set-fingerprint of
-    // "{instance_id}:{tool_name}" tuples, and broadcasts one
-    // `notifications/tools/list_changed` to gateway SSE subscribers when the
-    // aggregated set changes (skill loaded / unloaded on any DCC).
-    //
-    // Polling (vs. real SSE subscription to each backend) keeps the gateway
-    // decoupled from backend session lifecycles and works uniformly even when
-    // instances come and go. 3-second granularity is well within the latency
-    // budget for interactive skill loading.
-    let reg_tools = registry.clone();
-    let events_tx_tools = events_tx.clone();
-    let http_client_tools = http_client.clone();
-    let tools_own_host = own_host.clone();
-    let tools_own_port = own_port;
-    let tools_watcher_handle = tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(3));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        let mut last_fingerprint = String::new();
-
-        loop {
-            interval.tick().await;
-            // Always compute the fingerprint so a subscriber that connects after
-            // startup does not inherit a stale empty baseline. Only the broadcast
-            // itself is gated on receivers below.
-            let fingerprint = aggregator::compute_tools_fingerprint_with_own(
-                &reg_tools,
-                stale_timeout,
-                &http_client_tools,
-                backend_timeout,
-                Some(tools_own_host.as_str()),
-                tools_own_port,
-            )
-            .await;
-
-            if fingerprint != last_fingerprint {
-                // First tick always "changes" from empty-string → don't push
-                // on initial startup unless there are actually tools.
-                if (!last_fingerprint.is_empty() || !fingerprint.is_empty())
-                    && events_tx_tools.receiver_count() > 0
-                {
-                    tracing::debug!(
-                        "Gateway: aggregated tool set changed — broadcasting tools/list_changed"
-                    );
-                    let notif = serde_json::to_string(&serde_json::json!({
-                        "jsonrpc": "2.0",
-                        "method": "notifications/tools/list_changed",
-                        "params": {}
-                    }))
-                    .unwrap_or_default();
-                    let _ = events_tx_tools.send(notif);
                 }
                 last_fingerprint = fingerprint;
             }
@@ -1193,7 +1135,6 @@ pub(crate) async fn start_gateway_tasks(
     let mut task_handles = vec![
         cleanup_handle,
         watcher_handle,
-        tools_watcher_handle,
         prompts_watcher_handle,
         resources_watcher_handle,
         backend_sub_handle,

--- a/crates/dcc-mcp-gateway/src/gateway/tools/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools/mod.rs
@@ -185,13 +185,15 @@ pub async fn tool_load_skill(gs: &GatewayState, args: &Value) -> (String, bool) 
     let tool_group = args
         .get("tool_group")
         .or_else(|| args.get("group_name"))
-        .cloned();
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|group| !group.is_empty());
 
     if matches!(group_action.as_deref(), Some("deactivate")) {
         let mut forward = args.clone();
         if let Some(obj) = forward.as_object_mut() {
-            if let Some(g) = tool_group {
-                obj.insert("group_name".to_string(), g);
+            if let Some(group) = tool_group {
+                obj.insert("group_name".to_string(), json!(group));
             }
             obj.remove("tool_group");
             obj.remove("group_action");
@@ -204,18 +206,23 @@ pub async fn tool_load_skill(gs: &GatewayState, args: &Value) -> (String, bool) 
         .await;
     }
 
-    if tool_group.is_some() && matches!(group_action.as_deref(), Some("activate") | None) {
+    if let Some(group) = tool_group
+        && matches!(group_action.as_deref(), Some("activate") | None)
+    {
         if args.get("skill_name").and_then(Value::as_str).is_some() {
             let (load_text, load_err) =
                 crate::gateway::aggregator::skill_mgmt_dispatch(gs, "load_skill", args).await;
             if load_err {
                 return (load_text, true);
             }
+            if load_response_activated_group(&load_text, group) {
+                return (load_text, false);
+            }
+
+            // Compatibility for older backends that ignore load_skill.tool_group.
             let mut group_args = args.clone();
             if let Some(obj) = group_args.as_object_mut() {
-                if let Some(g) = tool_group {
-                    obj.insert("group_name".to_string(), g);
-                }
+                obj.insert("group_name".to_string(), json!(group));
                 obj.remove("tool_group");
                 obj.remove("group_action");
             }
@@ -228,14 +235,11 @@ pub async fn tool_load_skill(gs: &GatewayState, args: &Value) -> (String, bool) 
             if group_err {
                 return (group_text, true);
             }
-            let combined = format!("{load_text}\n{group_text}");
-            return (combined, false);
+            return (mark_load_response_group_active(load_text, group), false);
         }
         let mut forward = args.clone();
         if let Some(obj) = forward.as_object_mut() {
-            if let Some(g) = tool_group {
-                obj.insert("group_name".to_string(), g);
-            }
+            obj.insert("group_name".to_string(), json!(group));
             obj.remove("tool_group");
             obj.remove("group_action");
         }
@@ -248,6 +252,33 @@ pub async fn tool_load_skill(gs: &GatewayState, args: &Value) -> (String, bool) 
     }
 
     crate::gateway::aggregator::skill_mgmt_dispatch(gs, "load_skill", args).await
+}
+
+fn load_response_activated_group(text: &str, group: &str) -> bool {
+    serde_json::from_str::<Value>(text)
+        .ok()
+        .and_then(|value| value.get("activated_groups").cloned())
+        .and_then(|value| value.as_array().cloned())
+        .is_some_and(|groups| groups.iter().any(|value| value.as_str() == Some(group)))
+}
+
+fn mark_load_response_group_active(text: String, group: &str) -> String {
+    let Ok(mut value) = serde_json::from_str::<Value>(&text) else {
+        return text;
+    };
+    let Some(object) = value.as_object_mut() else {
+        return text;
+    };
+    let groups = object
+        .entry("activated_groups")
+        .or_insert_with(|| json!([]));
+    let Some(groups) = groups.as_array_mut() else {
+        return text;
+    };
+    if !groups.iter().any(|value| value.as_str() == Some(group)) {
+        groups.push(json!(group));
+    }
+    serde_json::to_string_pretty(&value).unwrap_or(text)
 }
 
 // ── #655 dynamic-capability MCP wrappers ──────────────────────────────────
@@ -264,17 +295,10 @@ pub async fn tool_search_tools(
     session_id: Option<&str>,
     agent_context: Option<&AgentContext>,
 ) -> Result<String, String> {
-    // Refresh on demand so the first query after startup (or after
-    // a skill load/unload) always sees current capabilities.
-    crate::gateway::capability_service::refresh_all_live_backends(
-        gs,
-        crate::gateway::capability::RefreshReason::Periodic,
-    )
-    .await;
-    let query = crate::gateway::capability_service::parse_search_payload(args);
-    let index_generation =
-        crate::gateway::capability_service::index_generation(&gs.capability_index);
-
+    let query = crate::gateway::capability_service::parse_and_resolve_search_payload(gs, args)
+        .await
+        .map_err(|err| err.to_string())?;
+    crate::gateway::capability_service::refresh_search_backends(gs, &query).await;
     // Shared helper: hybrid→fuzzy downgrade + semantic diagnostic
     let (query, semantic) = crate::gateway::capability_service::apply_search_mode_downgrade(
         query,
@@ -283,67 +307,44 @@ pub async fn tool_search_tools(
 
     // --- LRU cache check (PIP-2471) ---
     let cache_key = SearchCacheKey::from_query(&query);
-    let index_gen = crate::gateway::capability_service::index_generation(&gs.capability_index);
-    if let Some(cached_body) = gs
+    let index_gen = gs.capability_index.generation();
+    let cached_hits = gs
         .search_cache
         .get_with_index_gen(&cache_key, Some(&index_gen))
-    {
-        let cached_hits: Vec<Value> = serde_json::from_slice(&cached_body).unwrap_or_else(|e| {
-            tracing::warn!(
-                ?e,
-                "search cache entry corrupt (MCP), falling back to recompute"
-            );
-            Vec::new()
-        });
-        if !cached_hits.is_empty() {
-            let search_context = SearchResponseContext::new(
-                crate::gateway::search_telemetry::SearchTelemetryStore::new_search_id(),
-                index_gen,
-            );
-            gs.search_telemetry.record_search(SearchTelemetryInput {
-                search_id: search_context.search_id.clone(),
-                transport: "mcp".to_string(),
-                kind: "tool".to_string(),
-                query: query.query.clone(),
-                dcc_type: query.dcc_type.clone(),
-                dcc_types: query.dcc_types.clone(),
-                instance_id: query.instance_id.map(|id| id.to_string()),
-                limit: query.limit,
-                total: cached_hits.len(),
-                ranker_version: search_context.ranker_version.to_string(),
-                index_generation: search_context.index_generation.clone(),
-                hits: vec![],
-                trace_context: trace_context.cloned(),
-                session_id: session_id
-                    .map(str::to_string)
-                    .or_else(|| agent_context.and_then(|ctx| ctx.session_id.clone())),
-                agent_context: agent_context.cloned(),
-                tags_any: query.tags_any.clone(),
+        .and_then(|cached_body| {
+            let hits = serde_json::from_slice(&cached_body).unwrap_or_else(|e| {
+                tracing::warn!(
+                    ?e,
+                    "search cache entry corrupt (MCP), falling back to recompute"
+                );
+                Vec::new()
             });
-            return serde_json::to_string_pretty(&json!({
-                "search_id": search_context.search_id,
-                "ranker_version": search_context.ranker_version,
-                "index_generation": search_context.index_generation,
-                "total": cached_hits.len(),
-                "hits": cached_hits,
-                "semantic": semantic,
-                "search_cache_hit": true,
-            }))
-            .map_err(|e| e.to_string());
-        }
-    }
+            (!hits.is_empty()).then_some(hits)
+        });
     // --- end cache check ---
 
+    let (hits, index_generation, search_cache_hit) = match cached_hits {
+        Some(hits) => (hits, index_gen, true),
+        None => {
+            let (snapshot, generation) = gs.capability_index.snapshot_with_generation();
+            let hits = crate::gateway::capability_service::search_snapshot_hits_for_policy(
+                &snapshot, &query, &gs.policy,
+            );
+            (hits, generation, false)
+        }
+    };
     let search_context = SearchResponseContext::new(
         crate::gateway::search_telemetry::SearchTelemetryStore::new_search_id(),
         index_generation,
     );
-    let hits = crate::gateway::capability_service::search_service_hits_for_policy(
-        &gs.capability_index,
-        &query,
-        &gs.policy,
-    );
     let telemetry_hits = search_hits_for_telemetry(&hits);
+    if !search_cache_hit && let Ok(body_bytes) = serde_json::to_vec(&hits) {
+        gs.search_cache.put(
+            cache_key,
+            body_bytes,
+            search_context.index_generation.clone(),
+        );
+    }
     let annotated: Vec<Value> = hits
         .into_iter()
         .map(|hit| search_hit_to_value_with_context(hit, Some(&search_context)))
@@ -369,25 +370,18 @@ pub async fn tool_search_tools(
         tags_any: query.tags_any.clone(),
     });
 
-    // --- LRU cache store (PIP-2471) ---
-    if let Ok(body_bytes) = serde_json::to_vec(&annotated) {
-        gs.search_cache.put(
-            cache_key,
-            body_bytes,
-            search_context.index_generation.clone(),
-        );
-    }
-    // --- end cache store ---
-
-    serde_json::to_string_pretty(&json!({
+    let mut response = json!({
         "search_id": search_context.search_id,
         "ranker_version": search_context.ranker_version,
         "index_generation": search_context.index_generation,
         "total": annotated.len(),
         "hits":  annotated,
         "semantic": semantic,
-    }))
-    .map_err(|e| e.to_string())
+    });
+    if search_cache_hit {
+        response["search_cache_hit"] = json!(true);
+    }
+    serde_json::to_string_pretty(&response).map_err(|e| e.to_string())
 }
 
 /// `describe_tool` — MCP wrapper around
@@ -402,11 +396,7 @@ pub async fn tool_describe_tool(
         return Err("missing required argument: tool_slug".to_string());
     };
     if describe_needs_refresh(gs, slug, args, meta) {
-        crate::gateway::capability_service::refresh_all_live_backends(
-            gs,
-            crate::gateway::capability::RefreshReason::Periodic,
-        )
-        .await;
+        crate::gateway::capability_service::refresh_for_describe(gs, slug).await;
     }
     let search_id = search_id_from_inputs(args, meta);
     match crate::gateway::capability_service::describe_tool_full(gs, slug).await {
@@ -526,7 +516,7 @@ pub async fn tool_call_tool(
         Err(err) if call_error_needs_refresh(&err) => {
             // Refresh once when the slug just became valid or a live instance
             // has not reached this gateway's capability index yet.
-            crate::gateway::capability_service::refresh_all_live_backends(
+            crate::gateway::capability_service::refresh_all_live_backends_now(
                 gs,
                 crate::gateway::capability::RefreshReason::Periodic,
             )
@@ -748,7 +738,7 @@ pub async fn gateway_call_batch_inner(
             {
                 Ok(result) => Ok(result),
                 Err(err) if call_error_needs_refresh(&err) => {
-                    crate::gateway::capability_service::refresh_all_live_backends(
+                    crate::gateway::capability_service::refresh_all_live_backends_now(
                         gs,
                         crate::gateway::capability::RefreshReason::Periodic,
                     )
@@ -1137,44 +1127,12 @@ fn search_id_from_inputs(args: &Value, meta: Option<&Value>) -> Option<String> {
     search_id_from_payload(args).or_else(|| meta.and_then(search_id_from_meta))
 }
 
-fn index_generation_from_inputs(args: &Value, meta: Option<&Value>) -> Option<String> {
-    fn from_payload(value: &Value) -> Option<String> {
-        value
-            .get("index_generation")
-            .and_then(Value::as_str)
-            .map(str::to_string)
-            .or_else(|| {
-                value
-                    .get("meta")
-                    .and_then(|meta| meta.get("index_generation"))
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            })
-            .or_else(|| {
-                value
-                    .get("_meta")
-                    .and_then(|meta| meta.get("index_generation"))
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            })
-    }
-
-    from_payload(args).or_else(|| meta.and_then(from_payload))
-}
-
 pub(crate) fn describe_needs_refresh(
     gs: &GatewayState,
     slug: &str,
-    args: &Value,
-    meta: Option<&Value>,
+    _args: &Value,
+    _meta: Option<&Value>,
 ) -> bool {
-    if let Some(generation) = index_generation_from_inputs(args, meta) {
-        let current = crate::gateway::capability_service::index_generation(&gs.capability_index);
-        if generation != current {
-            return true;
-        }
-    }
-
     crate::gateway::capability_service::describe_service(&gs.capability_index, slug)
         .map(|_| false)
         .unwrap_or(true)
@@ -1241,8 +1199,8 @@ pub fn gateway_tool_defs() -> serde_json::Value {
             "name": "search",
             "description": "Discover backend capabilities and/or skills. Default `kind=tool` runs the \
                 capability index (`search_tools` semantics): compact hits with `tool_slug` and \
-                executable `next_step`. Follow `next_step`: tools with `has_schema=false` can go \
-                straight to `call`; tools with schema still use `describe` first to fetch \
+                executable `next_step`. Follow `next_step`: no-schema tools with compact safety \
+                hints can go straight to `call`; other tools use `describe` first to fetch \
                 `input_schema` / required parameter names. \
                 `kind=skill` lists or searches skills (`list_skills` / `search_skills`). `kind=all` returns both.",
             "inputSchema": {
@@ -1253,6 +1211,7 @@ pub fn gateway_tool_defs() -> serde_json::Value {
                     "dcc_type": {"type": "string"},
                     "dcc_types": {"type": "array", "items": {"type": "string"}, "description": "OR-matched DCC types. Combined with singular dcc_type."},
                     "dcc": {"type": "string", "description": "Alias of dcc_type for skill search"},
+                    "instance_id": {"type": "string", "description": "Target instance UUID or unique prefix."},
                     "tags": {"type": "array", "items": {"type": "string"}},
                     "tags_any": {"type": "array", "items": {"type": "string"}, "description": "OR tag filter — rows carrying any of these tags pass. tags remains AND."},
                     "mode": {"type": "string", "enum": ["fuzzy", "exact", "hybrid"], "default": "fuzzy", "description": "Search mode: fuzzy (default, BM25+nucleo), exact (substring), hybrid (fuzzy + semantic boost when configured)."},
@@ -1267,8 +1226,8 @@ pub fn gateway_tool_defs() -> serde_json::Value {
             "name": "describe",
             "description": "Fetch full metadata. Pass `tool_slug` from `search` to get `input_schema`, \
                 `properties`, and `required` (e.g. maya_geometry export uses `path`, not `destination`). \
-                MCP describe refreshes backend capabilities only when the slug is missing or the \
-                supplied `meta.index_generation` is stale. Pass `skill_name` for skill-level detail \
+                MCP describe refreshes capabilities only when the slug is missing; valid slugs \
+                refresh only their owning instance. Pass `skill_name` for skill-level detail \
                 (tools list, dependencies).",
             "inputSchema": {
                 "type": "object",
@@ -1291,7 +1250,7 @@ pub fn gateway_tool_defs() -> serde_json::Value {
                 activates all declared groups; set `activate_groups=false` for lazy loading, \
                 or pass `tool_group` to activate one group explicitly. When following a correlated \
                 search `next_step`, keep `target_tool_slug` and `meta.search_id`; the response may \
-                inline `compact_schema` and point directly to `call`.",
+                inline `compact_schema` with safety/execution hints and point directly to `call`.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1309,7 +1268,12 @@ pub fn gateway_tool_defs() -> serde_json::Value {
                     "response_format": {"type": "string", "enum": ["json", "toon"], "description": "Wrapper-level output format. Prefer MCP params._meta.response_format for clients that keep tool arguments pure."},
                     "compact": {"type": "boolean", "description": "Alias for response_format=toon when true."}
                 },
-                "required": ["skill_name"]
+                "anyOf": [
+                    {"required": ["skill_name"]},
+                    {"required": ["skill_names"]},
+                    {"required": ["tool_group"]},
+                    {"required": ["group_name"]}
+                ]
             },
             "annotations": {
                 "readOnlyHint": false,

--- a/crates/dcc-mcp-gateway/src/gateway/tools_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools_tests.rs
@@ -148,6 +148,22 @@ fn gateway_call_schema_keeps_compatibility_shape() {
 }
 
 #[test]
+fn gateway_search_schema_exposes_instance_filter() {
+    let defs = gateway_tool_defs();
+    let search = defs
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|tool| tool["name"] == "search")
+        .expect("search tool advertised");
+
+    assert_eq!(
+        search["inputSchema"]["properties"]["instance_id"]["type"],
+        "string"
+    );
+}
+
+#[test]
 fn gateway_tool_defs_use_expected_annotations() {
     let annotations = annotations_by_tool();
 
@@ -162,7 +178,7 @@ fn gateway_tool_defs_use_expected_annotations() {
 }
 
 #[test]
-fn describe_refresh_is_conditional_on_generation_and_index_hit() {
+fn describe_refresh_depends_only_on_index_hit() {
     let gs = test_gateway_state();
     let instance_id = Uuid::from_u128(0x1234);
     let record = crate::gateway::capability::CapabilityRecord::new(
@@ -193,12 +209,10 @@ fn describe_refresh_is_conditional_on_generation_and_index_hit() {
         "tool_slug": record.tool_slug,
         "meta": {"index_generation": "stale"}
     });
-    assert!(describe_needs_refresh(
-        &gs,
-        &record.tool_slug,
-        &stale_args,
-        None
-    ));
+    assert!(
+        !describe_needs_refresh(&gs, &record.tool_slug, &stale_args, None),
+        "a present slug must ignore unrelated generation drift"
+    );
 
     assert!(describe_needs_refresh(
         &gs,

--- a/crates/dcc-mcp-http-py/src/skill_server.rs
+++ b/crates/dcc-mcp-http-py/src/skill_server.rs
@@ -623,6 +623,43 @@ impl PyMcpHttpServer {
         self.catalog.clear_after_group_change_hook();
     }
 
+    /// Register the persistence-only observer for exact scoped group keys.
+    #[pyo3(signature = (hook))]
+    fn set_after_scoped_group_change_hook(
+        &self,
+        py: Python<'_>,
+        hook: Option<Py<PyAny>>,
+    ) -> PyResult<()> {
+        match hook {
+            None => self.catalog.clear_after_scoped_group_change_hook(),
+            Some(py_fn) => {
+                if !py_fn.bind(py).is_callable() {
+                    return Err(pyo3::exceptions::PyTypeError::new_err(
+                        "after-scoped-group-change hook must be callable",
+                    ));
+                }
+                let hook_ref = py_fn.clone_ref(py);
+                self.catalog
+                    .set_after_scoped_group_change_hook(move |key, activated| {
+                        Python::try_attach(|gil| {
+                            hook_ref
+                                .call1(gil, (key.to_string(), activated))
+                                .map(|_| ())
+                                .map_err(|e| format!("after-scoped-group-change hook failed: {e}"))
+                        })
+                        .ok_or_else(|| "Python interpreter not attached".to_string())
+                        .and_then(|r| r)
+                    });
+            }
+        }
+        Ok(())
+    }
+
+    /// Clear the scoped persistence observer.
+    fn clear_after_scoped_group_change_hook(&self) {
+        self.catalog.clear_after_scoped_group_change_hook();
+    }
+
     /// Replay a persisted state on the inner catalog (#1405).
     ///
     /// ``state_json`` is the JSON-encoded ``PersistedCatalogState``;

--- a/crates/dcc-mcp-http-server/src/handlers/tool_builder_core.rs
+++ b/crates/dcc-mcp-http-server/src/handlers/tool_builder_core.rs
@@ -140,6 +140,7 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
                           How to use:\n\
                           - Pass skill_name or skill_names.\n\
                           - Groups activate by default; set activate_groups=false for lazy group activation.\n\
+                          - Pass tool_group with one skill to activate only that group plus default-active groups.\n\
                           - After success, call tools/list or the specific tool directly."
                 .to_string(),
             input_schema: json!({
@@ -158,6 +159,10 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
                         "type": "boolean",
                         "default": true,
                         "description": "Cascade-activate all declared tool groups after loading. Set false for lazy activation."
+                    },
+                    "tool_group": {
+                        "type": "string",
+                        "description": "Activate one group for a skill; defaults activate_groups=false and includes default-active groups."
                     }
                 }
             }),
@@ -268,6 +273,10 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
                     "group": {
                         "type": "string",
                         "description": "Alias of group_name."
+                    },
+                    "skill_name": {
+                        "type": "string",
+                        "description": "Optional owning skill from a scoped group stub. Omit for legacy catalog-wide activation."
                     }
                 },
                 "required": ["group_name"]
@@ -301,6 +310,10 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
                     "group": {
                         "type": "string",
                         "description": "Alias of group_name."
+                    },
+                    "skill_name": {
+                        "type": "string",
+                        "description": "Optional owning skill from a scoped group stub. Omit for legacy catalog-wide deactivation."
                     }
                 },
                 "required": ["group_name"]

--- a/crates/dcc-mcp-http-server/src/mcp_tool_list_builder.rs
+++ b/crates/dcc-mcp-http-server/src/mcp_tool_list_builder.rs
@@ -1,6 +1,8 @@
 //! Assemble and paginate the MCP `tools/list` surface for rmcp.
 
+use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashSet};
+use std::hash::{Hash, Hasher};
 
 use dcc_mcp_gateway_core::naming::{BareNameInput, resolve_bare_names};
 use dcc_mcp_jsonrpc::{McpTool, TOOLS_LIST_PAGE_SIZE, decode_cursor, encode_cursor};
@@ -44,7 +46,7 @@ pub fn assemble_full_tool_list(
         HashSet::new()
     };
 
-    let mut inactive_groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut inactive_groups: BTreeMap<(Option<String>, String), Vec<String>> = BTreeMap::new();
     for meta in &actions {
         if meta.enabled {
             tools.push(action_meta_to_mcp_tool(
@@ -56,15 +58,33 @@ pub fn assemble_full_tool_list(
             ));
         } else if !meta.group.is_empty() {
             inactive_groups
-                .entry(meta.group.clone())
+                .entry((meta.skill_name.clone(), meta.group.clone()))
                 .or_default()
                 .push(meta.name.clone());
         }
     }
 
     if !state.exclude_group_stubs_from_tools_list {
-        for (group, names) in &inactive_groups {
-            tools.push(build_group_stub(group, names));
+        for ((skill_name, group), names) in &inactive_groups {
+            let mut stub = build_group_stub(group, names);
+            if let Some(skill_name) = skill_name {
+                stub.name = group_stub_name(Some(skill_name), group);
+                stub.description = stub
+                    .description
+                    .replacen(
+                        &format!("Inactive group '{group}'"),
+                        &format!("Inactive group '{group}' in skill '{skill_name}'"),
+                        1,
+                    )
+                    .replacen(
+                        &format!("activate_tool_group(\"{group}\")"),
+                        &format!(
+                            "activate_tool_group(group_name=\"{group}\", skill_name=\"{skill_name}\")"
+                        ),
+                        1,
+                    );
+            }
+            tools.push(stub);
         }
     }
 
@@ -81,6 +101,36 @@ pub fn assemble_full_tool_list(
 
     tools.retain(tool_name_is_client_safe);
     tools
+}
+
+const GROUP_SKILL_SEPARATOR: &str = "__for_skill__";
+
+pub(crate) fn group_stub_name(skill_name: Option<&str>, group: &str) -> String {
+    let name = match skill_name {
+        Some(skill_name) => format!("__group__{group}{GROUP_SKILL_SEPARATOR}{skill_name}"),
+        None => format!("__group__{group}"),
+    };
+    if validate_tool_name(&name).is_ok() {
+        return name;
+    }
+
+    // ponytail: long stubs are error-only; use a stable bounded key instead
+    // of adding a runtime lookup map solely to recover their display names.
+    let mut hasher = DefaultHasher::new();
+    skill_name.hash(&mut hasher);
+    group.hash(&mut hasher);
+    format!("__group__scoped_{:016x}", hasher.finish())
+}
+
+pub(crate) fn parse_group_stub_name(name: &str) -> Option<(Option<&str>, &str)> {
+    let value = name.strip_prefix("__group__")?;
+    match value.rsplit_once(GROUP_SKILL_SEPARATOR) {
+        Some((group, skill_name)) if !group.is_empty() && !skill_name.is_empty() => {
+            Some((Some(skill_name), group))
+        }
+        _ if !value.is_empty() => Some((None, value)),
+        _ => None,
+    }
 }
 
 fn tool_name_is_client_safe(tool: &McpTool) -> bool {
@@ -117,4 +167,22 @@ pub fn slice_tools_page(
         None
     };
     (page, next_cursor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scoped_group_stub_names_stay_client_safe() {
+        let skill_name = "a".repeat(40);
+        let name = group_stub_name(Some(&skill_name), "inspection");
+
+        assert!(validate_tool_name(&name).is_ok(), "{name}");
+        assert_eq!(name, group_stub_name(Some(&skill_name), "inspection"));
+        assert_eq!(
+            parse_group_stub_name("__group__inspection__for_skill__houdini-scene"),
+            Some((Some("houdini-scene"), "inspection"))
+        );
+    }
 }

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/discovery.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/discovery.rs
@@ -4,6 +4,7 @@ use serde_json::{Value, json};
 
 use dcc_mcp_jsonrpc::CallToolResult;
 
+use crate::mcp_tool_list_builder::group_stub_name;
 use crate::server_state::ServerState;
 
 pub(in crate::rmcp_tool_call_dispatch) fn is_progressive_stub(name: &str) -> bool {
@@ -16,6 +17,22 @@ pub(in crate::rmcp_tool_call_dispatch) fn schema_property_names(schema: &Value) 
         .and_then(Value::as_object)
         .map(|props| props.keys().cloned().collect())
         .unwrap_or_default()
+}
+
+fn schema_has_constraints(schema: &Value) -> bool {
+    let Some(object) = schema.as_object() else {
+        return !schema.is_null();
+    };
+    object.iter().any(|(key, value)| match key.as_str() {
+        "type" => value.as_str() != Some("object"),
+        "properties" => value
+            .as_object()
+            .is_none_or(|properties| !properties.is_empty()),
+        "required" => value.as_array().is_none_or(|required| !required.is_empty()),
+        "additionalProperties" => value != &Value::Bool(false),
+        "title" | "description" | "$schema" => false,
+        _ => true,
+    })
 }
 
 /// Check whether `haystack` matches a natural-language `query`.
@@ -80,6 +97,7 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_search_tools(
             continue;
         }
         let schema_props = schema_property_names(&meta.input_schema);
+        let has_schema = schema_has_constraints(&meta.input_schema);
         let haystack = format!(
             "{} {} {} {} {}",
             meta.name,
@@ -99,11 +117,28 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_search_tools(
             "category": meta.category,
             "group": meta.group,
             "enabled": meta.enabled,
+            "has_schema": has_schema,
             "dcc": meta.dcc,
         });
         if let Some(skill) = &meta.skill_name {
             hit["skill_name"] = Value::String(skill.clone());
         }
+        let annotations = serde_json::to_value(&meta.annotations).unwrap_or(Value::Null);
+        if annotations
+            .as_object()
+            .is_some_and(|value| !value.is_empty())
+        {
+            hit["annotations"] = annotations;
+        }
+        hit["metadata"] = json!({
+            "dcc": {
+                "affinity": &meta.thread_affinity,
+                "execution": &meta.execution,
+                "timeoutHintSecs": meta.timeout_hint_secs,
+                "jobStrategy": &meta.job_strategy,
+                "enforceThreadAffinity": meta.enforce_thread_affinity,
+            }
+        });
         tool_hits.push(hit);
         if tool_hits.len() >= limit {
             break;
@@ -148,25 +183,25 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_search_tools(
         }
 
         if tool_hits.len() < limit {
-            let mut seen_groups: std::collections::HashSet<String> =
+            let mut seen_groups: std::collections::HashSet<(String, String)> =
                 std::collections::HashSet::new();
             for (skill, group, active) in state.catalog.list_groups() {
                 if active {
                     continue;
                 }
-                if !seen_groups.insert(group.clone()) {
+                if !seen_groups.insert((skill.clone(), group.clone())) {
                     continue;
                 }
-                let haystack = format!("__group__{} {} {}", group, group, skill).to_lowercase();
+                let stub_name = group_stub_name(Some(&skill), &group);
+                let haystack = format!("{stub_name} {group} {skill}").to_lowercase();
                 if !matches_phrase(&haystack, &query, &query_words) {
                     continue;
                 }
                 tool_hits.push(json!({
                     "kind": "tool",
-                    "name": format!("__group__{}", group),
+                    "name": stub_name,
                     "description": format!(
-                        "[stub] inactive tool group `{}` — call activate_tool_group(group=\"{}\") to expose its members",
-                        group, group,
+                        "[stub] inactive tool group `{group}` in skill `{skill}` — call activate_tool_group(group_name=\"{group}\", skill_name=\"{skill}\") to expose its members",
                     ),
                     "category": "stub",
                     "group": group,
@@ -208,6 +243,18 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_search_tools(
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
+            let tool_group = detail.as_ref().and_then(|detail| {
+                let target = matching_tools.first()?;
+                detail
+                    .tools
+                    .iter()
+                    .find(|tool| tool.name == *target && !tool.group.is_empty())
+                    .map(|tool| tool.group.clone())
+            });
+            let mut load_arguments = json!({"skill_name": summary.name});
+            if let Some(group) = &tool_group {
+                load_arguments["tool_group"] = json!(group);
+            }
             skill_candidates.push(json!({
                 "kind": "skill_candidate",
                 "skill_name": summary.name,
@@ -217,10 +264,11 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_search_tools(
                 "scope": summary.scope,
                 "tool_count": summary.tool_count,
                 "matching_tools": matching_tools,
+                "tool_group": tool_group,
                 "requires_load_skill": true,
                 "load_hint": {
                     "tool": "load_skill",
-                    "arguments": { "skill_name": summary.name },
+                    "arguments": load_arguments,
                 },
             }));
         }
@@ -313,5 +361,35 @@ mod tests {
         let words: Vec<&str> = Vec::new();
         assert!(matches_phrase("at on", "at on", &words));
         assert!(!matches_phrase("create_sphere", "at on", &words));
+    }
+
+    #[test]
+    fn schema_constraints_include_non_property_json_schema_keywords() {
+        assert!(!schema_has_constraints(&json!({"type": "object"})));
+        assert!(!schema_has_constraints(&json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })));
+        for schema in [
+            json!({"type": "object", "oneOf": []}),
+            json!({"type": "object", "anyOf": []}),
+            json!({"type": "object", "allOf": []}),
+            json!({"type": "object", "$ref": "#/$defs/input"}),
+            json!({"type": "object", "patternProperties": {}}),
+            json!({"type": "object", "dependentRequired": {}}),
+            json!({"type": "object", "if": {}, "then": {}}),
+        ] {
+            assert!(schema_has_constraints(&schema), "schema: {schema}");
+        }
+    }
+
+    #[test]
+    fn closed_empty_object_has_no_call_arguments() {
+        assert!(!schema_has_constraints(&json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })));
     }
 }

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/skills.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/skills.rs
@@ -8,6 +8,7 @@ use crate::server_state::ServerState;
 use dcc_mcp_jsonrpc::CallToolResult;
 
 use super::super::helpers::notify_tools_changed;
+use crate::mcp_tool_list_builder::group_stub_name;
 pub(in crate::rmcp_tool_call_dispatch) fn handle_list_roots(
     state: &ServerState,
     session_id: Option<&str>,
@@ -156,10 +157,25 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_load_skill(
         return CallToolResult::error("Missing required parameter: skill_name or skill_names");
     }
 
-    let activate_groups = arguments
-        .get("activate_groups")
+    let tool_group = arguments
+        .get("tool_group")
+        .or_else(|| arguments.get("group"))
+        .or_else(|| arguments.get("group_name"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|group| !group.is_empty());
+    let strict_tool_group = arguments
+        .get("strict_tool_group")
         .and_then(Value::as_bool)
-        .unwrap_or(true);
+        .unwrap_or(false);
+    if strict_tool_group && tool_group.is_none() {
+        return CallToolResult::error("strict_tool_group requires tool_group");
+    }
+    let activate_groups = !strict_tool_group
+        && arguments
+            .get("activate_groups")
+            .and_then(Value::as_bool)
+            .unwrap_or(tool_group.is_none());
 
     let mut requested: Vec<String> = Vec::new();
     if !skill_name.is_empty() {
@@ -170,6 +186,23 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_load_skill(
             requested.push(name.clone());
         }
     }
+    if let Some(group) = tool_group {
+        if requested.len() != 1 {
+            return CallToolResult::error(
+                "tool_group requires exactly one skill_name; skill_names batching is not supported",
+            );
+        }
+        let group_exists = state
+            .catalog
+            .get_skill_info(&requested[0])
+            .is_some_and(|detail| detail.groups.iter().any(|item| item.name == group));
+        if !group_exists {
+            return CallToolResult::error(format!(
+                "Tool group '{group}' was not found in skill '{}'",
+                requested[0]
+            ));
+        }
+    }
 
     let mut all_registered_tools: Vec<String> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
@@ -178,7 +211,14 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_load_skill(
 
     for name in &requested {
         let was_loaded = state.catalog.is_loaded(name);
-        match state.catalog.load_skill_with_options(name, activate_groups) {
+        let loaded = if strict_tool_group && !was_loaded {
+            state
+                .catalog
+                .load_skill_target_group(name, tool_group.expect("strict group was validated"))
+        } else {
+            state.catalog.load_skill_with_options(name, activate_groups)
+        };
+        match loaded {
             Ok(tools) => {
                 all_registered_tools.extend(tools);
                 if was_loaded {
@@ -190,15 +230,35 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_load_skill(
             Err(e) => errors.push(format!("{name}: {e}")),
         }
     }
+    let activated_target_count = if errors.is_empty() {
+        tool_group
+            .map(|group| state.catalog.activate_skill_group(&requested[0], group))
+            .unwrap_or(0)
+    } else {
+        0
+    };
+    if tool_group.is_some() && errors.is_empty() {
+        all_registered_tools = state
+            .catalog
+            .registry()
+            .list_actions_by_skill(&requested[0])
+            .into_iter()
+            .filter(|meta| meta.enabled)
+            .map(|meta| meta.name)
+            .collect();
+    }
 
-    if !newly_loaded.is_empty() {
+    if !newly_loaded.is_empty() || activated_target_count > 0 {
         state.bump_registry_generation();
         if let Some(sid) = session_id {
             let added = all_registered_tools.clone();
-            let removed: Vec<String> = newly_loaded
+            let mut removed: Vec<String> = newly_loaded
                 .iter()
                 .map(|n| format!("__skill__{n}"))
                 .collect();
+            if let Some(group) = tool_group {
+                removed.push(group_stub_name(Some(&requested[0]), group));
+            }
             notify_tools_changed(&state.sessions, sid, &added, &removed);
         }
         (ctx.on_skill_catalog_mutated)();
@@ -207,12 +267,25 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_load_skill(
     let mut tool_schemas: Vec<Value> = Vec::new();
     for name in newly_loaded.iter().chain(already_loaded.iter()) {
         for meta in state.catalog.registry().list_actions_by_skill(name) {
+            if tool_group.is_some() && !meta.enabled {
+                continue;
+            }
             tool_schemas.push(json!({
                 "name":          meta.name,
                 "description":   meta.description,
                 "inputSchema":   meta.input_schema,
                 "outputSchema":  meta.output_schema,
                 "skill_name":    meta.skill_name,
+                "annotations":   meta.annotations,
+                "metadata": {
+                    "dcc": {
+                        "affinity": meta.thread_affinity,
+                        "execution": meta.execution,
+                        "timeoutHintSecs": meta.timeout_hint_secs,
+                        "jobStrategy": meta.job_strategy,
+                        "enforceThreadAffinity": meta.enforce_thread_affinity,
+                    }
+                },
             }));
         }
     }
@@ -293,6 +366,25 @@ fn group_state_payloads(
         }
     }
     groups
+}
+
+fn group_stub_names(state: &ServerState, skill_name: Option<&str>, group: &str) -> Vec<String> {
+    if let Some(skill_name) = skill_name {
+        return vec![group_stub_name(Some(skill_name), group)];
+    }
+    let owners: std::collections::BTreeSet<_> = state
+        .registry
+        .list_actions_in_group(group)
+        .into_iter()
+        .map(|meta| meta.skill_name)
+        .collect();
+    if owners.is_empty() {
+        return vec![group_stub_name(None, group)];
+    }
+    owners
+        .iter()
+        .map(|owner| group_stub_name(owner.as_deref(), group))
+        .collect()
 }
 
 pub(in crate::rmcp_tool_call_dispatch) fn handle_unload_skill(
@@ -494,16 +586,25 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_activate_tool_group(
     if group.is_empty() {
         return CallToolResult::error("Missing required parameter: group or group_name");
     }
-    let changed = state.catalog.activate_group(group);
+    let skill_name = arguments
+        .get("skill_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty());
+    let changed = skill_name.map_or_else(
+        || state.catalog.activate_group(group),
+        |skill| state.catalog.activate_skill_group(skill, group),
+    );
     state.bump_registry_generation();
     if let Some(sid) = session_id {
-        let added: Vec<String> = state
-            .registry
-            .list_actions_in_group(group)
-            .iter()
+        let added: Vec<String> = skill_name
+            .map(|skill| state.registry.list_actions_by_skill(skill))
+            .unwrap_or_else(|| state.registry.list_actions_in_group(group))
+            .into_iter()
+            .filter(|meta| meta.group == group)
             .map(|m| m.name.clone())
             .collect();
-        let removed = vec![format!("__group__{group}")];
+        let removed = group_stub_names(state, skill_name, group);
         notify_tools_changed(&state.sessions, sid, &added, &removed);
     }
     CallToolResult::text(
@@ -530,16 +631,25 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_deactivate_tool_group(
     if group.is_empty() {
         return CallToolResult::error("Missing required parameter: group or group_name");
     }
-    let changed = state.catalog.deactivate_group(group);
+    let skill_name = arguments
+        .get("skill_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty());
+    let changed = skill_name.map_or_else(
+        || state.catalog.deactivate_group(group),
+        |skill| state.catalog.deactivate_skill_group(skill, group),
+    );
     state.bump_registry_generation();
     if let Some(sid) = session_id {
-        let removed: Vec<String> = state
-            .registry
-            .list_actions_in_group(group)
-            .iter()
+        let removed: Vec<String> = skill_name
+            .map(|skill| state.registry.list_actions_by_skill(skill))
+            .unwrap_or_else(|| state.registry.list_actions_in_group(group))
+            .into_iter()
+            .filter(|meta| meta.group == group)
             .map(|m| m.name.clone())
             .collect();
-        let added = vec![format!("__group__{group}")];
+        let added = group_stub_names(state, skill_name, group);
         notify_tools_changed(&state.sessions, sid, &added, &removed);
     }
     CallToolResult::text(

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/helpers.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/helpers.rs
@@ -14,6 +14,7 @@ use dcc_mcp_models::NextTools;
 use dcc_mcp_protocols::error_envelope::DccMcpError;
 
 use crate::mcp_tool_catalog::missing_capabilities;
+use crate::mcp_tool_list_builder::{group_stub_name, parse_group_stub_name};
 use crate::rmcp_registry_context::RegistryContext;
 use crate::server_state::ServerState;
 use crate::session::SessionManager;
@@ -283,7 +284,32 @@ pub(crate) fn dispatch_err_result(tool_name: &str, msg: impl Into<String>) -> Ca
     CallToolResult::error(err_msg)
 }
 
-pub(crate) fn handle_stub_tool(tool_name: &str) -> Option<CallToolResult> {
+fn resolve_group_stub(state: &ServerState, tool_name: &str) -> Option<(Option<String>, String)> {
+    const HASHED_PREFIX: &str = "__group__scoped_";
+    let hashed = tool_name.strip_prefix(HASHED_PREFIX).is_some_and(|value| {
+        value.len() == 16 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+    });
+    if !hashed {
+        return parse_group_stub_name(tool_name)
+            .map(|(skill, group)| (skill.map(str::to_owned), group.to_owned()));
+    }
+
+    // ponytail: hashed stubs are an error path, so recover their display target
+    // with one registry scan instead of maintaining another runtime lookup map.
+    let mut matches = state
+        .registry
+        .list_actions(None)
+        .into_iter()
+        .filter(|meta| !meta.enabled && !meta.group.is_empty())
+        .filter_map(|meta| {
+            (group_stub_name(meta.skill_name.as_deref(), &meta.group) == tool_name)
+                .then_some((meta.skill_name, meta.group))
+        });
+    let target = matches.next()?;
+    (!matches.any(|candidate| candidate != target)).then_some(target)
+}
+
+pub(crate) fn handle_stub_tool(state: &ServerState, tool_name: &str) -> Option<CallToolResult> {
     if let Some(skill_name) = tool_name.strip_prefix("__skill__") {
         let envelope = DccMcpError::new(
             "gateway",
@@ -296,16 +322,27 @@ pub(crate) fn handle_stub_tool(tool_name: &str) -> Option<CallToolResult> {
         ));
         return Some(CallToolResult::error(envelope.to_json().to_string()));
     }
-    if let Some(group_name) = tool_name.strip_prefix("__group__") {
+    if let Some((skill_name, group_name)) = resolve_group_stub(state, tool_name) {
         let envelope = DccMcpError::new(
             "gateway",
             "GROUP_NOT_ACTIVATED",
-            format!("Tool group '{group_name}' is inactive."),
+            match skill_name.as_deref() {
+                Some(skill_name) => {
+                    format!("Tool group '{group_name}' in skill '{skill_name}' is inactive.")
+                }
+                None => format!("Tool group '{group_name}' is inactive."),
+            },
         )
-        .with_hint(format!(
-            "Call activate_tool_group with group=\"{group_name}\" to enable its tools, \
-             then re-list with tools/list."
-        ));
+        .with_hint(match skill_name.as_deref() {
+            Some(skill_name) => format!(
+                "Call activate_tool_group(group_name=\"{group_name}\", \
+                 skill_name=\"{skill_name}\") to enable its tools, then re-list with tools/list."
+            ),
+            None => format!(
+                "Call activate_tool_group with group=\"{group_name}\" to enable its tools, \
+                 then re-list with tools/list."
+            ),
+        });
         return Some(CallToolResult::error(envelope.to_json().to_string()));
     }
     None

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/mod.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/mod.rs
@@ -126,7 +126,7 @@ async fn dispatch_non_core_tool(
     tool_name: &str,
     arguments_value: Value,
 ) -> Result<CallToolResult, String> {
-    if let Some(r) = handle_stub_tool(tool_name) {
+    if let Some(r) = handle_stub_tool(state, tool_name) {
         return Ok(r);
     }
     if tool_name.starts_with(DYNAMIC_TOOL_PREFIX)
@@ -259,13 +259,16 @@ mod tests {
     use dcc_mcp_actions::registry::{ToolMeta, ToolRegistry};
     use dcc_mcp_job::job::JobStatus;
     use dcc_mcp_jsonrpc::ToolContent;
-    use dcc_mcp_models::{ExecutionMode, SkillScope, ThreadAffinity};
+    use dcc_mcp_models::{
+        ExecutionMode, SkillGroup, SkillMetadata, SkillScope, ThreadAffinity, ToolAnnotations,
+        ToolDeclaration,
+    };
     use dcc_mcp_skill_rest::StaticReadiness;
     use dcc_mcp_skills::SkillCatalog;
     use serde_json::json;
 
     use crate::executor::InProcessExecutor;
-    use crate::mcp_tool_list_builder::assemble_full_tool_list;
+    use crate::mcp_tool_list_builder::{assemble_full_tool_list, group_stub_name};
 
     fn skill_tool_meta(name: &str, skill_name: &str) -> ToolMeta {
         ToolMeta {
@@ -296,6 +299,502 @@ mod tests {
             panic!("expected text content, got {result:?}");
         };
         text
+    }
+
+    #[tokio::test]
+    async fn targeted_load_activates_only_the_requested_tool_group() {
+        let registry = Arc::new(ToolRegistry::new());
+        let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+        let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+            Arc::clone(&registry),
+            Arc::clone(&dispatcher),
+        ));
+        catalog.add_skill(SkillMetadata {
+            name: "houdini-scene".to_string(),
+            dcc: "houdini".to_string(),
+            groups: vec![
+                SkillGroup {
+                    name: "inspection".to_string(),
+                    tools: vec!["inspect_selection".to_string()],
+                    ..Default::default()
+                },
+                SkillGroup {
+                    name: "editing".to_string(),
+                    tools: vec!["mutate_scene".to_string()],
+                    default_active: true,
+                    ..Default::default()
+                },
+            ],
+            tools: vec![
+                ToolDeclaration {
+                    name: "inspect_selection".to_string(),
+                    group: "inspection".to_string(),
+                    annotations: ToolAnnotations {
+                        read_only_hint: Some(true),
+                        destructive_hint: Some(false),
+                        open_world_hint: Some(false),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ToolDeclaration {
+                    name: "mutate_scene".to_string(),
+                    group: "editing".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        });
+        catalog.add_skill(SkillMetadata {
+            name: "houdini-analysis".to_string(),
+            dcc: "houdini".to_string(),
+            groups: vec![SkillGroup {
+                name: "inspection".to_string(),
+                tools: vec!["inspect_dependencies".to_string()],
+                ..Default::default()
+            }],
+            tools: vec![ToolDeclaration {
+                name: "inspect_dependencies".to_string(),
+                group: "inspection".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        let publish_state = Arc::new(std::sync::Mutex::new(None));
+        let observed_publish_state = Arc::clone(&publish_state);
+        let observed_registry = Arc::clone(&registry);
+        catalog.set_after_load_hook(move |metadata, _| {
+            if metadata.name == "houdini-scene" {
+                *observed_publish_state.lock().unwrap() = Some((
+                    observed_registry
+                        .get_action("houdini_scene__inspect_selection", None)
+                        .is_some_and(|meta| meta.enabled),
+                    observed_registry
+                        .get_action("houdini_scene__mutate_scene", None)
+                        .is_some_and(|meta| meta.enabled),
+                ));
+            }
+            Ok(())
+        });
+        catalog
+            .load_skill_with_options("houdini-analysis", false)
+            .expect("comparison skill should load with its group disabled");
+        let state = ServerState::builder(registry, dispatcher, catalog).build();
+        let session_id = state.sessions.create();
+        assert!(state.sessions.set_supports_delta_tools(&session_id, true));
+        let mut notifications = state.sessions.subscribe(&session_id).unwrap();
+
+        let search = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "search_tools",
+            Some(json!({"query": "inspect_selection", "dcc": "houdini"})),
+            None,
+        )
+        .await
+        .expect("unloaded skill search should dispatch");
+        let search_payload = result_text_json(&search);
+        let candidate = search_payload["skill_candidates"]
+            .as_array()
+            .and_then(|candidates| {
+                candidates
+                    .iter()
+                    .find(|candidate| candidate["skill_name"] == "houdini-scene")
+            })
+            .expect("houdini-scene candidate");
+        assert_eq!(candidate["tool_group"], "inspection");
+        assert_eq!(
+            candidate["load_hint"]["arguments"]["tool_group"],
+            "inspection"
+        );
+
+        let result = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            Some(&session_id),
+            "load_skill",
+            Some(json!({
+                "skill_name": "houdini-scene",
+                "tool_group": "inspection",
+                "strict_tool_group": true
+            })),
+            None,
+        )
+        .await
+        .expect("targeted load should dispatch");
+        let payload = result_text_json(&result);
+
+        assert!(!result.is_error, "{payload:#}");
+        assert_eq!(
+            payload["registered_tools"],
+            json!(["houdini_scene__inspect_selection"])
+        );
+        assert_eq!(payload["activated_groups"], json!(["inspection"]));
+        assert_eq!(
+            *publish_state.lock().unwrap(),
+            Some((true, false)),
+            "strict load must publish only its target group"
+        );
+        assert!(
+            state
+                .registry
+                .get_action("houdini_scene__inspect_selection", None)
+                .is_some_and(|meta| meta.enabled)
+        );
+        assert!(
+            state
+                .registry
+                .get_action("houdini_scene__mutate_scene", None)
+                .is_some_and(|meta| !meta.enabled)
+        );
+        assert!(
+            state
+                .registry
+                .get_action("houdini_analysis__inspect_dependencies", None)
+                .is_some_and(|meta| !meta.enabled),
+            "a same-named group in another skill must stay disabled"
+        );
+        assert_eq!(
+            state
+                .catalog
+                .list_groups()
+                .into_iter()
+                .find(|(skill, group, _)| { skill == "houdini-analysis" && group == "inspection" })
+                .map(|(_, _, active)| active),
+            Some(false)
+        );
+
+        dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "activate_tool_group",
+            Some(json!({
+                "skill_name": "houdini-analysis",
+                "group": "inspection"
+            })),
+            None,
+        )
+        .await
+        .unwrap();
+        dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "deactivate_tool_group",
+            Some(json!({
+                "skill_name": "houdini-analysis",
+                "group": "inspection"
+            })),
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(
+            state
+                .registry
+                .get_action("houdini_scene__inspect_selection", None)
+                .is_some_and(|meta| meta.enabled),
+            "scoped group handlers must not change a sibling skill"
+        );
+        let event = notifications.try_recv().expect("delta tools notification");
+        let delta: Value = serde_json::from_str(
+            event
+                .strip_prefix("data: ")
+                .expect("SSE data prefix")
+                .trim(),
+        )
+        .unwrap();
+        assert!(
+            delta["params"]["removed"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|name| { name == &group_stub_name(Some("houdini-scene"), "inspection") })
+        );
+
+        dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "deactivate_tool_group",
+            Some(json!({
+                "skill_name": "houdini-scene",
+                "group": "inspection"
+            })),
+            None,
+        )
+        .await
+        .unwrap();
+        let listed = assemble_full_tool_list(&state, false, None);
+        assert_eq!(
+            listed
+                .iter()
+                .find(|tool| tool.name == "activate_tool_group")
+                .unwrap()
+                .input_schema["properties"]["skill_name"]["type"],
+            "string"
+        );
+        let expected_stubs = ["houdini-analysis", "houdini-scene"]
+            .map(|skill| group_stub_name(Some(skill), "inspection"));
+
+        let search = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "search_tools",
+            Some(json!({
+                "query": "inspection",
+                "dcc": "houdini",
+                "include_stubs": true,
+                "include_unloaded_skills": false,
+            })),
+            None,
+        )
+        .await
+        .expect("inactive group search should dispatch");
+        let search_payload = result_text_json(&search);
+        let searched_stubs: Vec<_> = search_payload["tools"]
+            .as_array()
+            .expect("search tools array")
+            .iter()
+            .filter(|hit| hit["group"] == "inspection" && hit["category"] == "stub")
+            .collect();
+        assert_eq!(searched_stubs.len(), 2);
+        for (skill, stub_name) in ["houdini-analysis", "houdini-scene"]
+            .into_iter()
+            .zip(expected_stubs.iter())
+        {
+            let hit = searched_stubs
+                .iter()
+                .find(|hit| hit["skill_name"] == skill)
+                .expect("same-named sibling group needs its own search hit");
+            assert_eq!(hit["name"], stub_name.as_str());
+            dcc_mcp_naming::validate_tool_name(hit["name"].as_str().unwrap())
+                .expect("scoped group stub name must be MCP-safe");
+            let description = hit["description"].as_str().unwrap();
+            assert!(description.contains(&format!("skill `{skill}`")));
+            assert!(description.contains(&format!("skill_name=\"{skill}\"")));
+        }
+
+        for (skill, stub_name) in ["houdini-analysis", "houdini-scene"]
+            .into_iter()
+            .zip(expected_stubs.iter())
+        {
+            let stub = listed
+                .iter()
+                .find(|tool| &tool.name == stub_name)
+                .expect("same-named sibling group needs its own stub");
+            assert!(stub.description.contains(&format!("skill '{skill}'")));
+            assert!(
+                stub.description
+                    .contains(&format!("skill_name=\"{skill}\""))
+            );
+        }
+
+        let stub_result = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            &expected_stubs[0],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(
+            result_text(&stub_result).contains(
+                "activate_tool_group(group_name=\\\"inspection\\\", skill_name=\\\"houdini-analysis\\\")"
+            )
+        );
+        let legacy_stub = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "__group__legacy",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(result_text(&legacy_stub).contains("group=\\\"legacy\\\""));
+        assert!(!result_text(&legacy_stub).contains("skill_name"));
+
+        dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            Some(&session_id),
+            "activate_tool_group",
+            Some(json!({"group_name": "inspection"})),
+            None,
+        )
+        .await
+        .unwrap();
+        let activation_event = notifications.try_recv().unwrap();
+        let activation_delta: Value =
+            serde_json::from_str(activation_event.strip_prefix("data: ").unwrap().trim()).unwrap();
+        let expected_stub_set: std::collections::BTreeSet<_> =
+            expected_stubs.iter().cloned().collect();
+        let removed_stub_set: std::collections::BTreeSet<_> = activation_delta["params"]["removed"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect();
+        assert_eq!(removed_stub_set, expected_stub_set);
+
+        dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            Some(&session_id),
+            "deactivate_tool_group",
+            Some(json!({"group_name": "inspection"})),
+            None,
+        )
+        .await
+        .unwrap();
+        let deactivation_event = notifications.try_recv().unwrap();
+        let deactivation_delta: Value =
+            serde_json::from_str(deactivation_event.strip_prefix("data: ").unwrap().trim())
+                .unwrap();
+        let added_stub_set: std::collections::BTreeSet<_> = deactivation_delta["params"]["added"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect();
+        assert_eq!(added_stub_set, expected_stub_set);
+    }
+
+    #[tokio::test]
+    async fn hashed_group_stub_reports_the_exact_activation_target() {
+        let registry = Arc::new(ToolRegistry::new());
+        let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+        let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+            Arc::clone(&registry),
+            Arc::clone(&dispatcher),
+        ));
+        let skill_name = "a".repeat(40);
+        catalog.add_skill(SkillMetadata {
+            name: skill_name.clone(),
+            dcc: "houdini".to_string(),
+            groups: vec![SkillGroup {
+                name: "inspection".to_string(),
+                tools: vec!["inspect".to_string()],
+                ..Default::default()
+            }],
+            tools: vec![ToolDeclaration {
+                name: "inspect".to_string(),
+                group: "inspection".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        catalog
+            .load_skill_with_options(&skill_name, false)
+            .expect("skill should load with its group disabled");
+        let state = ServerState::builder(registry, dispatcher, catalog).build();
+        let stub_name = group_stub_name(Some(&skill_name), "inspection");
+        assert!(stub_name.starts_with("__group__scoped_"));
+        assert!(
+            assemble_full_tool_list(&state, false, None)
+                .iter()
+                .any(|tool| tool.name == stub_name)
+        );
+
+        let result =
+            dispatch_rmcp_tool_call(&state, &ready_context(), None, &stub_name, None, None)
+                .await
+                .unwrap();
+        let text = result_text(&result);
+        assert!(text.contains(&format!("skill '{skill_name}'")), "{text}");
+        assert!(
+            text.contains(&format!(
+                "group_name=\\\"inspection\\\", skill_name=\\\"{skill_name}\\\""
+            )),
+            "{text}"
+        );
+
+        dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "activate_tool_group",
+            Some(json!({"skill_name": skill_name, "group_name": "inspection"})),
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(state.registry.list_actions(None).iter().any(|meta| {
+            meta.skill_name.as_deref() == Some(skill_name.as_str()) && meta.enabled
+        }));
+    }
+
+    #[tokio::test]
+    async fn ordinary_targeted_load_keeps_default_active_groups() {
+        let registry = Arc::new(ToolRegistry::new());
+        let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+        let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+            Arc::clone(&registry),
+            Arc::clone(&dispatcher),
+        ));
+        catalog.add_skill(SkillMetadata {
+            name: "houdini-scene".to_string(),
+            dcc: "houdini".to_string(),
+            groups: vec![
+                SkillGroup {
+                    name: "inspection".to_string(),
+                    ..Default::default()
+                },
+                SkillGroup {
+                    name: "core".to_string(),
+                    default_active: true,
+                    ..Default::default()
+                },
+            ],
+            tools: vec![
+                ToolDeclaration {
+                    name: "inspect".to_string(),
+                    group: "inspection".to_string(),
+                    ..Default::default()
+                },
+                ToolDeclaration {
+                    name: "status".to_string(),
+                    group: "core".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        });
+        let state = ServerState::builder(registry, dispatcher, catalog).build();
+
+        let result = dispatch_rmcp_tool_call(
+            &state,
+            &ready_context(),
+            None,
+            "load_skill",
+            Some(json!({
+                "skill_name": "houdini-scene",
+                "tool_group": "inspection"
+            })),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error);
+        for tool in ["houdini_scene__inspect", "houdini_scene__status"] {
+            assert!(
+                state
+                    .registry
+                    .get_action(tool, None)
+                    .is_some_and(|meta| meta.enabled),
+                "{tool} should remain enabled"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
@@ -98,6 +98,7 @@ impl SkillCatalog {
             after_load_hook: RwLock::new(None),
             after_unload_hook: RwLock::new(None),
             after_group_change_hook: RwLock::new(None),
+            after_scoped_group_change_hook: RwLock::new(None),
             active_groups: DashSet::new(),
             inverted_index: RwLock::new(IndexGuard::default()),
             dcc_shards: DashMap::new(),
@@ -122,6 +123,7 @@ impl SkillCatalog {
             after_load_hook: RwLock::new(None),
             after_unload_hook: RwLock::new(None),
             after_group_change_hook: RwLock::new(None),
+            after_scoped_group_change_hook: RwLock::new(None),
             active_groups: DashSet::new(),
             inverted_index: RwLock::new(IndexGuard::default()),
             dcc_shards: DashMap::new(),
@@ -252,9 +254,8 @@ impl SkillCatalog {
     }
 
     /// Register an observer that runs after [`Self::activate_group`] /
-    /// [`Self::deactivate_group`] (#1405). `activated` is `true` for
-    /// activate and `false` for deactivate; the persistence layer uses
-    /// it to mirror catalog-wide group state on disk.
+    /// [`Self::deactivate_group`] (#1405). The first argument is always the
+    /// declared group name, including for skill-scoped operations.
     pub fn set_after_group_change_hook<F>(&self, hook: F)
     where
         F: Fn(&str, bool) -> Result<(), String> + Send + Sync + 'static,
@@ -265,6 +266,23 @@ impl SkillCatalog {
     /// Remove the after-group-change observer.
     pub fn clear_after_group_change_hook(&self) {
         *self.after_group_change_hook.write() = None;
+    }
+
+    /// Register a persistence observer that receives exact active-group keys.
+    ///
+    /// Unlike [`Self::set_after_group_change_hook`], scoped activations use
+    /// `"<skill>:<group>"` so persisted state can restore one skill without
+    /// enabling a sibling skill that declares the same group name.
+    pub fn set_after_scoped_group_change_hook<F>(&self, hook: F)
+    where
+        F: Fn(&str, bool) -> Result<(), String> + Send + Sync + 'static,
+    {
+        *self.after_scoped_group_change_hook.write() = Some(Arc::new(hook));
+    }
+
+    /// Remove the scoped persistence observer.
+    pub fn clear_after_scoped_group_change_hook(&self) {
+        *self.after_scoped_group_change_hook.write() = None;
     }
 
     /// Discover skills from the standard scan paths.

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -1,15 +1,15 @@
 use super::*;
 use serde_json::{Map, Value, json};
 
-fn activate_skill_groups(catalog: &SkillCatalog, metadata: &SkillMetadata) {
+fn activate_skill_groups(catalog: &SkillCatalog, skill_name: &str, metadata: &SkillMetadata) {
     for group in &metadata.groups {
         if !group.name.is_empty() {
-            catalog.activate_group(&group.name);
+            catalog.activate_skill_group(skill_name, &group.name);
         }
     }
     for tool in &metadata.tools {
         if !tool.group.is_empty() {
-            catalog.activate_group(&tool.group);
+            catalog.activate_skill_group(skill_name, &tool.group);
         }
     }
 }
@@ -181,7 +181,18 @@ impl SkillCatalog {
         activate_groups: bool,
     ) -> Result<Vec<String>, String> {
         let mut visiting = Vec::new();
-        self.load_skill_recursive(skill_name, activate_groups, &mut visiting)
+        self.load_skill_recursive(skill_name, activate_groups, None, &mut visiting)
+    }
+
+    /// Load a new skill with only one declared group (plus ungrouped tools)
+    /// enabled before the registry and after-load observers can see it.
+    pub fn load_skill_target_group(
+        &self,
+        skill_name: &str,
+        target_group: &str,
+    ) -> Result<Vec<String>, String> {
+        let mut visiting = Vec::new();
+        self.load_skill_recursive(skill_name, false, Some(target_group), &mut visiting)
     }
 
     /// Load a caller-supplied skill metadata object through the normal catalog path.
@@ -226,6 +237,7 @@ impl SkillCatalog {
         &self,
         skill_name: &str,
         activate_groups: bool,
+        target_group: Option<&str>,
         visiting: &mut Vec<String>,
     ) -> Result<Vec<String>, String> {
         if self.loaded.contains(skill_name) {
@@ -234,7 +246,7 @@ impl SkillCatalog {
                 .get(skill_name)
                 .map(|entry| {
                     if activate_groups {
-                        activate_skill_groups(self, &entry.metadata);
+                        activate_skill_groups(self, skill_name, &entry.metadata);
                     }
                     entry.registered_tools.clone()
                 })
@@ -325,7 +337,7 @@ impl SkillCatalog {
         visiting.push(skill_name.to_string());
         for dep in &metadata.depends {
             if !self.loaded.contains(dep.as_str())
-                && let Err(err) = self.load_skill_recursive(dep, activate_groups, visiting)
+                && let Err(err) = self.load_skill_recursive(dep, activate_groups, None, visiting)
             {
                 let err =
                     format!("Failed to load dependency '{dep}' for skill '{skill_name}': {err}");
@@ -352,7 +364,7 @@ impl SkillCatalog {
                 .unwrap_or_default());
         }
 
-        self.load_skill_metadata(skill_name, &metadata, activate_groups)
+        self.load_skill_metadata(skill_name, &metadata, activate_groups, target_group)
     }
 
     fn load_skill_metadata(
@@ -360,6 +372,7 @@ impl SkillCatalog {
         skill_name: &str,
         metadata: &SkillMetadata,
         activate_groups: bool,
+        target_group: Option<&str>,
     ) -> Result<Vec<String>, String> {
         // Pin one executor for the complete registration. A concurrent clear or
         // replacement must not make later tools silently fall back to subprocesses.
@@ -438,12 +451,19 @@ impl SkillCatalog {
             return Err(err);
         }
 
-        if activate_groups {
-            activate_skill_groups(self, metadata);
+        if let Some(group) = target_group {
+            if !metadata.groups.iter().any(|item| item.name == group) {
+                return Err(format!(
+                    "Tool group '{group}' was not found in skill '{skill_name}'"
+                ));
+            }
+            self.activate_skill_group(skill_name, group);
+        } else if activate_groups {
+            activate_skill_groups(self, skill_name, metadata);
         } else {
             for group in &metadata.groups {
                 if group.default_active {
-                    self.active_groups.insert(group.name.clone());
+                    self.activate_skill_group(skill_name, &group.name);
                 }
             }
         }
@@ -498,8 +518,10 @@ impl SkillCatalog {
                 source_file: script_path.clone(),
                 skill_name: Some(skill_name.to_string()),
                 group: tool_decl.group.clone(),
-                enabled: activate_groups
-                    || group_default_active(&metadata.groups, &tool_decl.group),
+                enabled: target_group.map_or_else(
+                    || activate_groups || group_default_active(&metadata.groups, &tool_decl.group),
+                    |group| tool_decl.group.is_empty() || tool_decl.group == group,
+                ),
                 required_capabilities: tool_decl.required_capabilities.clone(),
                 execution: tool_decl.execution,
                 timeout_hint_secs: tool_decl.timeout_hint_secs,
@@ -693,6 +715,16 @@ impl SkillCatalog {
             }
         }
 
+        let scoped_prefix = format!("{skill_name}:");
+        let scoped_groups: Vec<_> = self
+            .active_groups
+            .iter()
+            .filter_map(|key| key.strip_prefix(&scoped_prefix).map(str::to_string))
+            .collect();
+        for group_name in scoped_groups {
+            self.deactivate_skill_group(skill_name, &group_name);
+        }
+
         let count = self.registry.unregister_skill(skill_name);
 
         if let Some(mut entry) = self.entries.get_mut(skill_name) {
@@ -757,9 +789,9 @@ impl SkillCatalog {
     /// Replay a persisted set of loaded skills + active groups (#1405).
     ///
     /// Walks `state.skills` in order and attempts to re-load each one
-    /// using `load_skill_with_options(name, false)` so the catalog's own
-    /// default-active group computation does not interfere with the
-    /// explicit `state.active_groups` set replayed afterwards.
+    /// using `load_skill_with_options(name, false)`, then clears each
+    /// skill's default-active groups before replaying the explicit
+    /// `state.active_groups` set.
     ///
     /// The `policy` argument decides how to treat a record whose on-disk
     /// version differs from the one that was persisted:
@@ -819,7 +851,12 @@ impl SkillCatalog {
             }
 
             match self.load_skill_with_options(&record.name, false) {
-                Ok(_) => report.loaded.push(record.name.clone()),
+                Ok(_) => {
+                    for group in &entry.metadata.groups {
+                        self.deactivate_skill_group(&record.name, &group.name);
+                    }
+                    report.loaded.push(record.name.clone());
+                }
                 Err(err) => {
                     tracing::warn!(
                         skill = %record.name,
@@ -834,11 +871,17 @@ impl SkillCatalog {
             }
         }
 
-        // Replay catalog-wide active group selection. Groups declared by
-        // skills that failed to load are best-effort no-ops (the
-        // registry has no tools tagged with them).
+        // Replay scoped keys only for skills that were restored successfully.
+        // Bare names remain supported for legacy catalog-wide snapshots.
         for group in &state.active_groups {
-            self.activate_group(group);
+            if let Some((skill, name)) = group.split_once(':') {
+                if !self.loaded.contains(skill) || !self.has_skill_group(skill, name) {
+                    continue;
+                }
+                self.activate_skill_group(skill, name);
+            } else {
+                self.activate_group(group);
+            }
             report.activated_groups.push(group.clone());
         }
 

--- a/crates/dcc-mcp-skills/src/catalog/groups.rs
+++ b/crates/dcc-mcp-skills/src/catalog/groups.rs
@@ -1,6 +1,25 @@
 use super::*;
 
 impl SkillCatalog {
+    fn skill_group_key(skill_name: &str, group_name: &str) -> String {
+        format!("{skill_name}:{group_name}")
+    }
+
+    pub(super) fn has_skill_group(&self, skill_name: &str, group_name: &str) -> bool {
+        self.entries.get(skill_name).is_some_and(|entry| {
+            entry
+                .metadata
+                .groups
+                .iter()
+                .any(|item| item.name == group_name)
+                || entry
+                    .metadata
+                    .tools
+                    .iter()
+                    .any(|tool| tool.group == group_name)
+        })
+    }
+
     /// Activate a tool group: enable every [`ToolMeta`] whose
     /// ``group`` field matches ``group_name``.
     ///
@@ -10,15 +29,82 @@ impl SkillCatalog {
         let count = self.registry.set_group_enabled(group_name, true);
         if inserted {
             self.notify_after_group_change_hook(group_name, true);
+            self.notify_after_scoped_group_change_hook(group_name, true);
         }
         count
     }
 
     /// Deactivate a tool group (inverse of [`activate_group`]).
     pub fn deactivate_group(&self, group_name: &str) -> usize {
-        let removed = self.active_groups.remove(group_name).is_some();
+        let mut removed_keys = Vec::new();
+        if self.active_groups.remove(group_name).is_some() {
+            removed_keys.push(group_name.to_string());
+        }
+        let scoped_suffix = format!(":{group_name}");
+        let scoped_keys: Vec<_> = self
+            .active_groups
+            .iter()
+            .filter(|key| key.ends_with(&scoped_suffix))
+            .map(|key| key.clone())
+            .collect();
+        for key in scoped_keys {
+            if self.active_groups.remove(&key).is_some() {
+                removed_keys.push(key);
+            }
+        }
         let count = self.registry.set_group_enabled(group_name, false);
+        if !removed_keys.is_empty() {
+            self.notify_after_group_change_hook(group_name, false);
+        }
+        for key in removed_keys {
+            self.notify_after_scoped_group_change_hook(&key, false);
+        }
+        count
+    }
+
+    /// Activate one group belonging to one skill.
+    pub fn activate_skill_group(&self, skill_name: &str, group_name: &str) -> usize {
+        let key = Self::skill_group_key(skill_name, group_name);
+        let inserted = self.active_groups.insert(key.clone());
+        let count = self
+            .registry
+            .set_skill_group_enabled(skill_name, group_name, true);
+        if inserted {
+            self.notify_after_group_change_hook(group_name, true);
+            self.notify_after_scoped_group_change_hook(&key, true);
+        }
+        count
+    }
+
+    /// Deactivate one group belonging to one skill.
+    pub fn deactivate_skill_group(&self, skill_name: &str, group_name: &str) -> usize {
+        let legacy_active = self.active_groups.contains(group_name);
+        if legacy_active {
+            let other_owners: Vec<_> = self
+                .loaded
+                .iter()
+                .map(|entry| entry.key().clone())
+                .filter(|owner| owner != skill_name && self.has_skill_group(owner, group_name))
+                .collect();
+            for owner in other_owners {
+                let key = Self::skill_group_key(&owner, group_name);
+                if self.active_groups.insert(key.clone()) {
+                    self.notify_after_scoped_group_change_hook(&key, true);
+                }
+            }
+            if self.active_groups.remove(group_name).is_some() {
+                self.notify_after_scoped_group_change_hook(group_name, false);
+            }
+        }
+        let key = Self::skill_group_key(skill_name, group_name);
+        let removed = self.active_groups.remove(&key).is_some();
+        let count = self
+            .registry
+            .set_skill_group_enabled(skill_name, group_name, false);
         if removed {
+            self.notify_after_scoped_group_change_hook(&key, false);
+        }
+        if legacy_active || removed {
             self.notify_after_group_change_hook(group_name, false);
         }
         count
@@ -40,9 +126,36 @@ impl SkillCatalog {
         }
     }
 
+    /// Fire the scoped persistence observer. Failures never roll back state.
+    fn notify_after_scoped_group_change_hook(&self, key: &str, activated: bool) {
+        let Some(hook) = self.after_scoped_group_change_hook.read().clone() else {
+            return;
+        };
+        if let Err(reason) = hook(key, activated) {
+            tracing::warn!(
+                group = key,
+                activated,
+                error = %reason,
+                "SkillCatalog after-scoped-group-change hook failed"
+            );
+        }
+    }
+
     /// Return all currently-active tool group names.
     pub fn active_groups(&self) -> Vec<String> {
-        self.active_groups.iter().map(|e| e.clone()).collect()
+        let mut groups = std::collections::BTreeSet::new();
+        for key in self.active_group_keys() {
+            let group = key
+                .rsplit_once(':')
+                .filter(|(skill, group)| self.has_skill_group(skill, group))
+                .map_or(key.as_str(), |(_, group)| group);
+            groups.insert(group.to_string());
+        }
+        groups.into_iter().collect()
+    }
+
+    pub(crate) fn active_group_keys(&self) -> Vec<String> {
+        self.active_groups.iter().map(|key| key.clone()).collect()
     }
 
     /// Return every distinct group name declared across loaded skills.
@@ -51,7 +164,10 @@ impl SkillCatalog {
         for entry in self.entries.iter() {
             let skill = entry.key().clone();
             for g in &entry.value().metadata.groups {
-                let active = self.active_groups.contains(&g.name);
+                let active = self.active_groups.contains(&g.name)
+                    || self
+                        .active_groups
+                        .contains(&Self::skill_group_key(&skill, &g.name));
                 out.push((skill.clone(), g.name.clone(), active));
             }
         }

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -90,9 +90,12 @@ pub type AfterSkillLoadFn = dyn Fn(&SkillMetadata, &[String]) -> Result<(), Stri
 pub type AfterSkillUnloadFn = dyn Fn(&str, &[String]) -> Result<(), String> + Send + Sync;
 /// Observer invoked after a successful
 /// [`SkillCatalog::activate_group`] / [`SkillCatalog::deactivate_group`].
-/// `activated` is `true` for activate, `false` for deactivate. Used by
-/// the persistence layer (#1405) to mirror catalog-wide group state.
+/// Receives the declared group name and whether it was activated. Scoped
+/// persistence consumers should use [`AfterScopedGroupChangeFn`] instead.
 pub type AfterGroupChangeFn = dyn Fn(&str, bool) -> Result<(), String> + Send + Sync;
+/// Internal observer for persistence consumers that need the exact active
+/// group key (`"<skill>:<group>"` for scoped state, bare for legacy state).
+pub type AfterScopedGroupChangeFn = dyn Fn(&str, bool) -> Result<(), String> + Send + Sync;
 
 // ── SkillCatalog ──
 
@@ -142,10 +145,11 @@ pub struct SkillCatalog {
     pub(super) after_load_hook: RwLock<Option<Arc<AfterSkillLoadFn>>>,
     /// Optional observer called after a skill is unloaded (#1405).
     pub(super) after_unload_hook: RwLock<Option<Arc<AfterSkillUnloadFn>>>,
-    /// Optional observer called after a tool group is activated or
-    /// deactivated (#1405). Lets the persistence layer mirror the
-    /// catalog-wide [`SkillCatalog::active_groups`] set on disk.
+    /// Optional public observer called after a tool group is activated or
+    /// deactivated (#1405). Always receives the declared, unscoped group name.
     pub(super) after_group_change_hook: RwLock<Option<Arc<AfterGroupChangeFn>>>,
+    /// Persistence-only observer that receives exact scoped group keys.
+    pub(super) after_scoped_group_change_hook: RwLock<Option<Arc<AfterScopedGroupChangeFn>>>,
     /// Tool groups currently active (`"<skill>:<group>"` keys).
     pub(super) active_groups: DashSet<String>,
     /// Inverted index for fast `search_skills` scoring. Built lazily on

--- a/crates/dcc-mcp-skills/src/catalog/persistence.rs
+++ b/crates/dcc-mcp-skills/src/catalog/persistence.rs
@@ -72,9 +72,9 @@ pub struct PersistedCatalogState {
     /// Skills that were loaded at checkpoint time.
     #[serde(default)]
     pub skills: Vec<LoadedSkillRecord>,
-    /// Tool-group names that were active at checkpoint time. Catalog-wide
-    /// because [`crate::catalog::SkillCatalog::active_groups`] is a flat
-    /// set, not per-skill.
+    /// Tool-group keys that were active at checkpoint time. New scoped
+    /// entries use `"<skill>:<group>"`; legacy catalog-wide group names are
+    /// still accepted during replay.
     #[serde(default)]
     pub active_groups: Vec<String>,
     /// UNIX-ms timestamp the snapshot was written.

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
@@ -376,6 +376,210 @@ fn test_load_skill_can_leave_groups_inactive_when_requested() {
 }
 
 #[test]
+fn scoped_group_changes_preserve_the_public_hook_contract() {
+    let catalog = make_test_catalog();
+    let mut skill = make_test_skill("maya-scene", "maya", &[]);
+    skill.groups = vec![SkillGroup {
+        name: "inspection".to_string(),
+        ..Default::default()
+    }];
+    skill.tools = vec![ToolDeclaration {
+        name: "inspect".to_string(),
+        group: "inspection".to_string(),
+        ..Default::default()
+    }];
+    catalog.add_skill(skill);
+    catalog
+        .load_skill_with_options("maya-scene", false)
+        .unwrap();
+
+    let public_changes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let public_observed = public_changes.clone();
+    catalog.set_after_group_change_hook(move |group, active| {
+        public_observed
+            .lock()
+            .unwrap()
+            .push((group.to_string(), active));
+        Ok(())
+    });
+    let scoped_changes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let scoped_observed = scoped_changes.clone();
+    catalog.set_after_scoped_group_change_hook(move |key, active| {
+        scoped_observed
+            .lock()
+            .unwrap()
+            .push((key.to_string(), active));
+        Ok(())
+    });
+
+    catalog.activate_skill_group("maya-scene", "inspection");
+
+    assert_eq!(
+        *public_changes.lock().unwrap(),
+        vec![("inspection".to_string(), true)]
+    );
+    assert_eq!(
+        *scoped_changes.lock().unwrap(),
+        vec![("maya-scene:inspection".to_string(), true)]
+    );
+}
+
+#[test]
+fn test_unload_clears_only_its_scoped_active_groups() {
+    let catalog = make_test_catalog();
+    let mut skill = make_test_skill("maya-scene", "maya", &[]);
+    skill.groups = ["inspection", "editing"]
+        .into_iter()
+        .map(|name| SkillGroup {
+            name: name.to_string(),
+            ..Default::default()
+        })
+        .collect();
+    skill.tools = ["inspection", "editing"]
+        .into_iter()
+        .map(|group| ToolDeclaration {
+            name: group.to_string(),
+            group: group.to_string(),
+            ..Default::default()
+        })
+        .collect();
+    catalog.add_skill(skill);
+
+    let public_changes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let public_observed = public_changes.clone();
+    catalog.set_after_group_change_hook(move |group, active| {
+        public_observed
+            .lock()
+            .unwrap()
+            .push((group.to_string(), active));
+        Ok(())
+    });
+    let scoped_changes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let scoped_observed = scoped_changes.clone();
+    catalog.set_after_scoped_group_change_hook(move |key, active| {
+        scoped_observed
+            .lock()
+            .unwrap()
+            .push((key.to_string(), active));
+        Ok(())
+    });
+    catalog
+        .load_skill_with_options("maya-scene", false)
+        .unwrap();
+    catalog.activate_group("legacy-global");
+    catalog.activate_skill_group("maya-scene", "inspection");
+
+    catalog.unload_skill("maya-scene").unwrap();
+    catalog
+        .load_skill_with_options("maya-scene", false)
+        .unwrap();
+    catalog.activate_skill_group("maya-scene", "editing");
+
+    assert!(
+        catalog
+            .active_groups()
+            .contains(&"legacy-global".to_string())
+    );
+    assert!(
+        !catalog
+            .active_group_keys()
+            .contains(&"maya-scene:inspection".to_string())
+    );
+    assert!(
+        catalog
+            .active_group_keys()
+            .contains(&"maya-scene:editing".to_string())
+    );
+    assert!(catalog.active_groups().contains(&"editing".to_string()));
+    let groups = catalog.list_groups();
+    assert!(groups.contains(&("maya-scene".to_string(), "inspection".to_string(), false)));
+    assert!(groups.contains(&("maya-scene".to_string(), "editing".to_string(), true)));
+    assert!(
+        scoped_changes
+            .lock()
+            .unwrap()
+            .contains(&("maya-scene:inspection".to_string(), false))
+    );
+
+    catalog.deactivate_group("editing");
+    assert!(
+        !catalog
+            .active_group_keys()
+            .contains(&"maya-scene:editing".to_string())
+    );
+    assert!(
+        scoped_changes
+            .lock()
+            .unwrap()
+            .contains(&("maya-scene:editing".to_string(), false))
+    );
+    assert!(
+        public_changes
+            .lock()
+            .unwrap()
+            .contains(&("editing".to_string(), false))
+    );
+}
+
+#[test]
+fn legacy_deactivate_clears_every_scoped_group_key() {
+    let catalog = make_test_catalog();
+    for name in ["alpha", "beta"] {
+        let mut skill = make_test_skill(name, "maya", &[]);
+        skill.groups = vec![SkillGroup {
+            name: "inspection".to_string(),
+            ..Default::default()
+        }];
+        skill.tools = vec![ToolDeclaration {
+            name: "inspect".to_string(),
+            group: "inspection".to_string(),
+            ..Default::default()
+        }];
+        catalog.add_skill(skill);
+        catalog.load_skill_with_options(name, false).unwrap();
+        catalog.activate_skill_group(name, "inspection");
+    }
+    let public_changes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let public_observed = public_changes.clone();
+    catalog.set_after_group_change_hook(move |group, active| {
+        public_observed
+            .lock()
+            .unwrap()
+            .push((group.to_string(), active));
+        Ok(())
+    });
+    let scoped_changes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let scoped_observed = scoped_changes.clone();
+    catalog.set_after_scoped_group_change_hook(move |key, active| {
+        scoped_observed
+            .lock()
+            .unwrap()
+            .push((key.to_string(), active));
+        Ok(())
+    });
+
+    catalog.deactivate_group("inspection");
+
+    assert!(catalog.active_group_keys().is_empty());
+    assert!(
+        catalog
+            .registry()
+            .list_actions_in_group("inspection")
+            .iter()
+            .all(|tool| !tool.enabled)
+    );
+    assert_eq!(
+        scoped_changes.lock().unwrap().len(),
+        2,
+        "each scoped key must emit a persistence hook"
+    );
+    assert_eq!(
+        *public_changes.lock().unwrap(),
+        vec![("inspection".to_string(), false)]
+    );
+}
+
+#[test]
 fn test_load_skill_propagates_thread_affinity_enforcement() {
     let (catalog, dispatcher) = make_catalog_with_dispatcher();
     catalog.set_in_process_executor(|_, _, _| Ok(serde_json::json!({"ok": true})));

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_replay_loaded.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_replay_loaded.rs
@@ -132,6 +132,255 @@ fn replay_restores_active_groups() {
     );
 }
 
+fn add_grouped_skill(catalog: &SkillCatalog, name: &str, group: &str) {
+    let mut skill = make_test_skill(name, "maya", &[]);
+    skill.groups = vec![SkillGroup {
+        name: group.to_string(),
+        ..Default::default()
+    }];
+    skill.tools = vec![dcc_mcp_models::ToolDeclaration {
+        name: "inspect".to_string(),
+        group: group.to_string(),
+        ..Default::default()
+    }];
+    catalog.add_skill(skill);
+}
+
+#[test]
+fn replay_restores_scoped_group_without_enabling_sibling_skill() {
+    let catalog = make_test_catalog();
+    for name in ["alpha", "beta"] {
+        let mut skill = make_test_skill(name, "maya", &[]);
+        skill.groups = vec![SkillGroup {
+            name: "inspection".to_string(),
+            ..Default::default()
+        }];
+        skill.tools = vec![dcc_mcp_models::ToolDeclaration {
+            name: "inspect".to_string(),
+            group: "inspection".to_string(),
+            ..Default::default()
+        }];
+        catalog.add_skill(skill);
+    }
+
+    let state = PersistedCatalogState {
+        skills: vec![
+            record("alpha", Some("1.0.0")),
+            record("beta", Some("1.0.0")),
+        ],
+        active_groups: vec!["alpha:inspection".to_string()],
+        saved_at_ms: 0,
+        schema_version: 1,
+    };
+    catalog.replay_loaded(&state, LoadReplayPolicy::SkipOnDrift);
+
+    assert!(
+        catalog
+            .registry()
+            .get_action("alpha__inspect", None)
+            .is_some_and(|tool| tool.enabled)
+    );
+    assert!(
+        catalog
+            .registry()
+            .get_action("beta__inspect", None)
+            .is_some_and(|tool| !tool.enabled)
+    );
+}
+
+#[test]
+fn replay_skips_scoped_groups_for_skills_that_are_not_loaded() {
+    let catalog = make_test_catalog();
+    add_grouped_skill(&catalog, "alpha", "inspection");
+    let state = PersistedCatalogState {
+        skills: vec![],
+        active_groups: vec!["alpha:inspection".to_string()],
+        saved_at_ms: 0,
+        schema_version: 1,
+    };
+
+    let report = catalog.replay_loaded(&state, LoadReplayPolicy::SkipOnDrift);
+
+    assert!(report.activated_groups.is_empty());
+    assert!(catalog.active_group_keys().is_empty());
+    catalog.load_skill_with_options("alpha", false).unwrap();
+    assert!(
+        catalog
+            .registry()
+            .get_action("alpha__inspect", None)
+            .is_some_and(|tool| !tool.enabled)
+    );
+    assert_eq!(
+        catalog
+            .list_groups()
+            .into_iter()
+            .find(|(skill, group, _)| skill == "alpha" && group == "inspection")
+            .map(|(_, _, active)| active),
+        Some(false)
+    );
+}
+
+#[test]
+fn scoped_deactivate_migrates_legacy_bare_group_before_snapshot_replay() {
+    let persisted = PersistedCatalogState {
+        skills: vec![
+            record("alpha", Some("1.0.0")),
+            record("beta", Some("1.0.0")),
+        ],
+        active_groups: vec!["inspection".to_string()],
+        saved_at_ms: 0,
+        schema_version: 1,
+    };
+    let catalog = make_test_catalog();
+    for name in ["alpha", "beta"] {
+        add_grouped_skill(&catalog, name, "inspection");
+    }
+    catalog.replay_loaded(&persisted, LoadReplayPolicy::SkipOnDrift);
+    let changes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let observed = changes.clone();
+    catalog.set_after_scoped_group_change_hook(move |key, active| {
+        observed.lock().unwrap().push((key.to_string(), active));
+        Ok(())
+    });
+
+    catalog.deactivate_skill_group("alpha", "inspection");
+
+    assert!(
+        catalog
+            .registry()
+            .get_action("alpha__inspect", None)
+            .is_some_and(|tool| !tool.enabled)
+    );
+    assert!(
+        catalog
+            .registry()
+            .get_action("beta__inspect", None)
+            .is_some_and(|tool| tool.enabled)
+    );
+    assert_eq!(
+        catalog.active_group_keys(),
+        vec!["beta:inspection".to_string()]
+    );
+    let changes = changes.lock().unwrap();
+    assert!(changes.contains(&("beta:inspection".to_string(), true)));
+    assert!(changes.contains(&("inspection".to_string(), false)));
+    drop(changes);
+
+    let snapshot = PersistedCatalogState {
+        skills: persisted.skills.clone(),
+        active_groups: catalog.active_group_keys(),
+        saved_at_ms: 0,
+        schema_version: 1,
+    };
+    let replayed = make_test_catalog();
+    for name in ["alpha", "beta"] {
+        add_grouped_skill(&replayed, name, "inspection");
+    }
+    replayed.replay_loaded(&snapshot, LoadReplayPolicy::SkipOnDrift);
+    assert!(
+        replayed
+            .registry()
+            .get_action("alpha__inspect", None)
+            .is_some_and(|tool| !tool.enabled)
+    );
+    assert!(
+        replayed
+            .registry()
+            .get_action("beta__inspect", None)
+            .is_some_and(|tool| tool.enabled)
+    );
+}
+
+#[test]
+fn default_active_group_persists_without_enabling_same_named_sibling() {
+    fn grouped_skill(name: &str, default_active: bool) -> SkillMetadata {
+        let mut skill = make_test_skill(name, "maya", &[]);
+        skill.groups = vec![SkillGroup {
+            name: "core".to_string(),
+            default_active,
+            ..Default::default()
+        }];
+        skill.tools = vec![dcc_mcp_models::ToolDeclaration {
+            name: "inspect".to_string(),
+            group: "core".to_string(),
+            ..Default::default()
+        }];
+        skill
+    }
+
+    let source = make_test_catalog();
+    source.add_skill(grouped_skill("alpha", true));
+    source.add_skill(grouped_skill("beta", false));
+    source.load_skill_with_options("alpha", false).unwrap();
+    source.load_skill_with_options("beta", false).unwrap();
+    assert!(source.active_groups().contains(&"core".to_string()));
+    assert!(
+        source
+            .active_group_keys()
+            .contains(&"alpha:core".to_string())
+    );
+
+    let state = PersistedCatalogState {
+        skills: vec![
+            record("alpha", Some("1.0.0")),
+            record("beta", Some("1.0.0")),
+        ],
+        active_groups: source.active_group_keys(),
+        saved_at_ms: 0,
+        schema_version: 1,
+    };
+    let replayed = make_test_catalog();
+    replayed.add_skill(grouped_skill("alpha", true));
+    replayed.add_skill(grouped_skill("beta", false));
+    replayed.replay_loaded(&state, LoadReplayPolicy::SkipOnDrift);
+
+    assert!(
+        replayed
+            .registry()
+            .get_action("alpha__inspect", None)
+            .is_some_and(|tool| tool.enabled)
+    );
+    assert!(
+        replayed
+            .registry()
+            .get_action("beta__inspect", None)
+            .is_some_and(|tool| !tool.enabled)
+    );
+}
+
+#[test]
+fn replay_empty_active_groups_override_skill_defaults() {
+    let catalog = make_test_catalog();
+    let mut skill = make_test_skill("alpha", "maya", &[]);
+    skill.groups = vec![SkillGroup {
+        name: "core".to_string(),
+        default_active: true,
+        ..Default::default()
+    }];
+    skill.tools = vec![dcc_mcp_models::ToolDeclaration {
+        name: "inspect".to_string(),
+        group: "core".to_string(),
+        ..Default::default()
+    }];
+    catalog.add_skill(skill);
+    let state = PersistedCatalogState {
+        skills: vec![record("alpha", Some("1.0.0"))],
+        active_groups: vec![],
+        saved_at_ms: 0,
+        schema_version: 1,
+    };
+
+    catalog.replay_loaded(&state, LoadReplayPolicy::SkipOnDrift);
+
+    assert!(catalog.active_groups().is_empty());
+    assert!(
+        catalog
+            .registry()
+            .get_action("alpha__inspect", None)
+            .is_some_and(|tool| !tool.enabled)
+    );
+}
+
 #[test]
 fn replay_persisted_record_without_version_loads_unconditionally() {
     // Records persisted by older code paths may not carry a version.

--- a/crates/dcc-mcp-skills/src/python/catalog.rs
+++ b/crates/dcc-mcp-skills/src/python/catalog.rs
@@ -332,6 +332,43 @@ impl SkillCatalog {
         self.clear_after_group_change_hook();
     }
 
+    /// Register the persistence-only observer for exact scoped group keys.
+    #[pyo3(name = "set_after_scoped_group_change_hook")]
+    fn py_set_after_scoped_group_change_hook(
+        &self,
+        py: Python<'_>,
+        hook: Option<Py<PyAny>>,
+    ) -> PyResult<()> {
+        match hook {
+            None => self.clear_after_scoped_group_change_hook(),
+            Some(py_fn) => {
+                if !py_fn.bind(py).is_callable() {
+                    return Err(pyo3::exceptions::PyTypeError::new_err(
+                        "after-scoped-group-change hook must be callable",
+                    ));
+                }
+                let hook_ref = py_fn.clone_ref(py);
+                self.set_after_scoped_group_change_hook(move |key, activated| {
+                    Python::try_attach(|gil| {
+                        hook_ref
+                            .call1(gil, (key.to_string(), activated))
+                            .map(|_| ())
+                            .map_err(|e| format!("after-scoped-group-change hook failed: {e}"))
+                    })
+                    .ok_or_else(|| "Python interpreter not attached".to_string())
+                    .and_then(|r| r)
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Clear the scoped persistence observer.
+    #[pyo3(name = "clear_after_scoped_group_change_hook")]
+    fn py_clear_after_scoped_group_change_hook(&self) {
+        self.clear_after_scoped_group_change_hook();
+    }
+
     /// Replay a persisted set of loaded skills + active groups (#1405).
     ///
     /// ``state_json`` is the JSON-encoded ``PersistedCatalogState`` (the

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -2580,6 +2580,14 @@ class SkillCatalog:
         r"""
         Clear any registered after-group-change hook.
         """
+    def set_after_scoped_group_change_hook(self, hook: typing.Optional[typing.Any]) -> None:
+        r"""
+        Register the persistence-only observer for exact scoped group keys.
+        """
+    def clear_after_scoped_group_change_hook(self) -> None:
+        r"""
+        Clear the scoped persistence observer.
+        """
     def replay_loaded(self, state_json: builtins.str, policy: builtins.str = 'skip_on_drift') -> builtins.str:
         r"""
         Replay a persisted set of loaded skills + active groups (#1405).

--- a/python/dcc_mcp_core/_server/observability_facade.py
+++ b/python/dcc_mcp_core/_server/observability_facade.py
@@ -245,7 +245,8 @@ class ObservabilityFacade:
 
         owner.set_after_load_skill_hook(_on_after_load)
         owner.set_after_unload_skill_hook(_on_after_unload)
-        owner.set_after_group_change_hook(_on_group_change)
+        if not owner._skill_client.set_after_scoped_group_change_hook(_on_group_change):
+            owner.set_after_group_change_hook(_on_group_change)
 
         snapshot = store.snapshot()
         if not snapshot.skills and not snapshot.active_groups:

--- a/python/dcc_mcp_core/_server/skill_query.py
+++ b/python/dcc_mcp_core/_server/skill_query.py
@@ -199,6 +199,42 @@ class SkillQueryClient:
                 return False
         return self.set_after_group_change_hook(None)
 
+    def set_after_scoped_group_change_hook(self, hook: Callable[[str, bool], Any] | None) -> bool:
+        """Register the exact-key observer used by loaded-state persistence."""
+        setter = getattr(self._server, "set_after_scoped_group_change_hook", None)
+        if not callable(setter):
+            logger.debug(
+                "[%s] set_after_scoped_group_change_hook unavailable on inner server",
+                self._dcc_name,
+            )
+            return False
+        try:
+            setter(hook)
+            return True
+        except Exception as exc:
+            logger.debug(
+                "[%s] set_after_scoped_group_change_hook failed: %s",
+                self._dcc_name,
+                exc,
+            )
+            return False
+
+    def clear_after_scoped_group_change_hook(self) -> bool:
+        """Remove the exact-key persistence observer, if registered."""
+        clearer = getattr(self._server, "clear_after_scoped_group_change_hook", None)
+        if callable(clearer):
+            try:
+                clearer()
+                return True
+            except Exception as exc:
+                logger.debug(
+                    "[%s] clear_after_scoped_group_change_hook failed: %s",
+                    self._dcc_name,
+                    exc,
+                )
+                return False
+        return self.set_after_scoped_group_change_hook(None)
+
     def replay_loaded_skills(self, state_json: str, *, policy: str = "skip_on_drift") -> str | None:
         """Replay a persisted catalog snapshot on the inner skill server (#1405).
 

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -140,6 +140,10 @@ does not replace a running server binary.
      idempotent, confirmation-gated, and free of credentials. Do not treat
      `elevation_required` as permission to automate UAC or another shell path.
 8. Use CLI profiles (`dcc-mcp-cli gateway ...`, `list/search/describe/call`) as the user UX; treat `dcc-mcp-server` modes as runtime plumbing. Read `docs/guide/gateway.md` before changing daemon, guardian, sentinel, registry, or idle-timeout behavior.
+   Gateway discovery reuses a recent capability snapshot across adjacent
+   queries. Route adapter catalog changes through the existing
+   load/reload/unload contracts that force a refresh; never depend on every
+   search polling the full backend catalog.
    `gateway://instances` is agent-safe by default and returns only live,
    routable rows. Use `?include_stale=true`, `?include_dead=true`, or
    `?view=all` only for explicit diagnosis; never route a call from those

--- a/skills/dcc-mcp-creator/references/TESTING_AND_RELEASE.md
+++ b/skills/dcc-mcp-creator/references/TESTING_AND_RELEASE.md
@@ -10,7 +10,7 @@ HTTP-level smoke when behavior crosses process boundaries.
 | Unit | option resolution, server construction, env vars, skill path collection |
 | Dispatcher | main-affinity calls run on the host dispatcher and return envelopes |
 | Skill lifecycle | `search_skills` -> `load_skill` -> typed tool -> `unload_skill` |
-| REST/MCP | direct `/mcp` or `/v1/*` search, describe, load, and call |
+| REST/MCP | direct `/mcp` or `/v1/*` search, then the returned `next_step` |
 | Gateway | multi-instance routing, policy, compact responses, debug traces |
 | Live DCC | one host smoke that creates/queries/cleans up real scene state |
 | Packaging | wheel or plugin archive installs into the target host runtime |

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -133,6 +133,8 @@ Generated `tools.yaml` entries follow the modern contract:
   not repo names or prose-only instructions. Use it when one skill must be
   discovered or loaded before another, for example `depends: ["qt-ui-inspector"]`.
 - `input_schema` and `output_schema` are declared explicitly.
+- A zero-argument tool still declares a closed schema:
+  `{"type":"object","properties":{},"additionalProperties":false}`.
 - Runtime discovery never imports or executes tool scripts to infer missing
   schemas by default. Treat Python-derived schemas as an authoring-time helper:
   generate them before publishing, then commit the JSON Schema to `tools.yaml`.
@@ -140,13 +142,20 @@ Generated `tools.yaml` entries follow the modern contract:
   `properties`, `required`, primitive `type`, bounds, and descriptions. Put
   mutually exclusive forms, conditional requirements, and cross-field rules in
   the tool script or handler validation instead of `anyOf`, `oneOf`, `allOf`,
-  `not`, `if`/`then`/`else`, or dependent-schema keywords.
+  `not`, `if`/`then`/`else`, or dependent-schema keywords. When a complex
+  schema is unavoidable, discovery must route through `describe` before call.
 - `execution` is `sync` or `async`; use `async` for deferred/long-running work.
 - `job_strategy` is `monolithic` (default), `chunked`, or `isolated`. Agents
   use it to select a safe execution and recovery workflow.
 - `affinity` is explicit. Use `main` for host API or scene mutation work and `any` for pure work.
 - `enforce_thread_affinity: true` is emitted so adapter dispatch stays honest.
-- `annotations` use MCP hints: read-only, destructive, idempotent, open-world, and deferred.
+- `annotations` explicitly declare boolean `read_only_hint`,
+  `destructive_hint`, `idempotent_hint`, and `open_world_hint`. Missing safety
+  fields force `describe`, even for a zero-argument tool; `deferred_hint` stays
+  optional.
+- Keep tool groups independently usable. A correlated load carrying
+  `target_tool_slug` activates only that tool's group; do not rely on a sibling
+  default-active group being activated with it.
 - `call_examples`: optional list of ready-to-copy argument payloads. Each entry has `arguments` (JSON object matching `input_schema.properties`) and an optional `note`. Surfaced in describe responses at `metadata.dcc.call_examples` so agents can construct correct arguments on the first attempt.
 
 ### Long-Running Main-Affinity Tools
@@ -267,7 +276,10 @@ or cancellation: rediscover the instance and query the job before retrying.
 5. Import dependency-light runtime helpers from `dcc_mcp_core.skills_helper` first: JSON/YAML codecs, bounded HTTP helpers, safe file/path helpers, validation, cancellation checks, and result helpers.
 6. Declare `metadata.dcc-mcp.depends` for prerequisite skills, then declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`. Do not rely on runtime Python introspection for missing schemas. For high-frequency tools, add `call_examples` so agents can copy argument payloads without trial-and-error.
 7. Put long examples, recipes, and host-specific notes under `references/`.
-8. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before loading it in an adapter.
+8. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before
+   loading it in an adapter. For discovery/load performance regressions, assert
+   deterministic backend operation counts; use elapsed-time thresholds only as
+   supplemental evidence.
 9. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.
 
 ## Improve Skills From Completed Tasks

--- a/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
+++ b/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
@@ -13,12 +13,46 @@ Use this checklist for every `tools.yaml` entry.
 - `execution`: `sync` for quick calls, `async` for long-running work.
 - `affinity`: `main` for host API calls, `any` for pure work.
 - `timeout_hint_secs`: realistic upper bound for dispatch and UX.
-- `annotations`: MCP safety hints.
+- `annotations`: MCP safety hints. Explicitly set all four boolean fields:
+  `read_only_hint`, `destructive_hint`, `idempotent_hint`, and
+  `open_world_hint`.
 
 Runtime discovery is manifest-first. Missing `input_schema` falls back to a
 permissive `{"type": "object"}` instead of importing or executing the script.
 If you derive schemas from Python annotations, do it while authoring and write
 the result into `tools.yaml`.
+
+A zero-argument tool must not use that permissive fallback. Declare the closed
+empty-object contract explicitly:
+
+```yaml
+input_schema:
+  type: object
+  properties: {}
+  additionalProperties: false
+```
+
+The gateway may skip `describe` only when the tool is known to take no
+arguments and all four safety annotations are present as booleans. Missing
+safety fields fail closed to `describe`. Schemas that use `$ref`, composition,
+conditionals, dependent schemas, pattern properties, or other complex JSON
+Schema features also require `describe`; do not treat a compact property list
+as the full validation contract.
+
+## Progressive Loading
+
+Keep every tool group independently usable. When a search result supplies a
+correlated `target_tool_slug`, loading activates only that target tool's group.
+Do not depend on default-active sibling groups being enabled as a side effect.
+An ordinary uncorrelated skill load keeps the declared default activation
+behavior.
+
+## Performance Regression Checks
+
+For discovery and load-path performance regressions, assert deterministic
+backend operation counts: searches, catalog/tool-list refreshes, loads, group
+activations, and describes. Wall-clock thresholds vary with CI load and should
+only supplement those contract checks.
 
 ## Sibling Imports
 

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -104,8 +104,9 @@ For these requests:
 3. Inventory live instances before choosing a host. If more than one matching
    instance exists, use task context or ask the user which scene/session owns
    the change.
-4. Search by the user's intent and target DCC, copy the returned tool slug,
-   inspect its schema and annotations, then call it.
+4. Search once by the user's intent and target DCC, then follow the returned
+   `next_step`. Describe only when requested; otherwise call directly or pass
+   correlated load arguments unchanged.
 5. Use raw scripting only when no typed tool covers the operation and the
    adapter exposes an explicit, policy-compliant automation tool. A repeated
    scripting pattern is a candidate for a reusable DCC skill.
@@ -128,7 +129,7 @@ or when the user explicitly chooses that integration.
 |-----------|----------------------------|---------------------------|
 | **Who** | OpenClaw, Hermes, Codex CLI, CI bots, custom agent runtimes, and any other host with shell access | MCP-only Cursor, Claude Desktop, VS Code MCP, or another client without shell access |
 | **Transport** | `dcc-mcp-cli` → local MCP or remote gateway REST | MCP Streamable HTTP → gateway `/mcp` |
-| **Discovery surface** | `search` → `describe` → `call` via CLI or bundled Python helper | Gateway MCP tools: `search`, `describe`, `load_skill`, `call` |
+| **Discovery surface** | `search` → returned `next_step` via CLI or bundled Python helper | Gateway MCP tools: `search`, `describe`, `load_skill`, `call` |
 | **Setup** | Install this skill and keep the official `dcc-mcp-cli` on `PATH`; installation/download requires user consent | Add gateway URL to IDE MCP settings (see repo `docs/guide/*`) |
 | **When to choose** | Default whenever the agent can run shell commands | The client cannot run shell commands or the user explicitly requests native MCP |
 | **Resources / prompts** | Not covered here; use REST `/v1/context` or IDE MCP if needed | `resources/read`, `prompts/get`, SSE subscribe via MCP |
@@ -138,10 +139,10 @@ or when the user explicitly chooses that integration.
 1. **Use this routing policy first** for every DCC-control request, whether the
    host is MCP-native or shell-only.
 2. **Shell-capable host** — use `dcc-mcp-cli`
-   (`inventory` → `search` → `describe` or `load-skill` → `call`), even when a
+   (`inventory` → one narrow `search` → returned `next_step`), even when a
    native MCP connector is also available.
 3. **MCP-only host** — call the gateway/DCC structured tools directly
-   (`inventory` → `search` → `describe` or `load_skill` → `call`). Do not ask the
+   (`inventory` → one narrow `search` → returned `next_step`). Do not ask the
    user to switch clients or manually repeat the operation.
 4. **Do not mix paths in one turn** — pick CLI+REST or MCP for the whole task,
    not both.
@@ -251,12 +252,10 @@ when setup, lifecycle, or transport troubleshooting is needed.
 ## Connection Order
 
 1. Use `dcc-mcp-cli list` for local inventory, or `dcc-mcp-cli list --gateway <name>` for a remote profile.
-2. Use `dcc-mcp-cli` for all subsequent commands when it is on `PATH`.
-3. If missing, ask user permission, then use the bundled verified installer for the official GitHub release.
-4. If manifest or SHA-256 verification fails, preserve any existing CLI and use the bundled Python stdlib REST fallback where supported.
+2. If missing, ask user permission, then use the bundled verified installer for the official GitHub release.
+3. If manifest or SHA-256 verification fails, preserve any existing CLI and use the bundled Python stdlib REST fallback where supported.
 
-Install via OpenClaw/ClawHub, or point your agent at this `SKILL.md` after cloning
-[`dcc-mcp-core/skills/dcc-mcp/`](https://github.com/dcc-mcp/dcc-mcp-core/tree/main/skills/dcc-mcp).
+Install via OpenClaw/ClawHub, or point your agent at this `SKILL.md` after cloning [`dcc-mcp-core/skills/dcc-mcp/`](https://github.com/dcc-mcp/dcc-mcp-core/tree/main/skills/dcc-mcp).
 
 `dcc-mcp` supersedes the former `dcc-cli-gateway` skill slug. Do not install or
 load both names in one agent: install `dcc-mcp`, verify it is discoverable, then
@@ -280,14 +279,6 @@ remove the old package to avoid duplicate intent routing.
 | User has not agreed to setup | Do not install packages, edit env files, launch GUI apps, or write configs |
 | User approved setup | Follow [`references/ZERO_INSTANCES_CLI.md`](references/ZERO_INSTANCES_CLI.md) |
 | Timeout, temporary `unreachable`, or DCC restart | Preserve operation IDs and follow the recovery contract in [`references/CLI_CHEATSHEET.md`](references/CLI_CHEATSHEET.md); never blindly replay a mutation or reuse stale slugs |
-
----
-
-## Configuration
-
-Use the local profile unless the user selected a remote gateway. For measured tasks,
-add `--require-gateway` and a stable `--agent-session-id`. See the [CLI
-cheatsheet](references/CLI_CHEATSHEET.md); never install or write configuration without consent.
 
 ---
 
@@ -341,7 +332,9 @@ dcc-mcp-cli search --query "create sphere" --dcc-type maya --limit 20
 python scripts/dcc_gateway.py search --query sphere --dcc-type maya --limit 20
 ```
 
-Copy the returned slug exactly. Local and gateway slugs use the same
+Copy the returned slug exactly and follow that hit's `next_step`; do not run
+separate broad searches for selection, geometry, and scripting unless the
+first result proves they are needed. Local and gateway slugs use the same
 agent-facing shape:
 
 ```text
@@ -352,17 +345,24 @@ Never hand-build slugs.
 
 ---
 
-## Step 3 — Describe Schema
+## Step 3 — Follow `next_step`
+
+- `action=call` — call directly; no-schema tools receive this only when compact safety hints are already present.
+- `action=describe` — inspect the schema and safety annotations, then call.
+- `action=load_skill` — pass the returned arguments unchanged. If the load
+  response includes `compact_schema` and `next_step.action=call`, call directly;
+  otherwise describe the selected target once.
 
 ```bash
-# CLI (primary)
+# Only when next_step.action=describe
 dcc-mcp-cli describe maya.a1b2c3d4.maya_primitives__create_sphere
 
 # Python fallback
 python scripts/dcc_gateway.py describe maya.a1b2c3d4.maya_primitives__create_sphere
 ```
 
-Read `tool.inputSchema` and safety annotations before calling.
+When describe or `compact_schema` is returned, use those exact parameter names
+and safety annotations before calling.
 
 ---
 

--- a/tests/test_context_bundle_rez_fixture.py
+++ b/tests/test_context_bundle_rez_fixture.py
@@ -350,6 +350,7 @@ def test_rez_skill_surface_stays_stubbed_until_context_load() -> None:
         before = _tool_names(url)
         registered_tool = "film_animation_blocking__summarize_blocking"
         visible_tool = "summarize_blocking"
+        group_stub = "__group__review__for_skill__film-animation-blocking"
 
         assert "__skill__film-animation-blocking" in before
         assert visible_tool not in before
@@ -370,7 +371,7 @@ def test_rez_skill_surface_stays_stubbed_until_context_load() -> None:
         assert load_payload["loaded"] is True
         assert load_payload["tool_count"] == 1
         assert registered_tool in load_payload["registered_tools"]
-        assert "__group__review" in loaded
+        assert group_stub in loaded
         assert visible_tool not in loaded
         assert "__skill__film-animation-blocking" not in loaded
         # Loading one context replaces its stub with one real tool; it must not
@@ -382,7 +383,7 @@ def test_rez_skill_surface_stays_stubbed_until_context_load() -> None:
         assert activate_is_error is False
         assert activate_payload["success"] is True
         assert visible_tool in activated
-        assert "__group__review" not in activated
+        assert group_stub not in activated
         assert len(activated) == len(before)
 
         unload_is_error, unload_payload = _tool_call_json(

--- a/tests/test_load_state_persistence.py
+++ b/tests/test_load_state_persistence.py
@@ -93,6 +93,69 @@ def test_store_evicts_on_unload(isolated_admin_env: Path) -> None:
     assert [s.name for s in reopened.state.skills] == ["maya-export"]
 
 
+def test_server_persistence_uses_the_scoped_group_observer(
+    isolated_admin_env: Path,
+) -> None:
+    from dcc_mcp_core._testing import make_test_server
+
+    class _InnerServer:
+        def __init__(self) -> None:
+            self.public_group_hook = None
+            self.scoped_group_hook = None
+
+        def set_after_load_skill_hook(self, _hook: object) -> None:
+            pass
+
+        def set_after_unload_skill_hook(self, _hook: object) -> None:
+            pass
+
+        def set_after_group_change_hook(self, hook: object) -> None:
+            self.public_group_hook = hook
+
+        def set_after_scoped_group_change_hook(self, hook: object) -> None:
+            self.scoped_group_hook = hook
+
+    inner = _InnerServer()
+    server = make_test_server(server=inner, dcc_name="maya")
+
+    result = server.enable_skill_load_persistence(sqlite_mirror=False)
+
+    assert result["reason"] == "empty_state"
+    assert inner.public_group_hook is None
+    assert callable(inner.scoped_group_hook)
+    inner.scoped_group_hook("maya-scene:inspection", True)
+    assert server._loaded_state_store.snapshot().active_groups == ["maya-scene:inspection"]
+
+
+def test_server_persistence_falls_back_for_an_older_binding(
+    isolated_admin_env: Path,
+) -> None:
+    from dcc_mcp_core._testing import make_test_server
+
+    class _OldInnerServer:
+        def __init__(self) -> None:
+            self.public_group_hook = None
+
+        def set_after_load_skill_hook(self, _hook: object) -> None:
+            pass
+
+        def set_after_unload_skill_hook(self, _hook: object) -> None:
+            pass
+
+        def set_after_group_change_hook(self, hook: object) -> None:
+            self.public_group_hook = hook
+
+    inner = _OldInnerServer()
+    server = make_test_server(server=inner, dcc_name="maya")
+
+    result = server.enable_skill_load_persistence(sqlite_mirror=False)
+
+    assert result["reason"] == "empty_state"
+    assert callable(inner.public_group_hook)
+    inner.public_group_hook("inspection", True)
+    assert server._loaded_state_store.snapshot().active_groups == ["inspection"]
+
+
 def test_admin_sqlite_mirror_writes_rows(isolated_admin_env: Path) -> None:
     store = LoadedStateStore("maya")
     store.record_loaded("maya-render", version="1.0.0", skill_path=None)

--- a/tests/test_mcp_mcpcall_e2e.py
+++ b/tests/test_mcp_mcpcall_e2e.py
@@ -1338,8 +1338,8 @@ class TestMcpcallToolGroupActivation:
         _mcpcall_call(url, name, "deactivate_tool_group", {"group": "rigging"})
         tools = _mcpcall_list_tools(url, name)
         tool_names = {t["name"] if isinstance(t, dict) else t for t in tools}
-        assert "__group__rigging" in tool_names, (
-            f"rigging group must collapse to __group__rigging stub, got: {tool_names}"
+        assert "__group__rigging__for_skill__maya-geometry" in tool_names, (
+            f"rigging group must collapse to its skill-scoped stub, got: {tool_names}"
         )
         assert "create_joint" not in tool_names, (
             f"create_joint must be hidden while rigging is inactive, got: {tool_names}"
@@ -1355,8 +1355,8 @@ class TestMcpcallToolGroupActivation:
         tools = _mcpcall_list_tools(url, name)
         tool_names = {t["name"] if isinstance(t, dict) else t for t in tools}
         assert "create_joint" in tool_names, f"create_joint must surface after activating rigging, got: {tool_names}"
-        assert "__group__rigging" not in tool_names, (
-            f"__group__rigging stub must disappear after activation, got: {tool_names}"
+        assert "__group__rigging__for_skill__maya-geometry" not in tool_names, (
+            f"skill-scoped rigging stub must disappear after activation, got: {tool_names}"
         )
 
     def test_deactivate_tool_group_collapses_members_again(self, server_for_tool_groups):
@@ -1368,7 +1368,7 @@ class TestMcpcallToolGroupActivation:
         tools = _mcpcall_list_tools(url, name)
         tool_names = {t["name"] if isinstance(t, dict) else t for t in tools}
         assert "create_joint" not in tool_names
-        assert "__group__rigging" in tool_names
+        assert "__group__rigging__for_skill__maya-geometry" in tool_names
 
     def test_activate_unknown_group_does_not_crash(self, server_for_tool_groups):
         """Activating a non-existent group should return a structured response, never panic."""


### PR DESCRIPTION
## Summary
- refresh capability discovery only for the target instance with single-flight stale revalidation and dead-instance eviction
- make search return executable load/call next steps without redundant describe calls or sibling group activation
- scope persisted group state by skill and add deterministic latency and concurrency regressions
- cover skill-only hits, legacy sibling groups, and closed zero-argument schemas

## Validation
- `cargo test -p dcc-mcp-gateway` (572 passed)
- `cargo test -p dcc-mcp-http-server` (65 passed)
- `cargo test -p dcc-mcp-cli --lib` (115 passed)
- `cargo test -p dcc-mcp-cli --test cli_e2e` (25 passed)
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `just lint-skills` (31 checked)
- Python 3.7 syntax and stub drift checks

Updates Core and agent-facing skill guidance for dcc-mcp/dcc-mcp-houdini#198.