### PR TITLE
Refresh updated skills without restarting DCCs

### DIFF
--- a/crates/dcc-mcp-http-py/src/skill_server.rs
+++ b/crates/dcc-mcp-http-py/src/skill_server.rs
@@ -772,6 +772,13 @@ impl PyMcpHttpServer {
         self.catalog.discover(extra_paths.as_deref(), dcc_name)
     }
 
+    /// Re-scan search paths and replace changed or removed skill definitions.
+    /// Loaded skills with changed declarations are refreshed in place.
+    #[pyo3(signature = (extra_paths=None, dcc_name=None))]
+    fn rediscover(&self, extra_paths: Option<Vec<String>>, dcc_name: Option<&str>) -> usize {
+        self.catalog.rediscover(extra_paths.as_deref(), dcc_name)
+    }
+
     /// Load a skill by name — registers its tools in the ToolRegistry.
     ///
     /// Returns the list of registered action names.

--- a/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
@@ -354,6 +354,8 @@ impl SkillCatalog {
         let mut seen = std::collections::HashSet::new();
         self.skipped.clear();
         let mut added = 0usize;
+        let mut updated = 0usize;
+        let mut loaded_to_reload = Vec::new();
 
         for (skill, path_source) in result.skills {
             let name = skill.name.clone();
@@ -362,11 +364,19 @@ impl SkillCatalog {
             seen.insert(name.clone());
             if let Some(mut entry) = self.entries.get_mut(&name) {
                 let old_dcc = entry.metadata.dcc.clone();
-                entry.metadata = skill;
-                entry.path_source = path_source;
-                entry.refresh_tokens();
-                if entry.state != SkillState::Loaded {
-                    entry.state = SkillState::Discovered;
+                let metadata_changed = entry.metadata != skill;
+                let source_changed = entry.path_source != path_source;
+                if metadata_changed || source_changed {
+                    let was_loaded = entry.state == SkillState::Loaded;
+                    entry.metadata = skill;
+                    entry.path_source = path_source;
+                    entry.refresh_tokens();
+                    if !was_loaded {
+                        entry.state = SkillState::Discovered;
+                    } else if metadata_changed {
+                        loaded_to_reload.push(name.clone());
+                    }
+                    updated += 1;
                 }
                 // Update shard if dcc changed.
                 self.shard_move(&name, &old_dcc, &dcc);
@@ -399,7 +409,17 @@ impl SkillCatalog {
         }
         self.refresh_dependency_states();
 
-        if added + removed > 0 {
+        for name in loaded_to_reload {
+            if let Err(err) = self.unload_skill(&name) {
+                tracing::warn!(skill = %name, error = %err, "SkillCatalog: failed to unload changed skill during rediscovery");
+                continue;
+            }
+            if let Err(err) = self.load_skill(&name) {
+                tracing::warn!(skill = %name, error = %err, "SkillCatalog: failed to reload changed skill during rediscovery");
+            }
+        }
+
+        if added + updated + removed > 0 {
             self.inverted_index.write().invalidate();
         }
 
@@ -413,12 +433,13 @@ impl SkillCatalog {
         }
 
         tracing::info!(
-            "SkillCatalog: rediscovered skills (added {}, removed {}, total {})",
+            "SkillCatalog: rediscovered skills (added {}, updated {}, removed {}, total {})",
             added,
+            updated,
             removed,
             self.entries.len()
         );
-        added + removed
+        added + updated + removed
     }
 
     /// Add a single skill to the catalog (e.g. from SkillWatcher).

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
@@ -18,6 +18,31 @@ fn write_skill_dir(root: &std::path::Path, name: &str, dcc: &str) {
     .unwrap();
 }
 
+fn write_tool_skill_dir(root: &std::path::Path, name: &str, dcc: &str, tool_name: &str) {
+    let dir = root.join(name);
+    let scripts = dir.join("scripts");
+    std::fs::create_dir_all(&scripts).unwrap();
+    std::fs::write(
+        dir.join(crate::constants::SKILL_METADATA_FILE),
+        format!(
+            "---\nname: {name}\ndescription: reload fixture\nmetadata:\n  dcc-mcp:\n    dcc: {dcc}\n    tools: tools.yaml\n---\n# {name}\n"
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("tools.yaml"),
+        format!(
+            "tools:\n  - name: {tool_name}\n    description: reload fixture {tool_name}\n    source_file: scripts/{tool_name}.py\n    input_schema:\n      type: object\n      properties: {{}}\n"
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        scripts.join(format!("{tool_name}.py")),
+        "def main(**kwargs):\n    return {'success': True}\n",
+    )
+    .unwrap();
+}
+
 #[test]
 fn test_catalog_new_is_empty() {
     let catalog = make_test_catalog();
@@ -166,6 +191,35 @@ fn test_rediscover_removes_missing_skill_and_registered_tools() {
     assert!(catalog.get_skill_info("stale-skill").is_none());
     assert!(!catalog.is_loaded("stale-skill"));
     assert_eq!(catalog.registry().len(), 0);
+}
+
+#[test]
+fn test_rediscover_refreshes_changed_loaded_skill_tools() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_tool_skill_dir(tmp.path(), "lookdev-turntable", "maya", "old_preset");
+
+    let catalog = make_test_catalog();
+    let paths = vec![tmp.path().to_string_lossy().to_string()];
+    assert!(catalog.rediscover(Some(&paths), Some("maya")) >= 1);
+    catalog.load_skill("lookdev-turntable").unwrap();
+
+    write_tool_skill_dir(
+        tmp.path(),
+        "lookdev-turntable",
+        "maya",
+        "recommend_hdr_preset",
+    );
+    assert!(catalog.rediscover(Some(&paths), Some("maya")) >= 1);
+
+    let info = catalog.get_skill_info("lookdev-turntable").unwrap();
+    assert_eq!(info.state, "loaded");
+    assert_eq!(info.tools.len(), 1);
+    assert_eq!(info.tools[0].name, "recommend_hdr_preset");
+    assert_eq!(
+        info.registered_tools,
+        vec!["lookdev_turntable__recommend_hdr_preset"]
+    );
+    assert_eq!(catalog.registry().len(), 1);
 }
 
 #[test]

--- a/crates/dcc-mcp-skills/src/python/catalog.rs
+++ b/crates/dcc-mcp-skills/src/python/catalog.rs
@@ -64,6 +64,14 @@ impl SkillCatalog {
         self.discover(extra_paths.as_deref(), dcc_name)
     }
 
+    /// Re-scan search paths, replace changed skill metadata, and refresh any
+    /// loaded tools whose declarations changed on disk.
+    #[pyo3(name = "rediscover")]
+    #[pyo3(signature = (extra_paths=None, dcc_name=None))]
+    fn py_rediscover(&self, extra_paths: Option<Vec<String>>, dcc_name: Option<&str>) -> usize {
+        self.rediscover(extra_paths.as_deref(), dcc_name)
+    }
+
     /// Register a Python callable as the in-process script executor.
     ///
     /// When registered, skill scripts are executed inside the **current**

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -2503,6 +2503,11 @@ class SkillCatalog:
 
         Returns the number of newly discovered skills.
         """
+    def rediscover(self, extra_paths: typing.Optional[typing.Sequence[builtins.str]] = None, dcc_name: typing.Optional[builtins.str] = None) -> builtins.int:
+        r"""
+        Re-scan search paths, replace changed skill metadata, and refresh any
+        loaded tools whose declarations changed on disk.
+        """
     def set_in_process_executor(self, executor: typing.Optional[typing.Any]) -> None:
         r"""
         Register a Python callable as the in-process script executor.

--- a/python/dcc_mcp_core/_server/skill_discovery.py
+++ b/python/dcc_mcp_core/_server/skill_discovery.py
@@ -238,7 +238,11 @@ class SkillDiscoveryController:
             len(skill_paths),
         )
         try:
-            count = owner._server.discover(extra_paths=skill_paths)
+            rediscover = getattr(owner._server, "rediscover", None)
+            if callable(rediscover):
+                count = rediscover(extra_paths=skill_paths)
+            else:
+                count = owner._server.discover(extra_paths=skill_paths)
         except Exception as exc:
             logger.warning("[%s] reload_skill_paths failed: %s", owner._dcc_name, exc)
             return 0

--- a/tests/test_admin_skill_paths_reload.py
+++ b/tests/test_admin_skill_paths_reload.py
@@ -77,6 +77,49 @@ def _write_skill(skill_root: Path, name: str) -> None:
     )
 
 
+def _write_tool_skill(skill_root: Path, name: str, tool_name: str) -> None:
+    skill_dir = skill_root / name
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                f"name: {name}",
+                f"description: reload fixture {name}",
+                "metadata:",
+                "  dcc-mcp:",
+                "    dcc: maya",
+                "    tools: tools.yaml",
+                "---",
+                f"# {name}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (skill_dir / "tools.yaml").write_text(
+        "\n".join(
+            [
+                "tools:",
+                f"  - name: {tool_name}",
+                f"    description: reload fixture {tool_name}",
+                f"    source_file: scripts/{tool_name}.py",
+                "    input_schema:",
+                "      type: object",
+                "      properties: {}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (scripts_dir / f"{tool_name}.py").write_text(
+        "def main(**kwargs):\n"
+        f'    return {{"success": True, "tool": "{tool_name}"}}\n',
+        encoding="utf-8",
+    )
+
+
 @pytest.fixture
 def registry_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Isolate the admin SQLite file under tmp_path via the env var."""
@@ -176,6 +219,43 @@ def test_server_base_reload_picks_up_admin_path(
     assert count >= 1
     after = _skill_names(server.list_skills())
     assert "ext-rigging" in after, f"reload_skill_paths did not pick up admin SQLite path; got {after}"
+
+
+def test_server_base_reload_refreshes_existing_skill_metadata(
+    registry_dir: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A marketplace update must replace an existing skill definition on disk."""
+    monkeypatch.delenv("DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS", raising=False)
+    skill_root = tmp_path_factory.mktemp("marketplace-skills")
+    _write_tool_skill(skill_root, "lookdev-turntable", "old_preset")
+
+    from dcc_mcp_core import DccServerBase
+    from dcc_mcp_core._server.options import DccServerOptions
+
+    opts = DccServerOptions.from_env(
+        dcc_name="maya",
+        builtin_skills_dir=tmp_path_factory.mktemp("builtin-skills"),
+        server_name="test-maya",
+        port=0,
+        gateway_port=None,
+        enable_gateway_failover=False,
+    )
+    server = DccServerBase(opts)
+    server.register_builtin_actions(extra_skill_paths=[str(skill_root)], include_bundled=False)
+    assert server.load_skill("lookdev-turntable")
+
+    _write_tool_skill(skill_root, "lookdev-turntable", "recommend_hdr_preset")
+    server.reload_skill_paths(extra_skill_paths=[str(skill_root)], include_bundled=False)
+    assert server.unload_skill("lookdev-turntable")
+    assert server.load_skill("lookdev-turntable")
+
+    detail = server.get_skill_info("lookdev-turntable")
+    assert detail is not None
+    tools = detail["tools"] if isinstance(detail, dict) else detail.tools
+    names = [tool["name"] if isinstance(tool, dict) else tool.name for tool in tools]
+    assert names == ["recommend_hdr_preset"]
 
 
 def test_module_re_exports() -> None:

--- a/tests/test_admin_skill_paths_reload.py
+++ b/tests/test_admin_skill_paths_reload.py
@@ -114,8 +114,7 @@ def _write_tool_skill(skill_root: Path, name: str, tool_name: str) -> None:
         encoding="utf-8",
     )
     (scripts_dir / f"{tool_name}.py").write_text(
-        "def main(**kwargs):\n"
-        f'    return {{"success": True, "tool": "{tool_name}"}}\n',
+        f'def main(**kwargs):\n    return {{"success": True, "tool": "{tool_name}"}}\n',
         encoding="utf-8",
     )
 


### PR DESCRIPTION
Replaces stale same-name Skill metadata during explicit rediscovery and re-registers changed loaded tools. Exposes rediscovery through the Python bindings and uses it for adapter reloads.\n\nValidation: 360 Skill catalog tests, HTTP Python binding tests, 9 adapter reload tests, Clippy, formatting, and Python compilation pass.