### PR TITLE
fix: keep local CLI catalog state coherent

### DIFF
--- a/crates/dcc-mcp-cli/src/application/control_plane.rs
+++ b/crates/dcc-mcp-cli/src/application/control_plane.rs
@@ -40,6 +40,7 @@ pub struct DccControlPlane {
     endpoint: Endpoint,
     registry_dir: PathBuf,
     require_gateway: bool,
+    auto_gateway_enabled: bool,
 }
 
 impl DccControlPlane {
@@ -55,7 +56,14 @@ impl DccControlPlane {
             endpoint,
             registry_dir,
             require_gateway,
+            auto_gateway_enabled: true,
         }
+    }
+
+    #[must_use]
+    pub fn with_auto_gateway_enabled(mut self, enabled: bool) -> Self {
+        self.auto_gateway_enabled = enabled;
+        self
     }
 
     fn uses_direct_local(&self) -> bool {
@@ -104,7 +112,16 @@ impl DccControlPlane {
     }
 
     pub async fn load_skill(&self, request: LoadSkillRequest) -> anyhow::Result<Value> {
-        if self.uses_direct_local() {
+        if self.uses_direct_local() && self.auto_gateway_enabled {
+            let fallback_body = request.body.clone();
+            match self.gateway_client().load_skill(request).await {
+                Ok(value) => Ok(value),
+                Err(ClientError::Http(HttpError::Request(error))) if error.is_connect() => {
+                    local_control::load_skill_local(self.registry_dir.clone(), fallback_body).await
+                }
+                Err(error) => Err(error.into()),
+            }
+        } else if self.uses_direct_local() {
             local_control::load_skill_local(self.registry_dir.clone(), request.body).await
         } else {
             self.gateway_client()
@@ -614,6 +631,46 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+
+    #[tokio::test]
+    async fn local_load_skill_routes_through_gateway_to_keep_index_coherent() {
+        async fn load_skill(Json(body): Json<Value>) -> Json<Value> {
+            Json(json!({
+                "loaded": true,
+                "skill_name": body["skill_name"],
+                "registered_tools": ["blender_scene__list_objects"],
+                "source": "gateway"
+            }))
+        }
+
+        let app = Router::new().route("/v1/load_skill", post(load_skill));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let registry = tempdir().unwrap();
+        let control = DccControlPlane::new(
+            GatewayTarget::Local,
+            Endpoint::new(format!("http://{addr}")),
+            registry.path().to_path_buf(),
+            false,
+        );
+
+        let result = control
+            .load_skill(LoadSkillRequest {
+                body: json!({
+                    "skill_name": "blender-scene",
+                    "dcc_type": "blender",
+                    "instance_id": "abc12345"
+                }),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result["loaded"], true);
+        assert_eq!(result["source"], "gateway");
+        assert_eq!(result["registered_tools"][0], "blender_scene__list_objects");
+        server.abort();
+    }
 
     #[tokio::test]
     async fn required_gateway_routes_a_local_call_and_reports_stats_coverage() {

--- a/crates/dcc-mcp-cli/src/application/local_control.rs
+++ b/crates/dcc-mcp-cli/src/application/local_control.rs
@@ -567,7 +567,13 @@ pub async fn wait_ready_local(
         attempts += 1;
         match gateway.get_json(&readyz_url).await {
             Ok(value) => {
-                let readiness = normalize_readiness_report(&value).unwrap_or(value);
+                let mut readiness = normalize_readiness_report(&value).unwrap_or(value);
+                if required.iter().any(|field| field == "skill_catalog")
+                    && readiness.get("skill_catalog").and_then(Value::as_bool) != Some(true)
+                {
+                    let catalog_observable = discovery_catalog_observable(&gateway, &entry).await;
+                    readiness = reconcile_catalog_readiness(readiness, catalog_observable);
+                }
                 let missing = missing_required_fields(Some(&readiness), &required);
                 let ready = missing.is_empty();
                 last = json!({
@@ -1231,6 +1237,35 @@ fn normalize_readiness_report(value: &Value) -> Option<Value> {
         return Some(value.clone());
     }
     None
+}
+
+async fn discovery_catalog_observable(gateway: &HttpGateway, entry: &ServiceEntry) -> bool {
+    list_mcp_tools(gateway, &local_instance::discovery_mcp_url(entry))
+        .await
+        .is_ok_and(|tools| {
+            tools.iter().any(|tool| {
+                tool.get("name")
+                    .and_then(Value::as_str)
+                    .is_some_and(|name| {
+                        matches!(name, "search_tools" | "search_skills" | "load_skill")
+                    })
+            })
+        })
+}
+
+fn reconcile_catalog_readiness(mut readiness: Value, catalog_observable: bool) -> Value {
+    if !catalog_observable || readiness.get("skill_catalog").and_then(Value::as_bool) == Some(true)
+    {
+        return readiness;
+    }
+    if let Some(object) = readiness.as_object_mut() {
+        object.insert("skill_catalog".to_string(), Value::Bool(true));
+        object.insert(
+            "skill_catalog_source".to_string(),
+            Value::String("discovery_mcp".to_string()),
+        );
+    }
+    readiness
 }
 
 fn missing_required_fields(readiness: Option<&Value>, required: &[String]) -> Vec<String> {

--- a/crates/dcc-mcp-cli/src/application/local_control_tests.rs
+++ b/crates/dcc-mcp-cli/src/application/local_control_tests.rs
@@ -247,3 +247,18 @@ fn call_result_rejects_nested_tool_failure_but_accepts_transport_success() {
         "output": {"success": true}
     })));
 }
+
+#[test]
+fn observable_discovery_catalog_satisfies_missing_readiness_bit() {
+    let readiness = json!({
+        "process": true,
+        "dcc": true,
+        "dispatcher": true
+    });
+
+    let reconciled = reconcile_catalog_readiness(readiness, true);
+
+    assert_eq!(reconciled["skill_catalog"], true);
+    assert_eq!(reconciled["skill_catalog_source"], "discovery_mcp");
+    assert!(missing_required_fields(Some(&reconciled), &["skill_catalog".to_string()]).is_empty());
+}

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -681,8 +681,8 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
         endpoint.clone(),
         gateway_ensure::default_registry_dir(),
         require_gateway,
-    );
-
+    )
+    .with_auto_gateway_enabled(!no_auto_gateway);
     if !no_auto_gateway {
         ensure_gateway_for_command(
             &base_url,

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -661,7 +661,7 @@ fn local_profile_controls_registered_instance_through_direct_mcp() {
             "--instance-id",
             &instance_short,
             "--require",
-            "dispatcher,host_execution_bridge",
+            "skill_catalog,dispatcher,host_execution_bridge",
             "--timeout-secs",
             "1",
         ],
@@ -669,6 +669,8 @@ fn local_profile_controls_registered_instance_through_direct_mcp() {
     );
     assert_eq!(ready["source"], "local_mcp");
     assert_eq!(ready["ready"], true);
+    assert_eq!(ready["readiness"]["skill_catalog"], true);
+    assert_eq!(ready["readiness"]["skill_catalog_source"], "discovery_mcp");
     assert_eq!(ready["missing"].as_array().unwrap().len(), 0);
 
     let stop = run_json_with_env(

--- a/crates/dcc-mcp-cli/tests/support/mod.rs
+++ b/crates/dcc-mcp-cli/tests/support/mod.rs
@@ -953,7 +953,6 @@ pub(crate) fn spawn_local_mcp_fixture() -> LocalMcpFixture {
                     "readiness": {
                         "process": true,
                         "dcc": true,
-                        "skill_catalog": true,
                         "dispatcher": true,
                         "host_execution_bridge": true,
                         "main_thread_executor": true

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -224,15 +224,15 @@ the complete target-binding, system-operation, capture, and artifact contract.
 
 `dcc-mcp-cli` has a built-in `local` profile. In local mode, agent-control
 commands first ensure the machine-wide loopback gateway is healthy, then
-`list` reads the core default FileRegistry directly, and `search`, `describe`,
-`load-skill`, `call`, `wait-ready`, and guarded `stop-instance` talk to the
-selected local DCC instance's advertised MCP/readyz/safe-stop endpoints. Remote
-machines are selected through named gateway profiles:
-
+`list` reads FileRegistry; `search`, `describe`, `call`, and guarded
+`stop-instance` use the selected instance endpoints. `load-skill` uses the
+ensured gateway to update its capability index; `--no-auto-gateway` retains
+direct loading. `wait-ready` uses discovery MCP when readyz cannot report
+`skill_catalog`. Remote machines use named gateway profiles:
 Treat `list` as inventory plus diagnostics, not proof that a row is callable.
 It intentionally keeps live `booting` / `dispatch_status=unavailable` sidecar
-rows visible. Local `search`, `describe`, `load-skill`, `call`, and
-`reload-skills` route only to rows ready for local CLI control. Per-DCC sidecar
+rows visible. Local control routes only to ready rows; gateway-owned
+`load-skill` targets the same row and refreshes its capabilities. Per-DCC sidecar
 rows become local MCP routes once they report `dispatch_status=ready`; before
 that, they remain visible for diagnostics. Use `wait-ready` or `doctor` when a
 listed instance is still booting.

--- a/skills/dcc-mcp/references/ZERO_INSTANCES_CLI.md
+++ b/skills/dcc-mcp/references/ZERO_INSTANCES_CLI.md
@@ -34,9 +34,12 @@ Before any setup step, confirm:
 
 Local `dcc-mcp-cli list` first ensures the machine-wide loopback gateway, then
 reads the FileRegistry directly. In the built-in `local` profile, `search`,
-`describe`, `load-skill`, `call`, `wait-ready`, and guarded `stop-instance` use
-the registered DCC instance's own MCP/readyz/safe-stop endpoints after the same
-gateway lifecycle check. Endpoint/admin/update workflows also auto-ensure a
+`describe`, `call`, and guarded `stop-instance` use the registered DCC
+instance's own MCP/safe-stop endpoints after the same gateway lifecycle check.
+`load-skill` goes through that ensured gateway so its capability index stays
+coherent, while explicit `--no-auto-gateway` mode retains direct loading.
+`wait-ready` combines the instance readyz report with the discovery MCP catalog
+contract when `skill_catalog` is absent. Endpoint/admin/update workflows also auto-ensure a
 machine-wide gateway daemon when they target loopback HTTP.
 Per-DCC adapters register themselves through their own sidecar/server runtime.
 The legacy first-wins election is only for explicit


### PR DESCRIPTION
## Summary\n- route default local skill loads through the ensured gateway so loaded tools enter its capability index\n- retain direct loading for explicit no-auto-gateway mode and connection-only fallback\n- let local readiness verify a missing skill catalog through the discovery MCP contract\n- update agent-facing CLI guidance\n\n## Validation\n- x cargo test -p dcc-mcp-cli --no-fail-fast\n- x cargo clippy -p dcc-mcp-cli --all-targets -- -D warnings\n\nCloses #2148\nCloses #2149