### PR TITLE
fix: honor UI Control task preapproval

### DIFF
--- a/crates/dcc-mcp-computer-use/src/ui_control_host.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host.rs
@@ -799,7 +799,9 @@ impl UiControlHost {
         if policy_tier == UiControlPolicyTier::HardDeny {
             return hard_deny_action(session, &action);
         }
-        if policy_tier >= UiControlPolicyTier::PreApproval {
+        if policy_tier >= UiControlPolicyTier::ActionConfirmation
+            || (policy_tier == UiControlPolicyTier::PreApproval && !session.grant.allow_raw_input)
+        {
             let confirmed_tier = policy_tier;
             match confirmation.confirm(
                 ConfirmationKind::ConsequentialAction(policy_tier),

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/tests.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/tests.rs
@@ -1800,6 +1800,56 @@ fn confirmation_round_trip_hard_denies_password_focus_before_input() {
 }
 
 #[test]
+fn full_dcc_grant_preapproves_tier_two_actions() {
+    let state = RuntimeAccessibilityState {
+        root: json!({
+            "runtime_id": "42.root",
+            "name": "Unreal Editor",
+            "children": [{
+                "runtime_id": "42.login",
+                "name": "Login",
+                "is_password": false,
+                "children": []
+            }]
+        }),
+        focus_runtime_id: None,
+        node_count: 2,
+    };
+    let mut host = host_with_accessibility_states(state.clone(), vec![state]);
+    host.confirmation = Box::new(DenyConfirmation);
+    let UiControlHostResponse::SessionOpened {
+        window_capability, ..
+    } = host.open_session("preapproved".to_owned(), grant(true))
+    else {
+        panic!("session not opened");
+    };
+    let UiControlHostResponse::Snapshot {
+        observation_id,
+        accessibility_state_id,
+        ..
+    } = host.snapshot("preapproved", "grant-1", &window_capability, 5, 250)
+    else {
+        panic!("snapshot failed");
+    };
+
+    assert!(matches!(
+        host.execute_action(
+            "preapproved",
+            "grant-1",
+            &window_capability,
+            &observation_id,
+            &accessibility_state_id,
+            action(Some("uia:42.login"), UiControlInputKind::Semantic),
+        ),
+        UiControlHostResponse::ActionCompleted {
+            success: true,
+            policy_tier: UiControlPolicyTier::PreApproval,
+            ..
+        }
+    ));
+}
+
+#[test]
 fn confirmation_denial_leaves_the_host_available_for_following_requests() {
     let snapshot = keyboard_accessibility_state("42.ordinary");
     let live = keyboard_accessibility_state("42.ordinary");

--- a/docs/adr/014-isolate-ui-control-host.md
+++ b/docs/adr/014-isolate-ui-control-host.md
@@ -130,10 +130,11 @@ with four enforcement tiers:
    escape the selected process/window scope.
 
 An explicit “full DCC control” grant enables raw pointer and keyboard actions
-inside the selected DCC window for that task. It does not bypass tiers 3 or 4.
-The native host itself is the trusted confirmation surface. If it cannot show
-that surface, or the user declines, actions in tiers 2 and 3 fail closed with a
-structured `approval_required` result.
+and satisfies tier 2 pre-approval inside the selected DCC window for that task.
+It does not bypass tiers 3 or 4. The native host itself is the trusted
+confirmation surface. If it cannot show that surface, or the user declines,
+ungranted tier 2 and all tier 3 actions fail closed with a structured
+`approval_required` result.
 
 ### Protocol and lifecycle
 
@@ -163,7 +164,8 @@ snapshot; input is never retried from stale state.
 
 The protocol does not contain `confirmed`, `approved`, or equivalent client
 booleans. The host starts a prominent non-modal notice for the initial
-exact-window grant and confirms every tier 2/3 action. An optional `intent` is a lower-bound classification hint: the
+exact-window grant. That grant can satisfy tier 2 pre-approval; the host
+confirms all tier 3 actions. An optional `intent` is a lower-bound classification hint: the
 host independently classifies UIA controls, pointed/focused controls, and
 keyboard chords, and may only raise the tier. Agent-controlled arguments and
 environment variables cannot resolve confirmation.

--- a/python/dcc_mcp_core/skills/ui-control/SKILL.md
+++ b/python/dcc_mcp_core/skills/ui-control/SKILL.md
@@ -247,9 +247,11 @@ denial on `keypress`.
 `ui_control__act` advertises a destructive annotation and accepts an optional
 `intent` consequence hint. The native host independently classifies the UIA
 control, focused/pointed control, keyboard chord, and requested intent; the hint
-can only raise the tier. Tier 2/3 operations use a trusted host-owned Windows
-confirmation dialog. There is no `confirmed`, `approved`, or environment-based
-approval field. A missing or denied confirmation returns `approval_required`.
+can only raise the tier. An explicit full DCC control grant satisfies tier 2
+pre-approval for that exact window and task; otherwise tier 2 and every tier 3
+operation use a trusted host-owned Windows confirmation dialog. There is no
+agent-supplied `confirmed` or `approved` field. A missing or denied required
+confirmation returns `approval_required`.
 
 With that operator-bound exact scope, `ui_control__snapshot` returns a bounded PNG
 through versioned shared memory plus a UIA tree, even when raw input is


### PR DESCRIPTION
## Summary
- let an explicit full DCC grant satisfy Tier 2 preapproval
- keep Tier 3 confirmation and Tier 4 hard-deny behavior unchanged
- document and test the session policy contract

## Validation
- focused Tier 2 grant regression test passed
- Tier 3 confirmation regression test passed
- cargo fmt --all -- --check