### PR TITLE
fix: refresh bundled adapter catalog

### DIFF
--- a/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
@@ -208,6 +208,25 @@ fn bundled_catalog_reports_current_unity_adapter_version() {
 }
 
 #[test]
+fn bundled_catalog_reports_current_core_adapter_versions() {
+    for (dcc_type, expected_version) in [
+        ("maya", "0.9.22"),
+        ("houdini", "0.31.5"),
+        ("blender", "0.1.43"),
+        ("3dsmax", "0.1.40"),
+        ("photoshop", "0.1.37"),
+    ] {
+        let plan = run_json_with_env_removed(
+            &["install", "--dcc-type", dcc_type],
+            &[],
+            &["DCC_MCP_CATALOG_PATH", "DCC_MCP_INSTALL_PYTHON"],
+        );
+
+        assert_eq!(plan["adapter"]["version"], expected_version, "{dcc_type}");
+    }
+}
+
+#[test]
 fn bundled_catalog_reports_marmoset_adapter() {
     let plan = run_json_with_env_removed(
         &["install", "--dcc-type", "marmoset"],

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -28,7 +28,7 @@ entries:
     dcc: ["maya"]
     url: "https://github.com/dcc-mcp/dcc-mcp-maya"
     tags: ["adapter", "maya", "official", "pip", "core"]
-    version: "0.9.15"
+    version: "0.9.22"
     min_core_version: "0.19.45"
     maintainer: "dcc-mcp"
     install:
@@ -41,7 +41,7 @@ entries:
     dcc: ["blender"]
     url: "https://github.com/dcc-mcp/dcc-mcp-blender"
     tags: ["adapter", "blender", "official", "pip", "addon", "core"]
-    version: "0.1.36"
+    version: "0.1.43"
     min_core_version: "0.19.45"
     maintainer: "dcc-mcp"
     install:
@@ -54,7 +54,7 @@ entries:
     dcc: ["houdini"]
     url: "https://github.com/dcc-mcp/dcc-mcp-houdini"
     tags: ["adapter", "houdini", "official", "pip", "core"]
-    version: "0.22.0"
+    version: "0.31.5"
     min_core_version: "0.19.45"
     maintainer: "dcc-mcp"
     install:
@@ -68,7 +68,7 @@ entries:
     dcc: ["3dsmax", "3ds max", "3ds-max", "max"]
     url: "https://github.com/dcc-mcp/dcc-mcp-3dsmax"
     tags: ["adapter", "3dsmax", "3ds-max", "official", "pip", "core"]
-    version: "0.1.37"
+    version: "0.1.40"
     min_core_version: "0.19.45"
     maintainer: "dcc-mcp"
     install:

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -24,15 +24,15 @@ submit a PR updating this matrix before the release PR merges.
 
 | DCC | Repository | Adapter Version | Core Pin | DCC Min Version | Dispatcher Pattern | Last Verified |
 |-----|-----------|----------------|----------|-----------------|-------------------|---------------|
-| Maya | [dcc-mcp-maya](https://github.com/dcc-mcp/dcc-mcp-maya) | 0.9.15 | >=0.19.45,<1.0.0 | 2024+ | Qt sidecar + HostUiDispatcherBase | 2026-06 |
+| Maya | [dcc-mcp-maya](https://github.com/dcc-mcp/dcc-mcp-maya) | 0.9.22 | >=0.19.45,<1.0.0 | 2024+ | Qt sidecar + HostUiDispatcherBase | 2026-08 |
 | Marmoset Toolbag | [dcc-mcp-marmoset](https://github.com/dcc-mcp/dcc-mcp-marmoset) | 0.1.1 | >=0.19.86,<1.0.0 | 4.03+ | External sidecar + Toolbag periodic callback | 2026-07 |
 | OpenSCAD | [dcc-mcp-openscad](https://github.com/dcc-mcp/dcc-mcp-openscad) | 0.1.1 | >=0.19.91,<1.0.0 | 2021.01+ | External OpenSCAD CLI subprocess | 2026-08 |
 | FreeCAD | [dcc-mcp-freecad](https://github.com/dcc-mcp/dcc-mcp-freecad) | 0.1.1 | >=0.19.91,<1.0.0 | 1.0+ | External FreeCADCmd subprocess | 2026-08 |
 | Cinema 4D | [dcc-mcp-cinema4d](https://github.com/dcc-mcp/dcc-mcp-cinema4d) | 0.1.2 | >=0.19.91,<1.0.0 | R21+ | External headless c4dpy subprocess | 2026-08 |
 | Mari | [dcc-mcp-mari](https://github.com/dcc-mcp/dcc-mcp-mari) | 0.2.1 | >=0.19.91,<1.0.0 | 5.0+ | Authenticated loopback sidecar + Qt UI timer | 2026-08 |
-| 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.37 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-06 |
-| Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.36 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-06 |
-| Houdini | [dcc-mcp-houdini](https://github.com/dcc-mcp/dcc-mcp-houdini) | 0.22.0 | >=0.19.45,<1.0.0 | 20.5+ | Event-loop callback | 2026-06 |
+| 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.40 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-08 |
+| Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.43 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-08 |
+| Houdini | [dcc-mcp-houdini](https://github.com/dcc-mcp/dcc-mcp-houdini) | 0.31.5 | >=0.19.45,<1.0.0 | 20.5+ | Event-loop callback | 2026-08 |
 | FPT / ShotGrid | [dcc-mcp-fpt](https://github.com/dcc-mcp/dcc-mcp-fpt) | 0.1.8 | >=0.19.45,<1.0.0 | — | REST bridge | 2026-06 |
 | Nuke | [dcc-mcp-nuke](https://github.com/dcc-mcp/dcc-mcp-nuke) | 0.13.1 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
 | Unreal | [dcc-mcp-unreal](https://github.com/dcc-mcp/dcc-mcp-unreal) | 0.2.0 | >=0.19.45,<1.0.0 | — | Unreal Python bridge | — |


### PR DESCRIPTION
## Summary\n- refresh Maya, Houdini, Blender, and 3ds Max adapter versions\n- keep the compatibility matrix aligned with the bundled catalog\n- add an install-plan regression matrix\n\n## Validation\n- x cargo test -p dcc-mcp-catalog --no-fail-fast\n- x cargo test -p dcc-mcp-cli --test cli_install_e2e bundled_catalog_reports_current_core_adapter_versions --no-fail-fast\n\nCloses #2147