### PR TITLE
fix: recover interrupted gateway recordings

### DIFF
--- a/crates/dcc-mcp-db/src/infra/gateway_admin_schema.rs
+++ b/crates/dcc-mcp-db/src/infra/gateway_admin_schema.rs
@@ -122,4 +122,5 @@ CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_dcc ON sessions(dcc_type, started_at_ms);
 CREATE INDEX IF NOT EXISTS idx_session_events_session ON session_events(session_id, created_at_ms);
+CREATE INDEX IF NOT EXISTS idx_session_events_type ON session_events(event_type, created_at_ms);
 "#;

--- a/crates/dcc-mcp-db/src/infra/gateway_admin_sqlite.rs
+++ b/crates/dcc-mcp-db/src/infra/gateway_admin_sqlite.rs
@@ -273,6 +273,61 @@ impl GatewayAdminSqliteReader {
         rows.filter_map(|r| r.ok()).collect()
     }
 
+    /// Read one recording's ordered projection from the shared session timeline.
+    pub fn list_recording_events_json(
+        &self,
+        session_id: &str,
+        recording_id: &str,
+        limit: usize,
+    ) -> Vec<String> {
+        let Some(conn) = self.open_ro() else {
+            return Vec::new();
+        };
+        let mut stmt = match conn.prepare_cached(
+            "SELECT event_json FROM session_events \
+             WHERE session_id = ?1 AND event_type LIKE 'recording.%' \
+             AND json_extract(event_json, '$.recording_id') = ?2 \
+             ORDER BY id ASC LIMIT ?3",
+        ) {
+            Ok(stmt) => stmt,
+            Err(_) => return Vec::new(),
+        };
+        let rows = stmt.query_map(
+            params![session_id, recording_id, limit.clamp(1, 2_000) as i64],
+            |row| row.get(0),
+        );
+        let Ok(rows) = rows else {
+            return Vec::new();
+        };
+        rows.filter_map(Result::ok).collect()
+    }
+
+    /// Return recording starts whose latest lifecycle event is still `started`.
+    pub fn list_unfinished_recording_starts_json(&self, limit: usize) -> Vec<String> {
+        let Some(conn) = self.open_ro() else {
+            return Vec::new();
+        };
+        let mut stmt = match conn.prepare_cached(
+            "SELECT current.event_json FROM session_events AS current \
+             JOIN ( \
+               SELECT json_extract(event_json, '$.recording_id') AS recording_id, MAX(id) AS latest_id \
+               FROM session_events \
+               WHERE event_type IN ('recording.started', 'recording.stopped', 'recording.interrupted') \
+               GROUP BY recording_id \
+             ) AS latest ON latest.latest_id = current.id \
+             WHERE current.event_type = 'recording.started' \
+             ORDER BY current.id DESC LIMIT ?1",
+        ) {
+            Ok(stmt) => stmt,
+            Err(_) => return Vec::new(),
+        };
+        let rows = stmt.query_map(params![limit.clamp(1, 1_000) as i64], |row| row.get(0));
+        let Ok(rows) = rows else {
+            return Vec::new();
+        };
+        rows.filter_map(Result::ok).collect()
+    }
+
     /// List experiment definitions from the existing session event timeline.
     pub fn list_experiments_json(&self, limit: usize) -> Vec<String> {
         let Some(conn) = self.open_ro() else {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -144,6 +144,8 @@ mod handlers;
 mod instance_update_tests;
 #[cfg(all(test, feature = "admin"))]
 mod integration_tests;
+#[cfg(all(test, feature = "admin-persist-sqlite"))]
+mod recordings_tests;
 #[cfg(feature = "admin")]
 mod router;
 #[cfg(all(test, feature = "admin"))]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/recordings.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/recordings.rs
@@ -91,9 +91,6 @@ pub async fn handle_recording_stop(
     };
     let response = match state.recordings.stop(&session_id, &body.recording_id) {
         Ok(draft) => {
-            for event in &draft.events {
-                persist_recording_event(&state, "recording.tool_call", &draft, Some(json!(event)));
-            }
             persist_recording_event(&state, "recording.stopped", &draft, None);
             (StatusCode::OK, Json(json!(draft))).into_response()
         }
@@ -116,7 +113,7 @@ pub async fn handle_recording_review(
             "A bounded x-dcc-mcp-agent-session-id header is required.",
         );
     };
-    match state.recordings.get(&session_id, &recording_id) {
+    match state.recording_for_caller(&session_id, &recording_id) {
         Some(draft) => (StatusCode::OK, Json(json!(draft))).into_response(),
         None => error_response(
             StatusCode::NOT_FOUND,
@@ -139,7 +136,7 @@ pub async fn handle_recording_review_body(
             "A bounded x-dcc-mcp-agent-session-id header is required.",
         );
     };
-    match state.recordings.get(&session_id, &body.recording_id) {
+    match state.recording_for_caller(&session_id, &body.recording_id) {
         Some(draft) => (StatusCode::OK, Json(json!(draft))).into_response(),
         None => error_response(
             StatusCode::NOT_FOUND,
@@ -169,7 +166,7 @@ pub async fn handle_recording_compile(
             "Review the stopped recording and set reviewed=true before compilation.",
         );
     }
-    let Some(draft) = state.recordings.get(&session_id, &body.recording_id) else {
+    let Some(draft) = state.recording_for_caller(&session_id, &body.recording_id) else {
         return error_response(
             StatusCode::NOT_FOUND,
             "recording_not_found",
@@ -471,18 +468,7 @@ fn persist_recording_event(
     let Some(lane) = &state.admin_sqlite_lane else {
         return;
     };
-    let created_at_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis()
-        .min(i64::MAX as u128) as i64;
-    lane.try_persist_session_event(&json!({
-        "session_id": draft.session_id,
-        "event_type": event_type,
-        "created_at_ms": created_at_ms,
-        "recording_id": draft.recording_id,
-        "dcc_type": draft.dcc_type,
-        "status": draft.status,
-        "payload": payload,
-    }));
+    lane.try_persist_session_event(&crate::gateway::record_replay::recording_session_event(
+        event_type, draft, payload,
+    ));
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/recordings_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/recordings_tests.rs
@@ -1,0 +1,187 @@
+//! Focused tests for durable record/replay lifecycle contracts.
+
+use axum::Router;
+use axum::body::to_bytes;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use crate::gateway::admin::router::build_v1_debug_router;
+use crate::gateway::admin::sqlite_lane::AdminSqliteLane;
+use crate::gateway::admin::tests::admin_tests::{make_admin_state, post_json_as_session};
+use crate::gateway::traffic::{TrafficFrame, basic_gateway_source, correlation, mcp_message};
+
+async fn get_json_as_session(router: Router, uri: &str, session_id: &str) -> (StatusCode, Value) {
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .header("x-dcc-mcp-agent-session-id", session_id)
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    (status, serde_json::from_slice(&bytes).unwrap())
+}
+
+#[tokio::test]
+async fn gateway_restart_recovers_incremental_recording_as_interrupted() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("recordings.sqlite");
+    let session_id = "maya-recording-session";
+
+    let lane = AdminSqliteLane::spawn(db_path.clone(), 30).unwrap();
+    let state = make_admin_state().with_admin_sqlite_lane(Some(lane.clone()));
+    let traffic = state.gateway.traffic_capture.clone();
+    let router = build_v1_debug_router(state);
+
+    let (status, started) = post_json_as_session(
+        router.clone(),
+        "/v1/recordings/start",
+        session_id,
+        json!({"dcc_type": "maya"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let recording_id = started["recording_id"].as_str().unwrap();
+
+    traffic.emit_json_frame(
+        TrafficFrame::json(
+            basic_gateway_source(),
+            correlation(Some("req-1"), Some("trace-1"), Some(session_id)),
+            "inbound",
+            "agent_to_gateway",
+            "mcp",
+            json!({
+                "tool_slug": "maya.abcd.scene__build",
+                "arguments": {"output": "demo", "api_token": "secret"}
+            }),
+        )
+        .with_session_id(Some(session_id))
+        .with_mcp(mcp_message("request", "tools/call", Some(json!(1)))),
+    );
+    traffic.emit_json_frame(
+        TrafficFrame::json(
+            basic_gateway_source(),
+            correlation(Some("req-1"), Some("trace-1"), Some(session_id)),
+            "outbound",
+            "gateway_to_agent",
+            "mcp",
+            json!({"result": {"isError": false}}),
+        )
+        .with_session_id(Some(session_id))
+        .with_mcp(mcp_message("response", "tools/call", Some(json!(1)))),
+    );
+
+    drop(router);
+    drop(traffic);
+    drop(lane);
+
+    let recovered_lane = AdminSqliteLane::spawn(db_path, 30).unwrap();
+    let recovered_state = make_admin_state().with_admin_sqlite_lane(Some(recovered_lane.clone()));
+    let recovered_router = build_v1_debug_router(recovered_state);
+
+    let (status, recording) = get_json_as_session(
+        recovered_router.clone(),
+        &format!("/v1/recordings/{recording_id}"),
+        session_id,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(recording["status"], "interrupted");
+    assert_eq!(recording["events"][0]["success"], true);
+    assert_eq!(
+        recording["events"][0]["arguments"]["api_token"],
+        "[REDACTED_SENSITIVE_INPUT]"
+    );
+
+    let (status, _) = post_json_as_session(
+        recovered_router,
+        "/v1/recordings/start",
+        session_id,
+        json!({"dcc_type": "maya"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+}
+
+#[tokio::test]
+async fn gateway_restart_preserves_stopped_recording_status() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("stopped-recording.sqlite");
+    let session_id = "houdini-recording-session";
+
+    let lane = AdminSqliteLane::spawn(db_path.clone(), 30).unwrap();
+    let state = make_admin_state().with_admin_sqlite_lane(Some(lane.clone()));
+    let traffic = state.gateway.traffic_capture.clone();
+    let router = build_v1_debug_router(state);
+
+    let (status, started) = post_json_as_session(
+        router.clone(),
+        "/v1/recordings/start",
+        session_id,
+        json!({"dcc_type": "houdini"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let recording_id = started["recording_id"].as_str().unwrap();
+
+    traffic.emit_json_frame(
+        TrafficFrame::json(
+            basic_gateway_source(),
+            correlation(Some("req-2"), Some("trace-2"), Some(session_id)),
+            "inbound",
+            "agent_to_gateway",
+            "mcp",
+            json!({
+                "tool_slug": "houdini.efgh.scene__build",
+                "arguments": {"output": "demo"}
+            }),
+        )
+        .with_session_id(Some(session_id))
+        .with_mcp(mcp_message("request", "tools/call", Some(json!(2)))),
+    );
+    traffic.emit_json_frame(
+        TrafficFrame::json(
+            basic_gateway_source(),
+            correlation(Some("req-2"), Some("trace-2"), Some(session_id)),
+            "outbound",
+            "gateway_to_agent",
+            "mcp",
+            json!({"result": {"isError": false}}),
+        )
+        .with_session_id(Some(session_id))
+        .with_mcp(mcp_message("response", "tools/call", Some(json!(2)))),
+    );
+    let (status, stopped) = post_json_as_session(
+        router.clone(),
+        "/v1/recordings/stop",
+        session_id,
+        json!({"recording_id": recording_id}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(stopped["status"], "stopped");
+
+    drop(router);
+    drop(traffic);
+    drop(lane);
+
+    let recovered_lane = AdminSqliteLane::spawn(db_path, 30).unwrap();
+    let recovered_state = make_admin_state().with_admin_sqlite_lane(Some(recovered_lane));
+    let recovered_router = build_v1_debug_router(recovered_state);
+
+    let (status, recording) = get_json_as_session(
+        recovered_router,
+        &format!("/v1/recordings/{recording_id}"),
+        session_id,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(recording["status"], "stopped");
+    assert_eq!(recording["events"].as_array().unwrap().len(), 1);
+    assert_eq!(recording["events"][0]["success"], true);
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/sqlite_lane.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/sqlite_lane.rs
@@ -146,6 +146,27 @@ impl AdminSqliteReader {
             .collect()
     }
 
+    pub fn list_recording_events(
+        &self,
+        session_id: &str,
+        recording_id: &str,
+        limit: usize,
+    ) -> Vec<serde_json::Value> {
+        self.inner
+            .list_recording_events_json(session_id, recording_id, limit)
+            .into_iter()
+            .filter_map(|value| serde_json::from_str(&value).ok())
+            .collect()
+    }
+
+    pub fn list_unfinished_recording_starts(&self, limit: usize) -> Vec<serde_json::Value> {
+        self.inner
+            .list_unfinished_recording_starts_json(limit)
+            .into_iter()
+            .filter_map(|value| serde_json::from_str(&value).ok())
+            .collect()
+    }
+
     pub fn list_experiments(&self, limit: usize) -> Vec<serde_json::Value> {
         self.inner
             .list_experiments_json(limit)
@@ -445,6 +466,19 @@ impl AdminSqliteReader {
     }
 
     pub fn list_session_events(&self, _session_id: &str, _limit: usize) -> Vec<serde_json::Value> {
+        vec![]
+    }
+
+    pub fn list_recording_events(
+        &self,
+        _session_id: &str,
+        _recording_id: &str,
+        _limit: usize,
+    ) -> Vec<serde_json::Value> {
+        vec![]
+    }
+
+    pub fn list_unfinished_recording_starts(&self, _limit: usize) -> Vec<serde_json::Value> {
         vec![]
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
@@ -698,11 +698,16 @@ impl AdminState {
             return;
         }
         let store = self.recordings.clone();
-        *subscription = Some(
-            self.gateway
-                .traffic_capture
-                .subscribe_redacted_frames(move |frame| store.capture_frame(frame)),
-        );
+        let lane = self.admin_sqlite_lane.clone();
+        *subscription = Some(self.gateway.traffic_capture.subscribe_redacted_frames(
+            move |frame| {
+                if let Some(event) = store.capture_frame(frame)
+                    && let Some(lane) = &lane
+                {
+                    lane.try_persist_session_event(&event);
+                }
+            },
+        ));
     }
 
     /// Release traffic projection when the last demonstration stops.
@@ -754,7 +759,78 @@ impl AdminState {
         lane: Option<crate::gateway::admin::sqlite_lane::AdminSqliteLane>,
     ) -> Self {
         self.admin_sqlite_lane = lane;
+        self.recover_interrupted_recordings();
         self
+    }
+
+    pub fn recording_for_caller(
+        &self,
+        session_id: &str,
+        recording_id: &str,
+    ) -> Option<crate::gateway::record_replay::RecordingDraft> {
+        if let Some(draft) = self.recordings.get(session_id, recording_id) {
+            return Some(draft);
+        }
+        let lane = self.admin_sqlite_lane.as_ref()?;
+        let rows = lane.reader().list_recording_events(
+            session_id,
+            recording_id,
+            crate::gateway::record_replay::MAX_RECORDING_EVENTS * 2 + 4,
+        );
+        let (draft, newly_interrupted) =
+            crate::gateway::record_replay::recover_recording(recording_id, &rows)?;
+        if draft.session_id != session_id {
+            return None;
+        }
+        if newly_interrupted {
+            lane.try_persist_session_event(
+                &crate::gateway::record_replay::recording_session_event(
+                    "recording.interrupted",
+                    &draft,
+                    Some(serde_json::json!({"reason": "gateway_restart"})),
+                ),
+            );
+        }
+        self.recordings.restore(draft.clone());
+        Some(draft)
+    }
+
+    fn recover_interrupted_recordings(&self) {
+        let Some(lane) = &self.admin_sqlite_lane else {
+            return;
+        };
+        let reader = lane.reader();
+        for started in reader.list_unfinished_recording_starts(1_000) {
+            let Some(session_id) = started
+                .get("session_id")
+                .and_then(serde_json::Value::as_str)
+            else {
+                continue;
+            };
+            let Some(recording_id) = started
+                .get("recording_id")
+                .and_then(serde_json::Value::as_str)
+            else {
+                continue;
+            };
+            let rows = reader.list_recording_events(
+                session_id,
+                recording_id,
+                crate::gateway::record_replay::MAX_RECORDING_EVENTS * 2 + 4,
+            );
+            let Some((draft, true)) =
+                crate::gateway::record_replay::recover_recording(recording_id, &rows)
+            else {
+                continue;
+            };
+            lane.try_persist_session_event(
+                &crate::gateway::record_replay::recording_session_event(
+                    "recording.interrupted",
+                    &draft,
+                    Some(serde_json::json!({"reason": "gateway_restart"})),
+                ),
+            );
+        }
     }
 
     /// Hook invoked after SQLite-backed custom skill paths change (add/delete).

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
@@ -189,7 +189,10 @@ demonstration. It is a semantic compiler, not raw timing playback:
 2. Demonstrate through normal `search` -> `describe` -> `call`; use scoped UI
    Control only when structured tools cannot reach the semantic UI.
 3. Stop and review the caller-scoped, redacted timeline. Another session
-   cannot read or stop it.
+   cannot read or stop it. Calls are appended to the existing Admin
+   `session_events` timeline as they occur; after a gateway restart, an
+   unfinished recording is reviewable as `interrupted` and is never resumed
+   automatically.
 4. Compile only with explicit `reviewed=true`. The compiler resolves current
    tools and schemas, removes failed exploration and recorded approvals, and
    emits a local Skill plus `WorkflowSpec`.

--- a/crates/dcc-mcp-gateway/src/gateway/record_replay.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/record_replay.rs
@@ -1,6 +1,6 @@
 //! Gateway-owned, caller-scoped demonstration capture over redacted traffic frames.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -54,7 +54,7 @@ pub struct RecordingDraft {
     /// Review-only demonstrated instance.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instance_id: Option<String>,
-    /// `recording`, `stopped`, or `truncated`.
+    /// `recording`, `stopped`, `interrupted`, or `truncated`.
     pub status: String,
     /// Start timestamp.
     pub started_at_ms: u64,
@@ -160,8 +160,8 @@ impl RecordReplayStore {
     }
 
     /// Consume one post-redaction traffic frame when its trusted session is recording.
-    pub fn capture_frame(&self, envelope: &EventEnvelope) {
-        let Some(session_id) = envelope
+    pub fn capture_frame(&self, envelope: &EventEnvelope) -> Option<Value> {
+        let session_id = envelope
             .attributes
             .get("session_id")
             .and_then(Value::as_str)
@@ -170,36 +170,35 @@ impl RecordReplayStore {
                     .correlation
                     .get("session_id")
                     .and_then(Value::as_str)
-            })
-        else {
-            return;
-        };
+            })?;
         let mut state = self.inner.lock();
-        let Some(recording_id) = state.active_by_session.get(session_id).cloned() else {
-            return;
-        };
-        let Some(draft) = state.recordings.get_mut(&recording_id) else {
-            return;
-        };
+        let recording_id = state.active_by_session.get(session_id).cloned()?;
+        let draft = state.recordings.get_mut(&recording_id)?;
         if let Some((request_id, success)) = captured_outcome(envelope) {
-            if let Some(event) = draft
+            let updated = draft
                 .events
                 .iter_mut()
                 .rev()
                 .find(|event| event.request_id.as_deref() == Some(request_id))
-            {
-                event.success = Some(success);
+                .map(|event| {
+                    event.success = Some(success);
+                    event.clone()
+                });
+            if let Some(event) = updated {
+                return Some(recording_session_event(
+                    "recording.tool_call",
+                    draft,
+                    Some(serde_json::json!(event)),
+                ));
             }
-            return;
+            return None;
         }
-        let Some((tool_slug, arguments)) = captured_call(envelope) else {
-            return;
-        };
+        let (tool_slug, arguments) = captured_call(envelope)?;
         if draft.events.len() >= MAX_RECORDING_EVENTS {
             draft.status = "truncated".to_owned();
-            return;
+            return None;
         }
-        draft.events.push(CapturedToolCall {
+        let event = CapturedToolCall {
             sequence: draft.events.len() as u64 + 1,
             tool_slug,
             arguments,
@@ -209,8 +208,116 @@ impl RecordReplayStore {
                 .and_then(Value::as_str)
                 .map(str::to_owned),
             success: None,
-        });
+        };
+        draft.events.push(event.clone());
+        Some(recording_session_event(
+            "recording.tool_call",
+            draft,
+            Some(serde_json::json!(event)),
+        ))
     }
+
+    /// Restore a stopped or interrupted draft without reopening capture authority.
+    pub fn restore(&self, draft: RecordingDraft) {
+        self.inner
+            .lock()
+            .recordings
+            .insert(draft.recording_id.clone(), draft);
+    }
+}
+
+/// Rebuild one recording from its ordered session-event projection.
+pub(crate) fn recover_recording(
+    recording_id: &str,
+    rows: &[Value],
+) -> Option<(RecordingDraft, bool)> {
+    let mut draft = None;
+    let mut calls = BTreeMap::new();
+    let mut terminal = false;
+
+    for row in rows
+        .iter()
+        .filter(|row| row.get("recording_id").and_then(Value::as_str) == Some(recording_id))
+    {
+        match row.get("event_type").and_then(Value::as_str) {
+            Some("recording.started") => {
+                let created_at_ms = row
+                    .get("created_at_ms")
+                    .and_then(Value::as_i64)
+                    .and_then(|value| u64::try_from(value).ok())
+                    .unwrap_or_else(now_ms);
+                draft = Some(RecordingDraft {
+                    recording_id: recording_id.to_owned(),
+                    session_id: row.get("session_id")?.as_str()?.to_owned(),
+                    dcc_type: row.get("dcc_type")?.as_str()?.to_owned(),
+                    instance_id: row
+                        .get("instance_id")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned),
+                    status: "recording".to_owned(),
+                    started_at_ms: row
+                        .get("started_at_ms")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(created_at_ms),
+                    stopped_at_ms: None,
+                    events: Vec::new(),
+                });
+            }
+            Some("recording.tool_call") => {
+                if let Some(payload) = row.get("payload")
+                    && let Ok(event) = serde_json::from_value::<CapturedToolCall>(payload.clone())
+                {
+                    calls.insert(event.sequence, event);
+                }
+            }
+            Some("recording.stopped") | Some("recording.interrupted") => {
+                let recovered = draft.as_mut()?;
+                recovered.status = row
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or("interrupted")
+                    .to_owned();
+                recovered.stopped_at_ms =
+                    row.get("stopped_at_ms")
+                        .and_then(Value::as_u64)
+                        .or_else(|| {
+                            row.get("created_at_ms")
+                                .and_then(Value::as_i64)
+                                .and_then(|value| u64::try_from(value).ok())
+                        });
+                terminal = true;
+            }
+            _ => {}
+        }
+    }
+
+    let mut draft = draft?;
+    draft.events = calls.into_values().collect();
+    if !terminal {
+        draft.status = "interrupted".to_owned();
+        draft.stopped_at_ms = Some(now_ms());
+    }
+    Some((draft, !terminal))
+}
+
+pub(crate) fn recording_session_event(
+    event_type: &str,
+    draft: &RecordingDraft,
+    payload: Option<Value>,
+) -> Value {
+    let created_at_ms = now_ms();
+    serde_json::json!({
+        "session_id": draft.session_id,
+        "event_type": event_type,
+        "created_at_ms": created_at_ms.min(i64::MAX as u64) as i64,
+        "recording_id": draft.recording_id,
+        "dcc_type": draft.dcc_type,
+        "instance_id": draft.instance_id,
+        "status": draft.status,
+        "started_at_ms": draft.started_at_ms,
+        "stopped_at_ms": draft.stopped_at_ms,
+        "payload": payload,
+    })
 }
 
 fn validate_label(value: &str, name: &'static str) -> Result<(), RecordingStoreError> {

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -1834,6 +1834,9 @@ return `Result<T, DccMcpError>` rather than introducing yet another error type.
 Use `dcc-mcp-cli record-replay` only for operator-reviewed demonstration-to-Skill
 workflows. Recording is caller-session scoped and captures post-redaction gateway
 traffic; it never records prompts, secrets, approvals, or reusable authority.
+Calls are persisted incrementally in the existing Admin `session_events` timeline.
+After a gateway restart, unfinished recordings are reviewable as `interrupted`
+and capture authority is not restored.
 Compilation emits a `WorkflowSpec`, `SKILL.md`, replay contract, and
 `replay.guard.json`. Replay requires a separate current approval and validates
 every current tool schema guard before execution. UI fallback must resolve fresh

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -212,9 +212,11 @@ does not replace a running server binary.
     `agent_context.session_id`, keep UI Control logical ids connection/caller
     scoped, and write only redacted recording projections to existing
     `session_events`. Do not add adapter-local recorder state, a second
-    database, or a replay authority flag. Generated workflows re-resolve
-    current tools and schemas; semantic UI replay resolves fresh control ids;
-    raw/visual fallback requires exact-window calibration and drift guards.
+    database, or a replay authority flag. Persist calls incrementally; after a
+    gateway restart, project unfinished recordings as `interrupted` without
+    restoring capture authority. Generated workflows re-resolve current tools
+    and schemas; semantic UI replay resolves fresh control ids; raw/visual
+    fallback requires exact-window calibration and drift guards.
 22. Record reproducible experiment definitions, run states, Session DAG links,
     metrics, and judge evidence through the gateway `/v1/experiments` APIs.
     Reuse `session_events`, workflow/recording identifiers, and artifact


### PR DESCRIPTION
## Summary
- persist redacted recording calls incrementally in the existing session timeline
- recover unfinished recordings as interrupted without restoring capture authority
- preserve stopped recordings across gateway restarts

## Validation
- cargo fmt --all -- --check
- cargo clippy -p dcc-mcp-gateway --features admin-persist-sqlite --lib -- -D warnings
- cargo test -p dcc-mcp-db --features gateway-admin-sqlite
- cargo test -p dcc-mcp-gateway --features admin-persist-sqlite gateway_restart_ --lib
- record/replay VRS dry-run