### PR TITLE
docs: align UI Control migration guidance

### DIFF
--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -109,25 +109,18 @@ host APIs, or adapter scripts first. Load `ui-control` only when that path retur
 authentication, or desktop unavailability are stop conditions, not fallback
 signals:
 
-1. `ui_control__snapshot` scoped to the exact process or window. Every Windows UIA
+1. `ui_control__snapshot` scoped to the exact process or window. Every native
    mutation requires the adapter/operator to bind its DCC with
-   `DCC_MCP_UI_CONTROL_UIA_PROCESS_ID` or `DCC_MCP_UI_CONTROL_UIA_WINDOW_HANDLE`.
+   `DCC_MCP_UI_CONTROL_PROCESS_ID` or `DCC_MCP_UI_CONTROL_WINDOW_HANDLE`.
    A request may select that exact PID/HWND or narrow it further, but cannot
    replace the trusted runtime scope with another application.
-   The visible session and bounded native screenshot do not require raw input.
-   Native pointer or keyboard control has a second gate and additionally
-   requires `DCC_MCP_COMPUTER_USE_ALLOW_RAW_INPUT=true`.
+   Raw pointer and keyboard input are enabled by default only inside that exact
+   bound scope. Operators can disable them with
+   `DCC_MCP_CUA_ALLOW_RAW_INPUT=false`.
 2. One semantic action when possible, otherwise one screenshot-coordinate
    `ui_control__act` using the returned `snapshot_id`.
 3. `ui_control__snapshot` after every action before deciding what to do next.
 4. `ui_control__stop_computer_use` when the task completes, fails, or is abandoned.
-
-Windows plug-in setup that needs an HKCU string/DWORD or a file/directory
-symbolic link uses the separate `ui_control__system_operation` tool. It requires an
-exact operator-owned grant catalog and trusted action-time confirmation, and it
-does not require a PID, HWND, or snapshot. It has no shell, deletion,
-replacement, alternate-hive, or elevation form. Treat `elevation_required`,
-`approval_required`, and `system_operation_not_granted` as stop conditions.
 
 Never automate the whole desktop or reuse coordinates from an older snapshot.
 The Windows session shows a click-through target border, control banner, and

--- a/README_zh.md
+++ b/README_zh.md
@@ -758,8 +758,8 @@ DPI 映射回目标窗口。每次操作必须引用最新 `snapshot_id`；发�
 - **作用域限定的窗口定位** —— 截图和操作均绑定到单一进程或窗口句柄，绝不作用于整个桌面。
 - **语义 UIA + 原始输入回退** —— 优先通过 `ui_control__find` 解析稳定的语义控件（按钮、文本框、复选框），
   仅当自定义绘制控件无语义节点时回退到截图坐标。
-- **带边界的安全模型** —— 每个操作都被适配器/操作者绑定的 PID/HWND 限定范围。原始输入需要显式启用
-  （`DCC_MCP_COMPUTER_USE_ALLOW_RAW_INPUT=true`）。硬性禁止：密码、认证控件、LockApp、Windows 安全界面、
+- **带边界的安全模型** —— 每个操作都被适配器/操作者绑定的 PID/HWND 限定范围。原始输入默认仅在该精确
+  范围内启用，可通过 `DCC_MCP_CUA_ALLOW_RAW_INPUT=false` 关闭。硬性禁止：密码、认证控件、LockApp、Windows 安全界面、
   终端和凭据管理器窗口。
 - **可见的胶囊覆盖层** —— DCC UI Control 处于活动状态时，目标窗口四周显示可穿透的角标，
   底部居中显示胶囊提示 `DCC UI Control · <应用名> | Esc 停止`。
@@ -776,7 +776,6 @@ DPI 映射回目标窗口。每次操作必须引用最新 `snapshot_id`；发�
 | `ui_control__act` | 执行一个限定作用域的语义或基于坐标的操作 |
 | `ui_control__wait_for` | 轮询直到 UI 条件成立或超时 |
 | `ui_control__stop_computer_use` | 释放胶囊、热键和全局输入所有者 |
-| `ui_control__system_operation` | 确保指定的 Windows 配置项（需要操作者授权） |
 
 详细的 Skill 参考和 Agent 工作流请参见
 [ui-control 技能文档](python/dcc_mcp_core/skills/ui-control/SKILL.md)。

--- a/python/dcc_mcp_core/skills/ui-control/tools.yaml
+++ b/python/dcc_mcp_core/skills/ui-control/tools.yaml
@@ -6,8 +6,8 @@ tools:
       stale controls can be detected. On Windows, an adapter/operator-bound
       PID/HWND starts the visible DCC UI Control session and captures a bounded
       target-window image even when raw input is disabled. Bind the
-      DCC through DCC_MCP_UI_CONTROL_UIA_PROCESS_ID or
-      DCC_MCP_UI_CONTROL_UIA_WINDOW_HANDLE; request scope can only narrow it. A
+      DCC through DCC_MCP_UI_CONTROL_PROCESS_ID or
+      DCC_MCP_UI_CONTROL_WINDOW_HANDLE; request scope can only narrow it. A
       locked, disconnected, or secure Windows desktop returns
       desktop_unavailable without ending the logical session. After unlock,
       discard old ids and take a fresh snapshot to restore the capsule.


### PR DESCRIPTION
Updates the public 0.20 UI Control contract to use the current dcc-cua scope variables, documents raw input as enabled by default within the trusted PID/HWND, and removes the obsolete system-operation guidance.

Validation: 30 targeted tests passed; git diff --check passed.