### PR TITLE
feat: support host-neutral Marketplace Skills

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -1226,15 +1226,11 @@ entries:
             ),
             ("dcc-mcp-comfyui", "comfyui", "dcc_mcp_comfyui.cli:main"),
             (
-                "dcc-mcp-cache-inspector",
-                "cache-inspector",
-                "dcc_mcp_cache_inspector.server:CacheInspectorMcpServer",
-            ),
-            (
                 "dcc-mcp-touchdesigner",
                 "touchdesigner",
                 "dcc_mcp_touchdesigner:TouchDesignerMcpServer",
             ),
+            ("dcc-mcp-shogun", "shogun", "dcc_mcp_shogun:ShogunMcpServer"),
             ("dcc-mcp-krita", "krita", "dcc_mcp_krita.server:main"),
             ("dcc-mcp-gimp", "gimp", "dcc_mcp_gimp.server:main"),
             ("dcc-mcp-tiled", "tiled", "dcc_mcp_tiled.server:main"),

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -805,7 +805,6 @@ mod tests {
         );
         for (expected_type, expected_adapter) in [
             ("c4d", "dcc-mcp-cinema4d"),
-            ("cache-inspector", "dcc-mcp-cache-inspector"),
             ("comfyui", "dcc-mcp-comfyui"),
             ("freecad", "dcc-mcp-freecad"),
             ("gimp", "dcc-mcp-gimp"),
@@ -816,6 +815,7 @@ mod tests {
             ("openscad", "dcc-mcp-openscad"),
             ("renderdoc", "dcc-mcp-renderdoc"),
             ("sketchup", "dcc-mcp-sketchup"),
+            ("shogun", "dcc-mcp-shogun"),
             ("tiled", "dcc-mcp-tiled"),
             ("touchdesigner", "dcc-mcp-touchdesigner"),
             ("unity", "dcc-mcp-unity"),

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -1743,7 +1743,6 @@ fn dcc_types_lists_release_catalog_without_a_gateway() {
     for expected in [
         "aftereffects",
         "c4d",
-        "cache-inspector",
         "comfyui",
         "freecad",
         "gimp",
@@ -1758,6 +1757,7 @@ fn dcc_types_lists_release_catalog_without_a_gateway() {
         "renderdoc",
         "shotgrid",
         "sketchup",
+        "shogun",
         "tiled",
         "touchdesigner",
         "unity",

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -943,6 +943,37 @@ mod tests {
     }
 
     #[test]
+    fn host_neutral_entry_requires_an_explicit_concrete_dcc() {
+        let entry = CatalogEntry {
+            name: "host-neutral".into(),
+            description: "desc".into(),
+            dcc: vec!["any".into()],
+            url: None,
+            tags: vec![],
+            version: None,
+            min_core_version: None,
+            install: None,
+            package: None,
+            maintainer: None,
+            category: None,
+            policy: None,
+            requires: None,
+            icon: None,
+            showcase: None,
+        };
+
+        assert_eq!(resolve_install_dcc(&entry, Some("Maya")).unwrap(), "maya");
+        assert!(matches!(
+            resolve_install_dcc(&entry, Some("any")),
+            Err(MarketplaceError::AmbiguousDcc { .. })
+        ));
+        assert!(matches!(
+            resolve_install_dcc(&entry, None),
+            Err(MarketplaceError::AmbiguousDcc { .. })
+        ));
+    }
+
+    #[test]
     fn installed_state_round_trip() {
         let tmp = tempfile::tempdir().unwrap();
         let svc = MarketplaceService::new(tmp.path().to_path_buf());

--- a/crates/dcc-mcp-marketplace/src/service_internals.rs
+++ b/crates/dcc-mcp-marketplace/src/service_internals.rs
@@ -157,12 +157,23 @@ pub fn resolve_install_dcc(
 ) -> Result<String, MarketplaceError> {
     if let Some(dcc) = requested {
         let dcc_name = path_component("DCC name", dcc)?.to_lowercase();
+        if dcc_name == "any" {
+            return Err(MarketplaceError::AmbiguousDcc {
+                name: entry.name.clone(),
+            });
+        }
         if entry_targets_dcc(entry, &dcc_name) {
             return Ok(dcc_name);
         }
         return Err(MarketplaceError::DccMismatch {
             name: entry.name.clone(),
             dcc: dcc.to_string(),
+        });
+    }
+
+    if entry.dcc.iter().any(|dcc| dcc.eq_ignore_ascii_case("any")) {
+        return Err(MarketplaceError::AmbiguousDcc {
+            name: entry.name.clone(),
         });
     }
 

--- a/crates/dcc-mcp-marketplace/src/types.rs
+++ b/crates/dcc-mcp-marketplace/src/types.rs
@@ -207,11 +207,14 @@ pub struct RepoInstallResult {
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 /// Check whether `entry` targets the given DCC type (case-insensitive).
+///
+/// `any` is the host-neutral wildcard used by Skills that can be loaded into a
+/// concrete adapter without owning a standalone DCC runtime.
 pub fn entry_targets_dcc(entry: &CatalogEntry, dcc: &str) -> bool {
     entry
         .dcc
         .iter()
-        .any(|value| value.eq_ignore_ascii_case(dcc))
+        .any(|value| value.eq_ignore_ascii_case("any") || value.eq_ignore_ascii_case(dcc))
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
@@ -242,5 +245,30 @@ mod tests {
         assert!(entry_targets_dcc(&entry, "Maya"));
         assert!(entry_targets_dcc(&entry, "BLENDER"));
         assert!(!entry_targets_dcc(&entry, "houdini"));
+    }
+
+    #[test]
+    fn entry_targets_dcc_treats_any_as_host_neutral() {
+        let entry = CatalogEntry {
+            name: "host-neutral".into(),
+            description: "desc".into(),
+            dcc: vec!["ANY".into()],
+            url: None,
+            tags: vec![],
+            version: None,
+            min_core_version: None,
+            install: None,
+            package: None,
+            maintainer: None,
+            category: None,
+            policy: None,
+            requires: None,
+            icon: None,
+            showcase: None,
+        };
+
+        assert!(entry_targets_dcc(&entry, "maya"));
+        assert!(entry_targets_dcc(&entry, "Blender"));
+        assert!(entry_targets_dcc(&entry, "custom-host"));
     }
 }

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -355,20 +355,6 @@ entries:
       entry_point: "dcc_mcp_comfyui.cli:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-comfyui/main/README.md"
 
-  - name: "dcc-mcp-cache-inspector"
-    description: "Standalone read-only inspector for bounded privacy-safe SideFX geo, bgeo, and bgeo.sc cache summaries"
-    dcc: ["cache-inspector"]
-    url: "https://github.com/dcc-mcp/dcc-mcp-cache-inspector"
-    tags: ["adapter", "cache-inspector", "official", "pip", "standalone", "read-only", "geometry-cache", "houdini"]
-    version: "0.2.0"
-    min_core_version: "0.19.91"
-    maintainer: "dcc-mcp"
-    install:
-      type: pip
-      pip_package: "dcc-mcp-cache-inspector"
-      entry_point: "dcc_mcp_cache_inspector.server:CacheInspectorMcpServer"
-      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-cache-inspector/main/README.md"
-
   - name: "dcc-mcp-mari"
     description: "Mari adapter for typed project, geometry, channel, node-graph, layer, shader, image, and export workflows"
     dcc: ["mari"]
@@ -409,6 +395,20 @@ entries:
       pip_package: "dcc-mcp-touchdesigner"
       entry_point: "dcc_mcp_touchdesigner:TouchDesignerMcpServer"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-touchdesigner/main/install.md"
+
+  - name: "dcc-mcp-shogun"
+    description: "Vicon Shogun Post adapter with typed scene, file, timeline, and capability-gated processing workflows"
+    dcc: ["shogun"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-shogun"
+    tags: ["adapter", "shogun", "vicon", "official", "pip", "motion-capture", "timeline", "processing"]
+    version: "0.2.0"
+    min_core_version: "0.19.91"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-shogun"
+      entry_point: "dcc_mcp_shogun:ShogunMcpServer"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-shogun/main/README.md"
 
   - name: "dcc-mcp-tiled"
     description: "Tiled adapter for typed workspace-bounded map authoring, validation, and conversion"

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -30,7 +30,7 @@ submit a PR updating this matrix before the release PR merges.
 | FreeCAD | [dcc-mcp-freecad](https://github.com/dcc-mcp/dcc-mcp-freecad) | 0.1.2 | >=0.19.91,<1.0.0 | 1.0+ | External FreeCADCmd subprocess | 2026-08 |
 | Cinema 4D | [dcc-mcp-cinema4d](https://github.com/dcc-mcp/dcc-mcp-cinema4d) | 0.1.3 | >=0.19.91,<1.0.0 | R21+ | External headless c4dpy subprocess | 2026-08 |
 | ComfyUI | [dcc-mcp-comfyui](https://github.com/dcc-mcp/dcc-mcp-comfyui) | 0.1.0 | >=0.19.91,<1.0.0 | 0.31+ | Standalone sidecar + local REST workflow bridge | 2026-08 |
-| Cache Inspector | [dcc-mcp-cache-inspector](https://github.com/dcc-mcp/dcc-mcp-cache-inspector) | 0.2.0 | >=0.19.91,<1.0.0 | — | Standalone inline read-only cache decoder | 2026-08 |
+| Shogun | [dcc-mcp-shogun](https://github.com/dcc-mcp/dcc-mcp-shogun) | 0.2.0 | >=0.19.91,<1.0.0 | Vicon Shogun Post | Typed scene and file workflows; Timeline and Offline processing are capability-gated | 2026-08 |
 | Mari | [dcc-mcp-mari](https://github.com/dcc-mcp/dcc-mcp-mari) | 0.2.1 | >=0.19.91,<1.0.0 | 5.0+ | Authenticated loopback sidecar + Qt UI timer | 2026-08 |
 | 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.40 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-08 |
 | Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.43 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-08 |

--- a/skills/marketplace-publish-extension/SKILL.md
+++ b/skills/marketplace-publish-extension/SKILL.md
@@ -93,6 +93,9 @@ push the change.
 - Pass `--min-core-version`; v1 entries require an explicit compatibility floor.
 - Git sources in the official catalog must use a complete 40-character commit
   SHA in `--install-ref`, never a mutable branch name.
+- Host-neutral Skills declare `dcc: any`. They match every concrete adapter,
+  but installation must still pass a concrete `--dcc`; `any` is never an
+  installation directory or a standalone DCC runtime.
 - Declare every installed skill directory with `--skill-root`. The installer
   only loads declared roots, so multi-skill repositories do not accidentally
   expose examples or development-only skills.


### PR DESCRIPTION
## Summary
- make dcc:any entries match any concrete Marketplace host
- require an explicit concrete --dcc and never install into an any bucket
- replace the retired Cache Inspector adapter entry with dcc-mcp-shogun 0.2.0
- document the public host-neutral publishing contract

## Validation
- cargo test -p dcc-mcp-marketplace (51 passed)
- cargo test -p dcc-mcp-catalog (34 passed)
- targeted CLI catalog unit and e2e tests
- cargo fmt --all -- --check