### PR TITLE
docs: publish agent indexes

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,3 +1,5 @@
+import { copyFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
 import { defineConfig } from 'vitepress'
 
 const siteUrl = 'https://dcc-mcp.github.io/dcc-mcp-core/'
@@ -10,6 +12,12 @@ export default defineConfig({
   lastUpdated: true,
   sitemap: {
     hostname: siteUrl,
+  },
+
+  async buildEnd({ outDir }) {
+    await Promise.all(['llms.txt', 'llms-full.txt'].map((file) =>
+      copyFile(new URL(`../../${file}`, import.meta.url), resolve(outDir, file)),
+    ))
   },
 
   transformPageData(pageData) {


### PR DESCRIPTION
## Summary
- publish the existing `llms.txt` and `llms-full.txt` at the documentation root
- keep the repository files as the single source of truth

## Validation
- `npm run docs:build`
- verified both built files match their source SHA-256 hashes
- creator Skill guidance unchanged: no adapter or Skill authoring contract changed