### PR TITLE
fix: label generic UI Control targets

### DIFF
--- a/crates/dcc-mcp-computer-use/src/lib.rs
+++ b/crates/dcc-mcp-computer-use/src/lib.rs
@@ -236,6 +236,23 @@ struct TargetSpec {
     app_name: String,
 }
 
+fn display_app_name(configured: &str, verified_window_title: &str) -> String {
+    let configured = configured.trim();
+    let name = if configured.eq_ignore_ascii_case("custom")
+        || configured.eq_ignore_ascii_case("DCC application")
+    {
+        verified_window_title.trim()
+    } else {
+        configured
+    };
+    let name = if name.is_empty() {
+        "DCC application"
+    } else {
+        name
+    };
+    name.chars().take(64).collect()
+}
+
 /// Exact target scope established by the adapter/runtime, not by an agent call.
 ///
 /// At least one stable native identity is required. Request parameters may
@@ -545,12 +562,13 @@ impl ComputerUseSession {
         let cleanup_pending = Arc::new(AtomicBool::new(false));
         state.cleanup_pending = Arc::clone(&cleanup_pending);
         let action_feedback = Arc::new(std::sync::Mutex::new(None));
+        let app_name = display_app_name(&self.spec.app_name, &target.title);
         let thread = retain_pending_control_thread(
             &mut state,
             platform::start_control_banner(
                 target.handle,
                 target.pid,
-                self.spec.app_name.clone(),
+                app_name,
                 #[cfg(windows)]
                 platform::ControlBannerSignals {
                     stop: Arc::clone(&self.stop_requested),
@@ -872,6 +890,14 @@ impl ComputerUseSession {
             && (state.overlay_thread.is_some() || state.cleanup_pending.load(Ordering::Acquire));
         let (desktop_interactive, desktop_generation) =
             desktop_state_snapshot(&state.desktop_state);
+        let app_name = display_app_name(
+            &self.spec.app_name,
+            state
+                .target
+                .as_ref()
+                .map(|target| target.title.as_str())
+                .unwrap_or_default(),
+        );
         json!({
             "success": true,
             "active": active,
@@ -881,13 +907,13 @@ impl ComputerUseSession {
             "desktop_interactive": desktop_interactive,
             "desktop_generation": desktop_generation,
             "input_suspended": active && !desktop_interactive,
-            "app_name": self.spec.app_name,
+            "app_name": app_name,
             "window_handle": state.target.as_ref().map(|target| target.handle),
             "process_id": state.target.as_ref().map(|target| target.pid),
             "window_title": state.target.as_ref().map(|target| target.title.clone()),
             "hint": format!(
                 "DCC UI Control is controlling {} - press Esc to stop",
-                self.spec.app_name
+                app_name
             ),
         })
     }

--- a/crates/dcc-mcp-computer-use/src/lib_tests.rs
+++ b/crates/dcc-mcp-computer-use/src/lib_tests.rs
@@ -28,6 +28,18 @@ fn status_uses_public_dcc_ui_control_name() {
 }
 
 #[test]
+fn generic_overlay_name_uses_the_verified_window_title() {
+    assert_eq!(
+        display_app_name("custom", "Epic Games Launcher"),
+        "Epic Games Launcher"
+    );
+    assert_eq!(
+        display_app_name("Unreal", "Project - Unreal Editor"),
+        "Unreal"
+    );
+}
+
+#[test]
 fn public_perform_cannot_bypass_the_game_navigation_host_fence() {
     let session = test_session(std::process::id());
     let error = session

--- a/python/dcc_mcp_core/skills/ui-control/SKILL.md
+++ b/python/dcc_mcp_core/skills/ui-control/SKILL.md
@@ -198,6 +198,10 @@ validates the caller's Windows session, user, and integrity level, then starts
 the prominent non-modal control notice before minting its opaque capability.
 Routine session start does not open a confirmation dialog.
 
+When a generic sidecar reports `custom` instead of an application name, the
+notice uses the Host-verified target window title while routing and audit keep
+the original DCC type.
+
 The native DCC UI Control boundary imports that PID/HWND as a separate trusted
 scope, rejects construction without it, and revalidates the resolved native
 identity before the capsule, every capture, and every action. A request-supplied


### PR DESCRIPTION
## Summary
- show the Host-verified window title when a sidecar reports the generic custom label
- preserve explicit DCC names and existing routing/audit identity
- bound the visible label to 64 characters

## Tests
- target Rust regression passed
- cargo clippy -p dcc-mcp-computer-use --lib -- -D warnings
- rustfmt passed