### PR TITLE
fix: clarify nested job identities

### DIFF
--- a/crates/dcc-mcp-cli/src/application/control_plane.rs
+++ b/crates/dcc-mcp-cli/src/application/control_plane.rs
@@ -9,6 +9,8 @@ use std::time::Duration;
 
 use serde_json::{Value, json};
 
+use dcc_mcp_models::{LinkedAdapterJob, linked_adapter_job_from_result};
+
 use crate::application::client::{ClientError, DccMcpClient};
 use crate::application::gateway_profile::GatewayTarget;
 use crate::application::instance_selection::{
@@ -245,6 +247,7 @@ impl DccControlPlane {
         let mut control_plane_disruptions = 0_u64;
         let mut last_poll_error: Option<String> = None;
         if is_terminal_job_status(&status) {
+            annotate_wait_result_job_identity(&mut result, &job_id, &status_tool);
             return Ok(result);
         }
 
@@ -323,6 +326,7 @@ impl DccControlPlane {
             on_progress(&update);
             last_progress = update;
             if is_terminal_job_status(&status) {
+                annotate_wait_result_job_identity(&mut result, &job_id, &status_tool);
                 attach_wait_recovery(&mut result, &job_id, control_plane_disruptions);
                 return Ok(result);
             }
@@ -483,6 +487,102 @@ fn attach_wait_recovery(result: &mut Value, job_id: &str, disruptions: u64) {
             }),
         );
     }
+}
+
+fn annotate_wait_result_job_identity(result: &mut Value, core_job_id: &str, status_tool: &str) {
+    let adapter_job = find_terminal_adapter_job(result, core_job_id, 0);
+    annotate_core_job_envelope(result, core_job_id, status_tool, adapter_job.as_ref(), 0);
+}
+
+fn find_terminal_adapter_job(
+    value: &Value,
+    core_job_id: &str,
+    depth: u8,
+) -> Option<LinkedAdapterJob> {
+    if depth > 4 {
+        return None;
+    }
+    if value.get("job_id").and_then(Value::as_str) == Some(core_job_id)
+        && value
+            .get("status")
+            .and_then(Value::as_str)
+            .is_some_and(is_terminal_job_status)
+        && let Some(result) = value.get("result")
+    {
+        return linked_adapter_job_from_result(result, core_job_id);
+    }
+    [
+        "output",
+        "result",
+        "structuredContent",
+        "structured_content",
+    ]
+    .iter()
+    .filter_map(|key| value.get(*key))
+    .find_map(|nested| find_terminal_adapter_job(nested, core_job_id, depth + 1))
+}
+
+fn annotate_core_job_envelope(
+    value: &mut Value,
+    core_job_id: &str,
+    status_tool: &str,
+    adapter_job: Option<&LinkedAdapterJob>,
+    depth: u8,
+) -> bool {
+    if depth > 4 {
+        return false;
+    }
+    if value.get("job_id").and_then(Value::as_str) == Some(core_job_id)
+        && value.get("status").and_then(Value::as_str).is_some()
+    {
+        let Some(object) = value.as_object_mut() else {
+            return false;
+        };
+        object
+            .entry("core_job_id")
+            .or_insert_with(|| Value::String(core_job_id.to_string()));
+        object
+            .entry("job_id_owner")
+            .or_insert_with(|| Value::String("core".to_string()));
+        object.entry("core_poll").or_insert_with(|| {
+            json!({
+                "owner": "core",
+                "tool": status_tool,
+                "arguments": {"job_id": core_job_id, "include_result": true},
+            })
+        });
+        if let Some(adapter_job) = adapter_job {
+            object
+                .entry("adapter_job_id")
+                .or_insert_with(|| Value::String(adapter_job.job_id.clone()));
+            object.entry("adapter_job").or_insert_with(|| {
+                json!({
+                    "job_id": adapter_job.job_id,
+                    "owner": "adapter",
+                    "identity_source": adapter_job.source,
+                    "core_job_id": core_job_id,
+                    "cancellation": {
+                        "owner": "adapter",
+                        "inherits_core_cancellation": false,
+                    },
+                    "hint": "Discover the adapter's typed status tool and pass adapter_job_id; do not pass this id to jobs_get_status.",
+                })
+            });
+        }
+        return true;
+    }
+    [
+        "output",
+        "result",
+        "structuredContent",
+        "structured_content",
+    ]
+    .iter()
+    .any(|key| {
+        value.get_mut(*key).is_some_and(|nested| {
+            annotate_core_job_envelope(nested, core_job_id, status_tool, adapter_job, depth + 1)
+        })
+    })
 }
 
 fn attach_call_route(mut value: Value, direct_local: bool) -> Value {
@@ -764,7 +864,11 @@ mod tests {
                         },
                         "result": (status == "completed").then(|| json!({
                             "success": true,
-                            "message": "done"
+                            "message": "Flipbook job launched",
+                            "context": {
+                                "job_id": "flipbook-f0631aa83e07",
+                                "progress": {"completed": 96, "total": 96}
+                            }
                         }))
                     }
                 }));
@@ -819,7 +923,20 @@ mod tests {
         assert!(poll_meta["dcc"].get("wait_for_terminal").is_none());
         assert!(poll_meta.get("progressToken").is_none());
         assert_eq!(result["structuredContent"]["status"], "completed");
-        assert_eq!(result["structuredContent"]["result"]["message"], "done");
+        assert_eq!(
+            result["structuredContent"]["result"]["message"],
+            "Flipbook job launched"
+        );
+        assert_eq!(result["structuredContent"]["core_job_id"], "job-42");
+        assert_eq!(result["structuredContent"]["job_id_owner"], "core");
+        assert_eq!(
+            result["structuredContent"]["adapter_job_id"],
+            "flipbook-f0631aa83e07"
+        );
+        assert_eq!(
+            result["structuredContent"]["adapter_job"]["owner"],
+            "adapter"
+        );
         assert_eq!(
             progress
                 .iter()

--- a/crates/dcc-mcp-http-server/src/handlers/tool_builder_core.rs
+++ b/crates/dcc-mcp-http-server/src/handlers/tool_builder_core.rs
@@ -399,10 +399,13 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
             McpTool {
                 name: TOOL_NAME.to_string(),
                 description: "Poll the status of an async tool-call job tracked by JobManager. \
-                              Returns a JSON envelope with job_id, parent_job_id, tool, status \
+                              Returns a JSON envelope with job_id, core_job_id, job_id_owner, \
+                              parent_job_id, tool, status \
                               (pending|running|completed|failed|cancelled|interrupted), timestamps, \
                               progress, error, and optionally the final ToolResult once the job \
-                              is terminal. Complements the `$/dcc.jobUpdated` SSE channel (#326) \
+                              is terminal. A terminal result that starts adapter-owned work also \
+                              exposes adapter_job_id and, when declared, its typed poll contract. \
+                              Complements the `$/dcc.jobUpdated` SSE channel (#326) \
                               for polling-based clients. Returns isError=true with a human-readable \
                               message when the job id is unknown (never a JSON-RPC transport error)."
                     .to_string(),

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
@@ -64,13 +64,23 @@ pub(super) fn async_dispatch_config(
 fn build_pending_envelope(job_id: &str, parent_job_id: Option<String>) -> CallToolResult {
     let structured = json!({
         "job_id": job_id,
+        "core_job_id": job_id,
+        "job_id_owner": "core",
         "status": "pending",
         "parent_job_id": parent_job_id,
+        "core_poll": {
+            "owner": "core",
+            "tool": "jobs_get_status",
+            "arguments": {"job_id": job_id, "include_result": true},
+        },
     });
     let mut meta = serde_json::Map::new();
     meta.insert("status".to_string(), json!("pending"));
     let mut dcc_meta = serde_json::Map::new();
     dcc_meta.insert("jobId".to_string(), json!(job_id));
+    dcc_meta.insert("coreJobId".to_string(), json!(job_id));
+    dcc_meta.insert("jobOwner".to_string(), json!("core"));
+    dcc_meta.insert("pollTool".to_string(), json!("jobs_get_status"));
     dcc_meta.insert(
         "parentJobId".to_string(),
         parent_job_id
@@ -88,7 +98,9 @@ fn build_pending_envelope(job_id: &str, parent_job_id: Option<String>) -> CallTo
 
     CallToolResult {
         content: vec![ToolContent::Text {
-            text: format!("Job {job_id} queued"),
+            text: format!(
+                "Core job {job_id} queued; poll jobs_get_status with core_job_id={job_id}"
+            ),
         }],
         structured_content: Some(structured_with_meta),
         is_error: false,

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/jobs.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/jobs.rs
@@ -3,8 +3,10 @@
 use chrono;
 use serde_json::{Value, json};
 
+use dcc_mcp_actions::registry::ToolMeta;
 use dcc_mcp_job::job::Job;
 use dcc_mcp_jsonrpc::{CallToolResult, ToolContent};
+use dcc_mcp_models::linked_adapter_job_from_result;
 
 use crate::server_state::ServerState;
 
@@ -53,6 +55,16 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_jobs_get_status(
     let (started_at, completed_at) = compute_job_timestamps(&job);
     let mut envelope = serde_json::Map::new();
     envelope.insert("job_id".into(), Value::String(job.id.clone()));
+    envelope.insert("core_job_id".into(), Value::String(job.id.clone()));
+    envelope.insert("job_id_owner".into(), Value::String("core".into()));
+    envelope.insert(
+        "core_poll".into(),
+        json!({
+            "owner": "core",
+            "tool": "jobs_get_status",
+            "arguments": {"job_id": job.id, "include_result": true},
+        }),
+    );
     envelope.insert(
         "parent_job_id".into(),
         match &job.parent_job_id {
@@ -102,6 +114,41 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_jobs_get_status(
     {
         envelope.insert("result".into(), r.clone());
     }
+    if job.status.is_terminal()
+        && let Some(adapter_job) = job
+            .result
+            .as_ref()
+            .and_then(|result| linked_adapter_job_from_result(result, &job.id))
+    {
+        let poll_tool = adapter_poll_tool(state, &job);
+        let hint = match poll_tool.as_deref() {
+            Some(tool) => format!(
+                "Call adapter-owned status tool {tool} with adapter_job_id; do not pass this id to jobs_get_status."
+            ),
+            None => "Discover the adapter's typed status tool and pass adapter_job_id; do not pass this id to jobs_get_status."
+                .to_string(),
+        };
+        let mut descriptor = json!({
+            "job_id": adapter_job.job_id,
+            "owner": "adapter",
+            "identity_source": adapter_job.source,
+            "core_job_id": job.id,
+            "cancellation": {
+                "owner": "adapter",
+                "inherits_core_cancellation": false,
+            },
+            "hint": hint,
+        });
+        if let Some(tool) = poll_tool {
+            descriptor["poll"] = json!({
+                "owner": "adapter",
+                "tool": tool,
+                "arguments": {"job_id": adapter_job.job_id},
+            });
+        }
+        envelope.insert("adapter_job_id".into(), Value::String(adapter_job.job_id));
+        envelope.insert("adapter_job".into(), descriptor);
+    }
     drop(job);
 
     let envelope_value = Value::Object(envelope);
@@ -112,6 +159,47 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_jobs_get_status(
         is_error: false,
         meta: None,
     }
+}
+
+fn adapter_poll_tool(state: &ServerState, job: &Job) -> Option<String> {
+    let action = state.registry.get_action(&job.tool_name, None)?;
+    action
+        .next_tools
+        .on_success
+        .iter()
+        .filter_map(|declared| resolve_follow_up(state, &action, declared))
+        .find(|(_, meta)| accepts_adapter_job_id(meta))
+        .map(|(name, _)| name)
+}
+
+fn resolve_follow_up(
+    state: &ServerState,
+    action: &ToolMeta,
+    declared: &str,
+) -> Option<(String, ToolMeta)> {
+    if let Some(meta) = state.registry.get_action(declared, None) {
+        return Some((declared.to_string(), meta));
+    }
+    let (prefix, _) = action.name.rsplit_once("__")?;
+    let qualified = format!("{prefix}__{declared}");
+    state
+        .registry
+        .get_action(&qualified, None)
+        .map(|meta| (qualified, meta))
+}
+
+fn accepts_adapter_job_id(meta: &ToolMeta) -> bool {
+    meta.annotations.read_only_hint == Some(true)
+        && meta
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .is_some_and(|properties| properties.contains_key("job_id"))
+        && meta
+            .input_schema
+            .get("required")
+            .and_then(Value::as_array)
+            .is_some_and(|required| required.iter().any(|name| name.as_str() == Some("job_id")))
 }
 
 pub(in crate::rmcp_tool_call_dispatch) fn handle_jobs_cleanup(
@@ -139,7 +227,12 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_jobs_cleanup(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
     use dcc_mcp_job::job::{JobManager, JobProgress};
+    use dcc_mcp_models::{NextTools, ToolAnnotations};
+    use dcc_mcp_skills::SkillCatalog;
 
     #[test]
     fn reported_start_timestamp_does_not_move_when_job_completes() {
@@ -163,5 +256,74 @@ mod tests {
         let (reported_start, reported_completion) = compute_job_timestamps(&handle.read());
         assert_eq!(reported_start, started_at);
         assert_eq!(reported_completion, Some(handle.read().updated_at));
+    }
+
+    #[test]
+    fn terminal_core_job_exposes_declared_adapter_poll_contract() {
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register_action(ToolMeta {
+            name: "houdini_render__flipbook".into(),
+            next_tools: NextTools {
+                on_success: vec!["get_flipbook_job".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        registry.register_action(ToolMeta {
+            name: "houdini_render__get_flipbook_job".into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {"job_id": {"type": "string"}},
+                "required": ["job_id"],
+            }),
+            annotations: ToolAnnotations {
+                read_only_hint: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+        let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+            Arc::clone(&registry),
+            Arc::clone(&dispatcher),
+        ));
+        let jobs = Arc::new(JobManager::new());
+        let handle = jobs.create("houdini_render__flipbook");
+        let core_job_id = handle.read().id.clone();
+        jobs.start(&core_job_id).unwrap();
+        jobs.complete(
+            &core_job_id,
+            json!({
+                "context": {"job_id": "flipbook-f0631aa83e07"},
+                "progress": {"current": 96, "total": 96},
+            }),
+        )
+        .unwrap();
+        let state = ServerState::builder(registry, dispatcher, catalog)
+            .with_jobs(jobs)
+            .build();
+
+        let result = handle_jobs_get_status(
+            &state,
+            &json!({"job_id": core_job_id, "include_result": true}),
+        );
+        let payload = result.structured_content.unwrap();
+
+        assert_eq!(payload["job_id_owner"], "core");
+        assert_eq!(payload["core_job_id"], core_job_id);
+        assert_eq!(payload["adapter_job_id"], "flipbook-f0631aa83e07");
+        assert_eq!(payload["adapter_job"]["owner"], "adapter");
+        assert_eq!(
+            payload["adapter_job"]["poll"],
+            json!({
+                "owner": "adapter",
+                "tool": "houdini_render__get_flipbook_job",
+                "arguments": {"job_id": "flipbook-f0631aa83e07"},
+            })
+        );
+        assert_eq!(
+            payload["adapter_job"]["cancellation"],
+            json!({"owner": "adapter", "inherits_core_cancellation": false})
+        );
     }
 }

--- a/crates/dcc-mcp-models/src/action_result.rs
+++ b/crates/dcc-mcp-models/src/action_result.rs
@@ -8,6 +8,45 @@ use pyo3_stub_gen_derive::{gen_stub_pyclass, gen_stub_pyclass_enum};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Adapter-owned job discovered inside the terminal result of a Core job.
+///
+/// New adapters should return the explicit ``adapter_job`` or
+/// ``adapter_job_id`` shape. ``context.job_id`` remains supported because
+/// released adapters historically returned pollable operation ids there.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkedAdapterJob {
+    pub job_id: String,
+    pub source: &'static str,
+}
+
+/// Find an adapter-owned job id in a completed tool result.
+///
+/// The caller supplies the Core job id so a handler that echoes the outer id
+/// is never misclassified as a second operation. This helper deliberately
+/// inspects only one tool-result object; transport wrappers must be removed by
+/// the caller before invoking it.
+#[must_use]
+pub fn linked_adapter_job_from_result(
+    result: &serde_json::Value,
+    core_job_id: &str,
+) -> Option<LinkedAdapterJob> {
+    const CANDIDATES: &[(&str, &str)] = &[
+        ("/adapter_job/job_id", "result.adapter_job.job_id"),
+        ("/adapter_job_id", "result.adapter_job_id"),
+        ("/context/adapter_job_id", "result.context.adapter_job_id"),
+        ("/context/job_id", "result.context.job_id"),
+        ("/job_id", "result.job_id"),
+    ];
+
+    CANDIDATES.iter().find_map(|(pointer, source)| {
+        let job_id = result.pointer(pointer)?.as_str()?.trim();
+        (!job_id.is_empty() && job_id != core_job_id).then(|| LinkedAdapterJob {
+            job_id: job_id.to_string(),
+            source,
+        })
+    })
+}
+
 // RTK-inspired: limit context depth and array size to reduce token consumption
 fn compact_json_value(
     value: &serde_json::Value,

--- a/crates/dcc-mcp-models/src/action_result_tests.rs
+++ b/crates/dcc-mcp-models/src/action_result_tests.rs
@@ -189,3 +189,44 @@ fn test_action_result_model_clone_eq() {
     let cloned = model.clone();
     assert_eq!(model, cloned);
 }
+
+// ── Nested adapter-job identity ─────────────────────────────────────────────
+
+#[test]
+fn test_linked_adapter_job_prefers_explicit_contract() {
+    let result = serde_json::json!({
+        "success": true,
+        "adapter_job": {"job_id": "render-adapter-42"},
+        "context": {"job_id": "legacy-context-id"}
+    });
+
+    let link = linked_adapter_job_from_result(&result, "core-uuid").expect("adapter job link");
+
+    assert_eq!(link.job_id, "render-adapter-42");
+    assert_eq!(link.source, "result.adapter_job.job_id");
+}
+
+#[test]
+fn test_linked_adapter_job_accepts_legacy_action_result_context() {
+    let result = serde_json::json!({
+        "success": true,
+        "message": "Flipbook job launched",
+        "context": {"job_id": "flipbook-f0631aa83e07"}
+    });
+
+    let link = linked_adapter_job_from_result(&result, "core-uuid").expect("adapter job link");
+
+    assert_eq!(link.job_id, "flipbook-f0631aa83e07");
+    assert_eq!(link.source, "result.context.job_id");
+}
+
+#[test]
+fn test_linked_adapter_job_rejects_core_id_and_empty_ids() {
+    for result in [
+        serde_json::json!({"context": {"job_id": "core-uuid"}}),
+        serde_json::json!({"context": {"job_id": "  "}}),
+        serde_json::json!({"context": {}}),
+    ] {
+        assert!(linked_adapter_job_from_result(&result, "core-uuid").is_none());
+    }
+}

--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -15,7 +15,10 @@ pub mod tool_call_event;
 mod python;
 
 pub use action_result::ActionResultModel as ToolResult;
-pub use action_result::{ActionResultModel, ActionResultModelData, SerializeFormat};
+pub use action_result::{
+    ActionResultModel, ActionResultModelData, LinkedAdapterJob, SerializeFormat,
+    linked_adapter_job_from_result,
+};
 pub use dcc_name::DccName;
 pub use error::DccMcpError;
 pub use registry::{DefaultRegistry, Registry, RegistryEntry, SearchQuery};

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -35,7 +35,7 @@ result = dispatcher.dispatch("name", json_str)   # returns dict
 **Async `tools/call` dispatch (#318) — opt-in, non-blocking:**
 ```python
 # Any of these routes the call through JobManager and returns immediately
-# with {job_id, status: "pending"}:
+# with {job_id, core_job_id, job_id_owner: "core", status: "pending"}:
 #   1. Request carries _meta.dcc.async = true
 #   2. Request carries _meta.progressToken
 #   3. Tool's ToolMeta declares execution: async or timeout_hint_secs > 0
@@ -45,10 +45,23 @@ body = {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {
     "arguments": {"start": 1, "end": 250},
     "_meta": {"dcc": {"async": True, "parentJobId": "<uuid-or-null>"}},
 }}
-# → result.structuredContent = {"job_id": "<uuid>", "status": "pending",
-#                               "parent_job_id": "<uuid>|null"}
-# Poll via jobs_get_status (#319); cancelling the parent cancels every child
-# whose _meta.dcc.parentJobId matches (CancellationToken child-token cascade).
+# → result.structuredContent = {"job_id": "<uuid>",
+#                               "core_job_id": "<same-uuid>",
+#                               "job_id_owner": "core", "status": "pending",
+#                               "parent_job_id": "<uuid>|null",
+#                               "core_poll": {"tool": "jobs_get_status", ...}}
+# `job_id` remains the backward-compatible alias for `core_job_id`. Poll it via
+# jobs_get_status (#319); cancelling the parent cancels every Core child whose
+# _meta.dcc.parentJobId matches (CancellationToken child-token cascade).
+#
+# A terminal Core result may launch a second, adapter-owned operation. In that
+# case jobs_get_status adds `adapter_job_id` and an `adapter_job` descriptor.
+# When the launching tool declares a read-only job_id follow-up in next-tools,
+# `adapter_job.poll` is machine-callable. Example: a completed Core flipbook
+# wrapper can expose `adapter_job_id: "flipbook-f0631aa83e07"` for the adapter
+# status tool, which then reports 96/96. Never pass an adapter job ID to
+# jobs_get_status. Core parent cancellation does not cancel adapter-owned work;
+# use the adapter's typed status/cancellation contract.
 ```
 
 **`ToolRegistry.register()` — keyword args only, no positional:**

--- a/python/dcc_mcp_core/docs_resources.py
+++ b/python/dcc_mcp_core/docs_resources.py
@@ -114,13 +114,25 @@ When ``_meta.dcc.async=true`` or a ``progressToken`` is present:
 {
   "structuredContent": {
     "job_id": "<uuid>",
+    "core_job_id": "<same-uuid>",
+    "job_id_owner": "core",
     "status": "pending",
-    "parent_job_id": null
+    "parent_job_id": null,
+    "core_poll": {
+      "owner": "core",
+      "tool": "jobs_get_status",
+      "arguments": {"job_id": "<same-uuid>", "include_result": true}
+    }
   }
 }
 ```
 
-Poll status via the ``jobs_get_status`` built-in tool.
+``job_id`` remains a backward-compatible alias for ``core_job_id``. Poll that
+ID via the ``jobs_get_status`` built-in tool. If the terminal tool result starts
+a second adapter-owned operation, the status response also exposes
+``adapter_job_id`` and ``adapter_job``. Use ``adapter_job.poll`` when present;
+never pass an adapter ID back to ``jobs_get_status``. Core ``parent_job_id``
+and cancellation apply only to Core-owned jobs.
 
 ## _meta.dcc.raw_trace (when enable_error_raw_trace=True)
 

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -393,7 +393,7 @@ python scripts/dcc_gateway.py call maya.a1b2c3d4.maya_primitives__create_sphere 
   --json '{"radius":2.0}'
 ```
 
-For asynchronous render/cook tools, add `--wait`; the CLI polls `jobs_get_status` at most once per second until terminal state and writes a 5%-step progress bar plus a 30-second stalled-job heartbeat to stderr while keeping the final result on stdout. Use `--wait-timeout-secs` for longer runs.
+For asynchronous render/cook tools, add `--wait`; the CLI polls `jobs_get_status` at most once per second until terminal state and writes a 5%-step progress bar plus a 30-second stalled-job heartbeat to stderr while keeping the final result on stdout. Use `--wait-timeout-secs` for longer runs. The returned `job_id` is the backward-compatible alias of `core_job_id` (`job_id_owner=core`). If the terminal result launches adapter-owned work, `--wait` surfaces `adapter_job_id`; call the typed `adapter_job.poll` descriptor when present, never pass that inner ID to `jobs_get_status`, and do not assume Core cancellation propagates across the ownership boundary.
 The bar uses `progress.current`, `progress.total`, and `progress.message`; do not repeatedly scan output files when typed progress exists.
 Native MCP/REST clients may subscribe to `/v1/jobs/{job_id}/events`; otherwise keep the returned `job_id` and use bounded status polling.
 Do not create a scheduled task by default. After an explicit cross-session monitoring request, schedule only a one-shot status check for that ID and stop it at terminal state.

--- a/skills/dcc-mcp/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-mcp/references/CLI_CHEATSHEET.md
@@ -108,6 +108,13 @@ path resubmits work. A 410 lifecycle response becomes
 `tracking_status=owner_exited`. Read `previous_status`, `retryable`, and
 `recommended_next_action` instead of treating every missing route as 503.
 
+Async responses identify the wrapper as `core_job_id` with
+`job_id_owner=core`; legacy `job_id` is the same Core ID. A terminal Core call
+may expose a second `adapter_job_id`. `call --wait` resolves the Core wrapper
+and surfaces the adapter identity; if `adapter_job.poll` is present, call that
+typed read-only tool with the adapter ID. Never pass an adapter ID to
+`jobs_get_status`, and do not assume Core parent cancellation propagates to it.
+
 If owner death or remote TTL expiry removes the row, wait for an explicitly
 authorized DCC restart, then use the replacement instance and fresh
 `search`/`describe` results. Old instance IDs, slugs, direct URLs, and core jobs

--- a/tests/test_jobs_get_status.py
+++ b/tests/test_jobs_get_status.py
@@ -267,3 +267,87 @@ def test_jobs_get_status_include_result_false_omits_result():
         assert "result" not in env, f"include_result=false must omit result: {env}"
     finally:
         handle.shutdown()
+
+
+def test_nested_adapter_job_identity_is_explicit_across_pending_and_terminal_results():
+    """Regression for #2153: Core UUID -> adapter-owned flipbook job id."""
+    reg = ToolRegistry()
+    reg.register(
+        "launch_flipbook",
+        description="Launch an adapter-owned 96-frame flipbook job",
+        category="test",
+        tags=[],
+        dcc="test",
+        version="1.0.0",
+        execution="sync",
+        timeout_hint_secs=30,
+    )
+    cfg = McpHttpConfig(port=0, server_name="nested-job-identity-test")
+    server = McpHttpServer(reg, cfg)
+    server.register_handler(
+        "launch_flipbook",
+        lambda _params: {
+            "success": True,
+            "message": "Flipbook job launched",
+            "context": {
+                "job_id": "flipbook-f0631aa83e07",
+                "progress": {"completed": 0, "total": 96},
+            },
+        },
+    )
+    handle = server.start()
+    try:
+        sid = _initialize_session(handle.mcp_url())
+        body = _post(
+            handle.mcp_url(),
+            {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": {"name": "launch_flipbook", "arguments": {}},
+            },
+            sid=sid,
+        )
+        pending = body["result"]["structuredContent"]
+        core_job_id = pending["job_id"]
+        assert pending["core_job_id"] == core_job_id
+        assert pending["job_id_owner"] == "core"
+        assert pending["core_poll"] == {
+            "owner": "core",
+            "tool": "jobs_get_status",
+            "arguments": {"job_id": core_job_id, "include_result": True},
+        }
+
+        deadline = time.monotonic() + 5.0
+        terminal = None
+        while time.monotonic() < deadline:
+            poll = _post(
+                handle.mcp_url(),
+                {
+                    "jsonrpc": "2.0",
+                    "id": 9,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "jobs_get_status",
+                        "arguments": {"job_id": core_job_id, "include_result": True},
+                    },
+                },
+                sid=sid,
+            )
+            terminal = poll["result"]["structuredContent"]
+            if terminal["status"] == "completed":
+                break
+            time.sleep(0.05)
+
+        assert terminal is not None and terminal["status"] == "completed"
+        assert terminal["job_id"] == core_job_id
+        assert terminal["core_job_id"] == core_job_id
+        assert terminal["job_id_owner"] == "core"
+        assert terminal["adapter_job_id"] == "flipbook-f0631aa83e07"
+        assert terminal["adapter_job"]["owner"] == "adapter"
+        assert terminal["adapter_job"]["identity_source"] == "result.context.job_id"
+        assert terminal["adapter_job"]["core_job_id"] == core_job_id
+        assert terminal["adapter_job"]["cancellation"]["inherits_core_cancellation"] is False
+        assert "jobs_get_status" in terminal["adapter_job"]["hint"]
+    finally:
+        handle.shutdown()


### PR DESCRIPTION
## Summary

- preserve legacy job_id while explicitly exposing core_job_id, job_id_owner, and core_poll
- surface adapter_job_id and an adapter-owned descriptor from terminal Core results without hard-coding any DCC
- let CLI call --wait normalize old-server nested results and expose the correct second identity without replaying or guessing a poll tool
- emit a machine-callable adapter poll descriptor only when the launching tool declares a read-only job_id follow-up through next-tools
- document Core versus adapter cancellation ownership and the real flipbook 96/96 chain

## Compatibility

Existing single-layer async clients can continue using job_id exactly as before. parent_job_id remains the Core cancellation tree. Adapter-owned work is explicitly non-inheriting and must use its typed adapter contract.

## Validation

- vx cargo test -p dcc-mcp-models -p dcc-mcp-http-server -p dcc-mcp-cli
- vx cargo clippy -p dcc-mcp-models -p dcc-mcp-http-server -p dcc-mcp-cli --all-targets -- -D warnings
- Python cross-layer regression: 10 passed
- Ruff check and format: passed
- git diff --check: passed

Fixes #2153