### PR TITLE
feat: catalog new production adapters

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -1210,7 +1210,7 @@ entries:
     }
 
     #[test]
-    fn bundled_adobe_adapters_expose_installable_entry_points() {
+    fn bundled_sidecar_adapters_expose_installable_entry_points() {
         let entries = load_from_str(include_str!("../../../dcc-mcp-catalog.yml")).unwrap();
 
         for (name, dcc, entry_point) in [
@@ -1224,6 +1224,26 @@ entries:
                 "illustrator",
                 "dcc_mcp_illustrator.cli:main",
             ),
+            ("dcc-mcp-comfyui", "comfyui", "dcc_mcp_comfyui.cli:main"),
+            (
+                "dcc-mcp-cache-inspector",
+                "cache-inspector",
+                "dcc_mcp_cache_inspector.server:CacheInspectorMcpServer",
+            ),
+            (
+                "dcc-mcp-touchdesigner",
+                "touchdesigner",
+                "dcc_mcp_touchdesigner:TouchDesignerMcpServer",
+            ),
+            ("dcc-mcp-krita", "krita", "dcc_mcp_krita.server:main"),
+            ("dcc-mcp-gimp", "gimp", "dcc_mcp_gimp.server:main"),
+            ("dcc-mcp-tiled", "tiled", "dcc_mcp_tiled.server:main"),
+            (
+                "dcc-mcp-material-maker",
+                "material-maker",
+                "dcc_mcp_material_maker.server:main",
+            ),
+            ("dcc-mcp-wwise", "wwise", "dcc_mcp_wwise.server:main"),
         ] {
             let entry = entries
                 .iter()

--- a/crates/dcc-mcp-cli/src/application/control_plane.rs
+++ b/crates/dcc-mcp-cli/src/application/control_plane.rs
@@ -225,7 +225,8 @@ impl DccControlPlane {
     where
         F: FnMut(&JobWaitProgress),
     {
-        let status_tool = job_status_tool(&tool_slug, dcc_type.as_deref(), instance_id.as_deref())?;
+        let mut status_tool =
+            job_status_tool(&tool_slug, dcc_type.as_deref(), instance_id.as_deref())?;
         let poll_meta = job_poll_meta(meta.clone());
         let mut result = self
             .call(
@@ -269,7 +270,7 @@ impl DccControlPlane {
                 }));
             }
             tokio::time::sleep(JOB_POLL_INTERVAL).await;
-            match self
+            let poll_result = self
                 .call(
                     status_tool.clone(),
                     dcc_type.clone(),
@@ -278,8 +279,32 @@ impl DccControlPlane {
                     poll_meta.clone(),
                     request_timeout,
                 )
-                .await
-            {
+                .await;
+            let poll_result = match poll_result {
+                Err(error)
+                    if status_tool != "jobs_get_status" && job_status_tool_is_unknown(&error) =>
+                {
+                    match self
+                        .call(
+                            "jobs_get_status".to_string(),
+                            None,
+                            None,
+                            json!({"job_id": job_id, "include_result": true}),
+                            poll_meta.clone(),
+                            request_timeout,
+                        )
+                        .await
+                    {
+                        Ok(value) => {
+                            status_tool = "jobs_get_status".to_string();
+                            Ok(value)
+                        }
+                        Err(fallback_error) => Err(fallback_error),
+                    }
+                }
+                other => other,
+            };
+            match poll_result {
                 Ok(value) => {
                     result = value;
                     last_poll_error = None;
@@ -453,6 +478,16 @@ fn job_poll_error_is_retryable(error: &anyhow::Error) -> bool {
         ),
         None => false,
     }
+}
+
+fn job_status_tool_is_unknown(error: &anyhow::Error) -> bool {
+    matches!(
+        job_poll_http_error(error),
+        Some(HttpError::Status { status, body })
+            if *status == reqwest::StatusCode::NOT_FOUND
+                && body.contains("unknown-slug")
+                && body.contains("jobs_get_status")
+    )
 }
 
 fn job_poll_owner_exited(error: &anyhow::Error) -> bool {
@@ -946,6 +981,84 @@ mod tests {
                 ("pending", None, None),
                 ("running", Some(45), Some(90)),
                 ("completed", Some(90), Some(90)),
+            ]
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn wait_falls_back_to_bare_job_status_for_direct_adapter_base_url() {
+        async fn call(
+            State(requests): State<Arc<Mutex<Vec<String>>>>,
+            Json(body): Json<Value>,
+        ) -> Response {
+            let slug = body["tool_slug"].as_str().unwrap_or_default().to_string();
+            requests.lock().unwrap().push(slug.clone());
+            if slug == "touchdesigner.touchdesigner-scripting.jobs_get_status" {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(json!({
+                        "kind": "unknown-slug",
+                        "message": "no action registered for slug 'touchdesigner.touchdesigner-scripting.jobs_get_status'"
+                    })),
+                )
+                    .into_response();
+            }
+            if slug == "jobs_get_status" {
+                return Json(json!({
+                    "output": {
+                        "job_id": "job-direct-42",
+                        "status": "completed",
+                        "result": {"success": true, "message": "done"}
+                    }
+                }))
+                .into_response();
+            }
+            Json(json!({
+                "output": {"job_id": "job-direct-42", "status": "pending"}
+            }))
+            .into_response()
+        }
+
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/v1/call", post(call))
+            .with_state(requests.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let registry = tempdir().unwrap();
+        let endpoint = Endpoint::new(format!("http://{addr}"));
+        let control = DccControlPlane::new(
+            GatewayTarget::Remote {
+                name: "adapter".to_string(),
+                endpoint: endpoint.clone(),
+            },
+            endpoint,
+            registry.path().to_path_buf(),
+            false,
+        );
+
+        let result = control
+            .call_and_wait(
+                "touchdesigner.touchdesigner-scripting.get_project_info".to_string(),
+                None,
+                None,
+                json!({}),
+                None,
+                Duration::from_secs(2),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result["output"]["status"], "completed");
+        assert_eq!(
+            *requests.lock().unwrap(),
+            vec![
+                "touchdesigner.touchdesigner-scripting.get_project_info",
+                "touchdesigner.touchdesigner-scripting.jobs_get_status",
+                "jobs_get_status",
             ]
         );
         server.abort();

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -9,7 +9,8 @@ use serde::Serialize;
 use thiserror::Error;
 
 use crate::domain::install::{
-    InstallPlan, InstallPlanError, InstallPlanner, InstallPolicy, InstallRequest, InstallStepAction,
+    InstallPlan, InstallPlanError, InstallPlanner, InstallPolicy, InstallRequest,
+    InstallStepAction, normalized_dcc_key,
 };
 
 const BUNDLED_CATALOG: &str = include_str!("../../../../dcc-mcp-catalog.yml");
@@ -108,6 +109,7 @@ impl InstallService {
     pub fn dcc_types(&self, catalog_path: Option<&Path>) -> Result<DccTypesCatalog, InstallError> {
         let entries = self.load_entries(catalog_path)?;
         let mut grouped: BTreeMap<String, BTreeMap<String, DccAdapterSummary>> = BTreeMap::new();
+        let mut canonical_by_normalized: BTreeMap<String, String> = BTreeMap::new();
 
         for entry in entries.iter().filter(|entry| {
             entry
@@ -122,10 +124,15 @@ impl InstallService {
                 catalog_install_available: entry.install.is_some(),
             };
             for dcc_type in &entry.dcc {
-                let canonical = DccName::parse(dcc_type).to_string();
-                if canonical.is_empty() {
+                let parsed = DccName::parse(dcc_type).to_string();
+                let normalized = normalized_dcc_key(&parsed);
+                if normalized.is_empty() {
                     continue;
                 }
+                let canonical = canonical_by_normalized
+                    .entry(normalized)
+                    .or_insert_with(|| parsed.clone())
+                    .clone();
                 grouped
                     .entry(canonical)
                     .or_default()
@@ -778,6 +785,16 @@ mod tests {
         let catalog = service.dcc_types(None).unwrap();
 
         assert!(catalog.custom_types_supported);
+        assert_eq!(catalog.dcc_types.len(), 34);
+        for alias in ["after effects", "after-effects", "comfy-ui"] {
+            assert!(
+                catalog
+                    .dcc_types
+                    .iter()
+                    .all(|entry| entry.dcc_type != alias),
+                "alias {alias} must collapse into its first canonical catalog spelling"
+            );
+        }
         assert_eq!(
             catalog
                 .dcc_types
@@ -788,12 +805,21 @@ mod tests {
         );
         for (expected_type, expected_adapter) in [
             ("c4d", "dcc-mcp-cinema4d"),
+            ("cache-inspector", "dcc-mcp-cache-inspector"),
+            ("comfyui", "dcc-mcp-comfyui"),
             ("freecad", "dcc-mcp-freecad"),
+            ("gimp", "dcc-mcp-gimp"),
             ("godot", "dcc-mcp-godot"),
+            ("krita", "dcc-mcp-krita"),
             ("mari", "dcc-mcp-mari"),
+            ("material-maker", "dcc-mcp-material-maker"),
             ("openscad", "dcc-mcp-openscad"),
             ("renderdoc", "dcc-mcp-renderdoc"),
+            ("sketchup", "dcc-mcp-sketchup"),
+            ("tiled", "dcc-mcp-tiled"),
+            ("touchdesigner", "dcc-mcp-touchdesigner"),
             ("unity", "dcc-mcp-unity"),
+            ("wwise", "dcc-mcp-wwise"),
         ] {
             let entry = catalog
                 .dcc_types

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -556,7 +556,7 @@ fn adapter_rank(entry: &CatalogEntry, dcc_key: &str) -> (bool, bool, bool, bool)
     )
 }
 
-fn normalized_dcc_key(value: &str) -> String {
+pub(crate) fn normalized_dcc_key(value: &str) -> String {
     value
         .chars()
         .filter(|ch| ch.is_ascii_alphanumeric())

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -1739,19 +1739,29 @@ fn dcc_types_lists_release_catalog_without_a_gateway() {
 
     assert_eq!(value["custom_types_supported"], true);
     let types = value["dcc_types"].as_array().unwrap();
+    assert_eq!(types.len(), 34);
     for expected in [
         "aftereffects",
         "c4d",
+        "cache-inspector",
+        "comfyui",
         "freecad",
+        "gimp",
         "godot",
         "illustrator",
+        "krita",
         "mari",
         "marmoset",
+        "material-maker",
         "openusd",
         "openscad",
         "renderdoc",
         "shotgrid",
+        "sketchup",
+        "tiled",
+        "touchdesigner",
         "unity",
+        "wwise",
     ] {
         assert!(types.iter().any(|entry| entry["dcc_type"] == expected));
     }

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -134,7 +134,7 @@ entries:
     dcc: ["premiere"]
     url: "https://github.com/dcc-mcp/dcc-mcp-premiere"
     tags: ["adapter", "premiere", "official", "pip", "editing"]
-    version: "0.4.0"
+    version: "0.5.0"
     min_core_version: "0.19.45"
     maintainer: "dcc-mcp"
     install:
@@ -161,7 +161,7 @@ entries:
     dcc: ["illustrator"]
     url: "https://github.com/dcc-mcp/dcc-mcp-illustrator"
     tags: ["adapter", "illustrator", "official", "pip", "cep", "vector-graphics"]
-    version: "0.1.0"
+    version: "0.2.0"
     min_core_version: "0.19.91"
     maintainer: "dcc-mcp"
     install:
@@ -170,12 +170,40 @@ entries:
       entry_point: "dcc_mcp_illustrator.cli:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-illustrator/main/README.md"
 
+  - name: "dcc-mcp-gimp"
+    description: "GIMP 3 adapter with typed image, layer, save, and production export workflows"
+    dcc: ["gimp"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-gimp"
+    tags: ["adapter", "gimp", "official", "pip", "image-editing", "painting"]
+    version: "0.3.0"
+    min_core_version: "0.19.38"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-gimp"
+      entry_point: "dcc_mcp_gimp.server:main"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-gimp/main/README.md"
+
+  - name: "dcc-mcp-krita"
+    description: "Krita adapter with typed document, layer, painting, save, and export workflows"
+    dcc: ["krita"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-krita"
+    tags: ["adapter", "krita", "official", "pip", "digital-painting", "image-editing"]
+    version: "0.3.0"
+    min_core_version: "0.19.38"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-krita"
+      entry_point: "dcc_mcp_krita.server:main"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-krita/main/README.md"
+
   - name: "dcc-mcp-katana"
     description: "Foundry Katana adapter for DCC-MCP"
     dcc: ["katana"]
     url: "https://github.com/dcc-mcp/dcc-mcp-katana"
     tags: ["adapter", "katana", "official", "pip", "lookdev"]
-    version: "0.3.0"
+    version: "0.4.0"
     min_core_version: "0.19.45"
     maintainer: "dcc-mcp"
     install:
@@ -279,7 +307,7 @@ entries:
     dcc: ["openscad"]
     url: "https://github.com/dcc-mcp/dcc-mcp-openscad"
     tags: ["adapter", "openscad", "official", "pip", "cad", "modeling"]
-    version: "0.1.1"
+    version: "0.1.2"
     min_core_version: "0.19.91"
     maintainer: "dcc-mcp"
     install:
@@ -292,7 +320,7 @@ entries:
     dcc: ["freecad"]
     url: "https://github.com/dcc-mcp/dcc-mcp-freecad"
     tags: ["adapter", "freecad", "official", "pip", "cad", "parametric-modeling"]
-    version: "0.1.1"
+    version: "0.1.2"
     min_core_version: "0.19.91"
     maintainer: "dcc-mcp"
     install:
@@ -305,13 +333,41 @@ entries:
     dcc: ["c4d", "cinema4d"]
     url: "https://github.com/dcc-mcp/dcc-mcp-cinema4d"
     tags: ["adapter", "cinema4d", "cinema-4d", "official", "pip", "modeling", "rendering"]
-    version: "0.1.2"
+    version: "0.1.3"
     min_core_version: "0.19.91"
     maintainer: "dcc-mcp"
     install:
       type: pip
       pip_package: "dcc-mcp-cinema4d"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-cinema4d/main/README.md"
+
+  - name: "dcc-mcp-comfyui"
+    description: "ComfyUI adapter for typed API-format workflow validation, bounded queue execution, status, and artifact retrieval"
+    dcc: ["comfyui", "comfy-ui"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-comfyui"
+    tags: ["adapter", "comfyui", "official", "pip", "node-graph", "image-generation"]
+    version: "0.1.0"
+    min_core_version: "0.19.91"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-comfyui"
+      entry_point: "dcc_mcp_comfyui.cli:main"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-comfyui/main/README.md"
+
+  - name: "dcc-mcp-cache-inspector"
+    description: "Standalone read-only inspector for bounded privacy-safe SideFX geo, bgeo, and bgeo.sc cache summaries"
+    dcc: ["cache-inspector"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-cache-inspector"
+    tags: ["adapter", "cache-inspector", "official", "pip", "standalone", "read-only", "geometry-cache", "houdini"]
+    version: "0.2.0"
+    min_core_version: "0.19.91"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-cache-inspector"
+      entry_point: "dcc_mcp_cache_inspector.server:CacheInspectorMcpServer"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-cache-inspector/main/README.md"
 
   - name: "dcc-mcp-mari"
     description: "Mari adapter for typed project, geometry, channel, node-graph, layer, shader, image, and export workflows"
@@ -325,6 +381,76 @@ entries:
       type: pip
       pip_package: "dcc-mcp-mari"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-mari/main/README.md"
+
+  - name: "dcc-mcp-sketchup"
+    description: "SketchUp adapter with typed modeling, materials, scenes, validation, and interchange workflows"
+    dcc: ["sketchup"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-sketchup"
+    tags: ["adapter", "sketchup", "official", "pip", "ruby", "modeling", "interchange"]
+    version: "0.1.0"
+    min_core_version: "0.19.91"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-sketchup"
+      entry_point: "dcc_mcp_sketchup.server:main"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-sketchup/main/README.md"
+
+  - name: "dcc-mcp-touchdesigner"
+    description: "TouchDesigner adapter with typed operator graphs, parameters, project saves, TOP capture, and main-thread-safe execution"
+    dcc: ["touchdesigner"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-touchdesigner"
+    tags: ["adapter", "touchdesigner", "official", "pip", "node-graph", "real-time", "interactive-media"]
+    version: "0.1.0"
+    min_core_version: "0.19.91"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-touchdesigner"
+      entry_point: "dcc_mcp_touchdesigner:TouchDesignerMcpServer"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-touchdesigner/main/install.md"
+
+  - name: "dcc-mcp-tiled"
+    description: "Tiled adapter for typed workspace-bounded map authoring, validation, and conversion"
+    dcc: ["tiled"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-tiled"
+    tags: ["adapter", "tiled", "official", "pip", "level-design", "tilemap", "game-engine"]
+    version: "0.3.0"
+    min_core_version: "0.19.38"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-tiled"
+      entry_point: "dcc_mcp_tiled.server:main"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-tiled/main/README.md"
+
+  - name: "dcc-mcp-material-maker"
+    description: "Material Maker adapter for typed bounded .ptex inspection, validation, and native export"
+    dcc: ["material-maker"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-material-maker"
+    tags: ["adapter", "material-maker", "official", "pip", "procedural-materials", "ptex", "lookdev"]
+    version: "0.3.0"
+    min_core_version: "0.19.38"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-material-maker"
+      entry_point: "dcc_mcp_material_maker.server:main"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-material-maker/main/README.md"
+
+  - name: "dcc-mcp-wwise"
+    description: "Audiokinetic Wwise Authoring adapter with typed WAAPI project, audio, SoundBank, and profiler workflows"
+    dcc: ["wwise"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-wwise"
+    tags: ["adapter", "wwise", "official", "pip", "waapi", "game-audio", "soundbank"]
+    version: "0.1.1"
+    min_core_version: "0.19.86"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-wwise"
+      entry_point: "dcc_mcp_wwise.server:main"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-wwise/main/install.md"
 
   - name: "dcc-mcp-fpt"
     description: "Autodesk Flow Production Tracking adapter for DCC-MCP"

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -26,9 +26,11 @@ submit a PR updating this matrix before the release PR merges.
 |-----|-----------|----------------|----------|-----------------|-------------------|---------------|
 | Maya | [dcc-mcp-maya](https://github.com/dcc-mcp/dcc-mcp-maya) | 0.9.22 | >=0.19.45,<1.0.0 | 2024+ | Qt sidecar + HostUiDispatcherBase | 2026-08 |
 | Marmoset Toolbag | [dcc-mcp-marmoset](https://github.com/dcc-mcp/dcc-mcp-marmoset) | 0.1.1 | >=0.19.86,<1.0.0 | 4.03+ | External sidecar + Toolbag periodic callback | 2026-07 |
-| OpenSCAD | [dcc-mcp-openscad](https://github.com/dcc-mcp/dcc-mcp-openscad) | 0.1.1 | >=0.19.91,<1.0.0 | 2021.01+ | External OpenSCAD CLI subprocess | 2026-08 |
-| FreeCAD | [dcc-mcp-freecad](https://github.com/dcc-mcp/dcc-mcp-freecad) | 0.1.1 | >=0.19.91,<1.0.0 | 1.0+ | External FreeCADCmd subprocess | 2026-08 |
-| Cinema 4D | [dcc-mcp-cinema4d](https://github.com/dcc-mcp/dcc-mcp-cinema4d) | 0.1.2 | >=0.19.91,<1.0.0 | R21+ | External headless c4dpy subprocess | 2026-08 |
+| OpenSCAD | [dcc-mcp-openscad](https://github.com/dcc-mcp/dcc-mcp-openscad) | 0.1.2 | >=0.19.91,<1.0.0 | 2021.01+ | External OpenSCAD CLI subprocess | 2026-08 |
+| FreeCAD | [dcc-mcp-freecad](https://github.com/dcc-mcp/dcc-mcp-freecad) | 0.1.2 | >=0.19.91,<1.0.0 | 1.0+ | External FreeCADCmd subprocess | 2026-08 |
+| Cinema 4D | [dcc-mcp-cinema4d](https://github.com/dcc-mcp/dcc-mcp-cinema4d) | 0.1.3 | >=0.19.91,<1.0.0 | R21+ | External headless c4dpy subprocess | 2026-08 |
+| ComfyUI | [dcc-mcp-comfyui](https://github.com/dcc-mcp/dcc-mcp-comfyui) | 0.1.0 | >=0.19.91,<1.0.0 | 0.31+ | Standalone sidecar + local REST workflow bridge | 2026-08 |
+| Cache Inspector | [dcc-mcp-cache-inspector](https://github.com/dcc-mcp/dcc-mcp-cache-inspector) | 0.2.0 | >=0.19.91,<1.0.0 | — | Standalone inline read-only cache decoder | 2026-08 |
 | Mari | [dcc-mcp-mari](https://github.com/dcc-mcp/dcc-mcp-mari) | 0.2.1 | >=0.19.91,<1.0.0 | 5.0+ | Authenticated loopback sidecar + Qt UI timer | 2026-08 |
 | 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.40 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-08 |
 | Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.43 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-08 |
@@ -38,10 +40,17 @@ submit a PR updating this matrix before the release PR merges.
 | Unreal | [dcc-mcp-unreal](https://github.com/dcc-mcp/dcc-mcp-unreal) | 0.2.0 | >=0.19.45,<1.0.0 | — | Unreal Python bridge | — |
 | ZBrush | [dcc-mcp-zbrush](https://github.com/dcc-mcp/dcc-mcp-zbrush) | 0.2.18 | >=0.19.45,<1.0.0 | — | Socket bridge + sidecar | — |
 | Photoshop | [dcc-mcp-photoshop](https://github.com/dcc-mcp/dcc-mcp-photoshop) | 0.1.37 | >=0.19.45,<1.0.0 | Photoshop UXP | WebSocket bridge | 2026-06 |
-| Premiere Pro | [dcc-mcp-premiere](https://github.com/dcc-mcp/dcc-mcp-premiere) | 0.4.0 | >=0.19.45,<1.0.0 | 25.6+ | UXP WebSocket bridge | — |
+| Premiere Pro | [dcc-mcp-premiere](https://github.com/dcc-mcp/dcc-mcp-premiere) | 0.5.0 | >=0.19.45,<1.0.0 | 25.6+ | UXP WebSocket bridge | — |
 | After Effects | [dcc-mcp-aftereffects](https://github.com/dcc-mcp/dcc-mcp-aftereffects) | 0.6.0 | >=0.19.91,<1.0.0 | — | Authenticated CEP bridge + broker | 2026-08 |
-| Illustrator | [dcc-mcp-illustrator](https://github.com/dcc-mcp/dcc-mcp-illustrator) | 0.1.0 | >=0.19.91,<1.0.0 | — | Authenticated CEP bridge + broker | 2026-08 |
-| Katana | [dcc-mcp-katana](https://github.com/dcc-mcp/dcc-mcp-katana) | 0.3.0 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
+| Illustrator | [dcc-mcp-illustrator](https://github.com/dcc-mcp/dcc-mcp-illustrator) | 0.2.0 | >=0.19.91,<1.0.0 | — | Authenticated CEP bridge + broker | 2026-08 |
+| GIMP | [dcc-mcp-gimp](https://github.com/dcc-mcp/dcc-mcp-gimp) | 0.3.0 | >=0.19.38,<1.0.0 | 3.0+ | Authenticated JSON-lines bridge + GLib main-thread dispatcher | — |
+| Krita | [dcc-mcp-krita](https://github.com/dcc-mcp/dcc-mcp-krita) | 0.3.0 | >=0.19.38,<1.0.0 | — | Authenticated JSON-lines bridge + UI main-thread queue | — |
+| SketchUp | [dcc-mcp-sketchup](https://github.com/dcc-mcp/dcc-mcp-sketchup) | 0.1.0 | >=0.19.91,<1.0.0 | 2021+ | Authenticated Ruby main-thread bridge + sidecar | 2026-08 |
+| TouchDesigner | [dcc-mcp-touchdesigner](https://github.com/dcc-mcp/dcc-mcp-touchdesigner) | 0.1.0 | >=0.19.91,<1.0.0 | 2025 official build | In-process HTTP runtime + `td.run()` main-thread dispatcher | — |
+| Tiled | [dcc-mcp-tiled](https://github.com/dcc-mcp/dcc-mcp-tiled) | 0.3.0 | >=0.19.38,<1.0.0 | 1.10+ | Standalone service + fixed JavaScript driver through `tiled --evaluate` | 2026-08 |
+| Material Maker | [dcc-mcp-material-maker](https://github.com/dcc-mcp/dcc-mcp-material-maker) | 0.3.0 | >=0.19.38,<1.0.0 | 1.7 | Standalone `.ptex` parser + native CLI exporter | — |
+| Wwise | [dcc-mcp-wwise](https://github.com/dcc-mcp/dcc-mcp-wwise) | 0.1.1 | >=0.19.86,<1.0.0 | 2024.1+ | External WAAPI client + host PID binding | 2026-07 |
+| Katana | [dcc-mcp-katana](https://github.com/dcc-mcp/dcc-mcp-katana) | 0.4.0 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
 | MotionBuilder | [dcc-mcp-mobu](https://github.com/dcc-mcp/dcc-mcp-mobu) | 0.3.0 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
 | RenderDoc | [dcc-mcp-renderdoc](https://github.com/dcc-mcp/dcc-mcp-renderdoc) | 0.3.0 | >=0.19.45,<1.0.0 | — | Headless CLI adapter | 2026-07 |
 | Substance 3D Designer | [dcc-mcp-substance3d-designer](https://github.com/dcc-mcp/dcc-mcp-substance3d-designer) | 0.3.0 | >=0.19.45,<1.0.0 | — | Host bridge | — |


### PR DESCRIPTION
## Summary
- publish 34 first-party DCC types through the bundled catalog and CLI
- add install metadata for the new production adapters
- align the compatibility matrix with the adapter release wave

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p dcc-mcp-catalog` (34 passed)
- `cargo test -p dcc-mcp-cli --test cli_e2e dcc_types_lists_release_catalog_without_a_gateway -- --exact`

## Privacy
- catalog entries contain public repository, package, and runtime metadata only
- no local host, THM, user path, or private validation evidence is included