### PR TITLE
docs: support private standalone MCP services

### DIFF
--- a/examples/remote-server/Dockerfile
+++ b/examples/remote-server/Dockerfile
@@ -5,12 +5,10 @@ WORKDIR /app
 RUN pip install --no-cache-dir dcc-mcp-core
 
 COPY server.py .
-COPY skills/ /opt/skills/
+COPY skills/ ./skills/
 
 ENV DCC_MCP_HOST=0.0.0.0
 ENV DCC_MCP_PORT=8765
-ENV DCC_MCP_SKILL_PATHS=/opt/skills
-# Set DCC_MCP_API_KEY at runtime: docker run -e DCC_MCP_API_KEY=secret ...
 
 EXPOSE 8765
 

--- a/examples/remote-server/README.md
+++ b/examples/remote-server/README.md
@@ -1,56 +1,86 @@
-# Remote MCP Server Example
+# Standalone Internal MCP Service Example
 
-Minimal example of a publicly reachable MCP server using `dcc-mcp-core`.
+Minimal non-DCC service using `dcc-mcp-core`. It discovers the bundled
+`hello-world` Skill, marks the runtime as `standalone`, and requires no DCC
+process, public catalog entry, or GitHub repository.
+
+The `remote-server` directory name is retained for stable links. Local
+development binds to loopback; remote or intranet exposure is an explicit
+operator choice.
 
 ## Quick Start
 
 ```bash
-# Install dependency
 pip install dcc-mcp-core
-
-# Run with optional API key
-DCC_MCP_API_KEY=secret python server.py
+python server.py
 ```
 
-The server binds to `0.0.0.0:8765` and prints its MCP URL.
+Expected output includes:
 
-## Docker
+```text
+MCP service listening at http://127.0.0.1:8765/mcp
+  identity: studio-service
+  lifetime: standalone
+```
+
+Validate the bundled Skill before starting:
 
 ```bash
-docker build -t remote-mcp .
-docker run -p 8765:8765 -e DCC_MCP_API_KEY=secret remote-mcp
+dcc-mcp-cli lint skills
 ```
 
-## Docker Compose
+## Play With The Open-Source Inspector
+
+Start the official [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
 
 ```bash
-DCC_MCP_API_KEY=secret docker-compose up
+npx @modelcontextprotocol/inspector@latest
 ```
 
-## Connect from MCP Clients
+Choose Streamable HTTP and connect to `http://127.0.0.1:8765/mcp`. Search for
+`hello-world`, load it, then call `hello_world__greet` with:
 
-**Claude Desktop** (`claude_desktop_config.json`):
 ```json
-{
-  "mcpServers": {
-    "remote-mcp": {
-      "url": "http://localhost:8765/mcp",
-      "headers": { "Authorization": "Bearer secret" }
-    }
-  }
-}
+{"name":"Agent"}
 ```
+
+The response message is `Hello, Agent! (from the internal MCP service)`.
+
+Agents can exercise the same registered service without guessing tool slugs:
+
+```bash
+dcc-mcp-cli list --output toon
+dcc-mcp-cli load-skill hello-world --dcc-type studio-service --output toon
+dcc-mcp-cli describe <tool-slug-returned-by-load> --output toon
+dcc-mcp-cli call <tool-slug-returned-by-load> --json '{"name":"Agent"}' --wait --output toon
+```
+
+Follow the returned `next_step`; do not guess the instance-qualified tool slug.
+
+## Intranet Or Container Use
+
+Set `DCC_MCP_HOST=0.0.0.0` only inside a trusted network boundary. The example
+does not implement application-layer authentication. Put intranet or public
+traffic behind operator-owned TLS, authentication, firewall/origin policy, and
+audit controls.
+
+```bash
+docker build -t internal-mcp .
+docker run --rm -p 127.0.0.1:8765:8765 internal-mcp
+```
+
+Do not expose the MCP Inspector proxy to an untrusted network.
 
 ## Environment Variables
 
 | Variable | Default | Description |
-|----------|---------|-------------|
-| `DCC_MCP_HOST` | `0.0.0.0` | Bind address |
-| `DCC_MCP_PORT` | `8765` | TCP port |
-| `DCC_MCP_API_KEY` | _(none)_ | Bearer token auth (dev mode if unset) |
-| `DCC_MCP_SKILL_PATHS` | _(none)_ | Extra skill directories |
+|---|---|---|
+| `DCC_MCP_HOST` | `127.0.0.1` | Bind address; keep loopback for local development |
+| `DCC_MCP_PORT` | `8765` | MCP service port |
+| `DCC_MCP_SKILL_PATHS` | _(none)_ | Optional additional private Skill directories |
 
 ## See Also
 
-- [Remote-First MCP Server Design Guide](../../docs/guide/remote-server.md)
-- [Production Deployment](../../docs/guide/production-deployment.md)
+- [Internal standalone service workflow](../../skills/dcc-mcp-creator/references/INTERNAL_SERVICE_WORKFLOW.md)
+- [Remote-first deployment guide](../../docs/guide/remote-server.md)
+- [Production deployment](../../docs/guide/production-deployment.md)

--- a/examples/remote-server/docker-compose.yml
+++ b/examples/remote-server/docker-compose.yml
@@ -4,17 +4,15 @@ services:
   mcp-server:
     build: .
     ports:
-      - "8765:8765"
+      - "127.0.0.1:8765:8765"
     environment:
       DCC_MCP_HOST: "0.0.0.0"
       DCC_MCP_PORT: "8765"
-      DCC_MCP_API_KEY: "${DCC_MCP_API_KEY:-change-me-in-production}"
-      DCC_MCP_SKILL_PATHS: "/opt/skills"
     volumes:
-      - ./skills:/opt/skills:ro
+      - ./skills:/app/skills:ro
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/mcp')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/v1/healthz')"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/examples/remote-server/server.py
+++ b/examples/remote-server/server.py
@@ -1,63 +1,53 @@
-"""Minimal remote-accessible MCP server example.
-
-Starts a publicly reachable MCP server on 0.0.0.0 with CORS and
-optional API-key auth from environment variables.
-
-Usage:
-    DCC_MCP_API_KEY=secret python server.py
-    # then connect from any MCP client at http://<host>:8765/mcp
-"""
+"""Minimal standalone MCP service for private or local development."""
 
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import signal
 import time
 
 from dcc_mcp_core import McpHttpConfig
 from dcc_mcp_core import create_skill_server
 
+HOST = os.environ.get("DCC_MCP_HOST", "127.0.0.1")
 PORT = int(os.environ.get("DCC_MCP_PORT", "8765"))
-HOST = os.environ.get("DCC_MCP_HOST", "0.0.0.0")
-API_KEY = os.environ.get("DCC_MCP_API_KEY", "")
-SKILL_PATHS = os.environ.get("DCC_MCP_SKILL_PATHS", "")
+SKILLS_DIR = Path(__file__).parent / "skills"
 
-cfg = McpHttpConfig(
+config = McpHttpConfig(
     port=PORT,
-    server_name="remote-mcp",
-    enable_cors=True,
+    server_name="studio-service-mcp",
+    enable_cors=HOST != "127.0.0.1",
 )
-cfg.host = HOST
+config.host = HOST
+config.dcc_type = "studio-service"
+config.instance_metadata = {"dcc_mcp_instance_type": "standalone"}
 
-if API_KEY:
-    cfg.api_key = API_KEY
-
-if SKILL_PATHS:
-    os.environ["DCC_MCP_SKILL_PATHS"] = SKILL_PATHS
-
-server = create_skill_server("generic", cfg)
+server = create_skill_server(
+    "studio-service",
+    config,
+    extra_paths=[str(SKILLS_DIR)],
+)
 handle = server.start()
 
-print(f"MCP server listening at {handle.mcp_url()}")
-print(f"  host:     {HOST}")
-print(f"  port:     {PORT}")
-print(f"  auth:     {'api-key' if API_KEY else 'none (dev mode)'}")
-print("  cors:     enabled")
+print(f"MCP service listening at {handle.mcp_url()}")
+print("  identity: studio-service")
+print("  lifetime: standalone")
 print("Press Ctrl+C to stop.")
 
-_running = True
+running = True
 
 
-def _stop(sig, frame):
-    global _running
-    _running = False
+def _stop(_signal_number, _frame):
+    global running
+    running = False
 
 
 signal.signal(signal.SIGINT, _stop)
 signal.signal(signal.SIGTERM, _stop)
 
-while _running:
+while running:
     time.sleep(1)
 
 handle.shutdown()
-print("Server stopped.")
+print("Service stopped.")

--- a/examples/remote-server/skills/hello-world/SKILL.md
+++ b/examples/remote-server/skills/hello-world/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: hello-world
 description: >-
-  Example skill — minimal greeting tool. Use only for testing remote server
-  connectivity and skill discovery. Not for production use.
+  Example skill - minimal greeting tool. Use only for testing standalone
+  internal service connectivity and Skill discovery. Not for production use.
 license: MIT
 metadata:
   dcc-mcp:
@@ -14,7 +14,7 @@ metadata:
 
 # Hello World
 
-Minimal skill bundled with the remote-server example.
+Minimal Skill bundled with the standalone internal-service example.
 
 After loading with `load_skill("hello-world")`, the tool `hello_world__greet`
 is available.

--- a/examples/remote-server/skills/hello-world/scripts/greet.py
+++ b/examples/remote-server/skills/hello-world/scripts/greet.py
@@ -1,39 +1,23 @@
-"""Hello World skill script — prints a greeting message.
-
-Parameter resolution order:
-1. stdin JSON: {"name": "..."} — used by dcc-mcp-core execute_script
-2. CLI positional arg: greet.py <name> — used by direct invocation / tests
-3. Default: "World"
-"""
+"""Read-only smoke tool for the standalone MCP service example."""
 
 from __future__ import annotations
 
-import json
-import sys
+from dcc_mcp_core.skills_helper import run_main
+from dcc_mcp_core.skills_helper import skill_entry
+from dcc_mcp_core.skills_helper import skill_error
+from dcc_mcp_core.skills_helper import skill_success
 
 
-def main() -> None:
-    """Entry point for the greet action."""
-    name = "World"
-
-    try:
-        if not sys.stdin.isatty():
-            raw = sys.stdin.read()
-            if raw.strip():
-                params = json.loads(raw)
-                name = params.get("name", name)
-    except Exception:
-        pass
-
-    if name == "World" and len(sys.argv) > 1:
-        name = sys.argv[1]
-
-    result = {
-        "success": True,
-        "message": f"Hello, {name}! (from remote MCP server)",
-    }
-    print(json.dumps(result))
+@skill_entry
+def main(name: str = "World"):
+    """Return a bounded greeting for connectivity validation."""
+    if not isinstance(name, str) or not name.strip():
+        return skill_error("Invalid name", "Name must be a non-empty string.")
+    return skill_success(
+        f"Hello, {name.strip()}! (from the internal MCP service)",
+        name=name.strip(),
+    )
 
 
 if __name__ == "__main__":
-    main()
+    run_main(main)

--- a/examples/remote-server/skills/hello-world/tools.yaml
+++ b/examples/remote-server/skills/hello-world/tools.yaml
@@ -1,16 +1,54 @@
 tools:
   - name: greet
     description: >-
-      Greet a user by name. Use to verify remote server connectivity and skill
-      loading. When to use: smoke-testing the remote MCP server after deploy.
-      How to use: pass {"name": "YourName"} — defaults to "World".
+      Greet a user by name. Use to verify standalone service connectivity and
+      Skill loading. Pass {"name": "YourName"}; the default is "World".
+    source_file: scripts/greet.py
+    execution: sync
+    affinity: any
+    enforce_thread_affinity: true
+    timeout_hint_secs: 5
     annotations:
       read_only_hint: true
+      destructive_hint: false
       idempotent_hint: true
+      open_world_hint: false
+      deferred_hint: false
     input_schema:
       type: object
       properties:
         name:
           type: string
-          description: Name to greet (default "World")
+          minLength: 1
+          maxLength: 100
+          description: Name to greet.
+          default: World
       required: []
+      additionalProperties: false
+    output_schema:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+          properties:
+            name:
+              type: string
+          required:
+            - name
+          additionalProperties: false
+      required:
+        - success
+        - message
+        - context
+      additionalProperties: false
+    call_examples:
+      - arguments:
+          name: Agent
+        note: Verify the standalone service call path.
+    next-tools:
+      on-success: []
+      on-failure: []

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -2,10 +2,11 @@
 name: dcc-mcp-creator
 description: >-
   Infrastructure skill - guide developers and agents through creating or
-  modernizing a full DCC-MCP adapter for Nuke, Blender, 3ds Max, Unreal,
-  ZBrush, Houdini, Maya, and custom studio tools. Use when building server,
-  dispatcher, gateway, packaging, and runtime integration. Not for authoring
-  individual SKILL.md tool packages - use dcc-mcp-skills-creator.
+  modernizing a DCC-MCP adapter or standalone internal MCP service for Nuke,
+  Blender, 3ds Max, Unreal, ZBrush, Houdini, Maya, and custom studio systems.
+  Use when building server, dispatcher, gateway, packaging, and runtime
+  integration. Not for authoring individual SKILL.md tool packages - use
+  dcc-mcp-skills-creator.
 license: MIT-0
 allowed-tools: Bash Read Write Edit
 metadata:
@@ -17,8 +18,9 @@ metadata:
     search-hint: >-
       create DCC MCP adapter, Nuke MCP, DccServerBase, HostExecutionBridge,
       dispatcher, readiness, resources, gateway, Blender, 3ds Max, Unreal,
-      ZBrush, Houdini, Maya, chunked main-thread jobs, cooperative cancellation
-    tags: "adapter-development, host-runtime, dispatcher, gateway, nuke, blender, 3dsmax, unreal, zbrush"
+      ZBrush, Houdini, Maya, standalone internal MCP service, private intranet,
+      non-DCC server, chunked main-thread jobs, cooperative cancellation
+    tags: "adapter-development, internal-mcp-service, standalone, host-runtime, dispatcher, gateway, nuke, blender, 3dsmax, unreal, zbrush"
     skill-reference-docs:
       - "references/*.md"
   openclaw:
@@ -27,10 +29,12 @@ metadata:
 
 # DCC-MCP Creator
 
-Use this skill when you are creating a new DCC-MCP adapter or modernizing an
-existing adapter repository: server composition, host-thread dispatch,
+Use this skill when you are creating a new DCC-MCP adapter, modernizing an
+existing adapter repository, or exposing a private non-DCC studio system as a
+standalone MCP service: server composition, host-thread dispatch,
 sidecar/gateway wiring, readiness, resources, project state, diagnostics,
-install lifecycle, or cross-DCC verification.
+install lifecycle, or cross-DCC verification. A local folder, intranet source
+tree, or private monorepo is sufficient; GitHub is not a runtime requirement.
 
 For individual skill packages (`SKILL.md`, `tools.yaml`, scripts, groups, and
 skill taxonomy), load `dcc-mcp-skills-creator` instead.
@@ -73,16 +77,24 @@ does not replace a running server binary.
 
 ## Fast Workflow
 
-1. Run `dcc-mcp-cli dcc-types` before creating a repository. If the DCC type is
-   already cataloged, improve that adapter instead of creating a duplicate.
-   Custom types remain supported; add the new adapter to `dcc-mcp-catalog.yml`
-   and the compatibility matrix in the same core PR.
-2. Classify the host integration:
+1. Classify the ownership boundary before creating files:
+   - Public DCC adapter: run `dcc-mcp-cli dcc-types`; improve an existing
+     adapter instead of creating a duplicate. Add a genuinely new public
+     adapter to `dcc-mcp-catalog.yml` and the compatibility matrix.
+   - Private non-DCC service: work in the supplied local or intranet project,
+     keep its stable custom service id private, and do not require a GitHub
+     repository, public catalog entry, issue, or release. Use a studio-owned
+     catalog only when operators need `dcc-mcp-cli install` plans.
+   - Skill package only: switch to `dcc-mcp-skills-creator`.
+2. Classify the runtime integration:
    - Embedded Python host: Blender, 3ds Max Python, Houdini, Maya, Nuke.
    - External bridge host: ZBrush, Photoshop, Unity, custom tools.
    - Game/editor host with mixed Python or C++ bridge: Unreal, Unity.
+   - Standalone internal service: no host bridge; use inline execution for
+     ordinary service/file/API tools and keep every tool typed.
 3. Read the relevant reference:
    - [ADAPTER_WORKFLOW.md](references/ADAPTER_WORKFLOW.md) for the build path.
+   - [INTERNAL_SERVICE_WORKFLOW.md](references/INTERNAL_SERVICE_WORKFLOW.md) for a private non-DCC service with no public repository requirement.
    - [HOST_PATTERN_MATRIX.md](references/HOST_PATTERN_MATRIX.md) for host-specific wiring.
    - [CORE_ESCALATION_CHECKLIST.md](references/CORE_ESCALATION_CHECKLIST.md) before adding adapter-local glue.
     - [TESTING_AND_RELEASE.md](references/TESTING_AND_RELEASE.md) before validating or publishing.
@@ -98,8 +110,8 @@ does not replace a running server binary.
    - Standard sidecar: pass `watch_pid=current_dcc_pid`; core publishes the sidecar owner and bound host as separate liveness signals.
    - Other out-of-process adapter: pass `dcc_pid=current_dcc_pid` so `McpHttpConfig.host_pid` binds discovery to the DCC lifetime.
    - Standalone/headless service: pass `instance_type="standalone"`, leave `dcc_pid` unset, and do not bind it to an optional GUI process. Runtime identity is independent from `standalone_main_thread`, which controls tool execution only.
-5. Route host API calls through `HostExecutionBridge`; do not hand-roll a second script executor.
-6. Keep DCC identity data-driven: `dcc_name`, `server_name`, env-var prefix, skill names, and gateway metadata.
+5. Route host API calls through `HostExecutionBridge`; do not hand-roll a second script executor. Standalone services with no host-thread boundary should keep the default inline execution path.
+6. Keep service identity data-driven: `dcc_name`/custom service id, `server_name`, env-var prefix, skill names, and gateway metadata.
    Leave the instance port unset so core resolves `DCC_MCP_<DCC>_PORT` or asks the OS for a free port.
 7. Use core helpers for skill discovery, `MinimalModeConfig`, project tools, resources, diagnostics, context snapshots, install lifecycle, and gateway failover before writing adapter-local wrappers. Python `DccServerBase.collect_skill_search_paths()` includes marketplace-installed skills under `~/.dcc-mcp/marketplace/<dcc>` (or `DCC_MCP_MARKETPLACE_INSTALL_ROOT/<dcc>`) when the directory exists, so adapters should not add a second marketplace path convention. Hermetic adapter tests should set `DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS=1`; this excludes implicit local/platform defaults, marketplace installs, and Admin custom paths while explicit, bundled, and environment-provided skill paths remain active.
    - For Windows visual UI fallback, reuse the bundled `ui-control` skill and the
@@ -190,7 +202,7 @@ does not replace a running server binary.
 14. For NAT or routed-subnet deployments, run the tunnel agent with stable `instance_id`, `capabilities_fingerprint`, `adapter_version`, and `scene` metadata, then configure the standalone gateway with `--relay-source ADMIN_URL=PUBLIC_BASE_URL`; the gateway will expose active tunnels as `source: "relay"` rows with relay details in `source_meta` after probing `/v1/healthz` through `<PUBLIC_BASE_URL>/tunnel/<tunnel_id>/mcp`.
 15. Preserve gateway caller attribution when adding adapter wrappers or admin/debug routes: let MCP `initialize.params.clientInfo`, MCP `_meta.agent_context`, REST `meta.agent_context`, `x-dcc-mcp-*` headers, and safe `User-Agent` fallbacks flow through core rather than logging raw prompts or local machine data.
 16. For lifecycle/memory/telemetry policy, use `register_lifecycle_hooks(...)`, `search_skills(..., session_id=...)`, `dispatch_session_start(...)`, `dispatch_before_tool_call(...)`, `dispatch_after_tool_call(...)`, and `dispatch_session_end(...)`; pair `MemoryRecorder(InMemoryMemoryStore()).install(hooks)` with those hooks when adapters need bounded memory summaries, failed-pattern avoidance, or session compaction. Memory injection is conservative and budgeted by default: search receives compact ranking hints, tool calls receive memory only when it matches the current `tool_name`, and session-start injection is opt-in. Use `SqliteMemoryStore()` only when longterm patterns should be durable, operator-managed in the Admin Memory tab, and included in memory hit-rate observability; disable the recorder for privacy-sensitive deployments. Open a focused core issue/RFC only when those public hooks cannot express the adapter boundary.
-17. Add one executable smoke path: unit tests for construction plus either headless DCC, mock dispatcher MCP calls, gateway REST replay, mDNS same-LAN discovery smoke, relay-source smoke, or `just idle-memory-smoke` for standalone server idle/regression checks.
+17. Add one executable smoke path: unit tests for construction plus either headless DCC, mock dispatcher MCP calls, gateway REST replay, mDNS same-LAN discovery smoke, relay-source smoke, the open-source MCP Inspector for a loopback internal service, or `just idle-memory-smoke` for standalone server idle/regression checks.
 18. For gateway/admin observability, surface explicit state instead of silent zeroes: traffic panels should report disabled, unavailable, filtered, or genuine no-traffic states; skill panels should distinguish discovered, loaded, searched, selected, called, failed, and low-adoption skills; and admin-facing frames/paths should stay metadata-only or aliased unless an operator explicitly configures a private raw sink. Keep `ServiceEntry.version` as the DCC application version; use core-published `dcc_mcp_server_version` and `dcc_mcp_instance_type=gui|standalone` metadata for server regression and runtime-shape diagnostics instead of overloading DCC or adapter versions.
 19. Preserve workflow observability: adapter calls should carry request, parent, trace, session, DCC, transport, and artifact/validation metadata so the Admin workflow graph can show Intent → Discovery → Skill Load → Tool Calls → Fallbacks → Artifacts → Validation → Report without raw log reading.
 20. Preserve bounded `agent_context` task/session/turn metadata and artifact/validation-friendly tool names so Admin task outcomes can group workflows, calls, deliverables, and checks without reading raw payloads or local paths.
@@ -293,6 +305,28 @@ bundled as default skills. Then scaffold the adapter around core primitives:
 - Core project, readiness, resource, diagnostics, and gateway helpers before adapter-local glue.
 - `dcc-mcp-skills-creator` for the first `nuke-*` skill packages.
 
+## Example: Private Non-DCC Service
+
+When asked to expose an internal asset, render-farm, review, or production
+service, stay in the supplied private project and start with
+[`examples/remote-server`](../../examples/remote-server). It is a standalone
+service despite the historical directory name: it binds to loopback for local
+development, discovers a bundled example Skill, and needs no DCC process or GitHub
+repository.
+
+- Use a stable custom identifier such as `studio-assets`; do not pretend it is
+  Maya or another cataloged DCC.
+- Pass `instance_type="standalone"`, leave `dcc_pid` unset, and use inline
+  execution unless a real external host boundary exists.
+- Validate the Skill, start the service, then exercise `tools/list`,
+  `tools/call`, resources, and errors with the official open-source MCP
+  Inspector before testing gateway discovery.
+- Keep development on loopback. Intranet exposure requires operator-owned
+  TLS, authentication, firewall policy, secret storage, and audit controls.
+- Package through the owner's existing wheel, archive, container, Rez, or
+  private registry workflow. Do not create or publish a public repository
+  unless the user explicitly requests it.
+
 ## Non-Negotiables
 
 - Do not touch a DCC API from a Tokio/HTTP worker thread.
@@ -300,4 +334,5 @@ bundled as default skills. Then scaffold the adapter around core primitives:
 - Do not reach into `server._server` unless no public core API exists; if you must, file a core issue and keep the adapter shim small.
 - Do not create Maya-only abstractions in shared core or adapter templates.
 - Do not expose raw script execution as the primary user workflow when a typed skill can cover the task.
+- Do not require GitHub, a public catalog entry, or public issue tracking for a private internal service.
 - Do not publish local paths, private machine names, or source-attribution markers in public issues or PR text.

--- a/skills/dcc-mcp-creator/references/ADAPTER_WORKFLOW.md
+++ b/skills/dcc-mcp-creator/references/ADAPTER_WORKFLOW.md
@@ -1,6 +1,7 @@
-# Adapter Workflow
+# Adapter And Service Workflow
 
-Use this reference to build a new adapter or simplify an existing one.
+Use this reference to build a new adapter, expose an internal standalone
+service, or simplify an existing integration.
 
 ## 1. Choose the Runtime Shape
 
@@ -12,6 +13,7 @@ Use the smallest shape that can honestly run the host API:
 | Embedded Python, headless | mayapy, Blender background, Houdini hython | `DccServerBase` with inline or blocking dispatcher |
 | External bridge | ZBrush, Photoshop, Unity, proprietary tools | `DccServerBase` plus IPC/WebSocket/HTTP bridge helpers |
 | Editor/game engine | Unreal, Unity | Adapter-owned plugin bridge plus typed skill tools; keep Python optional |
+| Standalone internal service | Asset/review/render APIs, private CLI tools | `DccServerBase` with `instance_type="standalone"`, no DCC PID, and inline typed tools |
 
 ## 2. Build the Composition Root
 
@@ -58,6 +60,11 @@ fixed direct endpoint is required.
 For `HostUiDispatcherBase` subclasses, the bridge creates and attaches the
 native HTTP main-affinity queue automatically. Keep the host timer calling the
 subclass's `drain_queue()`; do not wire a second queue in the adapter.
+
+For a non-DCC standalone service, keep the same composition root but omit
+`HostExecutionBridge`, pass `instance_type="standalone"`, and leave `dcc_pid`
+unset. Follow [INTERNAL_SERVICE_WORKFLOW.md](INTERNAL_SERVICE_WORKFLOW.md); a
+public repository and public catalog entry are not required.
 
 ## 3. Add Progressive Skills
 

--- a/skills/dcc-mcp-creator/references/INTERNAL_SERVICE_WORKFLOW.md
+++ b/skills/dcc-mcp-creator/references/INTERNAL_SERVICE_WORKFLOW.md
@@ -1,0 +1,116 @@
+# Internal Standalone Service Workflow
+
+Use this path when the target is a private API, command-line service, asset
+database, render farm, review system, or another non-DCC system. The source may
+live in a local folder, intranet monorepo, Perforce workspace, or private Git
+server. GitHub and the public DCC catalog are optional delivery choices, not
+prerequisites.
+
+## 1. Inspect Before Scaffolding
+
+Read the supplied project and reuse its language, package manager, service
+entry point, authentication, tests, and deployment path. Create a new project
+only when no owning codebase exists. Do not add an adapter bridge when typed
+tools can call an existing library or bounded HTTP/CLI client directly.
+
+Choose one boundary:
+
+| Need | Build |
+|---|---|
+| Expose an existing private service | Standalone `DccServerBase` composition root plus typed Skills |
+| Add tools to an existing DCC-MCP runtime | A Skill package with `dcc-mcp-skills-creator` |
+| Control a GUI or host-thread-only API | A DCC adapter with `HostExecutionBridge` |
+
+## 2. Start With the Standalone Runtime
+
+Use a stable custom service id that describes ownership, such as
+`studio-assets`. Do not reuse a DCC name to bypass routing.
+
+```python
+from pathlib import Path
+
+from dcc_mcp_core import DccServerBase, DccServerOptions
+
+skills_dir = Path(__file__).parent / "skills"
+options = DccServerOptions.from_env(
+    "studio-assets",
+    skills_dir,
+    server_name="studio-assets-mcp",
+    instance_type="standalone",
+)
+server = DccServerBase(options)
+server.register_builtin_actions(include_bundled=False)
+handle = server.start()
+print(handle.mcp_url())
+```
+
+Leave `dcc_pid` unset. `instance_type="standalone"` describes the service
+lifetime; it does not mean `standalone_main_thread=True`. Keep default inline
+execution for ordinary library, file, and network operations. Add a dispatcher
+or bridge only when a real thread/process boundary requires one.
+
+The complete runnable example is
+[`examples/remote-server`](../../../examples/remote-server). Its historical
+directory name is retained for stable links, but its default is a loopback,
+standalone internal service.
+
+## 3. Put Business Operations in Typed Skills
+
+Load `dcc-mcp-skills-creator` and create one small Skill around a user workflow,
+not one tool per private API endpoint. Every tool must have explicit input and
+output schemas, safety annotations, bounded timeouts, and actionable errors.
+Keep credentials in the owner's secret store or process environment; never put
+them in `SKILL.md`, `tools.yaml`, examples, logs, or result payloads.
+
+Validate before starting the service:
+
+```bash
+dcc-mcp-cli lint skills
+```
+
+For hermetic tests, set `DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS=1` so operator
+Skill directories cannot change discovery results.
+
+## 4. Play and Debug Locally
+
+Start on loopback and print the resolved MCP URL. Then run the official
+open-source [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+```bash
+npx @modelcontextprotocol/inspector@latest
+```
+
+Connect with Streamable HTTP to the printed `/mcp` URL. Verify this ladder in
+order:
+
+1. `tools/list` exposes only discovery/control tools before the Skill loads.
+2. List or search confirms the owning Skill and its exact slug.
+3. Load the Skill and inspect its schema.
+4. Call one read-only tool with a valid example.
+5. Call it once with invalid input and confirm the error is safe and actionable.
+6. Stop the service and confirm its registry row disappears.
+
+Use `dcc-mcp-cli list`, `load-skill`, `describe`, and `call --wait` as
+the agent smoke once the local service is registered. Keep the returned slug
+and `request_id`; do not guess names or retry before diagnosis.
+
+## 5. Expose and Deliver Privately
+
+Loopback is the development default. Before binding to an intranet interface,
+require the operator-owned security boundary: TLS termination, authentication,
+origin/network allow-lists, secret management, audit retention, and shutdown
+ownership. Never expose the Inspector proxy to an untrusted network.
+
+Use the existing internal delivery path: wheel, signed archive, container, Rez
+package, shared deployment system, or private package registry. A studio-owned
+`DCC_MCP_CATALOG_PATH` is useful only when operators need catalog-backed CLI
+install plans. Local execution and direct MCP testing do not require a public
+catalog or GitHub repository.
+
+## Acceptance
+
+- The service starts from the owner's documented command on a clean environment.
+- One typed read-only tool succeeds through MCP Inspector and the agent path.
+- Invalid input and unavailable dependency failures are structured and redacted.
+- The service is marked `standalone`, has no fake DCC PID, and shuts down cleanly.
+- Packaging uses the owner's private delivery channel with no accidental public publication.


### PR DESCRIPTION
## Summary
- support private standalone non-DCC MCP services without requiring GitHub or the public catalog
- add an internal-service workflow and modernize the runnable remote-server example
- document local play/debug with the open-source MCP Inspector

## Validation
- remote-main source package build: 0.19.87
- 59 relevant tests passed
- Skill lint, Ruff, and diff checks passed
- MCP Inspector discovery/load and CLI valid/invalid calls passed
- Docker CLI was unavailable; container paths and loopback publishing were reviewed statically

Skill guidance updated in dcc-mcp-creator. dcc-mcp-skills-creator already owns the typed Skill schema contract, so no duplicate guidance was added.