### PR TITLE
Preserve screenshots when UI Automation stalls

### DIFF
--- a/crates/dcc-mcp-computer-use/src/ui_control_host.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host.rs
@@ -568,25 +568,35 @@ impl UiControlHost {
             Err(failure) => return failure.into_response(),
         };
         let accessibility_state_id = new_capability("accessibility");
-        let current_state = accessibility_state_value(
-            &snapshot.root,
-            snapshot.focus_runtime_id.as_deref(),
-            snapshot.node_count,
-        );
-        let state_delta = diff_json_state(
-            session.last_accessibility_state.as_ref(),
-            &current_state,
-            DEFAULT_STATE_DELTA_MAX_CHANGES,
-        );
-        session.last_accessibility_state = Some(current_state);
+        let accessibility_available = snapshot.node_count > 0;
+        let state_delta = accessibility_available.then(|| {
+            let current_state = accessibility_state_value(
+                &snapshot.root,
+                snapshot.focus_runtime_id.as_deref(),
+                snapshot.node_count,
+            );
+            let delta = diff_json_state(
+                session.last_accessibility_state.as_ref(),
+                &current_state,
+                DEFAULT_STATE_DELTA_MAX_CHANGES,
+            );
+            session.last_accessibility_state = Some(current_state);
+            delta
+        });
+        if !accessibility_available {
+            session.last_accessibility_state = None;
+        }
         let cause_action_id = session.pending_action_id.take();
         session.observation_id = Some(snapshot.observation_id.clone());
         session.observation = Some(snapshot.observation.clone());
-        session.accessibility_state_id = Some(accessibility_state_id.clone());
-        session.accessibility_root = Some(snapshot.root.clone());
-        session.focus_runtime_id = snapshot.focus_runtime_id.clone();
-        session.accessibility_max_depth = Some(max_depth);
-        session.accessibility_max_nodes = Some(max_nodes);
+        session.accessibility_state_id =
+            accessibility_available.then(|| accessibility_state_id.clone());
+        session.accessibility_root = accessibility_available.then(|| snapshot.root.clone());
+        session.focus_runtime_id = accessibility_available
+            .then(|| snapshot.focus_runtime_id.clone())
+            .flatten();
+        session.accessibility_max_depth = accessibility_available.then_some(max_depth);
+        session.accessibility_max_nodes = accessibility_available.then_some(max_nodes);
         UiControlHostResponse::Snapshot {
             observation_id: snapshot.observation_id,
             accessibility_state_id,
@@ -595,7 +605,7 @@ impl UiControlHost {
             root: snapshot.root,
             focus_runtime_id: snapshot.focus_runtime_id,
             node_count: snapshot.node_count,
-            state_delta: Some(state_delta),
+            state_delta,
             cause_action_id,
             image: Box::new(snapshot.image),
         }

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/runtime_windows.rs
@@ -51,6 +51,7 @@ mod confirmation;
 pub(super) use confirmation::WindowsConfirmationSurface;
 
 const UIA_TIMEOUT: Duration = Duration::from_secs(30);
+const UIA_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(2);
 const UIA_STDERR_LIMIT: u64 = 64 * 1024;
 const UIA_SCRIPT: &str = include_str!(
     "../../../../python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.ps1"
@@ -147,6 +148,14 @@ impl UiaWorker {
     }
 
     fn request(&mut self, payload: &Value) -> Result<Value, HostFailure> {
+        self.request_with_timeout(payload, UIA_TIMEOUT)
+    }
+
+    fn request_with_timeout(
+        &mut self,
+        payload: &Value,
+        timeout: Duration,
+    ) -> Result<Value, HostFailure> {
         if self.child.is_none() {
             return Err(HostFailure::new(
                 UiControlHostErrorCode::BackendUnavailable,
@@ -175,10 +184,13 @@ impl UiaWorker {
                 "send the Windows UI Automation worker request: {error}"
             )));
         }
-        let response = match self.responses.recv_timeout(UIA_TIMEOUT) {
+        let response = match self.responses.recv_timeout(timeout) {
             Ok(response) => response,
             Err(RecvTimeoutError::Timeout) => {
-                return Err(self.fail("Windows UI Automation timed out after 30 seconds"));
+                return Err(self.fail(format!(
+                    "Windows UI Automation timed out after {} milliseconds",
+                    timeout.as_millis()
+                )));
             }
             Err(RecvTimeoutError::Disconnected) => {
                 return Err(self.fail("Windows UI Automation worker closed without a response"));
@@ -596,6 +608,24 @@ impl WindowsRuntimeSession {
         )
     }
 
+    fn query_accessibility_state_with_timeout(
+        &mut self,
+        max_depth: u32,
+        max_nodes: u32,
+        allow_owned_standard_menu_popup: bool,
+        timeout: Duration,
+    ) -> Result<RuntimeAccessibilityState, HostFailure> {
+        let target = self.target.clone();
+        query_accessibility_state_with_timeout(
+            self.uia_worker()?,
+            &target,
+            max_depth,
+            max_nodes,
+            allow_owned_standard_menu_popup,
+            timeout,
+        )
+    }
+
     fn run_uia(&mut self, payload: Value) -> Result<Value, HostFailure> {
         self.uia_worker()?.request(&payload)
     }
@@ -658,7 +688,7 @@ impl HostRuntimeSession for WindowsRuntimeSession {
         self.start_visible_notice()?;
         let screenshot = self.session.screenshot().map_err(map_computer_use_error)?;
         self.window_generation.verify()?;
-        let observation = serde_json::to_value(&screenshot.observation).map_err(|error| {
+        let mut observation = serde_json::to_value(&screenshot.observation).map_err(|error| {
             HostFailure::new(
                 UiControlHostErrorCode::CaptureFailed,
                 format!("serialize the native screenshot observation: {error}"),
@@ -669,7 +699,30 @@ impl HostRuntimeSession for WindowsRuntimeSession {
             window_handle: screenshot.observation.window_handle,
             window_title: screenshot.observation.window_title.clone(),
         };
-        let accessibility = self.query_accessibility_state(max_depth, max_nodes, true)?;
+        let accessibility = match self.query_accessibility_state_with_timeout(
+            max_depth,
+            max_nodes,
+            true,
+            UIA_SNAPSHOT_TIMEOUT,
+        ) {
+            Ok(accessibility) => accessibility,
+            Err(failure) if failure.code == UiControlHostErrorCode::BackendUnavailable => {
+                tracing::warn!(
+                    "Windows UI Automation is unavailable; returning a screenshot-only observation"
+                );
+                if let Some(object) = observation.as_object_mut() {
+                    object.insert(
+                        "accessibility".to_owned(),
+                        json!({
+                            "available": false,
+                            "error": "backend_unavailable",
+                        }),
+                    );
+                }
+                unavailable_accessibility_state(&self.target)
+            }
+            Err(failure) => return Err(failure),
+        };
 
         let buffer_id = Uuid::new_v4().simple().to_string()[..16].to_owned();
         let buffer =
@@ -1094,12 +1147,33 @@ fn query_accessibility_state(
     max_nodes: u32,
     allow_owned_standard_menu_popup: bool,
 ) -> Result<RuntimeAccessibilityState, HostFailure> {
-    let raw = worker.request(&json!({
-        "mode": "snapshot",
-        "scope": accessibility_scope(target, allow_owned_standard_menu_popup),
-        "max_depth": max_depth,
-        "max_nodes": max_nodes,
-    }))?;
+    query_accessibility_state_with_timeout(
+        worker,
+        target,
+        max_depth,
+        max_nodes,
+        allow_owned_standard_menu_popup,
+        UIA_TIMEOUT,
+    )
+}
+
+fn query_accessibility_state_with_timeout(
+    worker: &mut UiaWorker,
+    target: &UiControlTarget,
+    max_depth: u32,
+    max_nodes: u32,
+    allow_owned_standard_menu_popup: bool,
+    timeout: Duration,
+) -> Result<RuntimeAccessibilityState, HostFailure> {
+    let raw = worker.request_with_timeout(
+        &json!({
+            "mode": "snapshot",
+            "scope": accessibility_scope(target, allow_owned_standard_menu_popup),
+            "max_depth": max_depth,
+            "max_nodes": max_nodes,
+        }),
+        timeout,
+    )?;
     ensure_uia_ok(&raw, "Windows UI Automation snapshot failed")?;
     Ok(RuntimeAccessibilityState {
         root: raw.get("root").cloned().ok_or_else(|| {
@@ -1115,6 +1189,24 @@ fn query_accessibility_state(
             .and_then(|value| u32::try_from(value).ok())
             .unwrap_or(1),
     })
+}
+
+fn unavailable_accessibility_state(target: &UiControlTarget) -> RuntimeAccessibilityState {
+    RuntimeAccessibilityState {
+        root: json!({
+            "runtime_id": "accessibility-unavailable",
+            "name": "Scoped DCC window",
+            "control_type": "ControlType.Window",
+            "process_id": target.process_id,
+            "native_window_handle": target.window_handle,
+            "is_password": false,
+            "enabled": false,
+            "offscreen": false,
+            "children": [],
+        }),
+        focus_runtime_id: None,
+        node_count: 0,
+    }
 }
 
 fn target_from_status(status: &Value) -> Result<UiControlTarget, HostFailure> {

--- a/crates/dcc-mcp-computer-use/src/ui_control_host/tests.rs
+++ b/crates/dcc-mcp-computer-use/src/ui_control_host/tests.rs
@@ -764,6 +764,87 @@ fn exact_target_capability_and_observation_are_required() {
 }
 
 #[test]
+fn screenshot_only_snapshot_never_mints_an_action_fence() {
+    let snapshot = RuntimeAccessibilityState {
+        root: json!({
+            "runtime_id": "accessibility-unavailable",
+            "name": "Scoped DCC window",
+            "enabled": false,
+            "children": [],
+        }),
+        focus_runtime_id: None,
+        node_count: 0,
+    };
+    let mut host = host_with_accessibility_states(snapshot, Vec::new());
+    let mut connection = UiControlHostConnection::default();
+    assert!(matches!(
+        connection.handle(
+            &mut host,
+            UiControlHostRequest::Hello(UiControlHostHello {
+                protocol_version: UI_CONTROL_HOST_PROTOCOL_VERSION,
+                client_name: "test".to_owned(),
+            }),
+        ),
+        UiControlHostResponse::Hello { .. }
+    ));
+    let opened = connection.handle(
+        &mut host,
+        UiControlHostRequest::OpenSession {
+            session_id: "screenshot-only".to_owned(),
+            grant: grant(false),
+        },
+    );
+    let UiControlHostResponse::SessionOpened {
+        window_capability, ..
+    } = opened
+    else {
+        panic!("session not opened: {opened:?}");
+    };
+    let response = connection.handle(
+        &mut host,
+        UiControlHostRequest::Snapshot {
+            session_id: "screenshot-only".to_owned(),
+            task_grant_id: "grant-1".to_owned(),
+            window_capability: window_capability.clone(),
+            max_depth: 5,
+            max_nodes: 250,
+        },
+    );
+    let UiControlHostResponse::Snapshot {
+        observation_id,
+        accessibility_state_id,
+        node_count,
+        ..
+    } = response
+    else {
+        panic!("snapshot failed: {response:?}");
+    };
+    assert_eq!(node_count, 0);
+
+    assert!(matches!(
+        connection.handle(
+            &mut host,
+            UiControlHostRequest::ExecuteAction {
+                session_id: "screenshot-only".to_owned(),
+                task_grant_id: "grant-1".to_owned(),
+                window_capability,
+                observation_id,
+                accessibility_state_id,
+                action: Box::new(action(
+                    Some("uia:accessibility-unavailable"),
+                    UiControlInputKind::Semantic
+                )),
+            },
+        ),
+        UiControlHostResponse::ActionCompleted {
+            success: false,
+            error: Some(UiControlHostErrorCode::StaleObservation),
+            ..
+        }
+    ));
+}
+
+#[test]
 fn accessibility_snapshot_refreshes_uia_without_pixel_observation() {
     let (mut host, mut connection) = negotiated();
     let capability = open_recording_session(&mut host, &mut connection, "uia-poll");

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_ui_control_host_client.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_ui_control_host_client.py
@@ -401,7 +401,9 @@ class UiControlHostClient:
             expected_type="snapshot",
         )
         self._latest_observation_id = str(response["observation_id"])
-        self._latest_accessibility_state_id = str(response["accessibility_state_id"])
+        self._latest_accessibility_state_id = (
+            str(response["accessibility_state_id"]) if int(response.get("node_count") or 0) > 0 else None
+        )
         self._target = dict(response.get("target") or self._target)
         image = response.get("image") or {}
         try:

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_windows_uia_backend.py
@@ -362,6 +362,7 @@ def _capture_snapshot(
         return _host_error(exc)
 
     snapshot_id = str(raw["accessibility_state_id"])
+    accessibility_available = int(raw.get("node_count") or 0) > 0
     state_delta = _state_delta_event(raw, snapshot_id)
     root = _node_from_uia_dict(raw["root"], snapshot_id)
     focus_runtime_id = str(raw.get("focus_runtime_id") or "")
@@ -379,6 +380,8 @@ def _capture_snapshot(
                 "target": raw.get("target") or client.target,
                 "max_depth": max_depth,
                 "max_nodes": max_nodes,
+                "accessibility_available": accessibility_available,
+                "accessibility_error": (None if accessibility_available else "backend_unavailable"),
             },
             "computer_use": raw.get("observation") or {},
             "state_delta": state_delta,
@@ -395,6 +398,7 @@ def _capture_snapshot(
         "observation": raw.get("observation") or {},
         "target": raw.get("target") or client.target,
         "state_delta": state_delta,
+        "accessibility_available": accessibility_available,
     }
 
 
@@ -463,14 +467,27 @@ def snapshot_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     capture = _capture_snapshot(session_id, policy, params)
     if not capture.get("success"):
         return capture
+    accessibility_available = bool(capture.get("accessibility_available", True))
     return skill_success(
-        "Captured isolated Windows UI Control snapshot.",
-        prompt="Use ui_control__find or perform one scoped ui_control__act with this snapshot_id, then snapshot again.",
+        (
+            "Captured isolated Windows UI Control snapshot."
+            if accessibility_available
+            else "Captured screenshot-only Windows UI Control observation."
+        ),
+        prompt=(
+            "Use ui_control__find or perform one scoped ui_control__act with this snapshot_id, then snapshot again."
+            if accessibility_available
+            else (
+                "Windows UI Automation was unavailable for this frame. Inspect the pixels, but do not act "
+                "until a fresh snapshot returns accessibility_available=true."
+            )
+        ),
         session_id=session_id,
         snapshot_id=capture["snapshot_id"],
         snapshot=capture["snapshot"],
         observation=capture["observation"],
         state_delta=capture.get("state_delta"),
+        accessibility_available=accessibility_available,
         policy=policy.to_dict(),
         __rich__={
             "kind": "image",

--- a/tests/test_ui_control_skill.py
+++ b/tests/test_ui_control_skill.py
@@ -1517,6 +1517,103 @@ def test_ui_control_host_client_wire_has_no_approval_boolean() -> None:
     assert "window:opaque" not in wire
 
 
+def test_ui_control_host_client_keeps_screenshot_but_rejects_actions_without_uia(
+    monkeypatch: Any,
+) -> None:
+    import io
+    import struct
+
+    import dcc_mcp_core
+
+    backend = _load_windows_uia_module()
+    client_module = backend._HOST
+
+    def frame(value: dict[str, Any]) -> bytes:
+        body = json.dumps(value).encode("utf-8")
+        return struct.pack(">I", len(body)) + body
+
+    class Buffer:
+        def read(self) -> bytes:
+            return b"png"
+
+    class SharedBuffer:
+        @staticmethod
+        def open(name: str, buffer_id: str) -> Buffer:
+            assert name == "test"
+            assert buffer_id == "test-id"
+            return Buffer()
+
+    class ScriptedPipe:
+        def __init__(self) -> None:
+            self.responses = io.BytesIO(
+                frame({"type": "hello", "protocol_version": 3, "capabilities": []})
+                + frame(
+                    {
+                        "type": "session_opened",
+                        "session_id": "screenshot-only",
+                        "window_capability": "window:opaque",
+                        "target": {"process_id": 42, "window_handle": 500, "window_title": "DCC"},
+                    }
+                )
+                + frame(
+                    {
+                        "type": "snapshot",
+                        "observation_id": "obs-1",
+                        "accessibility_state_id": "accessibility:unusable",
+                        "target": {"process_id": 42, "window_handle": 500, "window_title": "DCC"},
+                        "observation": {
+                            "observation_id": "obs-1",
+                            "accessibility": {
+                                "available": False,
+                                "error": "backend_unavailable",
+                            },
+                        },
+                        "root": {
+                            "runtime_id": "accessibility-unavailable",
+                            "name": "Scoped DCC window",
+                            "enabled": False,
+                            "children": [],
+                        },
+                        "node_count": 0,
+                        "image": {
+                            "name": "test",
+                            "id": "test-id",
+                            "length": 3,
+                            "mime_type": "image/png",
+                        },
+                    }
+                )
+            )
+
+        def read(self, length: int) -> bytes:
+            return self.responses.read(length)
+
+        def write(self, data: bytes) -> int:
+            return len(data)
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(dcc_mcp_core, "PySharedBuffer", SharedBuffer)
+    client = client_module.UiControlHostClient(
+        session_id="screenshot-only",
+        task_grant_id="grant",
+        dcc_type="houdini",
+        process_id=42,
+        window_handle=500,
+        allow_raw_input=False,
+        stream=ScriptedPipe(),
+    )
+
+    response = client.snapshot(max_depth=5, max_nodes=250)
+
+    assert response["image_bytes"] == b"png"
+    assert client._latest_observation_id == "obs-1"
+    assert client._latest_accessibility_state_id is None
+    with pytest.raises(client_module.UiControlHostError, match="fresh ui_control snapshot"):
+        client.execute({"action": "click"})
+
+
 def test_ui_control_host_client_uses_versioned_binary_identity_pipe(monkeypatch: Any) -> None:
     backend = _load_windows_uia_module()
     client_module = backend._HOST


### PR DESCRIPTION
## Summary
- bound UI Automation work during pixel snapshots to two seconds
- return a screenshot-only observation when UIA is unavailable
- withhold the action fence until a trusted accessibility snapshot succeeds

## Validation
- 179 computer-use tests passed
- 56 UI Control Python tests passed
- affected Ruff and Clippy checks passed