### PR TITLE
fix(cli): route local discovery through discovery MCP URL

### DIFF
--- a/crates/dcc-mcp-cli/src/application/local_control.rs
+++ b/crates/dcc-mcp-cli/src/application/local_control.rs
@@ -39,10 +39,11 @@ pub async fn search_local(registry_dir: PathBuf, request: SearchRequest) -> anyh
         .map(str::to_string);
 
     for entry in &entries {
+        let discovery_mcp_url = local_instance::discovery_mcp_url(entry);
         let payload = if let Some(query) = query.as_deref() {
             let search_result = mcp_call_tool(
                 &gateway,
-                &local_instance::mcp_url(entry),
+                &discovery_mcp_url,
                 "search_tools",
                 json!({
                     "query": query,
@@ -62,7 +63,7 @@ pub async fn search_local(registry_dir: PathBuf, request: SearchRequest) -> anyh
             })?;
             call_result_payload(&search_result).unwrap_or(search_result)
         } else {
-            let tools = list_mcp_tools(&gateway, &local_instance::mcp_url(entry))
+            let tools = list_mcp_tools(&gateway, &discovery_mcp_url)
                 .await
                 .with_context(|| {
                     format!(
@@ -93,8 +94,8 @@ pub async fn search_local(registry_dir: PathBuf, request: SearchRequest) -> anyh
 pub async fn describe_local(registry_dir: PathBuf, tool_slug: String) -> anyhow::Result<Value> {
     let route = resolve_tool_route(&registry_dir, &tool_slug, None, None)?;
     let gateway = HttpGateway::default();
-    let mcp_url = local_instance::mcp_url(&route.entry);
-    let endpoint = Endpoint::from_mcp_url(&mcp_url);
+    let discovery_mcp_url = local_instance::discovery_mcp_url(&route.entry);
+    let endpoint = Endpoint::from_mcp_url(&discovery_mcp_url);
     let tool = match gateway
         .post_json(
             &endpoint.path("/v1/describe"),
@@ -109,7 +110,7 @@ pub async fn describe_local(registry_dir: PathBuf, tool_slug: String) -> anyhow:
             "annotations": described.get("annotations").cloned().unwrap_or_else(|| json!({})),
             "_meta": described.get("metadata").cloned().unwrap_or(Value::Null),
         }),
-        Err(describe_error) => list_mcp_tools(&gateway, &mcp_url)
+        Err(describe_error) => list_mcp_tools(&gateway, &discovery_mcp_url)
             .await
             .with_context(|| {
                 format!(
@@ -463,15 +464,36 @@ pub async fn call_local(
     )?;
     enforce_active_instance_lease(&route.entry, meta.as_ref())?;
     let gateway = HttpGateway::with_timeout(timeout);
-    let result = mcp_call_tool(
+    let dispatch_mcp_url = local_instance::mcp_url(&route.entry);
+    let mut result = mcp_call_tool(
         &gateway,
-        &local_instance::mcp_url(&route.entry),
+        &dispatch_mcp_url,
         &route.backend_tool,
         arguments.clone(),
-        meta,
+        meta.clone(),
     )
     .await
     .with_context(|| format!("calling local tool {}", route.tool_slug))?;
+
+    if should_retry_local_call_via_discovery(&result) {
+        let discovery_mcp_url = local_instance::discovery_mcp_url(&route.entry);
+        if discovery_mcp_url != dispatch_mcp_url {
+            result = mcp_call_tool(
+                &gateway,
+                &discovery_mcp_url,
+                &route.backend_tool,
+                arguments.clone(),
+                meta,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "calling local discovery tool {} after sidecar returned unknown-action",
+                    route.tool_slug
+                )
+            })?;
+        }
+    }
 
     Ok(json!({
         "success": !result.get("isError").and_then(Value::as_bool).unwrap_or(false),
@@ -484,6 +506,16 @@ pub async fn call_local(
         "result": result,
         "source": "local_mcp",
     }))
+}
+
+fn should_retry_local_call_via_discovery(result: &Value) -> bool {
+    (result.get("success").and_then(Value::as_bool) == Some(false)
+        && result.get("error").and_then(Value::as_str) == Some("unknown-action"))
+        || (result.get("isError").and_then(Value::as_bool) == Some(true)
+            && result
+                .pointer("/structuredContent/error")
+                .and_then(Value::as_str)
+                == Some("unknown-action"))
 }
 
 fn enforce_active_instance_lease(entry: &ServiceEntry, meta: Option<&Value>) -> anyhow::Result<()> {
@@ -1245,6 +1277,18 @@ mod tests {
             Some(local_instance::instance_short(&entry).as_str())
         );
         assert_eq!(parsed.backend_tool, "maya_scene__get_session_info");
+    }
+
+    #[test]
+    fn local_call_retries_only_after_structured_unknown_sidecar_action() {
+        assert!(should_retry_local_call_via_discovery(&json!({
+            "success": false,
+            "error": "unknown-action"
+        })));
+        assert!(!should_retry_local_call_via_discovery(&json!({
+            "isError": true,
+            "structuredContent": {"error": "dispatch-failed"}
+        })));
     }
 
     #[test]

--- a/crates/dcc-mcp-cli/src/application/local_instance.rs
+++ b/crates/dcc-mcp-cli/src/application/local_instance.rs
@@ -215,6 +215,15 @@ pub(crate) fn mcp_url(entry: &ServiceEntry) -> String {
         .unwrap_or_else(|| format!("http://{}:{}/mcp", entry.host, entry.port))
 }
 
+pub(crate) fn discovery_mcp_url(entry: &ServiceEntry) -> String {
+    entry
+        .metadata
+        .get("discovery_mcp_url")
+        .filter(|url| !url.trim().is_empty())
+        .cloned()
+        .unwrap_or_else(|| mcp_url(entry))
+}
+
 pub(crate) fn readyz_url(entry: &ServiceEntry) -> String {
     let mcp = mcp_url(entry);
     let trimmed = mcp.trim_end_matches('/');

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -777,6 +777,56 @@ fn local_search_without_query_lists_tools_for_dcc_filter() {
 }
 
 #[test]
+fn local_search_and_describe_use_sidecar_discovery_mcp_url() {
+    let fixture = spawn_local_mcp_fixture();
+    let registry = TempDir::new().unwrap();
+    let file_registry = FileRegistry::new(registry.path()).unwrap();
+    let mut entry = ServiceEntry::new("maya", "127.0.0.1", 9);
+    let instance_short = entry.instance_id.to_string()[..8].to_string();
+    entry.status = ServiceStatus::Available;
+    entry
+        .metadata
+        .insert("dcc_mcp_role".to_string(), "per-dcc-sidecar".to_string());
+    entry
+        .metadata
+        .insert("dispatch_status".to_string(), "ready".to_string());
+    entry
+        .metadata
+        .insert("mcp_url".to_string(), "http://127.0.0.1:9/mcp".to_string());
+    entry
+        .metadata
+        .insert("discovery_mcp_url".to_string(), fixture.mcp_url());
+    file_registry.register(entry).unwrap();
+
+    let registry_s = registry.path().to_string_lossy().to_string();
+    let profiles_s = registry
+        .path()
+        .join("gateway-profiles.json")
+        .to_string_lossy()
+        .to_string();
+    let envs = [
+        ("DCC_MCP_REGISTRY_DIR", registry_s.as_str()),
+        ("DCC_MCP_GATEWAY_PROFILES_FILE", profiles_s.as_str()),
+        ("DCC_MCP_GATEWAY_PROFILE", "local"),
+        ("DCC_MCP_BASE_URL", ""),
+        ("DCC_MCP_CLI_NO_AUTO_GATEWAY", "true"),
+    ];
+
+    let search = run_json_with_env(&["search", "--query", "scene", "--dcc-type", "maya"], &envs);
+    assert_eq!(search["source"], "local_mcp");
+    assert!(
+        search["hits"]
+            .as_array()
+            .is_some_and(|hits| !hits.is_empty()),
+        "sidecar discovery search should use discovery_mcp_url: {search}"
+    );
+
+    let slug = format!("maya.{instance_short}.dynamic__run");
+    let describe = run_json_with_env(&["describe", &slug], &envs);
+    assert_eq!(describe["tool"]["name"], "dynamic__run");
+}
+
+#[test]
 fn local_describe_prefers_exact_rest_lookup() {
     let fixture = spawn_local_mcp_fixture();
     let registry = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary
- use registry discovery_mcp_url for local search and describe
- keep ordinary actions on dispatch mcp_url, but retry discovery only after an explicit sidecar unknown-action
- add split discovery/dispatch regressions and guard the safe retry predicate

## Root cause
The local CLI treated a dispatch-only sidecar as a full MCP discovery server. Maya sidecars intentionally expose tools/call only, while tools/list, search_tools, and Core runtime tools live on discovery_mcp_url.

## Validation
- cargo test -p dcc-mcp-cli --lib: 116 passed
- cargo test -p dcc-mcp-cli --test cli_e2e -- --skip dcc_types_lists_release_catalog_without_a_gateway: 25 passed
- cargo clippy -p dcc-mcp-cli --all-targets -- -D warnings
- cargo fmt --all -- --check
- live Maya 2026: local search, empty browse, and exact describe use the registered discovery endpoint
- live Maya 2026: list_dynamic_tools falls back after sidecar unknown-action and succeeds through discovery_mcp_url

The skipped baseline assertion expects 19 catalog DCC types while current main contains 20 after the Marmoset catalog addition; this change does not modify that unrelated count.

No public API or Skill guidance changes are required.