### PR TITLE
docs: improve agent onboarding and recovery

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -14,6 +14,10 @@ The foundational library enabling AI assistants to interact with Digital Content
 
 | Task | Use this | Not this |
 |------|----------|----------|
+| Operate a live DCC from an agent | [`dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) + `dcc-mcp-cli` | embedding the Python API in the agent |
+| Create or modernize a DCC-MCP adapter | [`dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) | adapter-local copies of core wiring |
+| Create a DCC-specific Skill package | [`dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) | a new adapter repository |
+| Analyze or report a failed DCC call | `dcc-mcp` recovery flow: `doctor`, failure-filtered `stats`, `dcc_feedback__report`, public-safe issue report | raw unreviewed logs |
 | Return action result | `success_result()` / `error_result()` | raw dicts |
 | Load skills | `scan_and_load()` → `(skills, skipped)` | manual file scanning |
 | One-call MCP server | `create_skill_server("maya", McpHttpConfig(port=8765))` | manual wiring |
@@ -47,6 +51,20 @@ The foundational library enabling AI assistants to interact with Digital Content
 | **Skill Hot-Reload** | File-watching auto-reload for live skill development |
 
 ## Installation
+
+For agent-side DCC control, install the published `dcc-mcp` Skill and use its
+CLI workflow; the Python package below is for adapters and embedded runtimes:
+
+```bash
+openclaw skills install @loonghao/dcc-mcp
+# Direct ClawHub CLI:
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp
+```
+
+Use [`dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator)
+only for a complete adapter/runtime, and
+[`dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator)
+only for a DCC-specific Skill package.
 
 ```bash
 pip install dcc-mcp-core

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,24 @@ returned load/describe/call step, then invoke the typed tool.
 - **Human IDE users** continue using MCP configuration. The gateway serves both paths simultaneously.
 - **CLI-first does not deprecate MCP** — the gateway always exposes both MCP and REST side by side.
 
+**Public Agent Skill router:**
+
+| Intent | Install from ClawHub |
+|--------|----------------------|
+| Operate a live DCC, discover tools, or search the Marketplace | [`@loonghao/dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) |
+| Create or modernize a complete DCC-MCP adapter/runtime | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) |
+| Create, validate, or improve a DCC-specific Skill package | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) |
+
+Install only the Skill matching the task. OpenClaw uses
+`openclaw skills install @loonghao/<slug>`; a ClawHub-compatible agent can use
+`npx --yes clawhub@0.23.1 install @loonghao/<slug>`.
+Start a new agent turn after installation.
+
 **CLI availability and updates:**
 - If `dcc-mcp-cli` is missing, obtain user consent before running an official
-  installer from `scripts/install-cli.sh` or `scripts/install-cli.ps1`.
+  installer. Prefer the verified helper bundled with the installed `dcc-mcp`
+  Skill; otherwise inspect `scripts/install-cli.sh` or `scripts/install-cli.ps1`
+  before running the local file.
 - Keep official builds current with `dcc-mcp-cli update check`, then
   `dcc-mcp-cli update apply`. The apply step stages the latest CLI for the next
   launch; it does not replace a running `dcc-mcp-server`.
@@ -107,10 +122,10 @@ returned load/describe/call step, then invoke the typed tool.
 | Full index | `llms-full.txt` | When `llms.txt` lacks detail |
 | Detailed rules | [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md) | Before writing code — traps, do/don't, code style |
 | Conceptual docs | [`docs/guide/INDEX.md`](docs/guide/INDEX.md) + `docs/api/` | Building a new adapter or skill — see INDEX.md for topic list |
-| Skill authoring | [`skills/dcc-mcp-skills-creator/SKILL.md`](skills/dcc-mcp-skills-creator/SKILL.md) + `examples/skills/` | Creating or modifying skills |
-| Adapter developer guidance | [`skills/dcc-mcp-creator/SKILL.md`](skills/dcc-mcp-creator/SKILL.md) | Before creating or changing DCC adapter server/runtime wiring, dispatcher bridges, readiness, resources, gateway behavior, or core-escalation plans |
+| Skill authoring | [`dcc-mcp-skills-creator` on ClawHub](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) + [`skills/dcc-mcp-skills-creator/SKILL.md`](skills/dcc-mcp-skills-creator/SKILL.md) | Creating or modifying DCC-specific Skills |
+| Adapter developer guidance | [`dcc-mcp-creator` on ClawHub](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) + [`skills/dcc-mcp-creator/SKILL.md`](skills/dcc-mcp-creator/SKILL.md) | Before creating or changing DCC adapter server/runtime wiring, dispatcher bridges, readiness, resources, gateway behavior, or core-escalation plans |
 | Skill creator guidance | [`skills/dcc-mcp-skills-creator/SKILL.md`](skills/dcc-mcp-skills-creator/SKILL.md) | Before creating or changing adapter skill authoring, tool schemas, scripts, skill taxonomy, testing, or agent-facing workflows |
-| CLI + marketplace operations | [`skills/dcc-mcp/SKILL.md`](skills/dcc-mcp/SKILL.md) | Agents doing DCC control via `dcc-mcp-cli` — gateway ensure, inventory, search, describe, call, marketplace install/update |
+| CLI + marketplace operations | [`dcc-mcp` on ClawHub](https://clawhub.ai/loonghao/skills/dcc-mcp) + [`skills/dcc-mcp/SKILL.md`](skills/dcc-mcp/SKILL.md) | Agents doing DCC control via `dcc-mcp-cli` — gateway ensure, inventory, search, describe, call, marketplace install/update |
 | Marketplace extension publishing | [`skills/marketplace-publish-extension/SKILL.md`](skills/marketplace-publish-extension/SKILL.md) | Before publishing a new skill package to the DCC-MCP marketplace |
 | Marketplace extension creation | [`skills/marketplace-create-extension/SKILL.md`](skills/marketplace-create-extension/SKILL.md) | Before creating a new marketplace extension package |
 | Gateway REST regressions (VRS) | [`tests/vrs/README.md`](tests/vrs/README.md) + `scripts/vrs_replay.py` | After gateway `/v1/*` or live-adapter bugs — add a JSONL trace per regression |
@@ -147,14 +162,15 @@ Support check (only when unclear): `dcc-mcp-cli dcc-types` lists canonical adapt
 4. Batch execute: `dcc-mcp-cli call --batch --steps '<json-array>'` or `POST /v1/call_batch` for ordered batches (max 25).
 5. Package as a skill: fork or extend `dcc-mcp` to reuse `dcc-mcp-cli` calls as structured MCP tools.
 6. Review reusable friction only after acceptance: query narrowly scoped `dcc-mcp-cli stats`, then use the `review_skill_improvement` prompt from `dcc-mcp-skills-creator`; zero calls means no evidence, and review never expands edit/publish authority.
-7. The gateway never fans out per-tool backend tools into `tools/list`; the advertised gateway MCP surface is read-only discovery (`search`, `describe`) only.
-8. Use `ui-control` Computer Use only when a structured DCC skill/script/API is unsupported, missing, or cannot reach the required semantic UI. Never switch to another UI/input path after a policy, authorization, authentication, security, confirmation, desktop-availability, or user-interruption failure. The adapter/operator must bind native input to its DCC with `DCC_MCP_UI_CONTROL_UIA_PROCESS_ID` or `DCC_MCP_UI_CONTROL_UIA_WINDOW_HANDLE`; requests may only narrow that trusted scope. Use `snapshot` → one `act` → `snapshot`, then `stop_computer_use` on every exit path.
-9. The user presses `Esc` to stop UI Control across DCC adapter processes. After the hard stop, do not retry, change `session_id`, or restart. Resume only with `ui_control__snapshot(resume_computer_use=true)` after an explicit user request and only while no Computer Use owner is active.
-10. Treat `desktop_unavailable` as a pause when Windows is locked, disconnected, or on a secure desktop. No UIA/raw input runs, but the logical `session_id` remains and structured DCC/MCP calls may continue subject to host readiness. Never automate LockApp. After unlock, discard old ids and take a fresh exact-target snapshot so the banner returns.
-11. An ordinary process cannot show the banner on the Windows lock screen. Use a dedicated, always-unlocked VM for uninterrupted Windows GUI control. Public `openai/codex` `codex-rs` contains policy/plugin wiring, not the desktop Computer Use helper implementation; this repository's backend is independent.
-12. Computer Use executes on the adapter host in the interactive Windows logon session that owns the DCC. A central gateway routes calls but does not own coordinates. Never reuse gateway, other-host, or other-session coordinates. RDP disconnect/session switch pauses with `desktop_unavailable`; reconnect to the DCC session and take a fresh snapshot.
-13. Multi-monitor observations remain bounded to the scoped target window, which may sit at a negative virtual-desktop origin or span monitors with different DPI values. Any topology, resolution, or DPI/scaling change invalidates the observation and requires a fresh snapshot. The banner follows the scoped target within its owning session.
-14. Windows plug-in setup may use `ui_control__system_operation` only for an exact operator-owned HKCU String/DWORD or file/directory symlink grant. It is windowless and always confirmed, but never permits shell commands, arbitrary file operations, alternate registry hives, overwrite/delete, credentials, elevation, UAC, or security surfaces. Stop on `elevation_required`, `approval_required`, or `system_operation_not_granted`.
+7. On failure, preserve `request_id`; use `doctor`, failure-filtered `stats`, and the CLI-discovered `dcc_feedback__report`. Use public-safe `/v1/debug/issue-reports/{request_id}` for a reviewed bug report; never publish raw evidence or create an external issue without user authorization.
+8. The gateway never fans out per-tool backend tools into `tools/list`; the advertised gateway MCP surface is read-only discovery (`search`, `describe`) only.
+9. Use `ui-control` Computer Use only when a structured DCC skill/script/API is unsupported, missing, or cannot reach the required semantic UI. Never switch to another UI/input path after a policy, authorization, authentication, security, confirmation, desktop-availability, or user-interruption failure. The adapter/operator must bind native input to its DCC with `DCC_MCP_UI_CONTROL_UIA_PROCESS_ID` or `DCC_MCP_UI_CONTROL_UIA_WINDOW_HANDLE`; requests may only narrow that trusted scope. Use `snapshot` → one `act` → `snapshot`, then `stop_computer_use` on every exit path.
+10. The user presses `Esc` to stop UI Control across DCC adapter processes. After the hard stop, do not retry, change `session_id`, or restart. Resume only with `ui_control__snapshot(resume_computer_use=true)` after an explicit user request and only while no Computer Use owner is active.
+11. Treat `desktop_unavailable` as a pause when Windows is locked, disconnected, or on a secure desktop. No UIA/raw input runs, but the logical `session_id` remains and structured DCC/MCP calls may continue subject to host readiness. Never automate LockApp. After unlock, discard old ids and take a fresh exact-target snapshot so the banner returns.
+12. An ordinary process cannot show the banner on the Windows lock screen. Use a dedicated, always-unlocked VM for uninterrupted Windows GUI control. Public `openai/codex` `codex-rs` contains policy/plugin wiring, not the desktop Computer Use helper implementation; this repository's backend is independent.
+13. Computer Use executes on the adapter host in the interactive Windows logon session that owns the DCC. A central gateway routes calls but does not own coordinates. Never reuse gateway, other-host, or other-session coordinates. RDP disconnect/session switch pauses with `desktop_unavailable`; reconnect to the DCC session and take a fresh snapshot.
+14. Multi-monitor observations remain bounded to the scoped target window, which may sit at a negative virtual-desktop origin or span monitors with different DPI values. Any topology, resolution, or DPI/scaling change invalidates the observation and requires a fresh snapshot. The banner follows the scoped target within its owning session.
+15. Windows plug-in setup may use `ui_control__system_operation` only for an exact operator-owned HKCU String/DWORD or file/directory symlink grant. It is windowless and always confirmed, but never permits shell commands, arbitrary file operations, alternate registry hives, overwrite/delete, credentials, elevation, UAC, or security surfaces. Stop on `elevation_required`, `approval_required`, or `system_operation_not_granted`.
 
 IDE MCP (for human IDE users — Cursor, Claude Desktop, VS Code):
 1. Discover: MCP `search(query="keyword", dcc_type="maya")` → get `tool_slug`.

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -48,10 +48,34 @@ automation.
 
 CLI-first does **not** deprecate MCP. The gateway always exposes both MCP and REST side by side.
 
+### Install the right Agent Skill
+
+Choose by task; live DCC control does not require either creator Skill:
+
+| Intent | Install |
+|--------|---------|
+| Operate a DCC, discover capabilities, or search the Marketplace | [`@loonghao/dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) |
+| Create or modernize a complete DCC-MCP adapter | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) |
+| Create or improve a DCC-specific Skill package | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) |
+
+```bash
+# OpenClaw workspace
+openclaw skills install @loonghao/dcc-mcp
+
+# Direct ClawHub CLI
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp
+```
+
+Substitute the selected creator package only for its matching development
+task. Start a new agent turn after installation. Natural DCC requests trigger
+`dcc-mcp`; explicit-capability hosts can invoke `$dcc-mcp`,
+`$dcc-mcp-creator`, or `$dcc-mcp-skills-creator`.
+
 ### Install and keep the CLI current
 
 If `dcc-mcp-cli` is missing, obtain the user's consent, install the public
-`dcc-mcp` Skill, and run its bundled verified helper from the Skill directory:
+[`dcc-mcp` Skill](https://clawhub.ai/loonghao/skills/dcc-mcp) using the command
+above, and run its bundled verified helper from the Skill directory:
 
 ```bash
 python scripts/check_cli.py --ensure-cli --pretty
@@ -204,8 +228,18 @@ Use the `dcc-mcp` skill to wrap these CLI calls as structured MCP tools in your 
 
 `dcc-types` reads the release catalog without starting a gateway; it reports
 adapter-backed identifiers such as `godot` and `renderdoc`, while `list` reports
-live sessions. After the task passes its acceptance checks, query bounded
-evidence with `dcc-mcp-cli stats --range 24h --session-id task-42`, then use the
+live sessions.
+
+On failure, keep the CLI-returned `request_id` and run `doctor` for startup or
+readiness faults, then `stats --status failure --session-id task-42` for the
+bounded task slice. Discover and call `dcc_feedback__report` through
+`search -> describe -> call` to record structured runtime feedback. For a
+gateway-routed failure, `/v1/debug/issue-reports/<request_id>` returns a
+public-safe summary and suggested GitHub issue body; never publish `?mode=raw`
+without human review, and create an external issue only with user authorization.
+
+After the task passes its acceptance checks, query bounded evidence with
+`dcc-mcp-cli stats --range 24h --session-id task-42`, then use the
 `review_skill_improvement` prompt from `dcc-mcp-skills-creator`. Treat zero calls
 as missing evidence, never send raw prompts or secrets, and prefer no change or
 an existing-skill update over creating another skill.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ packaged CLI/server binaries needed to operate real sessions.
 
 | You want to… | Start with |
 |---|---|
-| Control a running DCC from an agent or CI job | [dcc-mcp-cli](docs/guide/cli-reference.md) |
+| Control a running DCC from an agent or CI job | Install the [`dcc-mcp` Agent Skill](https://clawhub.ai/loonghao/skills/dcc-mcp), then use [dcc-mcp-cli](docs/guide/cli-reference.md) |
 | Expose a DCC adapter over MCP/REST | [create_skill_server](docs/guide/getting-started.md) |
 | Add tools without Python registration code | [SKILL.md + tools.yaml](docs/guide/skills.md) |
 | Discover and install reusable Skills | [DCC-MCP Marketplace](https://github.com/dcc-mcp/marketplace) |
@@ -196,31 +196,38 @@ untouched if validation or download fails. This is an integrity check, not a
 digital signature. Never pipe a remote installer directly into a shell or
 bypass the machine's script execution policy.
 
-### Install the agent Skill suite
+### Install the Agent Skill you need
 
-Install the three public Skills directly from ClawHub; cloning this repository
-is not required:
+The three public Skills have separate jobs. Start with `dcc-mcp` for live DCC
+work; install a creator Skill only when the task reaches that boundary:
+
+| Agent task | Public Skill | Source |
+|---|---|---|
+| Operate a live DCC, discover tools, or search the Marketplace | [`@loonghao/dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) | [`skills/dcc-mcp`](skills/dcc-mcp/) |
+| Create or modernize a complete DCC-MCP adapter/runtime | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) | [`skills/dcc-mcp-creator`](skills/dcc-mcp-creator/) |
+| Create, validate, or improve a DCC-specific Skill package | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) | [`skills/dcc-mcp-skills-creator`](skills/dcc-mcp-skills-creator/) |
+
+OpenClaw installs into the active workspace by default; add `--global` only
+when every local OpenClaw agent should share the Skill:
 
 ~~~bash
 openclaw skills install @loonghao/dcc-mcp
-openclaw skills install @loonghao/dcc-mcp-skills-creator
 openclaw skills install @loonghao/dcc-mcp-creator
+openclaw skills install @loonghao/dcc-mcp-skills-creator
 ~~~
 
-Add `--global` to each command when every local OpenClaw agent should see the
-suite. Other ClawHub-compatible workspaces can use the registry CLI directly:
+For a Codex-compatible project, install into the standard project Skill root:
 
 ~~~bash
 npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp
-npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-skills-creator
 npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-creator
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-skills-creator
 ~~~
 
-| Skill | Agent role |
-|---|---|
-| [`dcc-mcp`](skills/dcc-mcp/) | Default live DCC control and marketplace discovery; Skill-store requests begin with `dcc-mcp-cli marketplace search` |
-| [`dcc-mcp-skills-creator`](skills/dcc-mcp-skills-creator/) | Create, validate, package, and review DCC-MCP Skill packages |
-| [`dcc-mcp-creator`](skills/dcc-mcp-creator/) | Create or modernize a complete DCC adapter and its runtime wiring |
+Other Agent Skills hosts should install the same ClawHub package into their
+configured Skill root. Start a new agent turn after installation. Natural DCC
+requests should trigger `dcc-mcp`; hosts with explicit Skill invocation can use
+`$dcc-mcp`, `$dcc-mcp-creator`, or `$dcc-mcp-skills-creator` respectively.
 
 All three packages carry Codex `agents/openai.yaml` metadata while preserving
 their DCC-MCP and ClawHub contracts. Their immutable ClawHub releases are
@@ -271,6 +278,12 @@ dcc-mcp-cli list
 Use dcc-mcp-cli doctor when startup or readiness is unclear. Open the local
 Admin UI at [http://127.0.0.1:9765/admin](http://127.0.0.1:9765/admin) after the
 gateway is available.
+
+When a call fails, preserve its `request_id`, run `doctor` or a failure-filtered
+`stats` query, and discover `dcc_feedback__report` through the normal
+`search -> describe -> call` flow. Gateway-routed failures also expose a
+public-safe `/v1/debug/issue-reports/<request_id>` payload for a reviewed bug
+report; raw bundles must never be uploaded automatically.
 
 After a task is accepted, agents can inspect bounded gateway evidence with
 `dcc-mcp-cli stats --range 24h --session-id task-42`. A zero call count means

--- a/README_zh.md
+++ b/README_zh.md
@@ -88,30 +88,38 @@ instance row -> gateway 统一路由所有 live DCC instance。
 
 ## 快速开始
 
-### 安装 Agent Skill 套件
+### 按任务安装 Agent Skill
 
-可以直接从 ClawHub 安装三个公开 Skill，无需克隆本仓库：
+三个公开 Skill 各自负责一个边界。操作现有 DCC 时只需先安装 `dcc-mcp`；只有
+任务进入 adapter 或专项 Skill 开发时，才安装对应 creator：
+
+| Agent 任务 | 公开 Skill | 源码 |
+|---|---|---|
+| 操作实时 DCC、发现工具或搜索 Marketplace | [`@loonghao/dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) | [`skills/dcc-mcp`](skills/dcc-mcp/) |
+| 创建或现代化完整 DCC-MCP adapter/runtime | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) | [`skills/dcc-mcp-creator`](skills/dcc-mcp-creator/) |
+| 创建、验证或改进 DCC 专项 Skill 包 | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) | [`skills/dcc-mcp-skills-creator`](skills/dcc-mcp-skills-creator/) |
+
+OpenClaw 默认安装到当前 workspace；只有需要本机所有 OpenClaw Agent 共享时
+才加 `--global`：
 
 ```bash
 openclaw skills install @loonghao/dcc-mcp
-openclaw skills install @loonghao/dcc-mcp-skills-creator
 openclaw skills install @loonghao/dcc-mcp-creator
+openclaw skills install @loonghao/dcc-mcp-skills-creator
 ```
 
-需要让本机所有 OpenClaw Agent 共享时，给每条命令加 `--global`。其他兼容
-ClawHub 的 workspace 可以直接使用 registry CLI：
+Codex 项目应安装到标准项目 Skill 根目录：
 
 ```bash
 npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp
-npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-skills-creator
 npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-creator
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-skills-creator
 ```
 
-| Skill | Agent 职责 |
-|---|---|
-| [`dcc-mcp`](skills/dcc-mcp/) | 默认实时 DCC 控制和 marketplace 发现；Skill 商城请求先运行 `dcc-mcp-cli marketplace search` |
-| [`dcc-mcp-skills-creator`](skills/dcc-mcp-skills-creator/) | 创建、验证、打包和评审 DCC-MCP Skill |
-| [`dcc-mcp-creator`](skills/dcc-mcp-creator/) | 创建或现代化完整 DCC adapter 及运行时接线 |
+其他 Agent Skills 宿主应把同一个 ClawHub 包安装到自身配置的 Skill 根目录。
+安装后开启新的 agent turn。自然语言 DCC 请求应触发 `dcc-mcp`；支持显式 Skill
+调用的宿主也可以分别使用 `$dcc-mcp`、`$dcc-mcp-creator` 或
+`$dcc-mcp-skills-creator`。
 
 ### 安装独立 CLI
 
@@ -173,6 +181,12 @@ dcc-mcp-cli update check --binary dcc-mcp-server --current-version <server_versi
    traces、logs 和 Token 活动。
 4. 对正在运行的 backend，使用 Instances 面板里的更新按钮暂存
    `dcc-mcp-server` 更新。`dcc-mcp-cli update apply` 只用于更新 CLI 二进制本身。
+
+调用失败时保留 `request_id`，根据故障类型运行 `doctor` 或带
+`--status failure --session-id <id>` 的 `stats`，再通过正常的
+`search -> describe -> call` 流程调用 `dcc_feedback__report`。gateway 路径还提供
+public-safe `/v1/debug/issue-reports/<request_id>` 作为经审查的 Bug 报告材料；
+禁止自动上传 raw bundle。
 
 任意 gateway-backed 命令成功后，默认浏览器控制台可访问
 `http://127.0.0.1:9765/admin`。如果 gateway 在其他地址，可以使用

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,11 +1,35 @@
 import { defineConfig } from 'vitepress'
 
+const siteUrl = 'https://dcc-mcp.github.io/dcc-mcp-core/'
+
 export default defineConfig({
   title: 'DCC-MCP-Core',
   description: 'Production-grade MCP + Skills foundation for AI-assisted DCC workflows',
   base: '/dcc-mcp-core/',
   cleanUrls: true,
   lastUpdated: true,
+  sitemap: {
+    hostname: siteUrl,
+  },
+
+  transformPageData(pageData) {
+    const canonicalUrl = `${siteUrl}${pageData.relativePath}`
+      .replace(/index\.md$/, '')
+      .replace(/\.md$/, '')
+    const title = pageData.frontmatter.layout === 'home'
+      ? 'DCC-MCP-Core'
+      : `${pageData.title} | DCC-MCP-Core`
+
+    pageData.frontmatter.head ??= []
+    pageData.frontmatter.head.push(
+      ['link', { rel: 'canonical', href: canonicalUrl }],
+      ['meta', { property: 'og:title', content: title }],
+      ['meta', { property: 'og:description', content: pageData.description }],
+      ['meta', { property: 'og:type', content: 'website' }],
+      ['meta', { property: 'og:url', content: canonicalUrl }],
+      ['meta', { name: 'twitter:card', content: 'summary' }],
+    )
+  },
 
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/dcc-mcp-core/logo.svg' }],
@@ -23,7 +47,7 @@ export default defineConfig({
           {
             text: 'v0.19.85', // x-release-please-version
             items: [
-              { text: 'Changelog', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
+              { text: 'Changelog', link: 'https://github.com/dcc-mcp/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },
             ]
           }
@@ -208,7 +232,7 @@ export default defineConfig({
           {
             text: 'v0.19.85', // x-release-please-version
             items: [
-              { text: '更新日志', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
+              { text: '更新日志', link: 'https://github.com/dcc-mcp/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },
             ]
           }
@@ -386,7 +410,7 @@ export default defineConfig({
   themeConfig: {
     logo: '/logo.svg',
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/loonghao/dcc-mcp-core' }
+      { icon: 'github', link: 'https://github.com/dcc-mcp/dcc-mcp-core' }
     ],
     footer: {
       message: 'Released under the MIT License.',
@@ -396,7 +420,7 @@ export default defineConfig({
       provider: 'local'
     },
     editLink: {
-      pattern: 'https://github.com/loonghao/dcc-mcp-core/edit/main/docs/:path'
+      pattern: 'https://github.com/dcc-mcp/dcc-mcp-core/edit/main/docs/:path'
     },
   },
 

--- a/docs/api/feedback.md
+++ b/docs/api/feedback.md
@@ -16,6 +16,28 @@ Register the `dcc_feedback__report` MCP tool on `server`. Call **before** `serve
 
 The tool accepts: `tool_name`, `intent`, `blocker`, `severity` (`"blocked"` | `"workaround_found"` | `"suggestion"`), optional `attempt`.
 
+## Agent failure-reporting workflow
+
+Shell-capable agents use the published `dcc-mcp` Skill and existing CLI
+surfaces:
+
+```bash
+dcc-mcp-cli doctor
+dcc-mcp-cli stats --range 24h --status failure --session-id <session-id>
+dcc-mcp-cli search --query "report feedback" --dcc-type <dcc>
+dcc-mcp-cli describe <returned-feedback-tool-slug>
+dcc-mcp-cli call <returned-feedback-tool-slug> --json \
+  '{"tool_name":"tool_that_failed","intent":"goal","attempt":"sanitized attempt","blocker":"observed failure","severity":"blocked"}'
+```
+
+The feedback call stores a structured runtime signal; it does not create an
+external issue. For a gateway-routed failure, preserve the CLI-returned
+`request_id` and retrieve public-safe
+`/v1/debug/issue-reports/<request_id>`. Review `?mode=raw` locally and never
+upload it automatically. Route Skill defects to the owning Skill, adapter or
+host-runtime defects to the adapter repository, and shared CLI/gateway/protocol
+defects to `dcc-mcp-core`; create an external issue only with user authorization.
+
 ## extract_rationale
 
 ```python

--- a/docs/guide/INDEX.md
+++ b/docs/guide/INDEX.md
@@ -19,6 +19,12 @@ Documentation contract:
 
 **Start here if you're an AI agent** — read these documents in order:
 
+| Your task | Install first |
+|-----------|---------------|
+| Operate a live DCC or discover Marketplace capabilities | [`dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) |
+| Create or modernize a complete DCC-MCP adapter | [`dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) |
+| Create or improve a DCC-specific Skill package | [`dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) |
+
 | Priority | Document | Why |
 |----------|----------|-----|
 | 1 | [`AGENTS.md`](https://github.com/dcc-mcp/dcc-mcp-core/blob/main/AGENTS.md) | Navigation map, response rules, PR rules, and links |
@@ -31,7 +37,7 @@ Documentation contract:
 
 | Document | Purpose |
 |----------|---------|
-| [getting-started.md](getting-started.md) | Install, first server, first tool |
+| [getting-started.md](getting-started.md) | Install the right Agent Skill/CLI, operate a DCC, or expose a first server |
 | [what-is-dcc-mcp-core.md](what-is-dcc-mcp-core.md) | High-level project overview and motivation |
 | [architecture.md](architecture.md) | Rust workspace layout, crate boundaries, PyO3 bridge |
 

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -8,8 +8,15 @@ same configuration surface.
 
 `dcc-mcp-cli` and `dcc-mcp-server` are published as raw GitHub Release
 assets on every release. It is the preferred control path for shell-capable
-agents. If it is missing, obtain the user's consent before installing it from
-the official release. From the installed `dcc-mcp` Skill directory, run:
+agents. Install the published
+[`dcc-mcp` Skill](https://clawhub.ai/loonghao/skills/dcc-mcp) for the routing,
+safety, and recovery workflow; use
+[`dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) only for
+a complete adapter and
+[`dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator)
+only for a DCC-specific Skill package. If the CLI is missing, obtain the user's
+consent before installing it from the official release. From the installed
+`dcc-mcp` Skill directory, run:
 
 ```bash
 python scripts/check_cli.py --ensure-cli --pretty
@@ -237,6 +244,28 @@ root-cause proof; `total_calls == 0` means no telemetry evidence, not that no
 calls occurred. The
 `review_skill_improvement` prompt in `skills/dcc-mcp-skills-creator/prompts.yaml`
 accepts this JSON plus bounded task and validation summaries.
+
+### Failure analysis and bug reporting
+
+Use the existing surfaces instead of copying unbounded logs:
+
+1. Preserve the failed call's `request_id`, trace/job ids, tool slug, instance,
+   sanitized arguments, error code, and validation result. Do not blindly
+   replay a mutating call.
+2. Run `dcc-mcp-cli doctor` for profile, registry, daemon, binary, or readiness
+   failures. For task-level evidence, run
+   `dcc-mcp-cli stats --range 24h --status failure --session-id <session-id>`.
+3. Discover `dcc_feedback__report` with `search --query "report feedback"`,
+   follow `describe`, and call the returned slug with `tool_name`, `intent`,
+   `attempt`, `blocker`, and `severity`. This records runtime feedback; it does
+   not open a GitHub issue.
+4. For a gateway-routed failure, read the public-safe
+   `/v1/debug/issue-reports/<request_id>` payload. It contains a bounded summary
+   and suggested GitHub title/body. Review `?mode=raw` locally and never attach
+   it automatically.
+5. Route schema/script/workflow bugs to the owning Skill, host dispatch or
+   readiness bugs to the adapter, and shared CLI/gateway/protocol bugs to
+   `dcc-mcp-core`. Create the external issue only with user authorization.
 
 `gateway daemon start` and `gateway daemon restart` are the durable operator
 paths. Their default `--gateway-idle-timeout-secs 0` disables idle shutdown;

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -52,6 +52,25 @@ pip install maturin
 maturin develop
 ```
 
+### Which Agent Skill should I install?
+
+Install by task; most agents only need the first row:
+
+| Task | Skill |
+|------|-------|
+| Operate a live DCC, discover tools, or search the Marketplace | [`@loonghao/dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) |
+| Create or modernize a complete DCC-MCP adapter/runtime | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) |
+| Create, validate, or improve a DCC-specific Skill package | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) |
+
+```bash
+openclaw skills install @loonghao/dcc-mcp
+# Direct ClawHub CLI:
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp
+```
+
+Start a new agent turn after installation. The `dcc-mcp` Skill then guides the
+agent through `dcc-mcp-cli list -> search -> describe/load-skill -> call`.
+
 ## Tools
 
 ### How do I register a tool?
@@ -293,7 +312,10 @@ handle = server.start()
 print(handle.is_gateway)  # True if this process won the gateway port
 ```
 
-Agents always connect to `http://localhost:9765/mcp` and read the `gateway://instances` MCP resource (`resources/read uri=gateway://instances`) to discover and route to specific DCC processes — each entry already carries `mcp_url`.
+Shell-capable agents use the `dcc-mcp` Skill and `dcc-mcp-cli`; the local
+profile discovers registered instances automatically. MCP-only clients connect
+to `http://localhost:9765/mcp` and read the `gateway://instances` resource when
+they need a concrete DCC process; each entry already carries `mcp_url`.
 
 ### What is BridgeKind?
 
@@ -341,12 +363,22 @@ cfg.init()
 
 ### How do I report a bug or request a feature?
 
-Please open an issue on [GitHub](https://github.com/dcc-mcp/dcc-mcp-core/issues) with:
-- DCC application and version
-- Python version (`python --version`)
-- dcc-mcp-core version (`python -c "import dcc_mcp_core; print(dcc_mcp_core.__version__)"`)
-- Minimal reproduction code
-- Expected vs actual behavior
+Agents should self-check before opening an issue:
+
+1. Keep the failed call's `request_id`; run `dcc-mcp-cli doctor` for startup or
+   readiness faults and `dcc-mcp-cli stats --status failure --session-id <id>`
+   for the bounded task slice.
+2. Discover and call `dcc_feedback__report` to record structured feedback in
+   the runtime.
+3. For a gateway-routed failure, retrieve public-safe
+   `/v1/debug/issue-reports/<request_id>`. It includes a suggested title/body;
+   never upload `?mode=raw` without human review.
+4. Route Skill contract bugs to the owning Skill, adapter/host bugs to the
+   adapter repository, and shared CLI/gateway/protocol bugs to
+   [dcc-mcp-core](https://github.com/dcc-mcp/dcc-mcp-core/issues).
+5. Open the external issue only when the user requested or approved it. Include
+   the DCC/core versions, smallest reproduction, expected/actual behavior, and
+   the public-safe report.
 
 ## Contributing
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -2,6 +2,28 @@
 
 ## Installation
 
+### Public Agent Skills
+
+Install the Skill that matches the agent's task. Cloning this repository is
+not required:
+
+| Task | Skill |
+|------|-------|
+| Operate a live DCC, discover tools, or search the Marketplace | [`@loonghao/dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) |
+| Create or modernize a complete DCC-MCP adapter/runtime | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) |
+| Create, validate, or improve a DCC-specific Skill package | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) |
+
+```bash
+# OpenClaw workspace: default live-DCC control Skill
+openclaw skills install @loonghao/dcc-mcp
+
+# Direct ClawHub CLI
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp
+```
+
+Substitute a creator slug only for its matching development task. Start a new
+agent turn after installation.
+
 ### CLI from the `dcc-mcp` Skill
 
 ```bash
@@ -81,6 +103,22 @@ The build is handled by [maturin](https://www.maturin.rs/) which compiles the Ru
 - **Python Dependencies**: Zero — everything is in the compiled Rust extension
 
 ## Quick Start
+
+### Operate a live DCC from an agent
+
+With `dcc-mcp` loaded, use the CLI as the structured control path:
+
+```bash
+dcc-mcp-cli dcc-types
+dcc-mcp-cli list
+dcc-mcp-cli search --query "create sphere" --dcc-type maya
+dcc-mcp-cli describe <tool-slug>
+dcc-mcp-cli call <tool-slug> --json '{"radius":2.0}'
+```
+
+Use the slug returned by `search`; never construct it. If `list` returns zero
+instances, follow the Skill's consent-gated setup flow instead of switching to
+raw DCC scripting or generic GUI automation.
 
 ### Skills-First: `create_skill_server` (recommended)
 

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -186,6 +186,13 @@ response payload previews, prompts, scripts, and scene data. Browser URLs such
 as `/admin?panel=traces&trace=<request_id>` and historical
 `/admin?agent=traces&trace=<id>` links are UI navigation, not a stable API.
 
+For bug reporting, start from the `request_id` returned by `dcc-mcp-cli`, read
+the agent trace packet, then retrieve
+`/v1/debug/issue-reports/{request_id}`. The default report is public-safe and
+includes a suggested GitHub title/body; `?mode=raw` is local evidence that must
+be reviewed before sharing. This endpoint prepares evidence but never
+authorizes or creates an external issue.
+
 ---
 
 ## `POST /v1/call` — the invocation contract

--- a/docs/guide/what-is-dcc-mcp-core.md
+++ b/docs/guide/what-is-dcc-mcp-core.md
@@ -2,14 +2,15 @@
 
 **DCC-MCP-Core** is a Rust-first library (with Python bindings) that exposes capabilities inside DCC (Digital Content Creation) tools — Maya, Blender, Houdini, Photoshop, ZBrush, Unreal, Unity, Figma, and custom studio hosts — through a **layered surface**:
 
-- **AI assistants** → a small, static **MCP** discovery set (`search`, `describe`) via the gateway, plus REST `/v1/*` for execution.
+- **Shell-capable AI agents** → the published `dcc-mcp` Skill plus `dcc-mcp-cli` for `search → describe → call`.
+- **MCP-only IDE clients** → the gateway's small, static MCP workflow (`search`, `describe`, `load_skill`, `call`).
 - **Traditional callers** (cURL, CI, any HTTP client) → a full **`/v1/*` REST API** on every per-DCC server and on the gateway facade.
 
 The core is Rust, compiled to a Python extension via [PyO3](https://pyo3.rs/) + [maturin](https://github.com/PyO3/maturin). It has no third-party Python library runtime dependencies; the companion `dcc-mcp-server` wheel supplies the packaged gateway daemon binary.
 
 ---
 
-## Core workflow (2026-05 refresh)
+## Core workflow (2026-07 refresh)
 
 ```mermaid
 flowchart LR
@@ -29,11 +30,12 @@ flowchart LR
       PERDCC --> GW
     end
 
-    AGENT([AI assistant]):::client
+    AGENT([Shell-capable agent + dcc-mcp Skill]):::client
+    IDE([MCP-only IDE client]):::client
     TRAD([cURL / CI / traditional backends]):::client
 
-    AGENT -->|MCP: search<br/>describe| GW
-    AGENT -->|REST: POST /v1/call| GW
+    AGENT -->|dcc-mcp-cli: search<br/>describe / call| GW
+    IDE -->|MCP: search<br/>describe / load_skill / call| GW
     TRAD -->|REST: POST /v1/search<br/>/describe /call| GW
     TRAD -.->|direct REST to per-DCC| PERDCC
     GW -->|/v1/call routes to owning DCC| PERDCC

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,16 @@ hero:
       text: Why MCP + Skills?
       link: /guide/what-is-dcc-mcp-core
     - theme: alt
+      text: Install dcc-mcp Skill
+      link: https://clawhub.ai/loonghao/skills/dcc-mcp
+    - theme: alt
       text: GitHub
       link: https://github.com/dcc-mcp/dcc-mcp-core
 
 features:
+  - icon: 🤖
+    title: Agent-Ready Entry
+    details: Install the public dcc-mcp Skill, then use dcc-mcp-cli to inventory, search, inspect, and call typed DCC capabilities.
   - icon: 🎯
     title: Dynamic Capability Routing
     details: Agents search, describe, load skills, and call tools through one gateway instead of carrying every backend tool in context.

--- a/docs/zh/api/feedback.md
+++ b/docs/zh/api/feedback.md
@@ -1,6 +1,6 @@
 # 反馈 API
 
-> **[English](../api/feedback.md)**
+> **[English](../../api/feedback.md)**
 
 代理反馈与决策理由机制。注册 `dcc_feedback__report` MCP 工具供代理提交反馈，提取和构建 `tools/call` 请求中的 `_meta.dcc.rationale` 决策理由。
 
@@ -14,4 +14,23 @@
 - `get_feedback_entries(*, tool_name=None, severity=None, limit=50) -> list[dict]` — 获取最近的反馈条目（最新在前）
 - `clear_feedback() -> int` — 清空内存中的反馈条目，返回清除数量
 
-详见 [English API 参考](../api/feedback.md)。
+## Agent 错误上报工作流
+
+具备 shell 能力的 Agent 使用公开 `dcc-mcp` Skill 和现有 CLI 接口：
+
+```bash
+dcc-mcp-cli doctor
+dcc-mcp-cli stats --range 24h --status failure --session-id <session-id>
+dcc-mcp-cli search --query "report feedback" --dcc-type <dcc>
+dcc-mcp-cli describe <returned-feedback-tool-slug>
+dcc-mcp-cli call <returned-feedback-tool-slug> --json \
+  '{"tool_name":"tool_that_failed","intent":"goal","attempt":"sanitized attempt","blocker":"observed failure","severity":"blocked"}'
+```
+
+feedback 调用只记录结构化 runtime 信号，不会创建外部 issue。gateway 路径失败时，
+保留 CLI 返回的 `request_id`，获取 public-safe
+`/v1/debug/issue-reports/<request_id>`；`?mode=raw` 必须本地人工审查，禁止自动上传。
+Skill 缺陷归属对应 Skill，adapter/host runtime 缺陷归属 adapter 仓库，
+CLI/gateway/protocol 共性缺陷归属 `dcc-mcp-core`。只有用户授权后才创建外部 issue。
+
+详见 [English API 参考](../../api/feedback.md)。

--- a/docs/zh/guide/INDEX.md
+++ b/docs/zh/guide/INDEX.md
@@ -6,6 +6,12 @@
 
 **如果你是 AI Agent**，请按以下顺序阅读：
 
+| 你的任务 | 首先安装 |
+|----------|----------|
+| 操作实时 DCC 或发现 Marketplace 能力 | [`dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) |
+| 创建或现代化完整 DCC-MCP adapter | [`dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) |
+| 创建或改进 DCC 专项 Skill 包 | [`dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) |
+
 | 优先级 | 文档 | 说明 |
 |--------|------|------|
 | 1 | [`AGENTS.md`](https://github.com/dcc-mcp/dcc-mcp-core/blob/main/AGENTS.md) | 导航地图、响应规则、PR 规则及链接 |
@@ -18,7 +24,7 @@
 
 | 文档 | 用途 |
 |------|------|
-| [getting-started.md](getting-started.md) | 安装、第一个服务器、第一个工具 |
+| [getting-started.md](getting-started.md) | 安装正确的 Agent Skill/CLI、操作 DCC 或暴露第一个 server |
 | [what-is-dcc-mcp-core.md](what-is-dcc-mcp-core.md) | 项目高层概述与背景 |
 | [architecture.md](architecture.md) | Rust workspace 布局、crate 边界、PyO3 桥接 |
 

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -6,7 +6,13 @@
 
 `dcc-mcp-cli` 与 `dcc-mcp-server` 会在每个 Release 作为原生 GitHub
 Release 资产发布。它是所有具备 shell 能力的 Agent 的首选控制路径。如果尚未
-安装，先征得用户同意，再从已安装的 `dcc-mcp` Skill 目录运行：
+安装，先安装公开的
+[`dcc-mcp` Skill](https://clawhub.ai/loonghao/skills/dcc-mcp)，让 Agent 获得路由、
+安全与恢复流程。只有创建完整 adapter 时才使用
+[`dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator)，创建 DCC
+专项 Skill 包时才使用
+[`dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator)。
+安装 CLI 前先征得用户同意，再从已安装的 `dcc-mcp` Skill 目录运行：
 
 ```bash
 python scripts/check_cli.py --ensure-cli --pretty
@@ -189,6 +195,23 @@ dcc-mcp-cli lint path/to/skills
 | `gateway daemon start/restart/stop/status` | local process | 显式管理本机 machine-wide gateway daemon 生命周期；`start` 和 `restart` 的启动阶段默认传 `--gateway-idle-timeout-secs 0`，无 backend 时也保持存活；`status` 会输出 registry dir、PID file、health URL 和 CLI version 等诊断字段。 |
 | `gateway ensure/start/stop/status` | local process | 旧脚本兼容 alias；面向用户文档优先使用 `gateway daemon ...`。 |
 | `lint [PATH ...]` | local filesystem validator | 默认递归校验每个路径下两层内的 SKILL.md 包。 |
+
+### 错误自查与 Bug 上报
+
+1. 保留失败调用的 `request_id`、trace/job id、tool slug、instance、脱敏后的参数、
+   error code 和验证结果；不要直接重放有副作用的调用。
+2. profile、registry、daemon、binary 或 readiness 异常先运行
+   `dcc-mcp-cli doctor`；任务范围内的失败证据运行
+   `dcc-mcp-cli stats --range 24h --status failure --session-id <session-id>`。
+3. 用 `search --query "report feedback" -> describe -> call` 找到并调用
+   `dcc_feedback__report`，提交 `tool_name`、`intent`、`attempt`、`blocker` 和
+   `severity`。它只记录结构化运行时反馈，不会创建 GitHub issue。
+4. gateway 路径失败时，读取 public-safe
+   `/v1/debug/issue-reports/<request_id>`；其中已有摘要和建议的 GitHub
+   title/body。`?mode=raw` 只能本地人工审查，禁止自动上传。
+5. schema/script/workflow 问题归属对应 Skill；host dispatch/readiness 问题归属
+   adapter；CLI/gateway/protocol 共性问题归属 `dcc-mcp-core`。只有得到用户授权后
+   才创建外部 issue。
 
 `gateway daemon start` 和 `gateway daemon restart` 是持久 operator 路径。默认
 `--gateway-idle-timeout-secs 0` 会关闭 idle shutdown；只有脚本明确想要短生命周期

--- a/docs/zh/guide/faq.md
+++ b/docs/zh/guide/faq.md
@@ -70,6 +70,25 @@ pip install maturin
 maturin develop
 ```
 
+### 应该安装哪个 Agent Skill？
+
+按任务安装；大多数 Agent 只需要第一项：
+
+| 任务 | Skill |
+|------|-------|
+| 操作实时 DCC、发现工具或搜索 Marketplace | [`@loonghao/dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) |
+| 创建或现代化完整 DCC-MCP adapter/runtime | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) |
+| 创建、验证或改进 DCC 专项 Skill 包 | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) |
+
+```bash
+openclaw skills install @loonghao/dcc-mcp
+# 直接使用 ClawHub CLI：
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp
+```
+
+安装后开启新的 agent turn。`dcc-mcp` 会指导 Agent 按
+`dcc-mcp-cli list -> search -> describe/load-skill -> call` 执行。
+
 ## Actions
 
 ### 如何注册 Action？
@@ -312,7 +331,10 @@ handle = server.start()
 print(handle.is_gateway)  # 如果此进程赢得了 Gateway 端口则为 True
 ```
 
-Agent 始终连接 `http://localhost:9765/mcp`，通过读取 `gateway://instances` MCP 资源（`resources/read uri=gateway://instances`）发现并路由到特定 DCC 进程 —— 每条记录已经携带 `mcp_url`，无需额外的连接工具。
+具备 shell 能力的 Agent 使用 `dcc-mcp` Skill 和 `dcc-mcp-cli`，local profile
+会自动发现已注册实例。只有 MCP-only 客户端才连接
+`http://localhost:9765/mcp`；需要指定 DCC 进程时读取
+`gateway://instances` 资源，每条记录已经携带 `mcp_url`。
 
 ### BridgeKind 是什么？
 
@@ -360,12 +382,20 @@ cfg.init()
 
 ### 如何报告 Bug 或请求功能？
 
-请在 [GitHub](https://github.com/dcc-mcp/dcc-mcp-core/issues) 上提 Issue，并包含：
-- DCC 应用及版本
-- Python 版本（`python --version`）
-- dcc-mcp-core 版本（`python -c "import dcc_mcp_core; print(dcc_mcp_core.__version__)"`）
-- 最小可复现代码
-- 预期行为与实际行为
+Agent 应先完成自查，再创建 issue：
+
+1. 保留失败调用的 `request_id`；启动/readiness 问题运行
+   `dcc-mcp-cli doctor`，任务范围证据运行
+   `dcc-mcp-cli stats --status failure --session-id <id>`。
+2. 发现并调用 `dcc_feedback__report`，把结构化反馈记录到 runtime。
+3. gateway 路径失败时获取 public-safe
+   `/v1/debug/issue-reports/<request_id>`；它包含建议 title/body，未经人工审查
+   禁止上传 `?mode=raw`。
+4. Skill 契约问题归属对应 Skill，adapter/host 问题归属 adapter 仓库，
+   CLI/gateway/protocol 共性问题归属
+   [dcc-mcp-core](https://github.com/dcc-mcp/dcc-mcp-core/issues)。
+5. 只有用户请求或授权后才创建外部 issue；附上 DCC/core 版本、最小复现、
+   预期/实际行为和 public-safe 报告。
 
 ## 贡献
 

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -2,6 +2,26 @@
 
 ## 安装
 
+### 公开 Agent Skills
+
+按 Agent 任务安装对应 Skill，无需克隆本仓库：
+
+| 任务 | Skill |
+|------|-------|
+| 操作实时 DCC、发现工具或搜索 Marketplace | [`@loonghao/dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) |
+| 创建或现代化完整 DCC-MCP adapter/runtime | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) |
+| 创建、验证或改进 DCC 专项 Skill 包 | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) |
+
+```bash
+# OpenClaw workspace：默认实时 DCC 控制 Skill
+openclaw skills install @loonghao/dcc-mcp
+
+# 直接使用 ClawHub CLI
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp
+```
+
+只有任务进入对应开发边界时才替换为 creator slug。安装后开启新的 agent turn。
+
 ### 从 `dcc-mcp` Skill 安装 CLI
 
 ```bash
@@ -79,6 +99,21 @@ pip install -e .
 - **Python 依赖**: 零 — 所有功能都在编译的 Rust 扩展中
 
 ## 快速上手
+
+### Agent 操作实时 DCC
+
+加载 `dcc-mcp` 后，把 CLI 作为结构化控制路径：
+
+```bash
+dcc-mcp-cli dcc-types
+dcc-mcp-cli list
+dcc-mcp-cli search --query "create sphere" --dcc-type maya
+dcc-mcp-cli describe <tool-slug>
+dcc-mcp-cli call <tool-slug> --json '{"radius":2.0}'
+```
+
+只使用 `search` 返回的 slug，不要自行拼接。如果 `list` 返回零实例，按 Skill
+中需要用户同意的 setup 流程处理，不要切换到原始 DCC 脚本或通用 GUI 自动化。
 
 ### Skills-First：`create_skill_server`（推荐）
 

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -158,6 +158,11 @@ OpenAPI contract 预留了 `cursor`、`since`、`until` 给后续 normalized env
 preview、prompt、script 和 scene data。`/admin?panel=traces&trace=<request_id>`
 以及历史 `/admin?agent=traces&trace=<id>` 是 UI 导航链接，不是稳定 API。
 
+上报 Bug 时，从 `dcc-mcp-cli` 返回的 `request_id` 开始，先读取 agent trace
+packet，再获取 `/v1/debug/issue-reports/{request_id}`。默认结果为 public-safe，
+并包含建议的 GitHub title/body；`?mode=raw` 是必须在分享前人工审查的本地证据。
+该接口只准备证据，不会授权或创建外部 issue。
+
 ---
 
 ## `POST /v1/call` —— 调用契约

--- a/docs/zh/guide/what-is-dcc-mcp-core.md
+++ b/docs/zh/guide/what-is-dcc-mcp-core.md
@@ -2,14 +2,15 @@
 
 **DCC-MCP-Core** 是一套 Rust 基础库（含 Python 绑定），把 DCC（数字内容创作）软件中的"能力"—— Maya、Blender、Houdini、Photoshop、ZBrush、Unreal、Unity、Figma 等 ——分层暴露给两类消费者：
 
-- **AI 助手** → 通过 gateway 的**少量、固定、只读** **MCP 发现工具**（`search` / `describe`），再用 REST `/v1/*` 执行。
+- **具备 shell 能力的 Agent** → 安装公开 `dcc-mcp` Skill，通过 `dcc-mcp-cli` 执行 `search → describe → call`。
+- **MCP-only IDE 客户端** → 使用 gateway 的少量固定 MCP 工作流（`search`、`describe`、`load_skill`、`call`）。
 - **传统调用方** →（cURL / CI / 任意 HTTP 客户端）通过**完整的 `/v1/*` REST 服务**。
 
 底层是 Rust，通过 [PyO3](https://pyo3.rs/) + [maturin](https://github.com/PyO3/maturin) 编译成一个 Python 扩展模块。它没有第三方 Python 库运行时依赖；配套的 `dcc-mcp-server` wheel 提供打包后的 gateway daemon 二进制。
 
 ---
 
-## 核心工作流程（2026-05 更新）
+## 核心工作流程（2026-07 更新）
 
 ```mermaid
 flowchart LR
@@ -29,11 +30,12 @@ flowchart LR
       PERDCC --> GW
     end
 
-    AGENT([AI 助手]):::client
+    AGENT([Shell Agent + dcc-mcp Skill]):::client
+    IDE([MCP-only IDE 客户端]):::client
     TRAD([cURL / CI / 传统后端]):::client
 
-    AGENT -->|MCP: search<br/>describe| GW
-    AGENT -->|REST: POST /v1/call| GW
+    AGENT -->|dcc-mcp-cli: search<br/>describe / call| GW
+    IDE -->|MCP: search<br/>describe / load_skill / call| GW
     TRAD -->|REST: POST /v1/search<br/>/describe /call| GW
     TRAD -.->|直连 per-DCC REST| PERDCC
     GW -->|/v1/call 路由到具体 DCC| PERDCC

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -16,10 +16,16 @@ hero:
       text: 为什么选择 MCP + Skills？
       link: /zh/guide/what-is-dcc-mcp-core
     - theme: alt
+      text: 安装 dcc-mcp Skill
+      link: https://clawhub.ai/loonghao/skills/dcc-mcp
+    - theme: alt
       text: GitHub
       link: https://github.com/dcc-mcp/dcc-mcp-core
 
 features:
+  - icon: 🤖
+    title: Agent 开箱即用
+    details: 安装公开 dcc-mcp Skill，再用 dcc-mcp-cli 完成实例盘点、能力搜索、契约检查与 typed tool 调用。
   - icon: 🎯
     title: 动态能力路由
     details: Agent 通过一个 gateway search、describe、call 工具，不再把所有后端工具塞进上下文。

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7,6 +7,30 @@
 
 ---
 
+## Agent Bootstrap
+
+Most agents should not begin with the Python API. Install one published Skill
+for the task, then use its workflow:
+
+| Intent | ClawHub Skill | Runtime path |
+|--------|---------------|--------------|
+| Operate a live DCC or discover Marketplace capabilities | [`@loonghao/dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) | `dcc-mcp-cli` |
+| Create or modernize a complete DCC-MCP adapter | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) | Shared core adapter contracts |
+| Create or improve a DCC-specific Skill package | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) | Skill scaffold, validation, and packaging |
+
+OpenClaw uses `openclaw skills install @loonghao/<slug>`. Direct ClawHub CLI uses
+`npx --yes clawhub@0.23.1 install @loonghao/<slug>`.
+Start a new agent turn after installation. Continue to the API guide only when
+the task is embedding core, implementing an adapter, or extending the runtime.
+
+On failure, the `dcc-mcp` workflow preserves `request_id`, uses `doctor` or a
+failure-filtered `stats` query for bounded diagnosis, records structured
+feedback through the CLI-discovered `dcc_feedback__report`, and uses public-safe
+`/v1/debug/issue-reports/<request_id>` for reviewed bug reports. Raw evidence
+and external issue creation require human review and user authorization.
+
+---
+
 ## Quick Decision Guide
 
 | I want to… | Use this API |

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,19 @@
 dcc-mcp-core Skills through it. Do not confuse the typed CLI with raw DCC
 scripting.**
 
+Choose one published Agent Skill by intent:
+
+| Intent | ClawHub Skill |
+|--------|---------------|
+| Operate a live DCC or discover Marketplace capabilities | [`@loonghao/dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) |
+| Create or modernize a complete DCC-MCP adapter | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) |
+| Create or improve a DCC-specific Skill package | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) |
+
+OpenClaw installs with `openclaw skills install @loonghao/<slug>`. A
+Direct ClawHub CLI uses
+`npx --yes clawhub@0.23.1 install @loonghao/<slug>`.
+Start a new agent turn after installation.
+
 ### Why Skills-First?
 
 | Aspect | dcc-mcp-core Skills | Raw CLI / Scripting |
@@ -31,7 +44,11 @@ scripting.**
 
 `search_tools` tokenizes backend tool names and summaries; literal underscores are honored but not required (`create_sphere` and `sphere` both match). Multi-word natural-language phrases ("create sphere", "rig framework") match word-split tokens across both names and descriptions.
 5. FOLLOW UP: Check next-tools.on-success for suggested next steps
-6. DEBUG: On failure, use dcc_diagnostics__screenshot or audit_log
+6. DEBUG: Preserve `request_id`; use `doctor` for startup/readiness and
+   `stats --status failure --session-id <id>` for bounded task evidence.
+7. REPORT: Discover and call `dcc_feedback__report`; for gateway failures use
+   public-safe `/v1/debug/issue-reports/<request_id>`. Never upload raw bundles
+   or create an external issue without user authorization.
 ```
 
 **❌ DON'T**: Run Maya/Blender/Python scripts directly via subprocess

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,9 +92,12 @@ semantic = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/dcc-mcp/dcc-mcp-core"
+Homepage = "https://dcc-mcp.github.io/dcc-mcp-core/"
+Documentation = "https://dcc-mcp.github.io/dcc-mcp-core/"
 Repository = "https://github.com/dcc-mcp/dcc-mcp-core"
 Issues = "https://github.com/dcc-mcp/dcc-mcp-core/issues"
+Changelog = "https://github.com/dcc-mcp/dcc-mcp-core/blob/main/CHANGELOG.md"
+"Release Notes" = "https://github.com/dcc-mcp/dcc-mcp-core/releases"
 
 [tool.maturin]
 python-source = "python"

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -35,6 +35,22 @@ install lifecycle, or cross-DCC verification.
 For individual skill packages (`SKILL.md`, `tools.yaml`, scripts, groups, and
 skill taxonomy), load `dcc-mcp-skills-creator` instead.
 
+## Install and Route
+
+Install the published
+[`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator)
+package, then start a new agent turn:
+
+```bash
+openclaw skills install @loonghao/dcc-mcp-creator
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-creator
+```
+
+Use [`dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) to operate an
+existing DCC. Use
+[`dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator)
+when only a DCC-specific Skill package is needed.
+
 ## CLI-First Control Path
 
 Use the `dcc-mcp` skill and `dcc-mcp-cli` for discovery, validation, and live
@@ -242,6 +258,22 @@ would be unsafe.
   `interrupted` and remain queryable through the replacement instance's
   `jobs_get_status`; adapter-owned isolated jobs need their own durable status
   tool when they outlive the request transport.
+
+## Failure Analysis and Bug Routing
+
+Reproduce through `dcc-mcp` and keep one gateway session id. Run
+`dcc-mcp-cli doctor`, then `dcc-mcp-cli stats --status failure --session-id
+<session-id>`; preserve the failed call's `request_id`, trace/job ids, adapter
+version, DCC version, readiness fields, and the smallest safe reproduction.
+Use `/v1/debug/issue-reports/<request_id>` for the public-safe issue body and
+review any `?mode=raw` export locally before sharing it.
+
+Report adapter-owned dispatch, host-thread, readiness, packaging, or install
+bugs in the adapter repository. Escalate shared CLI, gateway, protocol, or core
+contract failures to `dcc-mcp-core`. Tool schema/script/workflow defects belong
+to the owning Skill and `dcc-mcp-skills-creator`. Record runtime feedback with
+the CLI-discovered `dcc_feedback__report` tool; open an external issue only
+with user authorization.
 
 ## Example: New Nuke Adapter
 

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -34,35 +34,23 @@ a host such as Nuke, Blender, 3ds Max, Unreal, ZBrush, Houdini, or Maya. Use
 this skill when the task is to create or improve the skill packages loaded by
 those adapters.
 
-## Installation
+## Install and Route
 
-This skill ships with dcc-mcp-core. Add it to your skill path:
+Install the published
+[`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator)
+package, then start a new agent turn:
 
 ```bash
-# Linux/macOS
-export DCC_MCP_SKILL_PATHS="${DCC_MCP_SKILL_PATHS}:$(python -c 'import dcc_mcp_core; print(dcc_mcp_core.__file__)')/../skills"
-
-# Windows
-set DCC_MCP_SKILL_PATHS=%DCC_MCP_SKILL_PATHS%;C:\path\to\dcc-mcp-core\skills
+openclaw skills install @loonghao/dcc-mcp-skills-creator
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp-skills-creator
 ```
 
-Or reference it directly when starting your MCP server:
-
-```python
-from dcc_mcp_core import create_skill_server, McpHttpConfig
-
-server = create_skill_server(
-    "maya",
-    McpHttpConfig(),
-    extra_paths=["/path/to/dcc-mcp-core/skills"],
-)
-handle = server.start()
-print(handle.mcp_url())
-```
-
-The local instance port is OS-assigned by default. The CLI and gateway discover
-the resolved URL through the shared registry; pass an explicit port only when
-an external integration requires a fixed listener.
+Use [`dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp) to operate an
+existing DCC and
+[`dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) to build
+a complete adapter. A repository checkout may load this directory directly;
+`DCC_MCP_SKILL_PATHS` and `extra_paths` are runtime paths for DCC adapters, not
+installation instructions for an agent host.
 
 ## CLI-First Control Path
 
@@ -302,6 +290,18 @@ only for a repeated, reusable workflow that no current skill owns. Validate any
 accepted change with `validate_skill_dir` or `dcc-mcp-cli lint` before loading
 it. Statistics inform a proposal; they never authorize editing or publishing a
 skill without the task owner's requested scope.
+
+For a failed task, first use the `dcc-mcp` recovery flow: retain the
+`request_id`, run `doctor` for runtime/readiness faults, query
+`stats --status failure --session-id <session-id>`, and record structured
+feedback through the CLI-discovered `dcc_feedback__report` tool. The public-safe
+`/v1/debug/issue-reports/<request_id>` payload is suitable for a reviewed issue;
+never publish `?mode=raw` automatically.
+
+Fix this Skill only when the evidence identifies its schema, script,
+description, next-tool, or workflow contract. Route adapter/runtime failures to
+`dcc-mcp-creator` and shared CLI/gateway/core failures to `dcc-mcp-core`. A
+one-off tool bug is not evidence for creating another Skill.
 
 When reviewing existing skills, reject top-level DCC-MCP extension keys such
 as `dcc`, `version`, `tags`, `tools`, `groups`, `depends`, `search-hint`,

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -117,8 +117,6 @@ If the requested DCC is installed but no live adapter instance is registered,
 follow the zero-instance flow. Do not silently switch to GUI automation or a
 different DCC application.
 
----
-
 ## Agent Path vs IDE Path
 
 DCC-MCP supports two integration paths. `dcc-mcp-cli` is the default for every
@@ -188,8 +186,6 @@ the complete target-binding, system-operation, capture, and artifact contract.
 Internal studios can fork this skill once and reuse the same CLI+REST workflow across
 agents without maintaining per-host MCP server lists.
 
----
-
 ## Gateway Profiles And Local-First Inventory
 
 `dcc-mcp-cli` has a built-in `local` profile. In local mode, agent-control
@@ -247,21 +243,20 @@ Detailed daemon lifecycle, profile commands, release assets, and fallback
 behavior live in [CLI cheatsheet](references/CLI_CHEATSHEET.md). Read it only
 when setup, lifecycle, or transport troubleshooting is needed.
 
----
+## Install This Agent Skill
 
-## Connection Order
+Use this package to operate an existing DCC. For a new adapter use [`dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator); for a DCC-specific Skill use [`dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator).
 
-1. Use `dcc-mcp-cli list` for local inventory, or `dcc-mcp-cli list --gateway <name>` for a remote profile.
-2. If missing, ask user permission, then use the bundled verified installer for the official GitHub release.
-3. If manifest or SHA-256 verification fails, preserve any existing CLI and use the bundled Python stdlib REST fallback where supported.
+```bash
+openclaw skills install @loonghao/dcc-mcp
+npx --yes clawhub@0.23.1 install @loonghao/dcc-mcp
+```
 
-Install via OpenClaw/ClawHub, or point your agent at this `SKILL.md` after cloning [`dcc-mcp-core/skills/dcc-mcp/`](https://github.com/dcc-mcp/dcc-mcp-core/tree/main/skills/dcc-mcp).
+The published package is [`@loonghao/dcc-mcp`](https://clawhub.ai/loonghao/skills/dcc-mcp). Install it with the command for the current agent host, start a new agent turn, and invoke `$dcc-mcp` explicitly if automatic routing is uncertain. A checkout may load this directory directly.
 
-`dcc-mcp` supersedes the former `dcc-cli-gateway` skill slug. Do not install or
-load both names in one agent: install `dcc-mcp`, verify it is discoverable, then
-remove the old package to avoid duplicate intent routing.
+Then run `dcc-mcp-cli list`. If the CLI is missing, ask permission before the bundled verified installer downloads the official release. Preserve the existing CLI and use the Python REST fallback if manifest or SHA-256 verification fails.
 
----
+`dcc-mcp` supersedes `dcc-cli-gateway`; do not load both names in one agent.
 
 ## Critical Rules
 
@@ -280,45 +275,26 @@ remove the old package to avoid duplicate intent routing.
 | User approved setup | Follow [`references/ZERO_INSTANCES_CLI.md`](references/ZERO_INSTANCES_CLI.md) |
 | Timeout, temporary `unreachable`, or DCC restart | Preserve operation IDs and follow the recovery contract in [`references/CLI_CHEATSHEET.md`](references/CLI_CHEATSHEET.md); never blindly replay a mutation or reuse stale slugs |
 
----
-
 ## Step 0 — Local Inventory First
 
-Run this as the **very first step** every time you begin local work or after a
-DCC adapter restarts:
+Run this first when local work begins or a DCC adapter restarts:
 
 ```bash
-# Supported adapter identifiers, only when support is unclear
 dcc-mcp-cli dcc-types
-
-# Local FileRegistry inventory
 dcc-mcp-cli list
-
-# No-launch startup diagnostics when state is unclear
 dcc-mcp-cli doctor
-
-# Optional gateway health check
-dcc-mcp-cli health
 ```
 
 Interpret the result:
 
 - `list.total > 0` -> inspect status/dispatch metadata. Local `search`, `describe`, `load-skill`, `call`, and `reload-skills` only route to rows ready for local CLI control; use `wait-ready` or `doctor` for live-but-booting rows, including sidecars that have not reached `dispatch_status=ready`.
 - `doctor.profile.selected.mode` / `doctor.local.registry_dir` -> confirms which local/remote mode and registry path the CLI is using before adapter setup.
-- `health.status == "ok"` -> gateway is up when you need gateway endpoint/admin/update workflows.
 - Error / timeout -> stop; explain the failure to the user. For remote
   profiles, the CLI cannot auto-start the gateway.
 
----
-
 ## Step 1 — Select a Live Instance
 
-Run `dcc-mcp-cli list` whenever a DCC starts or stops. Report `total`, counts by
-`dcc_type`, stale rows, and the chosen `instance_id` or `instance_short`. If
-`total == 0`, stop and ask whether the user wants setup guidance. Continue only
-after explicit approval.
-
----
+Run `dcc-mcp-cli list` whenever a DCC starts or stops. Report `total`, counts by `dcc_type`, stale rows, and the chosen instance. If `total == 0`, stop and ask whether the user wants setup guidance; continue only after approval.
 
 ## Step 2 — Search Tools
 
@@ -343,8 +319,6 @@ maya.a1b2c3d4.maya_primitives__create_sphere
 
 Never hand-build slugs.
 
----
-
 ## Step 3 — Follow `next_step`
 
 - `action=call` — call directly; no-schema tools receive this only when compact safety hints are already present.
@@ -363,8 +337,6 @@ python scripts/dcc_gateway.py describe maya.a1b2c3d4.maya_primitives__create_sph
 
 When describe or `compact_schema` is returned, use those exact parameter names
 and safety annotations before calling.
-
----
 
 ## Step 4 — Call a Tool
 
@@ -422,30 +394,34 @@ off the process command line, which is especially important on Windows.
 See [`references/CLI_CHEATSHEET.md`](references/CLI_CHEATSHEET.md) for command
 patterns and common errors.
 
----
+## Step 5 — Analyze Failures and Report Bugs
 
-## Step 5 — Review Reusable Friction
+Do not guess a root cause or blindly replay a mutation. Preserve `request_id`, `trace_id`, `job_id`, tool slug, instance id, sanitized arguments, error code, and validation result.
 
-Only after task acceptance, query narrowly scoped gateway evidence:
+```bash
+dcc-mcp-cli doctor
+dcc-mcp-cli stats --range 24h --status failure --session-id task-42
+dcc-mcp-cli search --query "report feedback" --dcc-type maya
+dcc-mcp-cli describe <returned-feedback-tool-slug>
+dcc-mcp-cli call <returned-feedback-tool-slug> --json \
+  '{"tool_name":"maya_geometry__create_sphere","intent":"Create a sphere","attempt":"radius=2.0","blocker":"Radius was ignored","severity":"blocked"}'
+```
+
+Use `doctor` for profile, registry, daemon, binary, and readiness failures. For a tool failure, refresh `describe`, compare the schema/annotations with the attempt, inspect failure-only stats, and call `dcc_feedback__report`. Its severity is `blocked`, `workaround_found`, or `suggestion`; it records feedback but does not create an external issue.
+
+For a gateway-routed failure, use the CLI-returned `request_id` to read `/v1/debug/agent-traces/<request_id>` and public-safe `/v1/debug/issue-reports/<request_id>`. The latter supplies a bounded summary and suggested GitHub title/body. Never publish `?mode=raw` without human review; create an external issue only with user authorization.
+
+Route schema/script/Skill defects to the owning package and `dcc-mcp-skills-creator`; dispatch/readiness/install/wiring defects to the adapter and `dcc-mcp-creator`; shared gateway/CLI/protocol defects to `dcc-mcp-core`. Include the smallest reproduction and safe report, not hidden reasoning.
+
+### Review Reusable Friction
 
 ```bash
 dcc-mcp-cli stats --range 24h --dcc-type maya --session-id task-42
 ```
 
-Check `stats_coverage` before the count. Gateway SQLite excludes
-`local_mcp_direct`; `configured_route_recorded=false` means that route cannot
-support reflection. Re-run through `--require-gateway`; never manufacture
-telemetry or treat `total_calls == 0` as proof that no calls occurred.
+Only after acceptance, inspect `stats_coverage`. Gateway SQLite excludes `local_mcp_direct`; `configured_route_recorded=false` cannot support reflection. Re-run through `--require-gateway`; zero calls means missing evidence.
 
-Then load `dcc-mcp-skills-creator` and request its
-`review_skill_improvement` prompt. Pass only bounded task, stats, validation,
-and existing-skill summaries. Treat `total_calls == 0` as no telemetry
-evidence, not success. Stats show aggregates, not root cause; prefer
-`no_change`, then `update_existing`, and create a skill only for a repeated,
-stable workflow. This review does not authorize editing or publishing outside
-the task scope.
-
----
+Load `dcc-mcp-skills-creator` and request `review_skill_improvement` with bounded task, stats, validation, and existing-skill summaries. Stats are not root-cause proof; prefer `no_change`, then `update_existing`, and create only for a repeated stable workflow. The review never authorizes out-of-scope changes.
 
 ## Updates and Marketplace Maintenance
 
@@ -484,8 +460,6 @@ dcc-mcp-cli install --dcc-type maya --version 2026
 Ask before `--execute`, follow the returned `next_steps`, and do not treat
 package installation as live registration. If auto-install is disabled, show
 the returned policy prompt and hand off to the named deployment owner.
-
----
 
 ## What This Skill Does Not Use
 

--- a/tests/test_dcc_mcp_skill.py
+++ b/tests/test_dcc_mcp_skill.py
@@ -114,6 +114,9 @@ class TestDccMcpSkill:
         assert "dcc-mcp-cli dcc-types" in body
         assert "dcc-mcp-cli stats" in body
         assert "review_skill_improvement" in body
+        assert "dcc_feedback__report" in body
+        assert "/v1/debug/issue-reports/<request_id>" in body
+        assert "public-safe" in body
         assert "do not use this skill" not in body
 
     def test_async_calls_prefer_one_cli_wait_over_agent_polling(self) -> None:


### PR DESCRIPTION
## Summary
- document the three public ClawHub Skills and CLI-first agent onboarding
- add failure diagnosis, structured feedback, safe issue-reporting, and ownership routing
- align English, Chinese, agent-index, API, and conceptual docs
- add standard PyPI discovery links plus sitemap, canonical, and social metadata

## Validation
- 92 targeted Skill and ClawHub tests
- 19 package metadata and Python support tests
- three public Skills validate clean
- VitePress documentation build with 229 sitemap URLs and canonical/OG assertions
- markdownlint across 231 Markdown files
- ClawHub package build and publish dry-run
- Rust formatting check