### PR TITLE
feat: catalog new production adapters

### DIFF
--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -786,17 +786,25 @@ mod tests {
                 .count(),
             1
         );
-        for expected in ["godot", "renderdoc", "unity"] {
+        for (expected_type, expected_adapter) in [
+            ("c4d", "dcc-mcp-cinema4d"),
+            ("freecad", "dcc-mcp-freecad"),
+            ("godot", "dcc-mcp-godot"),
+            ("mari", "dcc-mcp-mari"),
+            ("openscad", "dcc-mcp-openscad"),
+            ("renderdoc", "dcc-mcp-renderdoc"),
+            ("unity", "dcc-mcp-unity"),
+        ] {
             let entry = catalog
                 .dcc_types
                 .iter()
-                .find(|entry| entry.dcc_type == expected)
-                .unwrap_or_else(|| panic!("missing cataloged DCC type {expected}"));
+                .find(|entry| entry.dcc_type == expected_type)
+                .unwrap_or_else(|| panic!("missing cataloged DCC type {expected_type}"));
             assert!(
                 entry
                     .adapters
                     .iter()
-                    .any(|adapter| adapter.name == format!("dcc-mcp-{expected}"))
+                    .any(|adapter| adapter.name == expected_adapter)
             );
         }
     }

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -1737,11 +1737,15 @@ fn dcc_types_lists_release_catalog_without_a_gateway() {
 
     assert_eq!(value["custom_types_supported"], true);
     let types = value["dcc_types"].as_array().unwrap();
-    assert_eq!(types.len(), 20);
+    assert_eq!(types.len(), 24);
     for expected in [
+        "c4d",
+        "freecad",
         "godot",
+        "mari",
         "marmoset",
         "openusd",
+        "openscad",
         "renderdoc",
         "shotgrid",
         "unity",

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -259,6 +259,58 @@ entries:
       pip_package: "dcc-mcp-marmoset"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-marmoset/main/install.md"
 
+  - name: "dcc-mcp-openscad"
+    description: "OpenSCAD adapter for deterministic model validation, export, and rendering"
+    dcc: ["openscad"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-openscad"
+    tags: ["adapter", "openscad", "official", "pip", "cad", "modeling"]
+    version: "0.1.1"
+    min_core_version: "0.19.91"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-openscad"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-openscad/main/README.md"
+
+  - name: "dcc-mcp-freecad"
+    description: "FreeCAD adapter for typed parametric modeling, document validation, and CAD exchange"
+    dcc: ["freecad"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-freecad"
+    tags: ["adapter", "freecad", "official", "pip", "cad", "parametric-modeling"]
+    version: "0.1.1"
+    min_core_version: "0.19.91"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-freecad"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-freecad/main/README.md"
+
+  - name: "dcc-mcp-cinema4d"
+    description: "Cinema 4D adapter for typed headless modeling, interchange, inspection, and rendering"
+    dcc: ["c4d", "cinema4d"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-cinema4d"
+    tags: ["adapter", "cinema4d", "cinema-4d", "official", "pip", "modeling", "rendering"]
+    version: "0.1.2"
+    min_core_version: "0.19.91"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-cinema4d"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-cinema4d/main/README.md"
+
+  - name: "dcc-mcp-mari"
+    description: "Mari adapter for typed project, geometry, channel, node-graph, layer, shader, image, and export workflows"
+    dcc: ["mari"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-mari"
+    tags: ["adapter", "mari", "official", "pip", "texturing", "lookdev"]
+    version: "0.2.1"
+    min_core_version: "0.19.91"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-mari"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-mari/main/README.md"
+
   - name: "dcc-mcp-fpt"
     description: "Autodesk Flow Production Tracking adapter for DCC-MCP"
     dcc: ["shotgrid"]

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -26,6 +26,10 @@ submit a PR updating this matrix before the release PR merges.
 |-----|-----------|----------------|----------|-----------------|-------------------|---------------|
 | Maya | [dcc-mcp-maya](https://github.com/dcc-mcp/dcc-mcp-maya) | 0.9.15 | >=0.19.45,<1.0.0 | 2024+ | Qt sidecar + HostUiDispatcherBase | 2026-06 |
 | Marmoset Toolbag | [dcc-mcp-marmoset](https://github.com/dcc-mcp/dcc-mcp-marmoset) | 0.1.1 | >=0.19.86,<1.0.0 | 4.03+ | External sidecar + Toolbag periodic callback | 2026-07 |
+| OpenSCAD | [dcc-mcp-openscad](https://github.com/dcc-mcp/dcc-mcp-openscad) | 0.1.1 | >=0.19.91,<1.0.0 | 2021.01+ | External OpenSCAD CLI subprocess | 2026-08 |
+| FreeCAD | [dcc-mcp-freecad](https://github.com/dcc-mcp/dcc-mcp-freecad) | 0.1.1 | >=0.19.91,<1.0.0 | 1.0+ | External FreeCADCmd subprocess | 2026-08 |
+| Cinema 4D | [dcc-mcp-cinema4d](https://github.com/dcc-mcp/dcc-mcp-cinema4d) | 0.1.2 | >=0.19.91,<1.0.0 | R21+ | External headless c4dpy subprocess | 2026-08 |
+| Mari | [dcc-mcp-mari](https://github.com/dcc-mcp/dcc-mcp-mari) | 0.2.1 | >=0.19.91,<1.0.0 | 5.0+ | Authenticated loopback sidecar + Qt UI timer | 2026-08 |
 | 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.37 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-06 |
 | Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.36 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-06 |
 | Houdini | [dcc-mcp-houdini](https://github.com/dcc-mcp/dcc-mcp-houdini) | 0.22.0 | >=0.19.45,<1.0.0 | 20.5+ | Event-loop callback | 2026-06 |


### PR DESCRIPTION
## Summary
- add released OpenSCAD, FreeCAD, Cinema 4D, and Mari adapters to the built-in install catalog
- document their released versions, core pins, host minimums, dispatcher patterns, and live verification month
- cover the new canonical DCC types in unit and CLI E2E contracts
- preserve `cinema4d` as an install alias while publishing Core's canonical `c4d` type
- track the public Cinema 4D v0.1.2 patch that fixes canonical type and packaged Skill routing

## Validation
- `vx cargo fmt --all -- --check`
- `vx cargo test -p dcc-mcp-catalog bundled_adapter_catalog_matches_compatibility_matrix`
- `vx cargo test -p dcc-mcp-cli bundled_catalog_lists_adapter_dcc_types_and_collapses_aliases`
- `vx cargo test -p dcc-mcp-cli --test cli_e2e dcc_types_lists_release_catalog_without_a_gateway`
- built CLI `dcc-types` reports `openscad`, `freecad`, `c4d`, and `mari` with install metadata
- built CLI install plans resolve `c4d` and `cinema4d` to public `dcc-mcp-cinema4d==0.1.2`

`vx just preflight` completed workspace generation/build/check and reached the Rust suite. The local Windows desktop was unavailable, so four existing `dcc-mcp-computer-use` interactive-desktop tests failed with `DesktopUnavailable` after 609 tests passed; targeted catalog/CLI tests above pass. CI remains the terminal gate.

No public API, adapter runtime, or Skill authoring contract changed, so the agent-facing creator Skills do not need a sync in this PR.