### PR TITLE
docs: add an open container MCP lab

### DIFF
--- a/examples/remote-server/.devcontainer/devcontainer.json
+++ b/examples/remote-server/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "DCC-MCP internal service lab",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    }
+  },
+  "forwardPorts": [8765, 6274, 6277],
+  "portsAttributes": {
+    "8765": {
+      "label": "MCP service"
+    },
+    "6274": {
+      "label": "MCP Inspector proxy"
+    },
+    "6277": {
+      "label": "MCP Inspector UI"
+    }
+  },
+  "postCreateCommand": "python -m pip install --disable-pip-version-check dcc-mcp-core",
+  "remoteUser": "vscode"
+}

--- a/examples/remote-server/README.md
+++ b/examples/remote-server/README.md
@@ -29,6 +29,38 @@ Validate the bundled Skill before starting:
 dcc-mcp-cli lint skills
 ```
 
+## Run In The Open Dev Container
+
+The example includes a
+[Development Container](https://containers.dev/) configuration with Python,
+Node.js, `dcc-mcp-core`, and forwarded MCP Inspector ports. Open this directory
+in a compatible editor and choose **Reopen in Container**, then run the Quick
+Start commands above. The container runs as a non-root user and does not mount
+the host container socket.
+
+Agents can use the open-source reference CLI from the repository root:
+
+```bash
+npm install --global @devcontainers/cli
+devcontainer up --workspace-folder examples/remote-server
+devcontainer exec --workspace-folder examples/remote-server python server.py
+```
+
+In another terminal, exercise the running service without a browser:
+
+```bash
+devcontainer exec --workspace-folder examples/remote-server \
+  npx --yes @modelcontextprotocol/inspector@latest --cli \
+  http://127.0.0.1:8765/mcp --transport http --method tools/list
+```
+
+The Dev Container is the zero-infrastructure lab. If a team later needs a
+self-hosted browser classroom with one isolated session per learner,
+step-by-step instructions, terminals, and an embedded editor, use the
+Apache-2.0 [Educates](https://docs.educates.dev/en/stable/) platform. Do not add
+its Kubernetes/ingress operational surface until multi-user hosting is an
+actual requirement.
+
 ## Play With The Open-Source Inspector
 
 Start the official [MCP Inspector](https://github.com/modelcontextprotocol/inspector):

--- a/skills/dcc-mcp-creator/references/INTERNAL_SERVICE_WORKFLOW.md
+++ b/skills/dcc-mcp-creator/references/INTERNAL_SERVICE_WORKFLOW.md
@@ -71,6 +71,13 @@ dcc-mcp-cli lint skills
 For hermetic tests, set `DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS=1` so operator
 Skill directories cannot change discovery results.
 
+When the owner needs a reproducible development environment, prefer the open
+Development Container specification and its open-source CLI over a bespoke
+sandbox. Reuse an existing `.devcontainer/devcontainer.json`; the runnable
+example includes one under `examples/remote-server`. Keep credentials outside
+the image and do not mount a host container socket unless the workflow truly
+needs nested container control.
+
 ## 4. Play and Debug Locally
 
 Start on loopback and print the resolved MCP URL. Then run the official
@@ -93,6 +100,13 @@ order:
 Use `dcc-mcp-cli list`, `load-skill`, `describe`, and `call --wait` as
 the agent smoke once the local service is registered. Keep the returned slug
 and `request_id`; do not guess names or retry before diagnosis.
+
+For a hosted multi-user teaching portal, Educates is the open-source upgrade
+path: it provides per-user isolated sessions, Markdown instructions, browser
+terminals, and an embedded editor. Treat its Kubernetes, ingress, identity,
+resource quota, image registry, and session-cleanup requirements as an
+operator-owned deployment project. A local Dev Container remains the default
+until that operational need exists.
 
 ## 5. Expose and Deliver Privately
 


### PR DESCRIPTION
## Summary
- add an open Dev Container for the standalone MCP service example
- document the container-first developer loop in `dcc-mcp-creator`
- keep Educates as the explicit multi-user, operator-owned upgrade path

## Validation
- `python -m json.tool examples/remote-server/.devcontainer/devcontainer.json`
- `npx --yes @devcontainers/cli read-configuration --workspace-folder examples/remote-server`
- `git diff --check`

A container runtime is unavailable on the validation host, so `devcontainer up` was not executed. `dcc-mcp-skills-creator` does not change because this is service-environment guidance.