### PR TITLE
docs: link the unified DCC-MCP website

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 [中文](README_zh.md) | English
 
+[Website](https://dcc-mcp.github.io/) · [Marketplace](https://dcc-mcp.github.io/marketplace) · [Showcase](https://dcc-mcp.github.io/showcase) · [For Agents](https://dcc-mcp.github.io/agents) · [Ecosystem](https://dcc-mcp.github.io/ecosystem)
+
 **Skill-first, Rust-powered control plane for a growing creative-tool ecosystem.**
 
 dcc-mcp-core connects agents to desktop DCCs, game engines, 2D tools,
@@ -25,7 +27,7 @@ packaged CLI/server binaries needed to operate real sessions.
 | Control a running DCC from an agent or CI job | Install the [`dcc-mcp` Agent Skill](https://clawhub.ai/loonghao/skills/dcc-mcp), then use [dcc-mcp-cli](docs/guide/cli-reference.md) |
 | Expose a DCC adapter over MCP/REST | [create_skill_server](docs/guide/getting-started.md) |
 | Add tools without Python registration code | [SKILL.md + tools.yaml](docs/guide/skills.md) |
-| Discover and install reusable Skills | [DCC-MCP Marketplace](https://github.com/dcc-mcp/marketplace) |
+| Discover and install reusable Skills | [DCC-MCP Marketplace](https://dcc-mcp.github.io/marketplace) |
 | Build a new DCC adapter | [new-adapter-onboarding.md](docs/guide/new-adapter-onboarding.md) |
 | Understand routing and multi-instance behavior | [gateway.md](docs/guide/gateway.md) |
 | Integrate from any HTTP client | [rest-api-surface.md](docs/guide/rest-api-surface.md) |
@@ -145,11 +147,11 @@ adapters:
 | Reusable Skills | Asset providers, generative 2D/3D services, UI automation, rigging, procedural authoring, game release and acceptance |
 
 Browse every integration in the
-[DCC-MCP organization](https://github.com/orgs/dcc-mcp/repositories), or use
-the [official Marketplace](https://github.com/dcc-mcp/marketplace) to discover
+[ecosystem directory](https://dcc-mcp.github.io/ecosystem), or use
+the [official Marketplace](https://dcc-mcp.github.io/marketplace) to discover
 optional Skills without changing an adapter.
 
-[![DCC-MCP Skill Marketplace](docs/assets/admin-ui/admin-marketplace.png)](https://github.com/dcc-mcp/marketplace)
+[![DCC-MCP Skill Marketplace](docs/assets/admin-ui/admin-marketplace.png)](https://dcc-mcp.github.io/marketplace)
 
 The Admin UI closes the feedback loop. Calls, traces, logs, health, statistics,
 and usage data show which tools agents selected and where they failed. Teams can

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,6 +20,8 @@
 
 [English](README.md) | 中文
 
+[官网](https://dcc-mcp.github.io/zh/) · [技能市场](https://dcc-mcp.github.io/zh/marketplace) · [案例画廊](https://dcc-mcp.github.io/zh/showcase) · [Agent 使用](https://dcc-mcp.github.io/zh/agents) · [生态目录](https://dcc-mcp.github.io/zh/ecosystem)
+
 **Skills 驱动、Rust 加速的创作工具控制面：一套公共运行时，连接不断增长的生态。**
 
 `dcc-mcp-core` 把桌面 DCC、游戏引擎、二维工具、生产管理系统、资产提供器、性能分析器和工作室自研宿主接入可发现、可路由的 MCP 与 REST 能力。Agent 可以面对实时场景状态、受作用域约束的工具目录、结构化结果、视口诊断、审计日志，以及能适应真实生产约束的工作流。


### PR DESCRIPTION
## Summary
- add localized website navigation to both READMEs
- route public Marketplace and ecosystem discovery to the unified site
- keep Core documentation focused on infrastructure contracts

## Validation
- markdownlint-cli2 README.md README_zh.md
- cargo fmt --check (pre-push)
- no Skill guidance update needed; public APIs and workflows are unchanged