### PR TITLE
perf: reuse UIA worker per control session

### DIFF
--- a/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows.rs
@@ -1,11 +1,12 @@
 use std::cell::RefCell;
 use std::io::ErrorKind;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::os::windows::fs::{symlink_dir, symlink_file};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 use dcc_mcp_capture::{
     CaptureError, CaptureTarget, WindowFinder, WindowRecordingConfig, record_window_jpeg_sequence,
@@ -50,12 +51,184 @@ mod confirmation;
 pub(super) use confirmation::WindowsConfirmationSurface;
 
 const UIA_TIMEOUT: Duration = Duration::from_secs(30);
+const UIA_STDERR_LIMIT: u64 = 64 * 1024;
 const UIA_SCRIPT: &str = include_str!(
     "../../../../python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.ps1"
 );
 const UIA_HELPERS: &str = include_str!(
     "../../../../python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_helpers.ps1"
 );
+
+struct UiaWorker {
+    child: Option<Child>,
+    stdin: Option<ChildStdin>,
+    responses: Receiver<Vec<u8>>,
+    stdout_reader: Option<JoinHandle<()>>,
+    stderr_reader: Option<JoinHandle<Vec<u8>>>,
+    stderr: Vec<u8>,
+    script_path: PathBuf,
+}
+
+impl UiaWorker {
+    fn start() -> Result<Self, HostFailure> {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+        let script = UIA_SCRIPT.replace("# DCC_MCP_UIA_HELPERS", UIA_HELPERS);
+        let script_path = std::env::temp_dir().join(format!(
+            "dcc-mcp-ui-control-host-{}.ps1",
+            Uuid::new_v4().simple()
+        ));
+        std::fs::write(&script_path, script).map_err(|error| {
+            HostFailure::new(
+                UiControlHostErrorCode::BackendUnavailable,
+                format!("materialize the Windows UI Automation helper: {error}"),
+            )
+        })?;
+        let child = Command::new("powershell.exe")
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+            ])
+            .arg(&script_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .creation_flags(CREATE_NO_WINDOW)
+            .spawn();
+        let mut child = match child {
+            Ok(child) => child,
+            Err(error) => {
+                let _ = std::fs::remove_file(&script_path);
+                return Err(HostFailure::new(
+                    UiControlHostErrorCode::BackendUnavailable,
+                    format!("start the Windows UI Automation helper: {error}"),
+                ));
+            }
+        };
+        let stdin = child.stdin.take().expect("piped UIA worker stdin");
+        let stdout = child.stdout.take().expect("piped UIA worker stdout");
+        let stderr = child.stderr.take().expect("piped UIA worker stderr");
+        let (response_tx, responses) = mpsc::channel();
+        let stdout_reader = thread::spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            loop {
+                let mut response = Vec::new();
+                match reader.read_until(b'\n', &mut response) {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {
+                        while response
+                            .last()
+                            .is_some_and(|byte| matches!(byte, b'\r' | b'\n'))
+                        {
+                            response.pop();
+                        }
+                        if response_tx.send(response).is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+        let stderr_reader = thread::spawn(move || read_bounded(stderr, UIA_STDERR_LIMIT));
+        Ok(Self {
+            child: Some(child),
+            stdin: Some(stdin),
+            responses,
+            stdout_reader: Some(stdout_reader),
+            stderr_reader: Some(stderr_reader),
+            stderr: Vec::new(),
+            script_path,
+        })
+    }
+
+    fn request(&mut self, payload: &Value) -> Result<Value, HostFailure> {
+        if self.child.is_none() {
+            return Err(HostFailure::new(
+                UiControlHostErrorCode::BackendUnavailable,
+                "the Windows UI Automation worker is unavailable; reopen the UI Control session",
+            ));
+        }
+        let exited = match self
+            .child
+            .as_mut()
+            .expect("active UIA worker child")
+            .try_wait()
+        {
+            Ok(exited) => exited,
+            Err(error) => {
+                return Err(self.fail(format!("poll the Windows UI Automation worker: {error}")));
+            }
+        };
+        if let Some(status) = exited {
+            return Err(self.fail(format!(
+                "Windows UI Automation worker exited before the request with status {status}"
+            )));
+        }
+        let stdin = self.stdin.as_mut().expect("active UIA worker stdin");
+        if let Err(error) = writeln!(stdin, "{payload}").and_then(|()| stdin.flush()) {
+            return Err(self.fail(format!(
+                "send the Windows UI Automation worker request: {error}"
+            )));
+        }
+        let response = match self.responses.recv_timeout(UIA_TIMEOUT) {
+            Ok(response) => response,
+            Err(RecvTimeoutError::Timeout) => {
+                return Err(self.fail("Windows UI Automation timed out after 30 seconds"));
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(self.fail("Windows UI Automation worker closed without a response"));
+            }
+        };
+        match serde_json::from_slice(&response) {
+            Ok(value) => Ok(value),
+            Err(error) => Err(self.fail(format!(
+                "decode the Windows UI Automation response: {error}"
+            ))),
+        }
+    }
+
+    fn fail(&mut self, message: impl Into<String>) -> HostFailure {
+        self.shutdown();
+        let mut message = message.into();
+        let stderr = String::from_utf8_lossy(&self.stderr);
+        if !stderr.trim().is_empty() {
+            message.push_str(": ");
+            message.push_str(stderr.trim());
+        }
+        HostFailure::new(UiControlHostErrorCode::BackendUnavailable, message)
+    }
+
+    fn shutdown(&mut self) {
+        self.stdin = None;
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Some(reader) = self.stdout_reader.take() {
+            let _ = reader.join();
+        }
+        if let Some(reader) = self.stderr_reader.take() {
+            self.stderr = reader.join().unwrap_or_default();
+        }
+        let _ = std::fs::remove_file(&self.script_path);
+    }
+
+    #[cfg(test)]
+    fn process_id(&self) -> u32 {
+        self.child.as_ref().map(Child::id).unwrap_or_default()
+    }
+}
+
+impl Drop for UiaWorker {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
 
 pub(super) struct WindowsHostRuntime;
 
@@ -382,6 +555,7 @@ impl HostRuntime for WindowsHostRuntime {
             window_generation,
             started: false,
             image_buffer: None,
+            uia_worker: None,
         }))
     }
 }
@@ -392,6 +566,39 @@ struct WindowsRuntimeSession {
     window_generation: WindowGenerationGuard,
     started: bool,
     image_buffer: Option<SharedBuffer>,
+    uia_worker: Option<UiaWorker>,
+}
+
+impl WindowsRuntimeSession {
+    fn uia_worker(&mut self) -> Result<&mut UiaWorker, HostFailure> {
+        if self.uia_worker.is_none() {
+            self.uia_worker = Some(UiaWorker::start()?);
+        }
+        Ok(self
+            .uia_worker
+            .as_mut()
+            .expect("UIA worker was initialized"))
+    }
+
+    fn query_accessibility_state(
+        &mut self,
+        max_depth: u32,
+        max_nodes: u32,
+        allow_owned_standard_menu_popup: bool,
+    ) -> Result<RuntimeAccessibilityState, HostFailure> {
+        let target = self.target.clone();
+        query_accessibility_state(
+            self.uia_worker()?,
+            &target,
+            max_depth,
+            max_nodes,
+            allow_owned_standard_menu_popup,
+        )
+    }
+
+    fn run_uia(&mut self, payload: Value) -> Result<Value, HostFailure> {
+        self.uia_worker()?.request(&payload)
+    }
 }
 
 impl HostRuntimeSession for WindowsRuntimeSession {
@@ -462,7 +669,7 @@ impl HostRuntimeSession for WindowsRuntimeSession {
             window_handle: screenshot.observation.window_handle,
             window_title: screenshot.observation.window_title.clone(),
         };
-        let accessibility = query_accessibility_state(&self.target, max_depth, max_nodes, true)?;
+        let accessibility = self.query_accessibility_state(max_depth, max_nodes, true)?;
 
         let buffer_id = Uuid::new_v4().simple().to_string()[..16].to_owned();
         let buffer =
@@ -591,12 +798,7 @@ impl HostRuntimeSession for WindowsRuntimeSession {
         allow_owned_standard_menu_popup: bool,
     ) -> Result<RuntimeAccessibilityState, HostFailure> {
         self.window_generation.verify()?;
-        query_accessibility_state(
-            &self.target,
-            max_depth,
-            max_nodes,
-            allow_owned_standard_menu_popup,
-        )
+        self.query_accessibility_state(max_depth, max_nodes, allow_owned_standard_menu_popup)
     }
 
     fn execute(
@@ -610,9 +812,18 @@ impl HostRuntimeSession for WindowsRuntimeSession {
         let result = match action.input_kind {
             UiControlInputKind::RawInput => {
                 let request = native_action(action, observation_id);
+                if self.uia_worker.is_none() {
+                    self.uia_worker = Some(UiaWorker::start()?);
+                }
+                let target = self.target.clone();
+                let worker = self
+                    .uia_worker
+                    .as_mut()
+                    .expect("UIA worker was initialized");
                 let mut pre_input_fence = || {
                     let live = query_accessibility_state(
-                        &self.target,
+                        worker,
+                        &target,
                         fence.max_depth,
                         fence.max_nodes,
                         allows_owned_standard_menu_popup(action),
@@ -622,7 +833,8 @@ impl HostRuntimeSession for WindowsRuntimeSession {
                         .map_err(map_host_failure_to_computer_use_error)?;
                     Ok(())
                 };
-                self.session
+                let session = &mut self.session;
+                session
                     .perform_with_pre_input_fence(&request, &mut pre_input_fence)
                     .map_err(map_computer_use_error)?;
                 Ok(RuntimeActionResult {
@@ -639,7 +851,7 @@ impl HostRuntimeSession for WindowsRuntimeSession {
                 self.session
                     .prepare_semantic_action(observation_id)
                     .map_err(map_computer_use_error)?;
-                let raw = run_uia(json!({
+                let raw = self.run_uia(json!({
                     "mode": "act",
                     "scope": exact_scope(&self.target),
                     "max_depth": fence.max_depth,
@@ -706,6 +918,9 @@ impl HostRuntimeSession for WindowsRuntimeSession {
 
     fn stop(&mut self) -> bool {
         self.image_buffer = None;
+        if let Some(mut worker) = self.uia_worker.take() {
+            worker.shutdown();
+        }
         if !self.started {
             return false;
         }
@@ -873,12 +1088,13 @@ fn accessibility_scope(target: &UiControlTarget, allow_owned_standard_menu_popup
 }
 
 fn query_accessibility_state(
+    worker: &mut UiaWorker,
     target: &UiControlTarget,
     max_depth: u32,
     max_nodes: u32,
     allow_owned_standard_menu_popup: bool,
 ) -> Result<RuntimeAccessibilityState, HostFailure> {
-    let raw = run_uia(json!({
+    let raw = worker.request(&json!({
         "mode": "snapshot",
         "scope": accessibility_scope(target, allow_owned_standard_menu_popup),
         "max_depth": max_depth,
@@ -959,107 +1175,8 @@ fn native_action(action: &UiControlAction, observation_id: &str) -> ComputerUseA
     }
 }
 
-fn run_uia(payload: Value) -> Result<Value, HostFailure> {
-    let script = UIA_SCRIPT.replace("# DCC_MCP_UIA_HELPERS", UIA_HELPERS);
-    let script_path = std::env::temp_dir().join(format!(
-        "dcc-mcp-ui-control-host-{}.ps1",
-        Uuid::new_v4().simple()
-    ));
-    std::fs::write(&script_path, script).map_err(|error| {
-        HostFailure::new(
-            UiControlHostErrorCode::BackendUnavailable,
-            format!("materialize the Windows UI Automation helper: {error}"),
-        )
-    })?;
-
-    let result = run_uia_child(&script_path, &payload);
-    let _ = std::fs::remove_file(script_path);
-    result
-}
-
-fn run_uia_child(script_path: &std::path::Path, payload: &Value) -> Result<Value, HostFailure> {
-    use std::os::windows::process::CommandExt;
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-
-    let mut child = Command::new("powershell.exe")
-        .args([
-            "-NoLogo",
-            "-NoProfile",
-            "-NonInteractive",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-File",
-        ])
-        .arg(script_path)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .creation_flags(CREATE_NO_WINDOW)
-        .spawn()
-        .map_err(|error| {
-            HostFailure::new(
-                UiControlHostErrorCode::BackendUnavailable,
-                format!("start the Windows UI Automation helper: {error}"),
-            )
-        })?;
-    let mut stdin = child.stdin.take().ok_or_else(|| {
-        HostFailure::new(
-            UiControlHostErrorCode::BackendUnavailable,
-            "the Windows UI Automation helper has no stdin",
-        )
-    })?;
-    stdin
-        .write_all(payload.to_string().as_bytes())
-        .map_err(|error| {
-            HostFailure::new(
-                UiControlHostErrorCode::BackendUnavailable,
-                format!("send the Windows UI Automation request: {error}"),
-            )
-        })?;
-    drop(stdin);
-
-    let stdout = child.stdout.take().expect("piped stdout");
-    let stderr = child.stderr.take().expect("piped stderr");
-    let stdout_reader = thread::spawn(move || read_all(stdout));
-    let stderr_reader = thread::spawn(move || read_all(stderr));
-    let deadline = Instant::now() + UIA_TIMEOUT;
-    let status = loop {
-        if let Some(status) = child.try_wait().map_err(|error| {
-            HostFailure::new(
-                UiControlHostErrorCode::BackendUnavailable,
-                format!("poll the Windows UI Automation helper: {error}"),
-            )
-        })? {
-            break status;
-        }
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(HostFailure::new(
-                UiControlHostErrorCode::BackendUnavailable,
-                "Windows UI Automation timed out after 30 seconds",
-            ));
-        }
-        thread::sleep(Duration::from_millis(10));
-    };
-    let stdout = stdout_reader.join().unwrap_or_default();
-    let stderr = stderr_reader.join().unwrap_or_default();
-    if !status.success() {
-        let message = String::from_utf8_lossy(if stderr.is_empty() { &stdout } else { &stderr });
-        return Err(HostFailure::new(
-            UiControlHostErrorCode::BackendUnavailable,
-            format!("Windows UI Automation helper failed: {}", message.trim()),
-        ));
-    }
-    serde_json::from_slice(&stdout).map_err(|error| {
-        HostFailure::new(
-            UiControlHostErrorCode::BackendUnavailable,
-            format!("decode the Windows UI Automation response: {error}"),
-        )
-    })
-}
-
-fn read_all(mut reader: impl Read) -> Vec<u8> {
+fn read_bounded(reader: impl Read, limit: u64) -> Vec<u8> {
+    let mut reader = reader.take(limit);
     let mut output = Vec::new();
     let _ = reader.read_to_end(&mut output);
     output

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows/tests.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows/tests.rs
@@ -308,6 +308,53 @@ fn owned_standard_menu_popup_scope_stays_bound_to_the_exact_root() {
 }
 
 #[test]
+fn uia_worker_reuses_one_process_for_multiple_requests() {
+    let window = SemanticCloseWindow::spawn();
+    let target = UiControlTarget {
+        process_id: unsafe { GetCurrentProcessId() },
+        window_handle: window.hwnd.0 as usize as u64,
+        window_title: "DCC MCP persistent UIA worker test".to_owned(),
+    };
+    let mut worker = UiaWorker::start().unwrap();
+    let worker_process_id = worker.process_id();
+
+    let first = query_accessibility_state(&mut worker, &target, 5, 100, false).unwrap();
+    let second = query_accessibility_state(&mut worker, &target, 5, 100, false).unwrap();
+
+    assert!(first.node_count > 1);
+    assert!(second.node_count > 1);
+    assert_eq!(worker.process_id(), worker_process_id);
+}
+
+#[test]
+fn uia_worker_shutdown_reaps_process_and_script() {
+    let mut worker = UiaWorker::start().unwrap();
+    let script_path = worker.script_path.clone();
+
+    assert_ne!(worker.process_id(), 0);
+    assert!(script_path.is_file());
+    worker.shutdown();
+
+    assert_eq!(worker.process_id(), 0);
+    assert!(!script_path.exists());
+}
+
+#[test]
+fn failed_uia_worker_is_not_restarted_or_replayed() {
+    let mut worker = UiaWorker::start().unwrap();
+    let worker_process_id = worker.process_id();
+    let child = worker.child.as_mut().unwrap();
+    child.kill().unwrap();
+    child.wait().unwrap();
+
+    let failure = worker.request(&json!({"mode": "snapshot"})).unwrap_err();
+
+    assert_eq!(failure.code, UiControlHostErrorCode::BackendUnavailable);
+    assert_eq!(worker.process_id(), 0);
+    assert_ne!(worker_process_id, 0);
+}
+
+#[test]
 fn semantic_invoke_that_destroys_the_target_reports_mutation_success() {
     let window = SemanticCloseWindow::spawn();
     let target = UiControlTarget {
@@ -315,7 +362,8 @@ fn semantic_invoke_that_destroys_the_target_reports_mutation_success() {
         window_handle: window.hwnd.0 as usize as u64,
         window_title: "DCC MCP semantic Invoke close test".to_owned(),
     };
-    let accessibility = query_accessibility_state(&target, 5, 100, false).unwrap();
+    let mut worker = UiaWorker::start().unwrap();
+    let accessibility = query_accessibility_state(&mut worker, &target, 5, 100, false).unwrap();
     let button = find_control_by_name(&accessibility.root, "Close test window")
         .expect("standard button must be present in the scoped UIA tree");
     let runtime_id = button
@@ -347,20 +395,21 @@ fn semantic_invoke_that_destroys_the_target_reports_mutation_success() {
         policy_tier: UiControlPolicyTier::TaskGrant,
     };
 
-    let raw = run_uia(json!({
-        "mode": "act",
-        "scope": exact_scope(&target),
-        "max_depth": 5,
-        "max_nodes": 100,
-        "expected_fence": control_fence_json(&expected),
-        "action": {
-            "control_id": control_id,
-            "action": "click",
-            "text": "",
-            "checked": false,
-        },
-    }))
-    .unwrap();
+    let raw = worker
+        .request(&json!({
+            "mode": "act",
+            "scope": exact_scope(&target),
+            "max_depth": 5,
+            "max_nodes": 100,
+            "expected_fence": control_fence_json(&expected),
+            "action": {
+                "control_id": control_id,
+                "action": "click",
+                "text": "",
+                "checked": false,
+            },
+        }))
+        .unwrap();
 
     assert_eq!(raw.get("ok").and_then(Value::as_bool), Some(true), "{raw}");
     assert_eq!(

--- a/docs/adr/014-isolate-ui-control-host.md
+++ b/docs/adr/014-isolate-ui-control-host.md
@@ -93,6 +93,10 @@ used only for the synchronous `PrintWindow` call. The UI Control host owns the
 deadline, kills and waits for a timed-out child, and validates the versioned
 shared-memory response before accepting pixels. Screenshot isolation is not
 merged into the long-lived host because a stuck window must remain killable.
+Windows UI Automation uses one lazily started PowerShell worker per exact Host
+runtime session. Snapshot, accessibility polling, and semantic actions reuse
+that worker; session stop, worker failure, or timeout reaps it without retrying
+or replaying a mutation.
 
 ```mermaid
 flowchart LR
@@ -170,7 +174,7 @@ environment variables cannot resolve confirmation.
   window capabilities, two observation fences, shared-image descriptors,
   action descriptors, permission tiers, and stable errors.
 - `dcc-mcp-ui-control-host.exe` owns window resolution, `ComputerUseSession`,
-  UIA snapshot/action children, the killable capture helper, shared-memory PNGs,
+  the session-scoped UIA worker, the killable capture helper, shared-memory PNGs,
   visible overlays, input ownership, stop latch, trusted confirmation, and
   redacted audit.
 - the Windows `app_ui` backend is a thin named-pipe proxy. Host absence,

--- a/docs/guide/adapter-runtime-contracts.md
+++ b/docs/guide/adapter-runtime-contracts.md
@@ -142,7 +142,9 @@ Vercel's `agent-browser` CLI, which exposes its DevTools URL through
 
 Set `DCC_MCP_UI_CONTROL_BACKEND=windows-uia` on Windows to use the reference
 Windows UI Automation backend. It uses the OS UIAutomationClient API through a
-PowerShell helper and stays behind the same contract. The backend refuses
+PowerShell worker that is reused only within one exact Host runtime session and
+reaped on stop or failure. It stays behind the same contract and never retries
+an uncertain mutation. The backend refuses
 unscoped whole-desktop access: provide an allowed window title, process id, or
 process name through the call policy or `DCC_MCP_UI_CONTROL_UIA_*` environment
 variables. It maps UIA control types into normalized ui_control roles and returns

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.ps1
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.ps1
@@ -1,11 +1,4 @@
 $ErrorActionPreference = "Stop"
-$rawInput = [Console]::In.ReadToEnd()
-if ([string]::IsNullOrWhiteSpace($rawInput)) {
-  $payload = @{}
-} else {
-  $payload = $rawInput | ConvertFrom-Json
-}
-
 Add-Type -AssemblyName UIAutomationClient
 Add-Type -AssemblyName UIAutomationTypes
 # DCC_MCP_UIA_HELPERS
@@ -432,80 +425,89 @@ function Invoke-Action($element) {
   return @{ok = $false; error = "unsupported_action"; message = "unsupported Windows UIA action"}
 }
 
-try {
-  $script:scopeError = $null
-  $root = Find-Scoped-Root
-  if ($null -eq $root) {
-    $scopeErrorCode = if ($null -eq $script:scopeError) { "missing_window" } else { "invalid_target" }
-    $scopeMessage = if ($null -eq $script:scopeError) {
-      "No scoped Windows UIA window matched the supplied policy."
-    } else {
-      $script:scopeError
+function Invoke-UiaRequest($requestPayload) {
+  $script:payload = $requestPayload
+  try {
+    $script:scopeError = $null
+    $root = Find-Scoped-Root
+    if ($null -eq $root) {
+      $scopeErrorCode = if ($null -eq $script:scopeError) { "missing_window" } else { "invalid_target" }
+      $scopeMessage = if ($null -eq $script:scopeError) {
+        "No scoped Windows UIA window matched the supplied policy."
+      } else {
+        $script:scopeError
+      }
+      return @{ok = $false; error = $scopeErrorCode; message = $scopeMessage}
     }
-    @{ok = $false; error = $scopeErrorCode; message = $scopeMessage} |
-      ConvertTo-Json -Depth 64 -Compress
-    exit 0
-  }
-  $deniedTargetReason = Denied-Target-Reason $root
-  if ($null -ne $deniedTargetReason) {
-    @{ok = $false; error = "permission_denied"; message = $deniedTargetReason} |
-      ConvertTo-Json -Depth 64 -Compress
-    exit 0
-  }
-  $script:nodeCount = 0
-  if ($payload.mode -eq "act") {
-    $target = Find-By-Id $root ([string]$payload.action.control_id) 0 "0"
-    if ($null -eq $target) {
-      @{ok = $false; error = "not_found"; message = "Control not found in scoped Windows UIA window."} |
-        ConvertTo-Json -Depth 64 -Compress
-      exit 0
+    $deniedTargetReason = Denied-Target-Reason $root
+    if ($null -ne $deniedTargetReason) {
+      return @{ok = $false; error = "permission_denied"; message = $deniedTargetReason}
     }
-    $beforeFocus = Runtime-Id ([System.Windows.Automation.AutomationElement]::FocusedElement)
-    if (-not (Matches-Expected-Fence $target $payload.expected_fence)) {
-      @{ok = $false; error = "stale_observation"; message = "The action-time UI Automation target changed after confirmation."} |
-        ConvertTo-Json -Depth 64 -Compress
-      exit 0
-    }
-    $deniedActionTargetReason = Denied-Action-Target-Reason $root $target
-    if ($null -ne $deniedActionTargetReason) {
-      @{ok = $false; error = "permission_denied"; message = $deniedActionTargetReason} |
-        ConvertTo-Json -Depth 64 -Compress
-      exit 0
-    }
-    $actionResult = Invoke-Action $target
-    if (-not [bool]$actionResult.ok) {
-      @{
-        ok = $false
-        error = $actionResult.error
+    $script:nodeCount = 0
+    if ($payload.mode -eq "act") {
+      $target = Find-By-Id $root ([string]$payload.action.control_id) 0 "0"
+      if ($null -eq $target) {
+        return @{ok = $false; error = "not_found"; message = "Control not found in scoped Windows UIA window."}
+      }
+      $beforeFocus = Runtime-Id ([System.Windows.Automation.AutomationElement]::FocusedElement)
+      if (-not (Matches-Expected-Fence $target $payload.expected_fence)) {
+        return @{ok = $false; error = "stale_observation"; message = "The action-time UI Automation target changed after confirmation."}
+      }
+      $deniedActionTargetReason = Denied-Action-Target-Reason $root $target
+      if ($null -ne $deniedActionTargetReason) {
+        return @{ok = $false; error = "permission_denied"; message = $deniedActionTargetReason}
+      }
+      $actionResult = Invoke-Action $target
+      if (-not [bool]$actionResult.ok) {
+        return @{
+          ok = $false
+          error = $actionResult.error
+          message = $actionResult.message
+          before_focus_runtime_id = $beforeFocus
+        }
+      }
+      $afterFocus = $null
+      try {
+        $afterFocus = Runtime-Id ([System.Windows.Automation.AutomationElement]::FocusedElement)
+      } catch {}
+      $control = $null
+      try {
+        $control = Element-Raw $target 0 "target"
+      } catch {}
+      return @{
+        ok = $true
         message = $actionResult.message
         before_focus_runtime_id = $beforeFocus
-      } | ConvertTo-Json -Depth 64 -Compress
-      exit 0
+        after_focus_runtime_id = $afterFocus
+        control = $control
+      }
     }
-    $afterFocus = $null
-    try {
-      $afterFocus = Runtime-Id ([System.Windows.Automation.AutomationElement]::FocusedElement)
-    } catch {}
-    $control = $null
-    try {
-      $control = Element-Raw $target 0 "target"
-    } catch {}
-    @{
+    return @{
       ok = $true
-      message = $actionResult.message
-      before_focus_runtime_id = $beforeFocus
-      after_focus_runtime_id = $afterFocus
-      control = $control
-    } | ConvertTo-Json -Depth 64 -Compress
-    exit 0
+      root = Element-Raw $root 0 "0"
+      focus_runtime_id = Runtime-Id ([System.Windows.Automation.AutomationElement]::FocusedElement)
+      node_count = $script:nodeCount
+    }
+  } catch {
+    return @{ok = $false; error = "backend_error"; message = $_.Exception.Message}
+  } finally {
+    $script:payload = $null
   }
-  @{
-    ok = $true
-    root = Element-Raw $root 0 "0"
-    focus_runtime_id = Runtime-Id ([System.Windows.Automation.AutomationElement]::FocusedElement)
-    node_count = $script:nodeCount
-  } | ConvertTo-Json -Depth 64 -Compress
-} catch {
-  @{ok = $false; error = "backend_error"; message = $_.Exception.Message} |
-    ConvertTo-Json -Depth 64 -Compress
+}
+
+while ($true) {
+  $rawInput = [Console]::In.ReadLine()
+  if ($null -eq $rawInput) { break }
+  try {
+    $requestPayload = if ([string]::IsNullOrWhiteSpace($rawInput)) {
+      @{}
+    } else {
+      $rawInput | ConvertFrom-Json
+    }
+    $response = Invoke-UiaRequest $requestPayload
+  } catch {
+    $response = @{ok = $false; error = "backend_error"; message = $_.Exception.Message}
+  }
+  [Console]::Out.WriteLine(($response | ConvertTo-Json -Depth 64 -Compress))
+  [Console]::Out.Flush()
 }

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -128,8 +128,9 @@ does not replace a running server binary.
      banner, Esc stop token, input owner, confirmation, and native input.
      `ui-control` declares `requires_in_process: true` while keeping
      `affinity: any`; register `HostExecutionBridge` before skill loading.
-     Never weaken this into per-call subprocess execution or route it onto a
-     blocked DCC UI thread.
+     The Host lazily owns one UIA worker per exact runtime session and reaps it
+     on stop or failure without replaying mutations. Never weaken this into
+     per-call subprocess execution or route it onto a blocked DCC UI thread.
      A minimized or hidden exact HWND is recovered only through the host-owned
      `get_window_state` / `restore_window` / `show_window` /
      `activate_window` actions. They need no snapshot, must retain the existing

--- a/tests/test_ui_control_skill.py
+++ b/tests/test_ui_control_skill.py
@@ -1145,7 +1145,11 @@ def test_ui_control_windows_uia_post_state_is_optional_after_semantic_success() 
 
     assert invoke < reject_failure < optional_control < success
     assert "ok = $false" in source[reject_failure:optional_control]
-    assert 'try {\n      $control = Element-Raw $target 0 "target"\n    } catch {}' in post_read
+    assert (
+        post_read.index("try {")
+        < post_read.index('$control = Element-Raw $target 0 "target"')
+        < post_read.index("} catch {}")
+    )
     assert "control = $control" in source[success:]
 
 


### PR DESCRIPTION
## Summary

- reuse one lazily started PowerShell UIA worker per exact UI Control Host runtime session
- reap the worker on stop, timeout, or protocol failure without retrying uncertain mutations
- keep the public `ui_control__*` contract unchanged and document the Host ownership boundary

## Validation

- `vx cargo test -p dcc-mcp-computer-use --lib` (176 passed)
- `vx cargo clippy -p dcc-mcp-computer-use --tests -- -D warnings`
- UI Control Python tests (104 passed)
- `vx cargo build -p dcc-mcp-computer-use --bin dcc-mcp-ui-control-host`
- `dcc-mcp-ui-control-host.exe --self-check`
- Rust fmt, Ruff, Skill validation, PowerShell parser, and diff checks
