### PR TITLE
docs: add marketplace entry points

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -50,6 +50,7 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: 'Guide', link: '/guide/what-is-dcc-mcp-core' },
+          { text: 'Marketplace', link: 'https://dcc-mcp.github.io/marketplace' },
           { text: 'API', link: '/api/models' },
           { text: 'RFCs', link: '/rfcs/' },
           {
@@ -236,6 +237,7 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: '指南', link: '/zh/guide/what-is-dcc-mcp-core' },
+          { text: '技能市场', link: 'https://dcc-mcp.github.io/zh/marketplace' },
           { text: 'API', link: '/zh/api/models' },
           {
             text: 'v0.19.86', // x-release-please-version

--- a/docs/guide/marketplace.md
+++ b/docs/guide/marketplace.md
@@ -5,6 +5,10 @@ community skill packages. It resolves human-readable names from one or more
 catalog sources, downloads or clones the matching package, and registers it so
 the DCC adapter discovers it on the next restart or `reload_skill_paths` call.
 
+> Browse installable packages, DCC filters, and showcase media in the
+> [official DCC-MCP Marketplace](https://dcc-mcp.github.io/marketplace).
+> This guide documents the CLI and installation contract behind that catalog.
+
 ## Architecture
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,8 @@ hero:
       text: Install dcc-mcp Skill
       link: https://clawhub.ai/loonghao/skills/dcc-mcp
     - theme: alt
-      text: GitHub
-      link: https://github.com/dcc-mcp/dcc-mcp-core
+      text: Browse Marketplace
+      link: https://dcc-mcp.github.io/marketplace
 
 features:
   - icon: 🤖

--- a/docs/zh/guide/marketplace.md
+++ b/docs/zh/guide/marketplace.md
@@ -2,6 +2,9 @@
 
 Marketplace 是一个 CLI 优先的发现和安装系统，用于官方和社区技能包。它将人类可读的名称从一个或多个目录源中解析，下载或克隆匹配的包，并注册到系统中，使得 DCC 适配器能够在下次重启或调用 `reload_skill_paths` 时发现它们。
 
+> 在[官方 DCC-MCP 技能市场](https://dcc-mcp.github.io/zh/marketplace)浏览可安装软件包、
+> DCC 筛选和展示素材。本指南说明该目录背后的 CLI 与安装契约。
+
 ## 架构
 
 ```

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -19,8 +19,8 @@ hero:
       text: 安装 dcc-mcp Skill
       link: https://clawhub.ai/loonghao/skills/dcc-mcp
     - theme: alt
-      text: GitHub
-      link: https://github.com/dcc-mcp/dcc-mcp-core
+      text: 浏览技能市场
+      link: https://dcc-mcp.github.io/zh/marketplace
 
 features:
   - icon: 🤖

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18,6 +18,10 @@ for the task, then use its workflow:
 | Create or modernize a complete DCC-MCP adapter | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) | Shared core adapter contracts |
 | Create or improve a DCC-specific Skill package | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) | Skill scaffold, validation, and packaging |
 
+Browse installable packages and showcase media in the
+[official DCC-MCP Marketplace](https://dcc-mcp.github.io/marketplace) before
+running inspect or install commands.
+
 OpenClaw uses `openclaw skills install @loonghao/<slug>`. Direct ClawHub CLI uses
 `npx --yes clawhub@0.23.1 install @loonghao/<slug>`.
 Start a new agent turn after installation. Continue to the API guide only when

--- a/llms.txt
+++ b/llms.txt
@@ -17,6 +17,10 @@ Choose one published Agent Skill by intent:
 | Create or modernize a complete DCC-MCP adapter | [`@loonghao/dcc-mcp-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-creator) |
 | Create or improve a DCC-specific Skill package | [`@loonghao/dcc-mcp-skills-creator`](https://clawhub.ai/loonghao/skills/dcc-mcp-skills-creator) |
 
+Browse installable packages and showcase media in the
+[official DCC-MCP Marketplace](https://dcc-mcp.github.io/marketplace) before
+running inspect or install commands.
+
 OpenClaw installs with `openclaw skills install @loonghao/<slug>`. A
 Direct ClawHub CLI uses
 `npx --yes clawhub@0.23.1 install @loonghao/<slug>`.


### PR DESCRIPTION
## Summary
- add the official Marketplace to the English and Chinese docs navigation
- surface Marketplace from both homepages, guides, and agent indexes

## Validation
- `cd docs && npm run docs:build`
- `npx --yes markdownlint-cli2 "docs/**/*.md" "README.md" "README_zh.md" "!docs/node_modules"`
- pre-push `cargo fmt --all -- --check`

No adapter or Skill contract changed; creator Skill guidance remains current.