### PR TITLE
feat: add marketplace install --reload

### DIFF
--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -419,8 +419,12 @@ enum MarketplaceAction {
     /// Install a marketplace skill package to the local marketplace root.
     Install {
         name: String,
+        /// Target DCC; inferred when the package declares exactly one.
         #[arg(long)]
         dcc: Option<String>,
+        /// Ask running instances of the installed DCC to re-scan skill paths.
+        #[arg(long)]
+        reload: bool,
         /// Use this source for the query instead of configured sources.
         #[arg(long = "source")]
         sources: Vec<String>,
@@ -1010,14 +1014,46 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                 MarketplaceAction::Install {
                     name,
                     dcc,
+                    reload,
                     sources,
                     force,
                     skip_validation,
-                } => to_json(
-                    service
+                } => {
+                    let installed = service
                         .install(name, dcc, sources, force, skip_validation)
-                        .await?,
-                )?,
+                        .await?;
+                    let installed_dcc = installed.dcc.clone();
+                    let mut value = to_json(installed)?;
+                    if reload {
+                        match control
+                            .reload_skills(ReloadSkillsRequest {
+                                dcc_type: Some(installed_dcc),
+                                instance_id: None,
+                            })
+                            .await
+                        {
+                            Ok(result) => {
+                                let reloaded =
+                                    result.get("ok").and_then(Value::as_bool).unwrap_or(false);
+                                value["reload_required"] = Value::Bool(!reloaded);
+                                value["reload"] = result;
+                                if !reloaded {
+                                    failed = true;
+                                    exit_code = ExitCode::Unavailable;
+                                }
+                            }
+                            Err(err) => {
+                                value["reload"] = serde_json::json!({
+                                    "ok": false,
+                                    "error": err.to_string(),
+                                });
+                                failed = true;
+                                exit_code = ExitCode::Unavailable;
+                            }
+                        }
+                    }
+                    value
+                }
                 MarketplaceAction::Uninstall { name, dcc } => {
                     to_json(service.uninstall(&name, &dcc)?)?
                 }
@@ -1166,6 +1202,9 @@ fn gateway_endpoint_for_command(
         | Command::WaitReady { .. }
         | Command::ReloadSkills { .. }
         | Command::StopInstance { .. } => Some(Endpoint::new(base_url)),
+        Command::Marketplace {
+            action: MarketplaceAction::Install { reload: true, .. },
+        } => Some(Endpoint::new(base_url)),
         // Local mode still executes these commands through FileRegistry/direct
         // MCP where that is the richer path, but the CLI owns gateway
         // lifecycle by default so agents can rely on the admin/control plane.

--- a/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
@@ -910,6 +910,40 @@ fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
     assert!(
         gateway_endpoint_for_command(
             DEFAULT_BASE_URL,
+            &Command::Marketplace {
+                action: MarketplaceAction::Install {
+                    name: "dcc-mcp-maya-mgear".to_string(),
+                    dcc: Some("maya".to_string()),
+                    reload: true,
+                    sources: Vec::new(),
+                    force: false,
+                    skip_validation: false,
+                },
+            },
+            &local,
+        )
+        .is_some()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
+            &Command::Marketplace {
+                action: MarketplaceAction::Install {
+                    name: "dcc-mcp-maya-mgear".to_string(),
+                    dcc: Some("maya".to_string()),
+                    reload: false,
+                    sources: Vec::new(),
+                    force: false,
+                    skip_validation: false,
+                },
+            },
+            &local,
+        )
+        .is_none()
+    );
+    assert!(
+        gateway_endpoint_for_command(
+            DEFAULT_BASE_URL,
             &Command::Gateway {
                 action: Some(GatewayAction::Status(GatewayStatusArgs {
                     host: "127.0.0.1".to_string(),

--- a/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
@@ -1,6 +1,8 @@
 mod support;
 
 use dcc_mcp_skills::parse_skill_md;
+use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+use dcc_mcp_transport::discovery::types::ServiceEntry;
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -508,6 +510,92 @@ fn marketplace_install_list_and_uninstall_path_package() {
 
     let listed = run_json_with_env(&["marketplace", "list-installed", "--dcc", "maya"], &envs);
     assert_eq!(listed["count"], 0);
+}
+
+#[test]
+fn marketplace_install_exact_name_infers_dcc_and_reloads_running_dcc() {
+    let tmp = TempDir::new().unwrap();
+    let fixture = spawn_local_mcp_fixture();
+    let registry_path = tmp.path().join("registry");
+    let registry = FileRegistry::new(&registry_path).unwrap();
+    let mut entry = ServiceEntry::new("maya", "127.0.0.1", 0);
+    entry
+        .metadata
+        .insert("mcp_url".to_string(), fixture.mcp_url());
+    registry.register(entry).unwrap();
+
+    let skill_dir = write_skill(
+        tmp.path(),
+        "source-skill",
+        "---\nname: dcc-mcp-maya-mgear\ndescription: mGear tools\n---\n",
+    );
+    let catalog_path = tmp.path().join("marketplace.json");
+    std::fs::write(
+        &catalog_path,
+        serde_json::to_string_pretty(&json!({
+            "version": "1",
+            "entries": [{
+                "name": "dcc-mcp-maya-mgear",
+                "description": "mGear tools for Maya",
+                "dcc": ["maya"],
+                "tags": ["rigging"],
+                "version": "0.1.0",
+                "install": {"type": "path", "url": skill_dir.to_string_lossy()}
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let source = catalog_path.to_string_lossy().to_string();
+    let sources_file = tmp
+        .path()
+        .join("sources.json")
+        .to_string_lossy()
+        .to_string();
+    let install_root = tmp
+        .path()
+        .join("marketplace-root")
+        .to_string_lossy()
+        .to_string();
+    let registry_dir = registry_path.to_string_lossy().to_string();
+    let profiles_file = tmp
+        .path()
+        .join("gateway-profiles.json")
+        .to_string_lossy()
+        .to_string();
+    let envs = [
+        ("DCC_MCP_MARKETPLACE_SOURCES_FILE", sources_file.as_str()),
+        ("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES", "1"),
+        ("DCC_MCP_MARKETPLACE_INSTALL_ROOT", install_root.as_str()),
+        ("DCC_MCP_REGISTRY_DIR", registry_dir.as_str()),
+        ("DCC_MCP_GATEWAY_PROFILES_FILE", profiles_file.as_str()),
+        ("DCC_MCP_GATEWAY_PROFILE", "local"),
+        ("DCC_MCP_BASE_URL", ""),
+        ("DCC_MCP_CLI_NO_AUTO_GATEWAY", "true"),
+    ];
+
+    let installed = run_json_with_env(
+        &[
+            "marketplace",
+            "install",
+            "dcc-mcp-maya-mgear",
+            "--source",
+            &source,
+            "--reload",
+        ],
+        &envs,
+    );
+
+    assert_eq!(installed["installed"], true);
+    assert_eq!(installed["dcc"], "maya");
+    assert_eq!(installed["reload_required"], false);
+    assert_eq!(installed["reload"]["reloaded"], true);
+    assert_eq!(installed["reload"]["count"], 1);
+    assert_eq!(
+        installed["reload"]["results"][0]["backend_tool"],
+        "dcc_admin__reload_skills"
+    );
 }
 
 #[test]

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -127,12 +127,13 @@ stdout/stderr log paths when the DCC supervisor records them in the registry.
 `local.inventory.direct_control.not_ready_instances`.
 
 Agent-control commands (`list`, `search`, `describe`, `load-skill`, `call`,
-`wait-ready`, `reload-skills`, and `stop-instance`) and endpoint-level commands
+`wait-ready`, `reload-skills`, `stop-instance`, and marketplace
+`install --reload`) and endpoint-level commands
 that need a local gateway (`health`, `stats`, `update`, and `smoke` without an explicit
 `--url`) auto-ensure only loopback HTTP targets (`http://127.0.0.1:<port>` or
 `http://localhost:<port>`). Disable this for one invocation with
 `--no-auto-gateway`. Commands that operate only on local files (`install`,
-`dcc-types`, `marketplace`, `lint`), explicit lifecycle commands
+`dcc-types`, marketplace commands without `--reload`, `lint`), explicit lifecycle commands
 (`gateway ...`), and smoke checks against an explicit `--url` do not
 auto-start the gateway.
 Use `dcc-mcp-cli doctor` when startup state is ambiguous: it reports the
@@ -168,8 +169,7 @@ dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Au
 dcc-mcp-cli marketplace add dcc-mcp/marketplace
 dcc-mcp-cli marketplace search --query "maya rigging" --limit 20
 dcc-mcp-cli marketplace inspect dcc-asset-hunyuan-download
-dcc-mcp-cli marketplace install dcc-asset-hunyuan-download --dcc maya
-dcc-mcp-cli reload-skills --dcc-type maya
+dcc-mcp-cli marketplace install dcc-asset-hunyuan-download --dcc maya --reload
 dcc-mcp-cli marketplace list-installed --dcc maya
 dcc-mcp-cli marketplace outdated --dcc maya
 dcc-mcp-cli marketplace update dcc-mcp-maya-skills --dcc maya
@@ -209,7 +209,7 @@ dcc-mcp-cli lint path/to/skills
 | `marketplace list` | local source registry | List the built-in, configured, and environment-provided marketplace sources. |
 | `marketplace search [-q\|--query <q>] [--dcc <dcc>] [--source <source>]` | marketplace catalog JSON/YAML | Fuzzy-rank Skill packages across configured or explicit sources using the shared search engine; the query flag works with released builds, while current builds also accept positional words as an alternative. Deduplicate by package name before applying `--limit`; `--dcc-type` is an alias for `--dcc`. |
 | `marketplace inspect <name> [--source <source>]` | marketplace catalog JSON/YAML | Print exact entry metadata including version and install fields. |
-| `marketplace install <name> [--dcc <dcc>] [--source <source>] [--force]` | marketplace catalog + local filesystem/git | Install a skill package to `~/.dcc-mcp/marketplace/<dcc>/<name>/`. |
+| `marketplace install <name> [--dcc <dcc>] [--source <source>] [--force] [--reload]` | marketplace catalog + local filesystem/git; optional running DCC control | Install a skill package to `~/.dcc-mcp/marketplace/<dcc>/<name>/`; `--reload` asks matching running adapters to re-scan skill paths and includes the reload result in the install JSON. |
 | `marketplace list-installed [--dcc <dcc>]` | local installed-state file | List locally installed marketplace packages and their versions/paths. |
 | `marketplace uninstall <name> --dcc <dcc>` | local installed-state file + filesystem | Remove an installed marketplace package. |
 | `marketplace outdated [NAME...] [--dcc <dcc>]` | marketplace catalog + local installed state | Compare installed versions against latest catalog entries and list packages with newer versions available. |
@@ -227,6 +227,10 @@ dcc-mcp-cli lint path/to/skills
 | `gateway daemon status [--port <port>]` | local process | Report gateway daemon health, PID, process liveness, registry dir, PID file, health URL, and CLI version. |
 | `gateway ensure/start/stop/status` | local process | Backward-compatible aliases for older scripts; prefer `gateway daemon ...` in user-facing docs. |
 | `lint [PATH ...]` | local filesystem validator | Recursively validate SKILL.md packages two levels below each path by default. |
+
+`marketplace install` resolves an exact package name directly, so `inspect` is
+optional when the ID is already known. `--dcc` may also be omitted when the
+catalog entry declares exactly one DCC; multi-DCC entries still require it.
 
 `dcc-types` describes release-catalog support, not currently running sessions;
 use `list` for live inventory. The core still accepts unknown/custom DCC names,
@@ -312,8 +316,10 @@ supports `install.type: git`, `install.type: path`, and `install.type: zip`.
 Archive installs verify `install.sha256` when present and reject entries that
 escape the install root. DCC adapters include
 `~/.dcc-mcp/marketplace/<dcc>` in their skill search paths, so installed skills
-are discovered on adapter startup or the next
-`dcc-mcp-cli reload-skills --dcc-type <dcc>`. After a reload, run
+are discovered on adapter startup. To expose an exact package to running
+adapters immediately, use
+`dcc-mcp-cli marketplace install <name> --dcc <dcc> --reload`; otherwise run
+`dcc-mcp-cli reload-skills --dcc-type <dcc>` separately. After a reload, run
 `dcc-mcp-cli load-skill <skill-name> --dcc-type <dcc> --instance-id <id>` when
 the adapter has not auto-loaded that skill yet.
 

--- a/docs/guide/marketplace.md
+++ b/docs/guide/marketplace.md
@@ -74,7 +74,7 @@ Set `DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES=1` to disable the built-in source.
 | `marketplace list`                        | List configured sources                        |
 | `marketplace search --query <q>`           | Fuzzy-rank entries across all sources; current builds also accept positional query words |
 | `marketplace inspect <name>`              | Show full entry metadata                       |
-| `marketplace install <name> --dcc <dcc>`  | Install a skill package                        |
+| `marketplace install <name> --dcc <dcc> --reload` | Install a skill package and refresh running adapters |
 | `marketplace list-installed --dcc <dcc>`  | List installed packages                        |
 | `marketplace uninstall <name> --dcc <dcc>`| Remove an installed package                    |
 | `marketplace outdated [name] --dcc <dcc>` | Check for newer versions                       |
@@ -365,18 +365,20 @@ future phase.
 | Aspect | CLI | Admin UI |
 |--------|-----|----------|
 | Catalog search | `marketplace search --query <q>` | Browse tab with search + DCC filter |
-| Install | `marketplace install <name> --dcc <dcc>` | Install button on card or detail modal |
+| Install | `marketplace install <name> --dcc <dcc> --reload` | Install button on card or detail modal |
 | Uninstall | `marketplace uninstall <name> --dcc <dcc>` | Uninstall button in Installed tab |
 | List installed | `marketplace list-installed --dcc <dcc>` | Installed tab |
 | Add source | `marketplace add <source>` | Source management in panel |
 | Direct GitHub install | `marketplace add-repo <repo> --dcc <dcc>` | Admin API (planned) |
 | Update | `marketplace update [name] --all` | Admin API (`POST /admin/api/marketplace/update`) |
-| Live adapter refresh | `reload-skills --dcc-type <dcc>` after install/update/uninstall | Automatic when the backend reports `reload_required` |
+| Live adapter refresh | Bundled with install `--reload`; standalone after update/uninstall | Automatic when the backend reports `reload_required` |
 
-Both interfaces share the same installed package state, but live adapters only
-see newly installed CLI packages after startup or an explicit
-`dcc-mcp-cli reload-skills --dcc-type <dcc>`. The Admin UI triggers that reload
-automatically when its backend reports `reload_required`.
+Both interfaces share the same installed package state. For a known exact ID,
+CLI users can install and refresh running adapters in one command with
+`marketplace install <name> --dcc <dcc> --reload`; `--dcc` is optional for a
+single-DCC package. The Admin UI triggers the same refresh automatically when
+its backend reports `reload_required`. Updates and uninstalls still use the
+standalone `reload-skills` command when a live refresh is needed.
 
 ## See Also
 

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -111,12 +111,13 @@ supervisor 写入 registry 的 stdout/stderr 日志路径。`doctor` 会把不�
 汇总到 `local.inventory.direct_control.not_ready_instances`。
 
 Agent 控制命令（`list`、`search`、`describe`、`load-skill`、`call`、
-`wait-ready`、`reload-skills`、`stop-instance`）以及仍需要本机 gateway 的
+`wait-ready`、`reload-skills`、`stop-instance`，以及 marketplace
+`install --reload`）和仍需要本机 gateway 的
 endpoint 级命令（`health`、`stats`、`update`，以及未显式传 `--url` 的 `smoke`）只会
 对 loopback HTTP 目标（`http://127.0.0.1:<port>` 或
 `http://localhost:<port>`）执行 auto-ensure。单次禁用可传
-`--no-auto-gateway`。只操作本地文件的命令（`install`、`marketplace`、
-`lint`）、显式生命周期命令（`gateway ...`），以及带显式 `--url` 的 smoke
+`--no-auto-gateway`。只操作本地文件的命令（`install`、未带 `--reload` 的
+marketplace 命令、`lint`）、显式生命周期命令（`gateway ...`），以及带显式 `--url` 的 smoke
 check 不会自动启动 gateway。
 启动状态不清楚时，先运行 `dcc-mcp-cli doctor`。它会输出当前 profile
 配置、选中的模式、registry 目录和 inventory、direct-control readiness 汇总、
@@ -148,8 +149,7 @@ dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Au
 dcc-mcp-cli marketplace add dcc-mcp/marketplace
 dcc-mcp-cli marketplace search --query hunyuan --dcc maya
 dcc-mcp-cli marketplace inspect dcc-asset-hunyuan-download
-dcc-mcp-cli marketplace install dcc-asset-hunyuan-download --dcc maya
-dcc-mcp-cli reload-skills --dcc-type maya
+dcc-mcp-cli marketplace install dcc-asset-hunyuan-download --dcc maya --reload
 dcc-mcp-cli marketplace list-installed --dcc maya
 dcc-mcp-cli marketplace outdated --dcc maya
 dcc-mcp-cli marketplace update dcc-mcp-maya-skills --dcc maya
@@ -184,7 +184,8 @@ dcc-mcp-cli lint path/to/skills
 | `reload-skills [--dcc-type <dcc>] [--instance-id <id>]` | 本地 MCP `tools/call dcc_admin__reload_skills`，或远程 `POST /v1/dcc/{dcc}/instances/{id}/call` | marketplace 安装或 skill path 变更后，让正在运行的 adapter 重新扫描 skill 搜索路径。 |
 | `stop-instance --dcc-type <dcc> --instance-id <id>` | 本地 `safe_stop_url` 或远程 `POST /v1/dcc/{dcc}/instances/{id}/stop` | 对声明了 `safe_stop_url` 的实例发起带保护条件的 safe-stop 请求。 |
 | `install --dcc-type <dcc> [--version <v>] [--python <path>] [--execute]` | catalog-backed local plan / executor | 解析匹配的 adapter 并输出可审计安装计划；加 `--execute` 后会在确认后执行 package 安装步骤、失败回滚并做 package/path 验证。Live DCC 检查保留在返回的 `next_steps` 中。 |
-| `marketplace search/install/update/...` | marketplace catalog + local installed state | 搜索、安装、卸载和更新本地 marketplace skill 包。 |
+| `marketplace install <name> [--dcc <dcc>] [--reload]` | marketplace catalog + local installed state；可选控制运行中的 DCC | 安装本地 marketplace skill 包；`--reload` 会让匹配的运行中 adapter 重新扫描 skill path，并把刷新结果写入安装 JSON。 |
+| `marketplace search/update/...` | marketplace catalog + local installed state | 搜索、卸载和更新本地 marketplace skill 包。 |
 | `marketplace pack <path> [--out <path>]` | local filesystem + zip | 生成 marketplace 发布 ZIP 并输出 SHA-256 摘要。 |
 | `marketplace publish <path> --catalog <file> --install-url <url>` | local marketplace catalog file | 根据 `SKILL.md` 元数据和 CLI 覆盖字段创建或更新 `marketplace.json` 条目。 |
 | `update check [--binary <name>] [--current-version <version>]` | `GET /v1/update/check` | 检查 gateway update manifest。默认检查 CLI 自身；检查 Admin 面板里的实例版本时，传 `--binary dcc-mcp-server` 和对应 server 版本。 |
@@ -195,6 +196,10 @@ dcc-mcp-cli lint path/to/skills
 | `gateway daemon start/restart/stop/status` | local process | 显式管理本机 machine-wide gateway daemon 生命周期；`start` 和 `restart` 的启动阶段默认传 `--gateway-idle-timeout-secs 0`，无 backend 时也保持存活；`status` 会输出 registry dir、PID file、health URL 和 CLI version 等诊断字段。 |
 | `gateway ensure/start/stop/status` | local process | 旧脚本兼容 alias；面向用户文档优先使用 `gateway daemon ...`。 |
 | `lint [PATH ...]` | local filesystem validator | 默认递归校验每个路径下两层内的 SKILL.md 包。 |
+
+`marketplace install` 会直接解析准确的包名，因此已知 ID 时可以省略
+`inspect`。当 catalog 条目只声明一个 DCC 时也可以省略 `--dcc`；多 DCC
+条目仍需显式指定。
 
 ### 错误自查与 Bug 上报
 
@@ -242,8 +247,9 @@ contact Pipeline TD to deploy {adapter} for {dcc_type}.” 的内部提示。
 `~/.dcc-mcp/marketplace/<dcc>/<name>/`，可用
 `DCC_MCP_MARKETPLACE_INSTALL_ROOT` 覆盖。DCC adapter 会把
 `~/.dcc-mcp/marketplace/<dcc>` 加入 skill 搜索路径，因此新安装的 skill 会在
-adapter 启动时，或下一次
-`dcc-mcp-cli reload-skills --dcc-type <dcc>` 后被发现。刷新后，如果 adapter
+adapter 启动时被发现。要让运行中的 adapter 立即看到准确包名对应的 skill，使用
+`dcc-mcp-cli marketplace install <name> --dcc <dcc> --reload`；否则单独运行
+`dcc-mcp-cli reload-skills --dcc-type <dcc>`。刷新后，如果 adapter
 没有自动加载该 skill，再运行
 `dcc-mcp-cli load-skill <skill-name> --dcc-type <dcc> --instance-id <id>`。
 

--- a/docs/zh/guide/marketplace.md
+++ b/docs/zh/guide/marketplace.md
@@ -67,7 +67,7 @@ Marketplace **源**是指向目录文件的命名引用。源持久化存储在 
 | `marketplace list`                        | 列出已配置的源            |
 | `marketplace search --query <q>`          | 跨源搜索条目              |
 | `marketplace inspect <name>`              | 显示完整条目元数据        |
-| `marketplace install <name> --dcc <dcc>`  | 安装技能包                |
+| `marketplace install <name> --dcc <dcc> --reload` | 安装技能包并刷新运行中的 adapter |
 | `marketplace list-installed --dcc <dcc>`  | 列出已安装的包            |
 | `marketplace uninstall <name> --dcc <dcc>`| 移除已安装的包            |
 | `marketplace outdated [name] --dcc <dcc>` | 检查是否有更新版本        |
@@ -273,16 +273,17 @@ Marketplace 面板反映与 CLI 相同的来源配置。来源管理功能通过
 | 方面 | CLI | Admin UI |
 |------|-----|----------|
 | 目录搜索 | `marketplace search --query <q>` | 浏览标签页，支持搜索 + DCC 筛选 |
-| 安装 | `marketplace install <name> --dcc <dcc>` | 卡片或详情弹窗上的 Install 按钮 |
+| 安装 | `marketplace install <name> --dcc <dcc> --reload` | 卡片或详情弹窗上的 Install 按钮 |
 | 卸载 | `marketplace uninstall <name> --dcc <dcc>` | 已安装标签页的 Uninstall 按钮 |
 | 列出已安装 | `marketplace list-installed --dcc <dcc>` | 已安装标签页 |
 | 添加来源 | `marketplace add <source>` | 面板中的来源管理界面 |
 | 更新 | `marketplace update [name] --all` | Admin API (`POST /admin/api/marketplace/update`) |
-| 刷新运行中的 adapter | 安装/更新/卸载后运行 `reload-skills --dcc-type <dcc>` | 后端报告 `reload_required` 时自动刷新 |
+| 刷新运行中的 adapter | 安装时由 `--reload` 合并完成；更新/卸载后单独运行 | 后端报告 `reload_required` 时自动刷新 |
 
-两种界面共享同一套已安装包状态，但运行中的 adapter 只有在启动时，或显式运行
-`dcc-mcp-cli reload-skills --dcc-type <dcc>` 后，才会看到 CLI 新安装的包。
-Admin UI 在后端报告 `reload_required` 时会自动触发该刷新。
+两种界面共享同一套已安装包状态。已知准确 ID 时，CLI 用户可用
+`marketplace install <name> --dcc <dcc> --reload` 一次完成安装和运行时刷新；
+单 DCC 包还可省略 `--dcc`。Admin UI 在后端报告 `reload_required` 时会自动触发
+相同刷新。更新和卸载如需立即生效，仍单独运行 `reload-skills`。
 
 ## 参见
 

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -49,11 +49,12 @@ The CLI returns JSON by default. The bundled Python fallback is gateway-REST
 only and sends `Accept: application/json` because the gateway REST API itself
 now defaults to compact TOON for agent-facing routes.
 
-## Marketplace Intent — Search Before Recommending
+## Marketplace Intent — Search Unless the Exact ID Is Known
 
-Any request to find, compare, recommend, install, or update a DCC-MCP
-marketplace Skill must start with the official CLI catalog, even when the user
-says “Skill store”, “marketplace”, or “商城” without naming DCC-MCP:
+Requests to find, compare, or recommend a DCC-MCP marketplace Skill must start
+with the official CLI catalog, even when the user says “Skill store”,
+“marketplace”, or “商城” without naming DCC-MCP. Install/update requests without
+an exact package ID follow the same discovery path:
 
 ```bash
 dcc-mcp-cli marketplace search --query "maya rigging" --limit 20
@@ -66,9 +67,10 @@ Use the user's capability words first. If there are no results, retry once with
 a shorter capability query or without the DCC filter; never invent a package
 name or substitute a web recommendation for the CLI result.
 
-Installing or updating changes local state. Inspect the exact returned package
-and obtain user consent before `marketplace install` or `update`; then run
-`reload-skills` and, only when needed, `load-skill`. The Python REST fallback
+Installing or updating changes local state. Inspect unfamiliar packages and
+obtain user consent before `marketplace install` or `update`. When the exact ID
+is already known, install it directly with `--reload`; then use `load-skill`
+only when needed. The Python REST fallback
 does not implement marketplace commands, so a missing CLI follows the
 consent-gated official CLI installation path below.
 
@@ -262,7 +264,7 @@ Then run `dcc-mcp-cli list`. If the CLI is missing, ask permission before the bu
 
 | Situation | You MUST |
 |-----------|----------|
-| **Marketplace/Skill store intent** | Run `dcc-mcp-cli marketplace search` first, then inspect the exact returned name before any recommendation or consent-gated mutation; live inventory is not required |
+| **Marketplace/Skill store intent** | Search the official catalog before recommendations or when no exact package ID was supplied; an exact known ID may go directly to consent-gated `marketplace install --reload`; live inventory is not required |
 | **Starting any local DCC task** | Run `dcc-mcp-cli list`; it ensures the local gateway, then reads the local FileRegistry |
 | **Startup state is ambiguous** | Run `dcc-mcp-cli doctor`; inspect selected profile, registry dir, local inventory, direct-control readiness counts, daemon status, and server binary diagnostics |
 | **Starting any remote DCC task** | Select or override a profile with `dcc-mcp-cli gateway set <name>` or `dcc-mcp-cli list --gateway <name>` |
@@ -436,18 +438,19 @@ dcc-mcp-cli update check
 dcc-mcp-cli update apply
 ```
 
-For marketplace Skills, preserve the mandatory search-first sequence:
+For marketplace Skills, search first when the exact package ID is not known:
 
 ```bash
 dcc-mcp-cli marketplace search --query "maya rigging" --limit 20
 dcc-mcp-cli marketplace inspect <package_name>
-dcc-mcp-cli marketplace install <package_name> --dcc maya
-dcc-mcp-cli reload-skills --dcc-type maya
+dcc-mcp-cli marketplace install <package_name> --dcc maya --reload
 ```
 
 `--query "maya rigging"` remains supported for scripts. Search and inspect are
-read-only; install/update require consent. After either mutation, run
-`reload-skills`, then `load-skill` only if the adapter did not auto-load it.
+read-only; install/update require consent. Inspect is optional when the exact
+package ID is already known, and `--dcc` is optional for single-DCC packages.
+After updates or installs without `--reload`, run `reload-skills`; then use
+`load-skill` only if the adapter did not auto-load it.
 Package authors use `marketplace pack` and `marketplace publish`; full commands
 live in the CLI cheatsheet.
 

--- a/skills/dcc-mcp/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-mcp/references/CLI_CHEATSHEET.md
@@ -131,7 +131,7 @@ paths, or full tool payloads.
 | `dcc-mcp-cli install --dcc-type maya --version 2026 --python "<mayapy>" --execute` | Execute package install after consent; rolls back on failure and verifies pip/path outputs |
 | `dcc-mcp-cli marketplace search --query "maya rigging" --limit 20` | Find installable Skill packages with released and current CLI builds |
 | `dcc-mcp-cli marketplace inspect <package_name>` | Inspect the selected skill package metadata before installing |
-| `dcc-mcp-cli marketplace install <package_name> --dcc maya` | Install a skill package into the local marketplace root |
+| `dcc-mcp-cli marketplace install <package_name> --dcc maya --reload` | Install an exact package ID and ask running Maya adapters to re-scan skill paths |
 | `dcc-mcp-cli reload-skills --dcc-type maya` | Ask running Maya adapters to re-scan installed skill paths |
 | `dcc-mcp-cli marketplace update <package_name> --dcc maya` | Update an installed skill package from the catalog |
 
@@ -150,10 +150,10 @@ any log paths, then run `wait-ready` or `doctor` before calling tools.
 Marketplace search and inspect do not require a live DCC instance. Always query
 the CLI before recommending a marketplace Skill. If the first query is empty,
 retry once with fewer capability words or without the DCC filter; never invent
-a package name. Inspect the selected package before a consent-gated install or
-update.
-After installing or updating marketplace skills, run `reload-skills`, then use
-`load-skill` if the adapter has not auto-loaded the new skill.
+a package name. Inspect unfamiliar packages before a consent-gated mutation;
+an exact known ID can be installed directly, and `--dcc` can be omitted for a
+single-DCC package. Prefer install `--reload`; after updates or installs without
+that flag, run `reload-skills`, then use `load-skill` if needed.
 
 ## Example: inventory
 

--- a/skills/dcc-mcp/references/ZERO_INSTANCES_CLI.md
+++ b/skills/dcc-mcp/references/ZERO_INSTANCES_CLI.md
@@ -78,8 +78,8 @@ remaining steps after installation: start/enable the DCC plugin, run
 `dcc-mcp-cli doctor`, confirm `dcc-mcp-cli list`, wait with
 `dcc-mcp-cli wait-ready --dcc-type <dcc>`, search tools, then install optional
 marketplace skills by running marketplace search, inspecting the selected
-package, installing it, and finally running
-`dcc-mcp-cli reload-skills --dcc-type <dcc>`.
+package when unfamiliar, then installing it with
+`dcc-mcp-cli marketplace install <package_name> --dcc <dcc> --reload`.
 
 Alternatively, when the CLI binary is not yet available:
 
@@ -128,7 +128,8 @@ When `total >= 1`, continue with the plan's CLI next steps:
 `direct_control.ready=false`, inspect `direct_control.diagnostics` first; it
 carries sidecar `failure_stage`, `failure_reason`, host RPC metadata, gateway
 recovery fields, and any supervisor-recorded stdout/stderr log paths. If
-marketplace skills are installed, finish with `reload-skills`.
+marketplace skills were installed without `--reload`, finish with
+`reload-skills`.
 
 If neither Python nor `py` is available, stop and ask the operator to provision
 Python or `vx` through a trusted OS or studio package manager. Do not fetch and


### PR DESCRIPTION
Adds consent-compatible one-command marketplace installation and live Skill reload, with structured failure output, E2E coverage, and bilingual public guidance. Validation: cargo test -p dcc-mcp-cli; cargo clippy -p dcc-mcp-cli --all-targets -- -D warnings; dcc-mcp-cli lint skills/dcc-mcp.