### PR TITLE
feat: catalog production Adobe adapters

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -1208,4 +1208,35 @@ entries:
             );
         }
     }
+
+    #[test]
+    fn bundled_adobe_adapters_expose_installable_entry_points() {
+        let entries = load_from_str(include_str!("../../../dcc-mcp-catalog.yml")).unwrap();
+
+        for (name, dcc, entry_point) in [
+            (
+                "dcc-mcp-aftereffects",
+                "aftereffects",
+                "dcc_mcp_aftereffects.cli:main",
+            ),
+            (
+                "dcc-mcp-illustrator",
+                "illustrator",
+                "dcc_mcp_illustrator.cli:main",
+            ),
+        ] {
+            let entry = entries
+                .iter()
+                .find(|entry| entry.name == name)
+                .unwrap_or_else(|| panic!("bundled catalog is missing {name}"));
+            assert!(entry.dcc.iter().any(|candidate| candidate == dcc));
+
+            let install = entry
+                .install
+                .as_ref()
+                .unwrap_or_else(|| panic!("{name} is missing install metadata"));
+            assert_eq!(install.pip_package.as_deref(), Some(name));
+            assert_eq!(install.entry_point.as_deref(), Some(entry_point));
+        }
+    }
 }

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -1737,11 +1737,12 @@ fn dcc_types_lists_release_catalog_without_a_gateway() {
 
     assert_eq!(value["custom_types_supported"], true);
     let types = value["dcc_types"].as_array().unwrap();
-    assert_eq!(types.len(), 24);
     for expected in [
+        "aftereffects",
         "c4d",
         "freecad",
         "godot",
+        "illustrator",
         "mari",
         "marmoset",
         "openusd",

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -143,17 +143,32 @@ entries:
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-premiere/main/README.md"
 
   - name: "dcc-mcp-aftereffects"
-    description: "Adobe After Effects adapter for DCC-MCP"
-    dcc: ["aftereffects"]
+    description: "Adobe After Effects adapter with typed project, layer, render queue, and official DOM workflows"
+    dcc: ["aftereffects", "after-effects", "after effects"]
     url: "https://github.com/dcc-mcp/dcc-mcp-aftereffects"
-    tags: ["adapter", "aftereffects", "official", "pip", "motion-graphics"]
-    version: "0.5.0"
-    min_core_version: "0.19.45"
+    tags: ["adapter", "aftereffects", "after-effects", "official", "pip", "cep", "motion-graphics"]
+    version: "0.6.0"
+    min_core_version: "0.19.91"
     maintainer: "dcc-mcp"
     install:
       type: pip
       pip_package: "dcc-mcp-aftereffects"
+      entry_point: "dcc_mcp_aftereffects.cli:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-aftereffects/main/README.md"
+
+  - name: "dcc-mcp-illustrator"
+    description: "Adobe Illustrator adapter with typed document, artwork, export, and official DOM workflows"
+    dcc: ["illustrator"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-illustrator"
+    tags: ["adapter", "illustrator", "official", "pip", "cep", "vector-graphics"]
+    version: "0.1.0"
+    min_core_version: "0.19.91"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-illustrator"
+      entry_point: "dcc_mcp_illustrator.cli:main"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-illustrator/main/README.md"
 
   - name: "dcc-mcp-katana"
     description: "Foundry Katana adapter for DCC-MCP"

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -39,7 +39,8 @@ submit a PR updating this matrix before the release PR merges.
 | ZBrush | [dcc-mcp-zbrush](https://github.com/dcc-mcp/dcc-mcp-zbrush) | 0.2.18 | >=0.19.45,<1.0.0 | — | Socket bridge + sidecar | — |
 | Photoshop | [dcc-mcp-photoshop](https://github.com/dcc-mcp/dcc-mcp-photoshop) | 0.1.37 | >=0.19.45,<1.0.0 | Photoshop UXP | WebSocket bridge | 2026-06 |
 | Premiere Pro | [dcc-mcp-premiere](https://github.com/dcc-mcp/dcc-mcp-premiere) | 0.4.0 | >=0.19.45,<1.0.0 | 25.6+ | UXP WebSocket bridge | — |
-| After Effects | [dcc-mcp-aftereffects](https://github.com/dcc-mcp/dcc-mcp-aftereffects) | 0.5.0 | >=0.19.45,<1.0.0 | — | CEP bridge | — |
+| After Effects | [dcc-mcp-aftereffects](https://github.com/dcc-mcp/dcc-mcp-aftereffects) | 0.6.0 | >=0.19.91,<1.0.0 | — | Authenticated CEP bridge + broker | 2026-08 |
+| Illustrator | [dcc-mcp-illustrator](https://github.com/dcc-mcp/dcc-mcp-illustrator) | 0.1.0 | >=0.19.91,<1.0.0 | — | Authenticated CEP bridge + broker | 2026-08 |
 | Katana | [dcc-mcp-katana](https://github.com/dcc-mcp/dcc-mcp-katana) | 0.3.0 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
 | MotionBuilder | [dcc-mcp-mobu](https://github.com/dcc-mcp/dcc-mcp-mobu) | 0.3.0 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
 | RenderDoc | [dcc-mcp-renderdoc](https://github.com/dcc-mcp/dcc-mcp-renderdoc) | 0.3.0 | >=0.19.45,<1.0.0 | — | Headless CLI adapter | 2026-07 |


### PR DESCRIPTION
## Summary
- catalog the production Illustrator adapter
- update After Effects metadata, aliases, and CLI entry point
- keep the compatibility matrix aligned with released adapter contracts

## Validation
- catalog tests: 34 passed
- rustfmt and catalog/schema validation passed