### PR TITLE
perf: add opt-in Tracy discovery profiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,8 @@ jobs:
       - name: Rust compile smoke
         if: matrix.rust-validation == 'smoke'
         run: vx cargo check --workspace --all-targets
+      - name: Tracy feature compile smoke
+        run: vx cargo check -p dcc-mcp-server --no-default-features --features gateway-daemon,tracy
       # Verify the composition binary still builds in its slim variants
       # (issue #1359). Defaults are already exercised by the workspace
       # check / clippy / test steps above.

--- a/.github/workflows/transport-bench.yml
+++ b/.github/workflows/transport-bench.yml
@@ -1,7 +1,7 @@
-name: Transport Benchmark
+name: Performance Benchmarks
 
-# Transport benchmarks are trend signals, not PR merge gates. Run them on a
-# schedule or manually when investigating transport performance.
+# Performance benchmarks are trend signals, not PR merge gates. Run them on a
+# schedule or manually when investigating regressions.
 
 on:
   workflow_dispatch:
@@ -40,5 +40,32 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: criterion-report
+          path: target/criterion/
+          if-no-files-found: ignore
+
+  gateway-discovery-bench:
+    name: Gateway discovery benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: gateway-discovery-bench
+
+      - name: Capability discovery criterion bench
+        run: |
+          cargo bench -p dcc-mcp-gateway --bench search_bench -- \
+            --sample-size 30 --measurement-time 5
+        shell: bash
+        env:
+          CRITERION_CI: "1"
+
+      - name: Upload gateway discovery criterion HTML report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gateway-discovery-criterion-report
           path: target/criterion/
           if-no-files-found: ignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,6 +1532,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "tracing-tracy",
  "workspace-hack",
 ]
 
@@ -2669,6 +2670,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3640,6 +3656,19 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "loop9"
@@ -6991,6 +7020,38 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-tracy"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracy-client",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f6fc3baeac5d86ab90c772e9e30620fc653bf1864295029921a15ef478e6a5"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
+dependencies = [
+ "cc",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ dirs = "6.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
+tracing-tracy = { version = "=0.11.4", default-features = false, features = ["enable", "ondemand", "only-localhost"] }
 time = { version = "0.3", features = ["formatting", "macros", "local-offset"] }
 parking_lot = "0.12"
 thiserror = "2.0"
@@ -265,6 +266,8 @@ job-persist-sqlite = ["dcc-mcp-http/job-persist-sqlite"]
 # `dcc-mcp-gateway/admin`. Off by default — when disabled, zero admin
 # UI code or front-end assets are compiled into the wheel.
 admin = ["dcc-mcp-gateway/admin"]
+# Opt-in local Tracy profiling through the existing logging subscriber.
+tracy = ["dcc-mcp-logging/tracy"]
 
 # py37-lite: pure-Python wheel profile for Maya 2022 / Python 3.7.
 # Intentionally empty: ``build-py37`` only packages ``python/`` sources and

--- a/crates/dcc-mcp-gateway/benches/search_bench.rs
+++ b/crates/dcc-mcp-gateway/benches/search_bench.rs
@@ -1,10 +1,8 @@
 //! Criterion benchmarks for the search-scoring strategy seam (issue #765).
 //!
-//! These benchmarks pin the raw throughput of [`StrategyFuzzyScorer`] and
-//! [`StrategyExactScorer`] so that adding trait dispatch overhead is
-//! detected before merging. The acceptance criterion is that either
-//! scorer stays within 10 % of today's baseline when called via a
-//! `Box<dyn StrategyScorer>` obtained from [`ScorerFactory`].
+//! These benchmarks track the raw scorer throughput and the warm
+//! [`CapabilityIndex`] search pipeline. Results are diagnostic trends,
+//! not deterministic merge gates.
 //!
 //! Run with:
 //!
@@ -16,9 +14,10 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use dcc_mcp_gateway::{
     ScorerFactory, SearchMode, SearchQuery, StrategyExactScorer, StrategyFuzzyScorer,
     StrategyScorer,
-    capability::{CapabilityRecord, IndexSnapshot, search},
+    capability::{CapabilityIndex, CapabilityRecord, IndexSnapshot, InstanceFingerprint, search},
+    capability_service::search_service,
 };
-use std::{hint::black_box, sync::Arc};
+use std::{collections::BTreeMap, hint::black_box, sync::Arc};
 
 // ---------------------------------------------------------------------------
 // Shared corpus
@@ -70,8 +69,8 @@ fn score_all(scorer: &dyn StrategyScorer) -> f32 {
     total
 }
 
-fn capability_snapshot(size: usize) -> IndexSnapshot {
-    let records: Vec<CapabilityRecord> = (0..size)
+fn capability_records(size: usize, instance_count: usize) -> Vec<CapabilityRecord> {
+    (0..size)
         .map(|i| {
             let dcc = match i % 4 {
                 0 => "maya",
@@ -107,7 +106,7 @@ fn capability_snapshot(size: usize) -> IndexSnapshot {
                 ),
                 _ => ("layers", "select_layer", "Select a layer or document node."),
             };
-            let iid = uuid::Uuid::from_u128((i as u128) + 1);
+            let iid = uuid::Uuid::from_u128((i % instance_count) as u128 + 1);
             CapabilityRecord::new(
                 format!("{dcc}.{:08x}.{}_{}", i, family.0, i),
                 format!("{}_{}", family.1, i),
@@ -122,11 +121,52 @@ fn capability_snapshot(size: usize) -> IndexSnapshot {
                 None,
             )
         })
-        .collect();
+        .collect()
+}
+
+fn capability_snapshot(size: usize) -> IndexSnapshot {
+    let records = capability_records(size, size);
     IndexSnapshot {
         records: Arc::from(records.into_boxed_slice()),
         fingerprints: Default::default(),
     }
+}
+
+fn capability_index(size: usize) -> CapabilityIndex {
+    let index = CapabilityIndex::new();
+    let mut records_by_instance = BTreeMap::<_, Vec<_>>::new();
+    for record in capability_records(size, 4) {
+        records_by_instance
+            .entry(record.instance_id)
+            .or_default()
+            .push(record);
+    }
+    for (instance_id, records) in records_by_instance {
+        index.upsert_instance(
+            instance_id,
+            records,
+            InstanceFingerprint(instance_id.as_u128() as u64),
+        );
+    }
+    index
+}
+
+fn capability_queries() -> Vec<SearchQuery> {
+    [
+        "create poly sphere",
+        "destination path export",
+        "material lookdev",
+        "uv unwrap shells",
+        "render preview",
+        "selct layer", // typo fallback
+    ]
+    .into_iter()
+    .map(|query| SearchQuery {
+        query: query.to_string(),
+        limit: Some(20),
+        ..Default::default()
+    })
+    .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -199,6 +239,27 @@ fn bench_hybrid_full_search_thousands(c: &mut Criterion) {
     });
 }
 
+fn bench_warm_capability_index(c: &mut Criterion) {
+    let index = capability_index(5_000);
+    let queries = capability_queries();
+    let mut group = c.benchmark_group("warm_capability_index/5000_records");
+
+    group.bench_function("snapshot_with_generation", |b| {
+        b.iter(|| black_box(&index).snapshot_with_generation())
+    });
+    group.bench_function("search_service", |b| {
+        b.iter(|| {
+            let mut total = 0usize;
+            for query in &queries {
+                let hits = search_service(black_box(&index), black_box(query));
+                total = total.saturating_add(hits.len());
+            }
+            black_box(total)
+        })
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_fuzzy_direct,
@@ -206,5 +267,6 @@ criterion_group!(
     bench_factory_dispatch,
     bench_factory_tag,
     bench_hybrid_full_search_thousands,
+    bench_warm_capability_index,
 );
 criterion_main!(benches);

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -35,6 +35,8 @@ use super::record::{CapabilityRecord, tool_slug};
 
 pub use dcc_mcp_gateway_core::capability::refresh::RefreshReason;
 
+const PROFILING_TARGET: &str = "dcc_mcp::profiling";
+
 /// Refresh one instance's slice of the index by fetching its current
 /// `tools/list` from `mcp_url`.
 ///
@@ -90,10 +92,18 @@ pub async fn refresh_instance(
     if !tools.iter().any(|tool| is_backend_job_tool(&tool.name)) {
         tools.push(backend_job_status_tool());
     }
-    let outcome = build_records_from_backend(BuildInput {
-        instance_id,
-        dcc_type,
-        backend_tools: &tools,
+    let outcome = tracing::trace_span!(
+        target: PROFILING_TARGET,
+        "capability.discovery.build_records",
+        instance = %instance_id,
+        tools = tools.len(),
+    )
+    .in_scope(|| {
+        build_records_from_backend(BuildInput {
+            instance_id,
+            dcc_type,
+            backend_tools: &tools,
+        })
     });
     let mut records = outcome.records;
     let loaded_records_len = records.len();
@@ -101,7 +111,13 @@ pub async fn refresh_instance(
     let unloaded_count = unloaded_records.len();
     records.append(&mut unloaded_records);
     records.sort_by(|a, b| a.tool_slug.cmp(&b.tool_slug));
-    let fingerprint = compute_fingerprint(&records);
+    let fingerprint = tracing::trace_span!(
+        target: PROFILING_TARGET,
+        "capability.discovery.fingerprint",
+        instance = %instance_id,
+        records = records.len(),
+    )
+    .in_scope(|| compute_fingerprint(&records));
 
     // Short-circuit when nothing changed. This is the common path —
     // most periodic refreshes find an identical tool list.
@@ -119,7 +135,13 @@ pub async fn refresh_instance(
     }
 
     let records_len = records.len();
-    let prev = index.upsert_instance(instance_id, records, fingerprint);
+    let prev = tracing::trace_span!(
+        target: PROFILING_TARGET,
+        "capability.discovery.upsert",
+        instance = %instance_id,
+        records = records_len,
+    )
+    .in_scope(|| index.upsert_instance(instance_id, records, fingerprint));
 
     tracing::info!(
         instance = %instance_id,

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -46,6 +46,8 @@ use super::request_meta::meta_with_agent_context;
 use super::state::{GatewayState, ResolveInstanceError};
 use dcc_mcp_gateway_core::naming::instance_short;
 
+const PROFILING_TARGET: &str = "dcc_mcp::profiling";
+
 /// Metadata attached to one gateway search response for follow-up correlation.
 #[derive(Debug, Clone)]
 pub struct SearchResponseContext {
@@ -139,11 +141,15 @@ impl ServiceError {
     }
 }
 
-/// Run a capability search against the index. Pure and synchronous —
-/// every callable path reuses this function.
+/// Run a capability search against one coherent index snapshot.
+/// Pure and synchronous.
 pub fn search_service(index: &CapabilityIndex, query: &SearchQuery) -> Vec<SearchHit> {
-    let snap = index.snapshot();
-    search(&snap, query)
+    let snap = tracing::trace_span!(
+        target: PROFILING_TARGET,
+        "capability.discovery.snapshot"
+    )
+    .in_scope(|| index.snapshot());
+    search_snapshot(&snap, query)
 }
 
 /// Search and materialise transport-neutral JSON rows. Unloaded
@@ -181,21 +187,43 @@ pub fn search_service_hits_for_policy(
     query: &SearchQuery,
     policy: &GatewayPolicy,
 ) -> Vec<SearchHit> {
-    let snapshot = index.snapshot();
+    let snapshot = tracing::trace_span!(
+        target: PROFILING_TARGET,
+        "capability.discovery.snapshot"
+    )
+    .in_scope(|| index.snapshot());
     search_snapshot_hits_for_policy(&snapshot, query, policy)
+}
+
+/// Search one generation-coherent snapshot after applying gateway policy.
+///
+/// REST and MCP share this helper so their cache generation and profiling
+/// boundaries remain identical.
+pub fn search_service_hits_for_policy_with_generation(
+    index: &CapabilityIndex,
+    query: &SearchQuery,
+    policy: &GatewayPolicy,
+) -> (Vec<SearchHit>, String) {
+    let (snapshot, generation) = tracing::trace_span!(
+        target: PROFILING_TARGET,
+        "capability.discovery.snapshot"
+    )
+    .in_scope(|| index.snapshot_with_generation());
+    let hits = search_snapshot_hits_for_policy(&snapshot, query, policy);
+    (hits, generation)
 }
 
 /// Search one immutable index snapshot after applying gateway policy filters.
 ///
-/// Callers that also publish an index generation should obtain both values via
-/// [`CapabilityIndex::snapshot_with_generation`] so cached hits and response
-/// metadata describe the same coherent view.
+/// Callers that also publish an index generation should use
+/// [`search_service_hits_for_policy_with_generation`] so cached hits and
+/// response metadata describe the same coherent view.
 pub fn search_snapshot_hits_for_policy(
     snapshot: &IndexSnapshot,
     query: &SearchQuery,
     policy: &GatewayPolicy,
 ) -> Vec<SearchHit> {
-    search(snapshot, query)
+    search_snapshot(snapshot, query)
         .into_iter()
         .filter(|hit| {
             policy
@@ -203,6 +231,15 @@ pub fn search_snapshot_hits_for_policy(
                 .is_ok()
         })
         .collect()
+}
+
+fn search_snapshot(snapshot: &IndexSnapshot, query: &SearchQuery) -> Vec<SearchHit> {
+    tracing::trace_span!(
+        target: PROFILING_TARGET,
+        "capability.discovery.search",
+        records = snapshot.records.len(),
+    )
+    .in_scope(|| search(snapshot, query))
 }
 
 pub fn search_service_rows_for_policy_with_context(
@@ -1407,6 +1444,24 @@ mod unit_tests {
             .map(|h| h.record.tool_slug.as_str())
             .collect();
         assert_eq!(service_slugs, raw_slugs);
+    }
+
+    #[test]
+    fn search_with_generation_preserves_hits_and_generation() {
+        let idx = CapabilityIndex::new();
+        let iid = Uuid::from_u128(1);
+        push(&idx, "maya", iid, "create_sphere", true);
+        let query = SearchQuery {
+            query: "sphere".into(),
+            ..Default::default()
+        };
+
+        let (hits, generation) =
+            search_service_hits_for_policy_with_generation(&idx, &query, &GatewayPolicy::default());
+
+        assert_eq!(generation, idx.generation());
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].record.backend_tool, "create_sphere");
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -12,7 +12,8 @@ use crate::gateway::capability::{RefreshReason, tool_slug};
 use crate::gateway::capability_service::{
     SearchResponseContext, ServiceError, describe_tool_full, index_generation,
     parse_and_resolve_search_payload, refresh_all_live_backends, refresh_search_backends,
-    search_hit_to_value_with_context, search_snapshot_hits_for_policy, service_error_to_json,
+    search_hit_to_value_with_context, search_service_hits_for_policy_with_generation,
+    service_error_to_json,
 };
 use crate::gateway::response_codec::{compact_call_batch_payload, compact_describe_payload};
 use crate::gateway::search_telemetry::{SearchTelemetryInput, search_id_from_payload};
@@ -579,8 +580,11 @@ pub async fn handle_v1_search(
     let (hits, index_generation, search_cache_hit) = match cached_hits {
         Some(hits) => (hits, index_gen, true),
         None => {
-            let (snapshot, generation) = gs.capability_index.snapshot_with_generation();
-            let hits = search_snapshot_hits_for_policy(&snapshot, &query, &gs.policy);
+            let (hits, generation) = search_service_hits_for_policy_with_generation(
+                &gs.capability_index,
+                &query,
+                &gs.policy,
+            );
             (hits, generation, false)
         }
     };

--- a/crates/dcc-mcp-gateway/src/gateway/tools/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools/mod.rs
@@ -8,7 +8,10 @@ use uuid;
 
 use crate::gateway::admin::trace::{AgentContext, TraceContext};
 use crate::gateway::capability::search_cache::SearchCacheKey;
-use crate::gateway::capability_service::{SearchResponseContext, search_hit_to_value_with_context};
+use crate::gateway::capability_service::{
+    SearchResponseContext, search_hit_to_value_with_context,
+    search_service_hits_for_policy_with_generation,
+};
 use crate::gateway::search_telemetry::{
     RANKER_VERSION, SearchFollowupInput, SearchTelemetryHit, SearchTelemetryInput,
     search_id_from_meta, search_id_from_payload,
@@ -326,9 +329,10 @@ pub async fn tool_search_tools(
     let (hits, index_generation, search_cache_hit) = match cached_hits {
         Some(hits) => (hits, index_gen, true),
         None => {
-            let (snapshot, generation) = gs.capability_index.snapshot_with_generation();
-            let hits = crate::gateway::capability_service::search_snapshot_hits_for_policy(
-                &snapshot, &query, &gs.policy,
+            let (hits, generation) = search_service_hits_for_policy_with_generation(
+                &gs.capability_index,
+                &query,
+                &gs.policy,
             );
             (hits, generation, false)
         }

--- a/crates/dcc-mcp-logging/Cargo.toml
+++ b/crates/dcc-mcp-logging/Cargo.toml
@@ -20,6 +20,7 @@ dcc-mcp-paths = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
+tracing-tracy = { workspace = true, optional = true }
 time = { workspace = true }
 parking_lot = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
@@ -27,5 +28,6 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [features]
 default = []
 python-bindings = ["pyo3"]
+tracy = ["dep:tracing-tracy"]
 # Enable `pyo3-stub-gen` annotations on this crate's PyO3 types.
 stub-gen = ["python-bindings", "dep:pyo3-stub-gen", "dep:pyo3-stub-gen-derive"]

--- a/crates/dcc-mcp-logging/src/config.rs
+++ b/crates/dcc-mcp-logging/src/config.rs
@@ -5,7 +5,8 @@
 //! ```text
 //! Registry
 //!   ├── fmt::Layer  → stderr (always on)
-//!   └── reload::Layer<Option<FileLayer>>  → disabled initially
+//!   ├── reload::Layer<Option<FileLayer>>  → disabled initially
+//!   └── TracyLayer  → local on-demand profiler (`tracy` feature only)
 //! ```
 //!
 //! The reload layer lets [`crate::file_logging::init_file_logging`]
@@ -19,6 +20,52 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::reload::{self, Handle};
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
+
+#[cfg(feature = "tracy")]
+use tracing_subscriber::fmt::format::DefaultFields;
+
+#[cfg(feature = "tracy")]
+const TRACY_TARGET: &str = "dcc_mcp::profiling";
+
+#[cfg(feature = "tracy")]
+fn is_tracy_profile(target: &str, is_span: bool) -> bool {
+    is_span && target == TRACY_TARGET
+}
+
+#[cfg(feature = "tracy")]
+fn is_tracy_metadata(metadata: &tracing::Metadata<'_>) -> bool {
+    is_tracy_profile(metadata.target(), metadata.is_span())
+}
+
+#[cfg(feature = "tracy")]
+fn enable_tracy_target(filter: EnvFilter) -> EnvFilter {
+    filter.add_directive(
+        format!("{TRACY_TARGET}=trace")
+            .parse()
+            .expect("static Tracy filter directive must be valid"),
+    )
+}
+
+#[cfg(feature = "tracy")]
+#[derive(Default)]
+struct TracyConfig(DefaultFields);
+
+#[cfg(feature = "tracy")]
+impl tracing_tracy::Config for TracyConfig {
+    type Formatter = DefaultFields;
+
+    fn formatter(&self) -> &Self::Formatter {
+        &self.0
+    }
+
+    fn stack_depth(&self, _metadata: &tracing::Metadata<'_>) -> u16 {
+        0
+    }
+
+    fn format_fields_in_zone_name(&self) -> bool {
+        false
+    }
+}
 
 /// Type-erased subscriber-agnostic layer installed behind the reload handle.
 ///
@@ -44,6 +91,7 @@ static RELOAD_HANDLE: OnceLock<FileLayerReloadHandle> = OnceLock::new();
 /// - a [`reload::Layer`] holding an `Option<BoxedLayer>` for dynamic
 ///   attachment of a rolling-file layer by
 ///   [`crate::file_logging::init_file_logging`].
+/// - a target-filtered local Tracy layer when the `tracy` feature is enabled.
 ///
 /// Safe to call multiple times — subsequent calls are no-ops thanks to
 /// the internal [`std::sync::Once`].
@@ -52,6 +100,9 @@ pub fn init_logging() {
         let filter = EnvFilter::try_from_env(ENV_LOG_LEVEL)
             .or_else(|_| EnvFilter::try_from_env(LEGACY_ENV_LOG_LEVEL))
             .unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_LEVEL));
+
+        #[cfg(feature = "tracy")]
+        let filter = enable_tracy_target(filter);
 
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_target(true)
@@ -73,11 +124,18 @@ pub fn init_logging() {
         // `Layer<Registry>` so it MUST be attached directly on top of
         // `Registry`. Generic layers (`EnvFilter`, `fmt::Layer`) are
         // composed above it.
-        let _ = tracing_subscriber::registry()
+        let subscriber = tracing_subscriber::registry()
             .with(file_layer)
             .with(filter)
-            .with(fmt_layer)
-            .try_init();
+            .with(fmt_layer);
+
+        #[cfg(feature = "tracy")]
+        let subscriber = subscriber.with(
+            tracing_tracy::TracyLayer::new(TracyConfig::default())
+                .with_filter(tracing_subscriber::filter::filter_fn(is_tracy_metadata)),
+        );
+
+        let _ = subscriber.try_init();
     });
 }
 
@@ -141,5 +199,28 @@ mod tests {
         init_logging();
         init_logging();
         assert!(reload_handle().is_some());
+    }
+
+    #[cfg(feature = "tracy")]
+    #[test]
+    fn tracy_config_keeps_zone_names_stable_without_callstacks() {
+        use tracing_tracy::Config as _;
+
+        assert!(is_tracy_profile(TRACY_TARGET, true));
+        assert!(!is_tracy_profile("dcc_mcp::gateway", true));
+        assert!(!is_tracy_profile(TRACY_TARGET, false));
+        assert!(
+            enable_tracy_target(EnvFilter::new("off"))
+                .to_string()
+                .contains("dcc_mcp::profiling=trace")
+        );
+
+        let config = TracyConfig::default();
+        assert!(!config.format_fields_in_zone_name());
+
+        tracing::subscriber::with_default(tracing_subscriber::registry(), || {
+            let span = tracing::info_span!(target: "dcc_mcp::profiling", "config_test");
+            assert_eq!(config.stack_depth(span.metadata().unwrap()), 0);
+        });
     }
 }

--- a/crates/dcc-mcp-server/Cargo.toml
+++ b/crates/dcc-mcp-server/Cargo.toml
@@ -127,6 +127,9 @@ prometheus = [
 otlp-exporter = ["dcc-mcp-telemetry/otlp-exporter", "dep:dcc-mcp-telemetry"]
 telemetry = ["dep:dcc-mcp-telemetry"]
 
+# Opt-in local Tracy profiling through dcc-mcp-logging's existing subscriber.
+tracy = ["dcc-mcp-logging/tracy"]
+
 # Sentry error monitoring (Rust backend). Controlled by DCC_MCP_SENTRY_DSN
 # env var at startup. Does nothing when the env var is absent.
 sentry = ["dep:sentry"]

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -401,6 +401,30 @@ rate(dcc_mcp_gateway_probes_total{outcome="ready"}[5m])
 
 ---
 
+## 6. Local Tracy Profiling
+
+Use Tracy for local diagnosis when a deterministic benchmark or regression test
+shows discovery latency but not where the time is spent. The integration is
+compile-time opt-in, accepts profiler connections from localhost only, and
+exports only spans with the dedicated `dcc_mcp::profiling` target.
+
+```bash
+vx cargo run -p dcc-mcp-server --no-default-features --features gateway-daemon,tracy -- gateway --host 127.0.0.1 --port 9765
+```
+
+Run the slow search or refresh workload, then use
+[`dcc-mcp-tracy`](https://github.com/dcc-mcp/dcc-mcp-tracy) to capture a
+`.tracy` file, export its zones to CSV, and summarize the high-variance zones.
+Tracy zones deliberately cover synchronous capability-index work only; use the
+existing request IDs and OTLP spans to correlate async or cross-process work.
+
+Tracy traces are diagnostic artifacts, not merge gates. Keep deterministic
+unit/integration tests and Criterion benchmarks as the regression gates, and
+treat captured traces as sensitive debug artifacts because they contain build
+symbols and source locations.
+
+---
+
 ## See also
 
 - [metric-dictionary.md](metric-dictionary.md) — canonical reference for every metric, dimension, unit, sampling window, and null semantics

--- a/skills/dcc-mcp-creator/references/TESTING_AND_RELEASE.md
+++ b/skills/dcc-mcp-creator/references/TESTING_AND_RELEASE.md
@@ -32,6 +32,13 @@ python -m pytest
 For Rust/PyO3 core changes, run the workspace's `just` or `cargo` gates that
 match the touched crates.
 
+For gateway discovery performance, use deterministic tests or Criterion as the
+regression gate. If a regression needs local diagnosis, build
+`dcc-mcp-server` with `--no-default-features --features gateway-daemon,tracy`
+and follow the [local Tracy workflow](../../../docs/guide/observability.md#6-local-tracy-profiling).
+Do not wrap async work across `.await` in a Tracy zone; correlate those phases
+with the existing request IDs and OTLP spans instead.
+
 For `dcc-mcp-core` toolchain or dependency refreshes, prefer vx-managed Cargo so
 local runs match CI:
 


### PR DESCRIPTION
## Summary
- add an opt-in, localhost-only Tracy layer to the existing logging subscriber
- profile synchronous capability snapshot, search, record build, fingerprint, and upsert stages
- compile the Tracy feature on all CI operating systems and document the local workflow

## Validation
- `vx cargo test -p dcc-mcp-logging --features tracy`
- `vx cargo check -p dcc-mcp-server --no-default-features --features gateway-daemon,tracy`
- `vx cargo clippy -p dcc-mcp-logging --features tracy --all-targets -- -D warnings`
- workspace check, Clippy, format, 3675/3675 nextest tests, and doctests
- Hakari and cargo-deny dependency policy checks
- VitePress documentation build

No live-DCC behavior changes. Tracy captures remain an explicit local diagnostic workflow; deterministic tests and benchmarks remain the regression gates.