### PR TITLE
feat: add Marmoset adapter catalog entry

### DIFF
--- a/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
@@ -216,7 +216,7 @@ fn bundled_catalog_reports_marmoset_adapter() {
     );
 
     assert_eq!(plan["adapter"]["name"], "dcc-mcp-marmoset");
-    assert_eq!(plan["adapter"]["version"], "0.1.0");
+    assert_eq!(plan["adapter"]["version"], "0.1.1");
     assert_eq!(plan["adapter"]["min_core_version"], "0.19.86");
 }
 

--- a/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
@@ -208,6 +208,19 @@ fn bundled_catalog_reports_current_unity_adapter_version() {
 }
 
 #[test]
+fn bundled_catalog_reports_marmoset_adapter() {
+    let plan = run_json_with_env_removed(
+        &["install", "--dcc-type", "marmoset"],
+        &[],
+        &["DCC_MCP_CATALOG_PATH", "DCC_MCP_INSTALL_PYTHON"],
+    );
+
+    assert_eq!(plan["adapter"]["name"], "dcc-mcp-marmoset");
+    assert_eq!(plan["adapter"]["version"], "0.1.0");
+    assert_eq!(plan["adapter"]["min_core_version"], "0.19.86");
+}
+
+#[test]
 fn install_prefers_adapter_over_same_dcc_skill_pack() {
     let plan = run_json_with_env_removed(
         &["install", "--dcc-type", "photoshop"],

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -251,7 +251,7 @@ entries:
     dcc: ["marmoset"]
     url: "https://github.com/dcc-mcp/dcc-mcp-marmoset"
     tags: ["adapter", "marmoset", "toolbag", "official", "pip", "pbr", "rendering"]
-    version: "0.1.0"
+    version: "0.1.1"
     min_core_version: "0.19.86"
     maintainer: "dcc-mcp"
     install:

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -246,6 +246,19 @@ entries:
       pip_package: "dcc-mcp-unity"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unity/main/install.md"
 
+  - name: "dcc-mcp-marmoset"
+    description: "Marmoset Toolbag adapter and typed PBR scene/rendering skills for DCC-MCP"
+    dcc: ["marmoset"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-marmoset"
+    tags: ["adapter", "marmoset", "toolbag", "official", "pip", "pbr", "rendering"]
+    version: "0.1.0"
+    min_core_version: "0.19.86"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-marmoset"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-marmoset/main/install.md"
+
   - name: "dcc-mcp-fpt"
     description: "Autodesk Flow Production Tracking adapter for DCC-MCP"
     dcc: ["shotgrid"]

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -25,6 +25,7 @@ submit a PR updating this matrix before the release PR merges.
 | DCC | Repository | Adapter Version | Core Pin | DCC Min Version | Dispatcher Pattern | Last Verified |
 |-----|-----------|----------------|----------|-----------------|-------------------|---------------|
 | Maya | [dcc-mcp-maya](https://github.com/dcc-mcp/dcc-mcp-maya) | 0.9.15 | >=0.19.45,<1.0.0 | 2024+ | Qt sidecar + HostUiDispatcherBase | 2026-06 |
+| Marmoset Toolbag | [dcc-mcp-marmoset](https://github.com/dcc-mcp/dcc-mcp-marmoset) | 0.1.0 ⏳ | >=0.19.86,<1.0.0 | 4.03+ | External sidecar + Toolbag periodic callback | 2026-07 |
 | 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.37 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-06 |
 | Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.36 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-06 |
 | Houdini | [dcc-mcp-houdini](https://github.com/dcc-mcp/dcc-mcp-houdini) | 0.22.0 | >=0.19.45,<1.0.0 | 20.5+ | Event-loop callback | 2026-06 |

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -25,7 +25,7 @@ submit a PR updating this matrix before the release PR merges.
 | DCC | Repository | Adapter Version | Core Pin | DCC Min Version | Dispatcher Pattern | Last Verified |
 |-----|-----------|----------------|----------|-----------------|-------------------|---------------|
 | Maya | [dcc-mcp-maya](https://github.com/dcc-mcp/dcc-mcp-maya) | 0.9.15 | >=0.19.45,<1.0.0 | 2024+ | Qt sidecar + HostUiDispatcherBase | 2026-06 |
-| Marmoset Toolbag | [dcc-mcp-marmoset](https://github.com/dcc-mcp/dcc-mcp-marmoset) | 0.1.0 ⏳ | >=0.19.86,<1.0.0 | 4.03+ | External sidecar + Toolbag periodic callback | 2026-07 |
+| Marmoset Toolbag | [dcc-mcp-marmoset](https://github.com/dcc-mcp/dcc-mcp-marmoset) | 0.1.1 | >=0.19.86,<1.0.0 | 4.03+ | External sidecar + Toolbag periodic callback | 2026-07 |
 | 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.37 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-06 |
 | Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.36 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-06 |
 | Houdini | [dcc-mcp-houdini](https://github.com/dcc-mcp/dcc-mcp-houdini) | 0.22.0 | >=0.19.45,<1.0.0 | 20.5+ | Event-loop callback | 2026-06 |


### PR DESCRIPTION
## Summary

- register dcc-mcp-marmoset 0.1.1 in the first-party catalog
- add the verified Toolbag compatibility row
- cover the CLI install plan with a focused regression test

## Validation

- cargo fmt --all -- --check
- cargo test -p dcc-mcp-cli --test cli_install_e2e bundled_catalog_reports_marmoset_adapter
- PyPI release: https://pypi.org/project/dcc-mcp-marmoset/0.1.1/