### PR TITLE
feat: install CUA profiles from marketplace

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -37,6 +37,9 @@ pub struct CatalogEntry {
     /// DCC application(s) this entry targets (e.g. `["maya", "blender"]`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dcc: Vec<String>,
+    /// Generic application targets for this package.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub targets: Vec<CatalogTarget>,
     /// Canonical URL (GitHub repo, docs site, …).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -89,9 +92,73 @@ pub struct CatalogEntry {
 pub struct CatalogPackage {
     /// Package format. `agent-plugin` follows agent-plugins.org; `skill-bundle`
     /// is the legacy DCC-MCP multi-skill layout.
-    pub format: String,
+    pub format: CatalogPackageFormat,
     /// Agent Skill names included in the package.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub skills: Vec<String>,
+    /// Typed installable components contained by this package.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub components: Vec<CatalogComponent>,
+}
+
+/// A generic marketplace target, independent from DCC adapters.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct CatalogTarget {
+    pub kind: CatalogTargetKind,
+    pub id: String,
+}
+
+impl std::fmt::Display for CatalogTarget {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}:{}", self.kind, self.id)
+    }
+}
+
+/// Supported target namespaces.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "kebab-case")]
+pub enum CatalogTargetKind {
+    Dcc,
+    Application,
+    Game,
+    Web,
+}
+
+impl std::fmt::Display for CatalogTargetKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Dcc => "dcc",
+            Self::Application => "application",
+            Self::Game => "game",
+            Self::Web => "web",
+        })
+    }
+}
+
+/// Portable package formats with explicit install semantics.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CatalogPackageFormat {
+    Skill,
+    SkillBundle,
+    AgentPlugin,
+    CuaProfile,
+    Composite,
+}
+
+/// A typed package component and its safe package-relative root.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CatalogComponent {
+    pub kind: CatalogComponentKind,
+    pub id: String,
+    pub root: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CatalogComponentKind {
+    Skill,
+    CuaProfile,
 }
 
 /// Installation policy attached to a marketplace package.
@@ -266,6 +333,12 @@ impl SearchRecord for CatalogSearchRecord<'_> {
 
 fn catalog_search_tokens(entry: &CatalogEntry) -> Vec<String> {
     let mut tokens = entry.dcc.clone();
+    tokens.extend(
+        entry
+            .targets
+            .iter()
+            .flat_map(|target| [target.kind.to_string(), target.id.clone()]),
+    );
     tokens.extend(entry.url.iter().cloned());
     tokens.extend(entry.version.iter().cloned());
     tokens.extend(entry.min_core_version.iter().cloned());
@@ -282,6 +355,12 @@ fn catalog_search_tokens(entry: &CatalogEntry) -> Vec<String> {
     }
     if let Some(package) = &entry.package {
         tokens.extend(package.skills.iter().cloned());
+        tokens.extend(
+            package
+                .components
+                .iter()
+                .flat_map(|component| [component.id.clone(), component.root.clone()]),
+        );
     }
 
     if let Some(install) = &entry.install {
@@ -368,14 +447,14 @@ pub fn describe(entries: &[CatalogEntry], name: &str) -> Option<CatalogEntry> {
 
 // ── schema validation ─────────────────────────────────────────────────────────
 
-/// JSON Schema (Draft 2020-12) for marketplace-v1 catalog entries.
+/// JSON Schema (Draft 2020-12) for marketplace-v2 catalog entries.
 ///
 /// Each entry must declare at least `name` and `description`; all other
 /// fields are optional.  `additionalProperties: false` on both the top-level
 /// document and each entry catches typos early.
-const MARKETPLACE_V1_SCHEMA_JSON: &str = r##"{
+const MARKETPLACE_V2_SCHEMA_JSON: &str = r##"{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://dcc-mcp.github.io/schemas/marketplace-v1.schema.json",
+  "$id": "https://dcc-mcp.github.io/schemas/marketplace-v2.schema.json",
   "title": "DCC-MCP Marketplace Catalog",
   "description": "Schema for marketplace.json catalog entries",
   "type": "object",
@@ -396,6 +475,20 @@ const MARKETPLACE_V1_SCHEMA_JSON: &str = r##"{
         "name":        { "type": "string", "minLength": 1 },
         "description": { "type": "string", "minLength": 1 },
         "dcc":         { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "targets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["kind", "id"],
+            "properties": {
+              "kind": { "type": "string", "enum": ["dcc", "application", "game", "web"] },
+              "id": { "type": "string", "minLength": 1 }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
+        },
         "url":         { "type": "string" },
         "tags":        { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
         "version":          { "type": "string" },
@@ -427,20 +520,42 @@ const MARKETPLACE_V1_SCHEMA_JSON: &str = r##"{
         },
         "package": {
           "type": "object",
-          "required": ["format", "skills"],
+          "required": ["format"],
           "properties": {
-            "format": { "type": "string", "enum": ["agent-plugin", "skill-bundle"] },
+            "format": { "type": "string", "enum": ["skill", "agent-plugin", "skill-bundle", "cua-profile", "composite"] },
             "skills": {
               "type": "array",
-              "minItems": 1,
               "items": { "type": "string", "minLength": 1 },
               "uniqueItems": true
+            },
+            "components": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["kind", "id", "root"],
+                "properties": {
+                  "kind": { "type": "string", "enum": ["skill", "cua-profile"] },
+                  "id": { "type": "string", "minLength": 1 },
+                  "root": { "type": "string", "minLength": 1 }
+                },
+                "additionalProperties": false
+              }
             }
           },
-          "allOf": [{
-            "if": { "properties": { "format": { "const": "skill-bundle" } } },
-            "then": { "properties": { "skills": { "minItems": 2 } } }
-          }],
+          "allOf": [
+            {
+              "if": { "properties": { "format": { "enum": ["skill", "agent-plugin", "skill-bundle"] } } },
+              "then": { "required": ["skills"], "properties": { "skills": { "minItems": 1 } } }
+            },
+            {
+              "if": { "properties": { "format": { "const": "skill-bundle" } } },
+              "then": { "properties": { "skills": { "minItems": 2 } } }
+            },
+            {
+              "if": { "properties": { "format": { "const": "cua-profile" } } },
+              "then": { "required": ["components"], "properties": { "components": { "minItems": 1, "maxItems": 1 } } }
+            }
+          ],
           "additionalProperties": false
         },
         "install": {
@@ -466,7 +581,7 @@ const MARKETPLACE_V1_SCHEMA_JSON: &str = r##"{
   }
 }"##;
 
-/// Validate a single [`CatalogEntry`] against the marketplace-v1 JSON Schema.
+/// Validate a single [`CatalogEntry`] against the marketplace-v2 JSON Schema.
 ///
 /// Returns `Ok(())` if the entry is valid, or a
 /// [`CatalogValidationError::ValidationFailed`] with a human-readable message
@@ -490,7 +605,7 @@ pub fn validate_entry(entry: &CatalogEntry) -> Result<(), CatalogValidationError
     Ok(())
 }
 
-/// Validate a slice of [`CatalogEntry`] against the marketplace-v1 JSON Schema.
+/// Validate a slice of [`CatalogEntry`] against the marketplace-v2 JSON Schema.
 ///
 /// Returns `Ok(())` if all entries pass, or
 /// [`CatalogValidationError::MultipleFailures`] aggregating each failed entry.
@@ -511,7 +626,7 @@ pub fn validate_catalog_entries(entries: &[CatalogEntry]) -> Result<(), CatalogV
 
 /// Compile the entry sub-schema once from `$defs/entry`.
 fn entry_schema() -> Result<jsonschema::Validator, CatalogValidationError> {
-    let schema_value: serde_json::Value = serde_json::from_str(MARKETPLACE_V1_SCHEMA_JSON)
+    let schema_value: serde_json::Value = serde_json::from_str(MARKETPLACE_V2_SCHEMA_JSON)
         .map_err(|e| {
             CatalogValidationError::SchemaError(format!("invalid embedded schema: {e}"))
         })?;
@@ -580,8 +695,9 @@ entries:
     fn test_search_by_packaged_skill() {
         let mut entry = make_entry("maya-mgear", "Maya rigging bundle");
         entry.package = Some(CatalogPackage {
-            format: "skill-bundle".into(),
+            format: CatalogPackageFormat::SkillBundle,
             skills: vec!["maya-mgear".into(), "mgear-import-to-scene".into()],
+            components: vec![],
         });
 
         let results = search(&[entry], "mgear-import-to-scene");
@@ -670,6 +786,7 @@ entries:
             name: "maya-toolkit".into(),
             description: "Advanced Maya pipeline tools".into(),
             dcc: vec!["maya".into()],
+            targets: vec![],
             url: None,
             tags: vec!["maya".into(), "official".into()],
             version: None,
@@ -864,6 +981,7 @@ entries:
             name: name.into(),
             description: description.into(),
             dcc: vec![],
+            targets: vec![],
             url: None,
             tags: vec![],
             version: None,
@@ -889,8 +1007,9 @@ entries:
     fn test_validate_entry_rejects_single_skill_bundle() {
         let mut entry = make_entry("my-bundle", "A bundle");
         entry.package = Some(CatalogPackage {
-            format: "skill-bundle".into(),
+            format: CatalogPackageFormat::SkillBundle,
             skills: vec!["only-one".into()],
+            components: vec![],
         });
         assert!(validate_entry(&entry).is_err());
     }
@@ -921,6 +1040,7 @@ entries:
             name: "zip-skill".into(),
             description: "A zip-installed skill".into(),
             dcc: vec!["maya".into()],
+            targets: vec![],
             url: Some("https://example.com/skill".into()),
             tags: vec!["test".into()],
             version: Some("0.1.0".into()),
@@ -954,6 +1074,7 @@ entries:
             name: "pip-skill".into(),
             description: "A pip-installed skill".into(),
             dcc: vec!["maya".into()],
+            targets: vec![],
             url: Some("https://pypi.org/project/dcc-mcp-maya".into()),
             tags: vec!["pip".into(), "maya".into()],
             version: Some("0.3.0".into()),
@@ -1035,6 +1156,7 @@ entries:
             name: "minimal-pip".into(),
             description: "A minimal pip-installed adapter".into(),
             dcc: vec![],
+            targets: vec![],
             url: None,
             tags: vec![],
             version: None,
@@ -1068,6 +1190,7 @@ entries:
             name: "icon-skill".into(),
             description: "A skill with an icon".into(),
             dcc: vec![],
+            targets: vec![],
             url: None,
             tags: vec![],
             version: None,

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -983,6 +983,7 @@ mod tests {
                 name: "dcc-mcp-maya".into(),
                 description: "Maya adapter".into(),
                 dcc: vec!["maya".into()],
+                targets: vec![],
                 url: None,
                 tags: vec![],
                 version: None,

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -573,6 +573,7 @@ mod tests {
             name: name.into(),
             description: "Adapter".into(),
             dcc: dcc.iter().map(|value| value.to_string()).collect(),
+            targets: vec![],
             url: Some("https://example.invalid/adapter".into()),
             tags: vec!["official".into()],
             version: None,

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 #[cfg(test)]
 use base64::Engine;
 use clap::{Parser, Subcommand};
@@ -414,6 +414,9 @@ enum MarketplaceAction {
         query_terms: Vec<String>,
         #[arg(long, visible_alias = "dcc-type")]
         dcc: Option<String>,
+        /// Generic target in KIND:ID form (for example game:the-bazaar).
+        #[arg(long, conflicts_with = "dcc")]
+        target: Option<String>,
         /// Use this source for the query instead of configured sources.
         #[arg(long = "source")]
         sources: Vec<String>,
@@ -439,6 +442,9 @@ enum MarketplaceAction {
         /// Target DCC; inferred when the package declares exactly one.
         #[arg(long)]
         dcc: Option<String>,
+        /// Generic target in KIND:ID form (for example application:excel).
+        #[arg(long, conflicts_with = "dcc")]
+        target: Option<String>,
         /// Ask running instances of the installed DCC to re-scan skill paths.
         #[arg(long)]
         reload: bool,
@@ -458,6 +464,9 @@ enum MarketplaceAction {
         /// Target DCC; inferred from installed state when omitted.
         #[arg(long)]
         dcc: Option<String>,
+        /// Generic target in KIND:ID form; inferred from installed state when omitted.
+        #[arg(long, conflicts_with = "dcc")]
+        target: Option<String>,
         /// Ask the running adapter to re-scan skill paths after removal.
         #[arg(long)]
         reload: bool,
@@ -466,6 +475,8 @@ enum MarketplaceAction {
     ListInstalled {
         #[arg(long)]
         dcc: Option<String>,
+        #[arg(long, conflicts_with = "dcc")]
+        target: Option<String>,
     },
     /// List installed packages that have newer versions in the catalog.
     Outdated {
@@ -1007,20 +1018,27 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                     query,
                     query_terms,
                     dcc,
+                    target,
                     sources,
                     limit,
                     skip_validation,
-                } => to_json(
-                    service
-                        .search(
-                            resolve_query(query, query_terms),
-                            dcc,
-                            sources,
-                            limit,
-                            skip_validation,
-                        )
-                        .await?,
-                )?,
+                } => {
+                    let query = resolve_query(query, query_terms);
+                    if let Some(target) = target {
+                        let target = parse_marketplace_target(&target)?;
+                        to_json(
+                            service
+                                .search_for_target(query, target, sources, limit, skip_validation)
+                                .await?,
+                        )?
+                    } else {
+                        to_json(
+                            service
+                                .search(query, dcc, sources, limit, skip_validation)
+                                .await?,
+                        )?
+                    }
+                }
                 MarketplaceAction::Inspect {
                     name,
                     sources,
@@ -1029,17 +1047,32 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                 MarketplaceAction::Install {
                     name,
                     dcc,
+                    target,
                     reload,
                     sources,
                     force,
                     skip_validation,
                 } => {
-                    let installed = service
-                        .install(name, dcc, sources, force, skip_validation)
-                        .await?;
+                    let installed = if let Some(target) = target {
+                        service
+                            .install_for_target(
+                                name,
+                                parse_marketplace_target(&target)?,
+                                sources,
+                                force,
+                                skip_validation,
+                            )
+                            .await?
+                    } else {
+                        service
+                            .install(name, dcc, sources, force, skip_validation)
+                            .await?
+                    };
                     let installed_dcc = installed.dcc.clone();
+                    let skill_reload = installed.activation
+                        == dcc_mcp_marketplace::MarketplaceActivation::SkillReload;
                     let mut value = to_json(installed)?;
-                    if reload {
+                    if reload && skill_reload {
                         let (reloaded_value, reload_failed) =
                             reload_marketplace_value(&control, value, installed_dcc).await;
                         value = reloaded_value;
@@ -1050,11 +1083,30 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                     }
                     value
                 }
-                MarketplaceAction::Uninstall { name, dcc, reload } => {
-                    let installed_dcc = service.resolve_installed_dcc(&name, dcc.as_deref())?;
-                    let result = service.uninstall(&name, &installed_dcc)?;
+                MarketplaceAction::Uninstall {
+                    name,
+                    dcc,
+                    target,
+                    reload,
+                } => {
+                    let requested_target = target
+                        .as_deref()
+                        .map(parse_marketplace_target)
+                        .transpose()?;
+                    let installed_target = if requested_target.is_some() || dcc.is_none() {
+                        service.resolve_installed_target(&name, requested_target.as_ref())?
+                    } else {
+                        dcc_mcp_catalog::CatalogTarget {
+                            kind: dcc_mcp_catalog::CatalogTargetKind::Dcc,
+                            id: dcc.clone().unwrap_or_default(),
+                        }
+                    };
+                    let installed_dcc = installed_target.id.clone();
+                    let result = service.uninstall_for_target(&name, &installed_target)?;
+                    let skill_reload = result.activation
+                        == dcc_mcp_marketplace::MarketplaceActivation::SkillReload;
                     let mut value = to_json(result)?;
-                    if reload {
+                    if reload && skill_reload {
                         let (reloaded_value, reload_failed) =
                             reload_marketplace_value(&control, value, installed_dcc).await;
                         value = reloaded_value;
@@ -1065,8 +1117,13 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                     }
                     value
                 }
-                MarketplaceAction::ListInstalled { dcc } => {
-                    to_json(service.list_installed(dcc.as_deref())?)?
+                MarketplaceAction::ListInstalled { dcc, target } => {
+                    if let Some(target) = target {
+                        let target = parse_marketplace_target(&target)?;
+                        to_json(service.list_installed_for_target(Some(&target))?)?
+                    } else {
+                        to_json(service.list_installed(dcc.as_deref())?)?
+                    }
                 }
                 MarketplaceAction::Outdated { dcc, names } => {
                     to_json(service.outdated(dcc.as_deref(), names).await?)?
@@ -1350,6 +1407,12 @@ fn resolve_query(query: Option<String>, query_terms: Vec<String>) -> Option<Stri
     query.or_else(|| {
         let joined = query_terms.join(" ");
         (!joined.is_empty()).then_some(joined)
+    })
+}
+
+fn parse_marketplace_target(value: &str) -> anyhow::Result<dcc_mcp_catalog::CatalogTarget> {
+    dcc_mcp_marketplace::parse_target(value).map_err(|_| {
+        anyhow!("invalid marketplace target '{value}'; expected dcc|application|game|web:ID")
     })
 }
 

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -45,7 +45,7 @@ use marketplace_output::reload_marketplace_value;
 use record_replay::{RecordReplayAction, run_record_replay};
 use ui_control_output::compact_ui_control_result;
 
-use super::marketplace_cmd;
+use super::marketplace_cmd::{self, MarketplaceAction};
 #[cfg(test)]
 use super::update_cmd::UpdateAction;
 
@@ -393,131 +393,6 @@ struct UiControlArgs {
     /// Print the complete underlying MCP response, including the bounded UI tree.
     #[arg(long, default_value_t = false)]
     full_output: bool,
-}
-
-#[derive(Debug, Subcommand)]
-enum MarketplaceAction {
-    /// Add a marketplace source (raw URL, local file, or GitHub owner/repo).
-    Add {
-        #[arg(value_name = "SOURCE")]
-        source: String,
-    },
-    /// List configured marketplace sources.
-    List,
-    /// Search marketplace entries across configured sources.
-    Search {
-        /// Query text. Positional words are also accepted, for example `search maya rigging`.
-        #[arg(short, long, conflicts_with = "query_terms")]
-        query: Option<String>,
-        /// Unquoted positional query words joined with spaces.
-        #[arg(value_name = "QUERY", num_args = 1.., conflicts_with = "query")]
-        query_terms: Vec<String>,
-        #[arg(long, visible_alias = "dcc-type")]
-        dcc: Option<String>,
-        /// Generic target in KIND:ID form (for example game:the-bazaar).
-        #[arg(long, conflicts_with = "dcc")]
-        target: Option<String>,
-        /// Use this source for the query instead of configured sources.
-        #[arg(long = "source")]
-        sources: Vec<String>,
-        #[arg(long)]
-        limit: Option<usize>,
-        /// Bypass JSON Schema validation of marketplace entries.
-        #[arg(long)]
-        skip_validation: bool,
-    },
-    /// Inspect one marketplace entry by exact name.
-    Inspect {
-        name: String,
-        /// Use this source for the query instead of configured sources.
-        #[arg(long = "source")]
-        sources: Vec<String>,
-        /// Bypass JSON Schema validation of marketplace entries.
-        #[arg(long)]
-        skip_validation: bool,
-    },
-    /// Install a marketplace plugin, bundle, or Skill package.
-    Install {
-        name: String,
-        /// Target DCC; inferred when the package declares exactly one.
-        #[arg(long)]
-        dcc: Option<String>,
-        /// Generic target in KIND:ID form (for example application:excel).
-        #[arg(long, conflicts_with = "dcc")]
-        target: Option<String>,
-        /// Ask running instances of the installed DCC to re-scan skill paths.
-        #[arg(long)]
-        reload: bool,
-        /// Use this source for the query instead of configured sources.
-        #[arg(long = "source")]
-        sources: Vec<String>,
-        /// Replace an existing installed package.
-        #[arg(long)]
-        force: bool,
-        /// Bypass JSON Schema validation of marketplace entries.
-        #[arg(long)]
-        skip_validation: bool,
-    },
-    /// Remove an installed marketplace package.
-    Uninstall {
-        name: String,
-        /// Target DCC; inferred from installed state when omitted.
-        #[arg(long)]
-        dcc: Option<String>,
-        /// Generic target in KIND:ID form; inferred from installed state when omitted.
-        #[arg(long, conflicts_with = "dcc")]
-        target: Option<String>,
-        /// Ask the running adapter to re-scan skill paths after removal.
-        #[arg(long)]
-        reload: bool,
-    },
-    /// List installed marketplace packages.
-    ListInstalled {
-        #[arg(long)]
-        dcc: Option<String>,
-        #[arg(long, conflicts_with = "dcc")]
-        target: Option<String>,
-    },
-    /// List installed packages that have newer versions in the catalog.
-    Outdated {
-        #[arg(long)]
-        dcc: Option<String>,
-        /// Only check these package names.
-        #[arg(value_name = "NAME")]
-        names: Vec<String>,
-    },
-    /// Upgrade installed marketplace packages to the latest catalog version.
-    Update {
-        /// Upgrade a specific package by name.
-        name: Option<String>,
-        /// Upgrade all outdated packages.
-        #[arg(long, short = 'a')]
-        all: bool,
-        /// Filter to installed packages for this DCC.
-        #[arg(long)]
-        dcc: Option<String>,
-    },
-    /// Install a Skill or Agent Plugin directly from a GitHub repo.
-    ///
-    /// Clones the repo, discovers SKILL.md files, and installs to the
-    /// marketplace root. Supports owner/repo, full URL, and @subpath syntax.
-    AddRepo {
-        /// GitHub owner/repo, full URL, or owner/repo@subpath.
-        repo_ref: String,
-        /// Override the DCC type (required when SKILL.md doesn't declare one).
-        #[arg(long)]
-        dcc: Option<String>,
-        /// List available skills in the repo without installing.
-        #[arg(long)]
-        list: bool,
-        /// Replace an existing installation.
-        #[arg(long)]
-        force: bool,
-    },
-    /// Create a zip package and SHA-256 digest for a local marketplace package.
-    Pack(marketplace_cmd::MarketplacePackArgs),
-    /// Upsert a package entry into a local marketplace.json catalog.
-    Publish(Box<marketplace_cmd::MarketplacePublishArgs>),
 }
 
 #[derive(Debug, clap::Args)]

--- a/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
@@ -886,6 +886,7 @@ fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
                 action: MarketplaceAction::Install {
                     name: "dcc-mcp-maya-mgear".to_string(),
                     dcc: Some("maya".to_string()),
+                    target: None,
                     reload: true,
                     sources: Vec::new(),
                     force: false,
@@ -903,6 +904,7 @@ fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
                 action: MarketplaceAction::Install {
                     name: "dcc-mcp-maya-mgear".to_string(),
                     dcc: Some("maya".to_string()),
+                    target: None,
                     reload: false,
                     sources: Vec::new(),
                     force: false,

--- a/crates/dcc-mcp-cli/src/presentation/marketplace_cmd.rs
+++ b/crates/dcc-mcp-cli/src/presentation/marketplace_cmd.rs
@@ -3,6 +3,90 @@ use std::path::PathBuf;
 use anyhow::Context;
 use serde_json::Value;
 
+#[derive(Debug, clap::Subcommand)]
+pub(crate) enum MarketplaceAction {
+    Add {
+        source: String,
+    },
+    List,
+    Search {
+        #[arg(short, long, conflicts_with = "query_terms")]
+        query: Option<String>,
+        #[arg(value_name = "QUERY", num_args = 1.., conflicts_with = "query")]
+        query_terms: Vec<String>,
+        #[arg(long, visible_alias = "dcc-type")]
+        dcc: Option<String>,
+        #[arg(long, conflicts_with = "dcc")]
+        target: Option<String>,
+        #[arg(long = "source")]
+        sources: Vec<String>,
+        #[arg(long)]
+        limit: Option<usize>,
+        #[arg(long)]
+        skip_validation: bool,
+    },
+    Inspect {
+        name: String,
+        #[arg(long = "source")]
+        sources: Vec<String>,
+        #[arg(long)]
+        skip_validation: bool,
+    },
+    Install {
+        name: String,
+        #[arg(long)]
+        dcc: Option<String>,
+        #[arg(long, conflicts_with = "dcc")]
+        target: Option<String>,
+        #[arg(long)]
+        reload: bool,
+        #[arg(long = "source")]
+        sources: Vec<String>,
+        #[arg(long)]
+        force: bool,
+        #[arg(long)]
+        skip_validation: bool,
+    },
+    Uninstall {
+        name: String,
+        #[arg(long)]
+        dcc: Option<String>,
+        #[arg(long, conflicts_with = "dcc")]
+        target: Option<String>,
+        #[arg(long)]
+        reload: bool,
+    },
+    ListInstalled {
+        #[arg(long)]
+        dcc: Option<String>,
+        #[arg(long, conflicts_with = "dcc")]
+        target: Option<String>,
+    },
+    Outdated {
+        #[arg(long)]
+        dcc: Option<String>,
+        names: Vec<String>,
+    },
+    Update {
+        name: Option<String>,
+        #[arg(long, short = 'a')]
+        all: bool,
+        #[arg(long)]
+        dcc: Option<String>,
+    },
+    AddRepo {
+        repo_ref: String,
+        #[arg(long)]
+        dcc: Option<String>,
+        #[arg(long)]
+        list: bool,
+        #[arg(long)]
+        force: bool,
+    },
+    Pack(MarketplacePackArgs),
+    Publish(Box<MarketplacePublishArgs>),
+}
+
 #[derive(Debug, clap::Args)]
 pub(crate) struct MarketplacePackArgs {
     #[arg(value_name = "PATH")]

--- a/crates/dcc-mcp-cli/src/presentation/marketplace_cmd.rs
+++ b/crates/dcc-mcp-cli/src/presentation/marketplace_cmd.rs
@@ -43,6 +43,15 @@ pub(crate) struct MarketplacePublishArgs {
     /// Target DCC. Repeat for multi-DCC packages.
     #[arg(long)]
     pub(crate) dcc: Vec<String>,
+    /// Generic target in KIND:ID form. Repeat for multi-target packages.
+    #[arg(long = "target")]
+    pub(crate) targets: Vec<String>,
+    /// Typed package format.
+    #[arg(long = "format")]
+    pub(crate) package_format: Option<String>,
+    /// Typed component in KIND:ID=ROOT form. Repeat for composite packages.
+    #[arg(long = "component")]
+    pub(crate) components: Vec<String>,
     #[arg(long)]
     pub(crate) version: Option<String>,
     #[arg(long)]
@@ -84,6 +93,24 @@ pub(crate) fn run_pack(args: MarketplacePackArgs) -> anyhow::Result<Value> {
 }
 
 pub(crate) fn run_publish(args: MarketplacePublishArgs) -> anyhow::Result<Value> {
+    let targets = args
+        .targets
+        .iter()
+        .map(|value| {
+            dcc_mcp_marketplace::parse_target(value)
+                .map_err(|_| anyhow::anyhow!("invalid target '{value}'; expected KIND:ID"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let package_format = args
+        .package_format
+        .as_deref()
+        .map(parse_package_format)
+        .transpose()?;
+    let components = args
+        .components
+        .iter()
+        .map(|value| parse_component(value))
+        .collect::<anyhow::Result<Vec<_>>>()?;
     let result = dcc_mcp_marketplace::publish_marketplace_package(
         dcc_mcp_marketplace::MarketplacePublishOptions {
             package_dir: args.path,
@@ -96,6 +123,9 @@ pub(crate) fn run_publish(args: MarketplacePublishArgs) -> anyhow::Result<Value>
             name: args.name,
             description: args.description,
             dcc: args.dcc,
+            targets,
+            package_format,
+            components,
             version: args.version,
             maintainer: args.maintainer,
             tags: args.tags,
@@ -110,6 +140,41 @@ pub(crate) fn run_publish(args: MarketplacePublishArgs) -> anyhow::Result<Value>
         },
     )?;
     to_json(result)
+}
+
+fn parse_package_format(value: &str) -> anyhow::Result<dcc_mcp_catalog::CatalogPackageFormat> {
+    use dcc_mcp_catalog::CatalogPackageFormat;
+    match value {
+        "skill" => Ok(CatalogPackageFormat::Skill),
+        "skill-bundle" => Ok(CatalogPackageFormat::SkillBundle),
+        "agent-plugin" => Ok(CatalogPackageFormat::AgentPlugin),
+        "cua-profile" => Ok(CatalogPackageFormat::CuaProfile),
+        "composite" => Ok(CatalogPackageFormat::Composite),
+        _ => anyhow::bail!("invalid package format '{value}'"),
+    }
+}
+
+fn parse_component(value: &str) -> anyhow::Result<dcc_mcp_catalog::CatalogComponent> {
+    use dcc_mcp_catalog::CatalogComponentKind;
+    let (identity, root) = value
+        .split_once('=')
+        .ok_or_else(|| anyhow::anyhow!("invalid component '{value}'; expected KIND:ID=ROOT"))?;
+    let (kind, id) = identity
+        .split_once(':')
+        .ok_or_else(|| anyhow::anyhow!("invalid component '{value}'; expected KIND:ID=ROOT"))?;
+    let kind = match kind {
+        "skill" => CatalogComponentKind::Skill,
+        "cua-profile" => CatalogComponentKind::CuaProfile,
+        _ => anyhow::bail!("invalid component kind '{kind}'"),
+    };
+    if id.is_empty() || root.is_empty() {
+        anyhow::bail!("invalid component '{value}'; id and root are required");
+    }
+    Ok(dcc_mcp_catalog::CatalogComponent {
+        kind,
+        id: id.to_string(),
+        root: root.to_string(),
+    })
 }
 
 fn to_json(value: impl serde::Serialize) -> anyhow::Result<Value> {

--- a/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
@@ -329,7 +329,7 @@ fn marketplace_pack_and_publish_updates_catalog() {
     );
     let catalog =
         serde_json::from_str::<Value>(&std::fs::read_to_string(&catalog_path).unwrap()).unwrap();
-    assert_eq!(catalog["schemaVersion"], "1");
+    assert_eq!(catalog["schemaVersion"], "2");
     assert_eq!(catalog["skills"][0]["minCoreVersion"], "0.19.0");
     assert_eq!(catalog["skills"][0]["source"]["type"], "zip");
     assert_eq!(
@@ -1879,4 +1879,110 @@ fn marketplace_entry_with_icon_validates() {
     let search = run_json_with_env(&["marketplace", "search", "--source", &source], &envs);
     assert_eq!(search["count"], 1);
     assert_eq!(search["hits"][0]["entry"]["name"], "skill-with-icon");
+}
+
+#[test]
+fn marketplace_installs_and_uninstalls_cua_profile_through_exact_cli() {
+    let tmp = TempDir::new().unwrap();
+    let package = tmp.path().join("the-bazaar-profile");
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::write(package.join("profile.json"), "{}\n").unwrap();
+    let catalog = tmp.path().join("marketplace.json");
+    let published = run_json(&[
+        "marketplace",
+        "publish",
+        package.to_str().unwrap(),
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "--install-url",
+        package.to_str().unwrap(),
+        "--install-type",
+        "path",
+        "--name",
+        "the-bazaar-profile",
+        "--description",
+        "The Bazaar semantic profile",
+        "--target",
+        "game:the-bazaar",
+        "--format",
+        "cua-profile",
+        "--component",
+        "cua-profile:the-bazaar=.",
+        "--version",
+        "1.0.0",
+        "--maintainer",
+        "dcc-mcp",
+        "--min-core-version",
+        "0.20.0",
+        "--tag",
+        "profile",
+    ]);
+    assert_eq!(published["entry"]["package"]["format"], "cua-profile");
+    let log = tmp.path().join("dcc-cua.log");
+    let fake = tmp.path().join(if cfg!(windows) {
+        "dcc-cua.cmd"
+    } else {
+        "dcc-cua"
+    });
+    if cfg!(windows) {
+        std::fs::write(
+            &fake,
+            "@echo off\r\necho %*>>\"%DCC_CUA_TEST_LOG%\"\r\nexit /b 0\r\n",
+        )
+        .unwrap();
+    } else {
+        std::fs::write(
+            &fake,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DCC_CUA_TEST_LOG\"\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+    let root = tmp.path().join("installed");
+    let config = tmp.path().join("sources.json");
+    let envs = [
+        ("DCC_MCP_MARKETPLACE_SOURCES_FILE", config.to_str().unwrap()),
+        ("DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES", "1"),
+        ("DCC_MCP_MARKETPLACE_INSTALL_ROOT", root.to_str().unwrap()),
+        ("DCC_MCP_CUA_BINARY", fake.to_str().unwrap()),
+        ("DCC_CUA_TEST_LOG", log.to_str().unwrap()),
+    ];
+    let source = catalog.to_str().unwrap();
+    let installed = run_json_with_env(
+        &[
+            "marketplace",
+            "install",
+            "the-bazaar-profile",
+            "--target",
+            "game:the-bazaar",
+            "--source",
+            source,
+            "--reload",
+        ],
+        &envs,
+    );
+    assert_eq!(installed["target"]["kind"], "game");
+    assert_eq!(installed["activation"], "none");
+    let removed = run_json_with_env(
+        &[
+            "marketplace",
+            "uninstall",
+            "the-bazaar-profile",
+            "--target",
+            "game:the-bazaar",
+            "--reload",
+        ],
+        &envs,
+    );
+    assert_eq!(removed["uninstalled"], true);
+    let calls = std::fs::read_to_string(log).unwrap();
+    let lines = calls.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 3);
+    assert!(lines[0].starts_with("profile validate "));
+    assert!(lines[1].starts_with("profile install "));
+    assert_eq!(lines[2], "profile uninstall the-bazaar --confirm");
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/marketplace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/marketplace.rs
@@ -530,6 +530,7 @@ mod tests {
             name: "test".into(),
             description: "desc".into(),
             dcc: vec!["maya".into(), "blender".into()],
+            targets: vec![],
             url: None,
             tags: vec![],
             version: None,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/marketplace_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/marketplace_tests.rs
@@ -225,6 +225,7 @@ async fn test_marketplace_uninstall_triggers_skill_paths_reload_hook() {
             "packages": [{
                 "name": "test-skill",
                 "dcc": "maya",
+                "target": { "kind": "dcc", "id": "maya" },
                 "version": "0.1.0",
                 "path": pkg_root.display().to_string(),
                 "source_name": "test",
@@ -611,6 +612,7 @@ async fn test_marketplace_update_triggers_skill_paths_reload_hook() {
             "packages": [{
                 "name": "test-update-skill",
                 "dcc": "maya",
+                "target": { "kind": "dcc", "id": "maya" },
                 "version": "0.1.0",
                 "path": marketplace_root.join("maya").join("test-update-skill")
                     .display().to_string(),

--- a/crates/dcc-mcp-marketplace/src/handler.rs
+++ b/crates/dcc-mcp-marketplace/src/handler.rs
@@ -1,0 +1,221 @@
+//! Package-handler port and infrastructure adapters.
+
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use dcc_mcp_catalog::{CatalogComponent, CatalogComponentKind, CatalogPackageFormat};
+
+use crate::bundle::{install_staged_package, remove_installed_path};
+use crate::error::MarketplaceError;
+
+#[derive(Debug)]
+pub(crate) struct InstallRequest<'a> {
+    pub staging: &'a Path,
+    pub destination: &'a Path,
+    pub target_root: &'a Path,
+    pub package_name: &'a str,
+    pub target_id: &'a str,
+    pub skill_roots: Option<&'a [String]>,
+    pub components: &'a [CatalogComponent],
+    pub force: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct UninstallRequest<'a> {
+    pub installed_path: &'a Path,
+    pub target_root: &'a Path,
+    pub components: &'a [CatalogComponent],
+}
+
+pub(crate) trait PackageHandler: Send + Sync {
+    fn install(&self, request: InstallRequest<'_>) -> Result<PathBuf, MarketplaceError>;
+    fn uninstall(&self, request: UninstallRequest<'_>) -> Result<(), MarketplaceError>;
+}
+
+pub(crate) fn handler_for(
+    format: CatalogPackageFormat,
+) -> Result<Box<dyn PackageHandler>, MarketplaceError> {
+    match format {
+        CatalogPackageFormat::CuaProfile => Ok(Box::new(CuaProfileHandler::default())),
+        CatalogPackageFormat::Skill
+        | CatalogPackageFormat::SkillBundle
+        | CatalogPackageFormat::AgentPlugin => Ok(Box::new(SkillPackageHandler)),
+        CatalogPackageFormat::Composite => Err(MarketplaceError::CommandFailed(
+            "composite package installation is not supported yet".into(),
+        )),
+    }
+}
+
+struct SkillPackageHandler;
+
+impl PackageHandler for SkillPackageHandler {
+    fn install(&self, request: InstallRequest<'_>) -> Result<PathBuf, MarketplaceError> {
+        install_staged_package(
+            request.staging,
+            request.destination,
+            request.target_root,
+            request.package_name,
+            request.target_id,
+            request.skill_roots,
+            request.force,
+        )
+    }
+
+    fn uninstall(&self, request: UninstallRequest<'_>) -> Result<(), MarketplaceError> {
+        remove_installed_path(request.target_root, request.installed_path)
+    }
+}
+
+#[derive(Default)]
+struct CuaProfileHandler {
+    executable: Option<PathBuf>,
+}
+
+impl PackageHandler for CuaProfileHandler {
+    fn install(&self, request: InstallRequest<'_>) -> Result<PathBuf, MarketplaceError> {
+        let component = one_profile_component(request.components)?;
+        let profile_root = resolve_component_root(request.staging, &component.root)?;
+        self.run(vec![
+            OsString::from("profile"),
+            OsString::from("validate"),
+            profile_root.as_os_str().to_owned(),
+        ])?;
+        let mut install = vec![
+            OsString::from("profile"),
+            OsString::from("install"),
+            profile_root.as_os_str().to_owned(),
+        ];
+        if request.force {
+            install.push(OsString::from("--replace"));
+        }
+        self.run(install)?;
+        Ok(PathBuf::from(format!("dcc-cua-profile:{}", component.id)))
+    }
+
+    fn uninstall(&self, request: UninstallRequest<'_>) -> Result<(), MarketplaceError> {
+        let component = one_profile_component(request.components)?;
+        self.run([
+            OsString::from("profile"),
+            OsString::from("uninstall"),
+            OsString::from(&component.id),
+            OsString::from("--confirm"),
+        ])
+    }
+}
+
+impl CuaProfileHandler {
+    fn run(&self, args: impl IntoIterator<Item = OsString>) -> Result<(), MarketplaceError> {
+        let executable = self
+            .executable
+            .clone()
+            .or_else(resolve_dcc_cua_executable)
+            .unwrap_or_else(|| PathBuf::from("dcc-cua"));
+        let mut command = Command::new(&executable);
+        command.args(args);
+        let output = command.output().map_err(|error| {
+            MarketplaceError::CommandFailed(format!(
+                "failed to execute '{}': {error}",
+                executable.display()
+            ))
+        })?;
+        if output.status.success() {
+            return Ok(());
+        }
+        Err(MarketplaceError::CommandFailed(format!(
+            "dcc-cua command exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )))
+    }
+}
+
+fn resolve_dcc_cua_executable() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("DCC_MCP_CUA_BINARY").map(PathBuf::from) {
+        return Some(path);
+    }
+    let sibling = std::env::current_exe()
+        .ok()?
+        .with_file_name(if cfg!(windows) {
+            "dcc-cua.exe"
+        } else {
+            "dcc-cua"
+        });
+    sibling.is_file().then_some(sibling)
+}
+
+fn one_profile_component(
+    components: &[CatalogComponent],
+) -> Result<&CatalogComponent, MarketplaceError> {
+    let profiles = components
+        .iter()
+        .filter(|component| component.kind == CatalogComponentKind::CuaProfile)
+        .collect::<Vec<_>>();
+    match profiles.as_slice() {
+        [component] => Ok(component),
+        [] => Err(MarketplaceError::CommandFailed(
+            "cua-profile package requires one cua-profile component".into(),
+        )),
+        _ => Err(MarketplaceError::CommandFailed(
+            "cua-profile package must not contain multiple cua-profile components".into(),
+        )),
+    }
+}
+
+fn resolve_component_root(staging: &Path, root: &str) -> Result<PathBuf, MarketplaceError> {
+    if root == "." {
+        return Ok(staging.to_path_buf());
+    }
+    let relative = Path::new(root);
+    if root.trim().is_empty()
+        || relative.is_absolute()
+        || relative.components().any(|part| {
+            matches!(
+                part,
+                Component::ParentDir
+                    | Component::CurDir
+                    | Component::RootDir
+                    | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(MarketplaceError::CommandFailed(format!(
+            "marketplace component root '{root}' must be a safe relative path"
+        )));
+    }
+    let direct = staging.join(relative);
+    if direct.is_dir() {
+        return Ok(direct);
+    }
+    let children = std::fs::read_dir(staging)
+        .map_err(|error| MarketplaceError::ConfigIo(staging.display().to_string(), error))?
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            entry
+                .file_type()
+                .ok()
+                .filter(|kind| kind.is_dir())
+                .map(|_| entry.path())
+        })
+        .collect::<Vec<_>>();
+    if let [child] = children.as_slice() {
+        let nested = child.join(relative);
+        if nested.is_dir() {
+            return Ok(nested);
+        }
+    }
+    Err(MarketplaceError::CommandFailed(format!(
+        "marketplace component root '{root}' does not exist in package"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn component_root_rejects_parent_traversal() {
+        let temp = tempfile::tempdir().unwrap();
+        assert!(resolve_component_root(temp.path(), "../profile").is_err());
+    }
+}

--- a/crates/dcc-mcp-marketplace/src/lib.rs
+++ b/crates/dcc-mcp-marketplace/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod add_repo;
 pub(crate) mod bundle;
 pub mod error;
+pub(crate) mod handler;
 pub mod package;
 pub mod path;
 pub(crate) mod plugin;
@@ -48,10 +49,11 @@ pub use path::{default_config_path, home_dir, marketplace_root, marketplace_root
 pub use service::{MarketplaceService, default_sources_disabled, env_sources, path_component};
 pub use source::{builtin_source, dedupe_sources, normalise_source, resolve_catalog_asset_url};
 pub use types::{
-    InstalledMarketplacePackage, MarketplaceHit, MarketplaceInspectResult,
+    InstalledMarketplacePackage, MarketplaceActivation, MarketplaceHit, MarketplaceInspectResult,
     MarketplaceInstallResult, MarketplaceInstalledList, MarketplaceInstalledState,
     MarketplaceOutdatedList, MarketplaceSearchResult, MarketplaceSource, MarketplaceSourceConfig,
-    MarketplaceSourceOrigin, MarketplaceUninstallResult, MarketplaceUpdateResult,
-    OFFICIAL_MARKETPLACE_SOURCE, OutdatedMarketplacePackage, RepoInstallResult, RepoSkillInfo,
-    RepoSkillList, StoredMarketplaceSource, entry_targets_dcc,
+    MarketplaceSourceOrigin, MarketplaceTargetParseError, MarketplaceUninstallResult,
+    MarketplaceUpdateResult, OFFICIAL_MARKETPLACE_SOURCE, OutdatedMarketplacePackage,
+    RepoInstallResult, RepoSkillInfo, RepoSkillList, StoredMarketplaceSource, entry_targets,
+    entry_targets_dcc, parse_target,
 };

--- a/crates/dcc-mcp-marketplace/src/package.rs
+++ b/crates/dcc-mcp-marketplace/src/package.rs
@@ -3,7 +3,8 @@ use std::io::{Cursor, Write};
 use std::path::{Path, PathBuf};
 
 use dcc_mcp_catalog::{
-    CatalogEntry, CatalogInstall, CatalogPackage, CatalogPolicy, CatalogRequirements,
+    CatalogComponent, CatalogEntry, CatalogInstall, CatalogPackage, CatalogPackageFormat,
+    CatalogPolicy, CatalogRequirements, CatalogTarget,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -39,6 +40,9 @@ pub struct MarketplacePublishOptions {
     pub name: Option<String>,
     pub description: Option<String>,
     pub dcc: Vec<String>,
+    pub targets: Vec<CatalogTarget>,
+    pub package_format: Option<CatalogPackageFormat>,
+    pub components: Vec<CatalogComponent>,
     pub version: Option<String>,
     pub maintainer: Option<String>,
     pub tags: Vec<String>,
@@ -140,12 +144,21 @@ pub fn publish_marketplace_package(
             .unwrap_or_else(|| list_or_csv_at(&skill_meta, &["metadata", "dcc-mcp", "tags"])),
         options.tags,
     );
-    let package = package_metadata(plugin.as_ref(), &options.skill_roots);
+    let package = if let Some(format) = options.package_format {
+        Some(CatalogPackage {
+            format,
+            skills: Vec::new(),
+            components: options.components.clone(),
+        })
+    } else {
+        package_metadata(plugin.as_ref(), &options.skill_roots)
+    };
 
     let entry = CatalogEntry {
         name: path_component("package name", &name)?,
         description,
         dcc,
+        targets: options.targets,
         url: options.homepage_url.or_else(|| {
             plugin
                 .as_ref()
@@ -214,16 +227,18 @@ fn package_metadata(
             .map(|skill| skill.name)
             .collect();
         return Some(CatalogPackage {
-            format: "agent-plugin".into(),
+            format: CatalogPackageFormat::AgentPlugin,
             skills,
+            components: Vec::new(),
         });
     }
     (skill_roots.len() > 1).then(|| CatalogPackage {
-        format: "skill-bundle".into(),
+        format: CatalogPackageFormat::SkillBundle,
         skills: skill_roots
             .iter()
             .filter_map(|root| Path::new(root).file_name()?.to_str().map(String::from))
             .collect(),
+        components: Vec::new(),
     })
 }
 
@@ -350,7 +365,7 @@ fn load_catalog_value(path: &Path) -> Result<Value, MarketplaceError> {
     if !path.exists() {
         return Ok(json!({
             "name": "dcc-mcp-local",
-            "schemaVersion": "1",
+            "schemaVersion": "2",
             "version": "1.0.0",
             "skills": []
         }));
@@ -374,9 +389,9 @@ fn save_catalog_value(path: &Path, catalog: &Value) -> Result<(), MarketplaceErr
 
 fn marketplace_v1_entry_value(entry: &CatalogEntry) -> Result<Value, MarketplaceError> {
     let version = required_entry_value(entry, "version", entry.version.as_deref())?;
-    if entry.dcc.is_empty() {
+    if entry.dcc.is_empty() && entry.targets.is_empty() {
         return Err(MarketplaceError::CommandFailed(format!(
-            "marketplace v1 entry '{}' requires at least one DCC target",
+            "marketplace entry '{}' requires at least one target",
             entry.name
         )));
     }
@@ -405,6 +420,7 @@ fn marketplace_v1_entry_value(entry: &CatalogEntry) -> Result<Value, Marketplace
         "description": entry.description,
         "version": version,
         "dcc": entry.dcc,
+        "targets": entry.targets,
         "tags": entry.tags,
         "category": entry.category.as_deref().unwrap_or("Skills"),
         "source": install,
@@ -521,13 +537,17 @@ fn validate_marketplace_v1_entry(entry: &Value) -> Result<(), MarketplaceError> 
             )));
         }
     }
-    if entry
+    let has_dcc = entry
         .get("dcc")
         .and_then(Value::as_array)
-        .is_none_or(Vec::is_empty)
-    {
+        .is_some_and(|values| !values.is_empty());
+    let has_target = entry
+        .get("targets")
+        .and_then(Value::as_array)
+        .is_some_and(|values| !values.is_empty());
+    if !has_dcc && !has_target {
         return Err(MarketplaceError::CommandFailed(
-            "marketplace v1 entry requires at least one DCC target".into(),
+            "marketplace entry requires at least one target".into(),
         ));
     }
     if entry
@@ -713,7 +733,7 @@ fn required_value(kind: &str, value: Option<String>) -> Result<String, Marketpla
 }
 
 fn default_catalog_version() -> String {
-    "1".to_string()
+    "2".to_string()
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
@@ -779,6 +799,9 @@ mod tests {
             name: None,
             description: None,
             dcc: Vec::new(),
+            targets: Vec::new(),
+            package_format: None,
+            components: Vec::new(),
             version: None,
             maintainer: Some("dcc-mcp".into()),
             tags: vec!["extra".into()],
@@ -807,7 +830,7 @@ mod tests {
         assert_eq!(requires.python, vec!["my_skill"]);
         assert_eq!(requires.skills, vec!["dcc-base"]);
         let text = fs::read_to_string(catalog_path).unwrap();
-        assert!(text.contains("\"schemaVersion\": \"1\""));
+        assert!(text.contains("\"schemaVersion\": \"2\""));
         assert!(text.contains("\"skills\": ["));
         assert!(text.contains("\"minCoreVersion\": \"0.19.0\""));
         assert!(text.contains("\"source\": {"));
@@ -849,6 +872,9 @@ mod tests {
             name: None,
             description: None,
             dcc: vec!["maya".into()],
+            targets: Vec::new(),
+            package_format: None,
+            components: Vec::new(),
             version: None,
             maintainer: None,
             tags: Vec::new(),
@@ -868,7 +894,7 @@ mod tests {
         assert_eq!(result.entry.maintainer.as_deref(), Some("dcc-mcp"));
         assert_eq!(result.entry.tags, vec!["rigging"]);
         let package = result.entry.package.unwrap();
-        assert_eq!(package.format, "agent-plugin");
+        assert_eq!(package.format, CatalogPackageFormat::AgentPlugin);
         assert_eq!(package.skills, vec!["act", "inspect"]);
     }
 

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -1308,6 +1308,7 @@ mod tests {
             name: "host-neutral".into(),
             description: "desc".into(),
             dcc: vec!["any".into()],
+            targets: vec![],
             url: None,
             tags: vec![],
             version: None,

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -6,17 +6,20 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use dcc_mcp_catalog::{self, CatalogEntry, CatalogInstall};
+use dcc_mcp_catalog::{
+    self, CatalogEntry, CatalogInstall, CatalogPackageFormat, CatalogTarget, CatalogTargetKind,
+};
 
-use crate::bundle::{bundle_package_dir, install_staged_package, remove_installed_path};
+use crate::bundle::bundle_package_dir;
 use crate::error::MarketplaceError;
+use crate::handler::{InstallRequest, UninstallRequest, handler_for};
 use crate::source::{builtin_source, dedupe_sources, normalise_source};
 use crate::types::{
-    InstalledMarketplacePackage, MarketplaceHit, MarketplaceInspectResult,
+    InstalledMarketplacePackage, MarketplaceActivation, MarketplaceHit, MarketplaceInspectResult,
     MarketplaceInstallResult, MarketplaceInstalledList, MarketplaceInstalledState,
     MarketplaceOutdatedList, MarketplaceSearchResult, MarketplaceSource, MarketplaceSourceOrigin,
     MarketplaceUninstallResult, MarketplaceUpdateResult, OutdatedMarketplacePackage,
-    RepoInstallResult, RepoSkillList, StoredMarketplaceSource, entry_targets_dcc,
+    RepoInstallResult, RepoSkillList, StoredMarketplaceSource, entry_targets, entry_targets_dcc,
 };
 
 #[path = "service_internals.rs"]
@@ -193,10 +196,38 @@ impl MarketplaceService {
         }
         Ok(MarketplaceSearchResult {
             query,
+            target: dcc.as_ref().map(|id| CatalogTarget {
+                kind: CatalogTargetKind::Dcc,
+                id: id.clone(),
+            }),
             dcc,
             count: hits.len(),
             hits,
         })
+    }
+
+    pub async fn search_for_target(
+        &self,
+        query: Option<String>,
+        target: CatalogTarget,
+        explicit_sources: Vec<String>,
+        limit: Option<usize>,
+        skip_validation: bool,
+    ) -> Result<MarketplaceSearchResult, MarketplaceError> {
+        let mut result = self
+            .search(query, None, explicit_sources, None, skip_validation)
+            .await?;
+        result.hits.retain(|hit| {
+            entry_targets(&hit.entry)
+                .iter()
+                .any(|candidate| candidate == &target)
+        });
+        if let Some(limit) = limit {
+            result.hits.truncate(limit);
+        }
+        result.count = result.hits.len();
+        result.target = Some(target);
+        Ok(result)
     }
 
     /// Inspect a specific entry by name.
@@ -287,15 +318,28 @@ impl MarketplaceService {
             return Err(err);
         }
 
-        let final_path = match install_staged_package(
-            &staging,
-            &dest,
-            &dcc_root,
-            &package_name,
-            &dcc,
-            install.skill_roots.as_deref(),
+        let package_format = hit
+            .entry
+            .package
+            .as_ref()
+            .map(|package| package.format)
+            .unwrap_or(CatalogPackageFormat::Skill);
+        let components = hit
+            .entry
+            .package
+            .as_ref()
+            .map(|package| package.components.as_slice())
+            .unwrap_or_default();
+        let final_path = match handler_for(package_format)?.install(InstallRequest {
+            staging: &staging,
+            destination: &dest,
+            target_root: &dcc_root,
+            package_name: &package_name,
+            target_id: &dcc,
+            skill_roots: install.skill_roots.as_deref(),
+            components,
             force,
-        ) {
+        }) {
             Ok(path) => path,
             Err(err) => {
                 let _ = remove_path(&staging);
@@ -307,6 +351,17 @@ impl MarketplaceService {
         let package = InstalledMarketplacePackage {
             name: package_name.clone(),
             dcc: dcc.clone(),
+            target: CatalogTarget {
+                kind: CatalogTargetKind::Dcc,
+                id: dcc.clone(),
+            },
+            components: hit
+                .entry
+                .package
+                .as_ref()
+                .map(|package| package.components.clone())
+                .unwrap_or_default(),
+            package_format: hit.entry.package.as_ref().map(|package| package.format),
             version: hit.entry.version.clone(),
             path: final_path.display().to_string(),
             source_name: hit.source.name.clone(),
@@ -322,6 +377,10 @@ impl MarketplaceService {
         Ok(MarketplaceInstallResult {
             installed: true,
             name: package_name,
+            target: CatalogTarget {
+                kind: CatalogTargetKind::Dcc,
+                id: dcc.clone(),
+            },
             dcc,
             version: hit.entry.version.clone(),
             path: final_path.display().to_string(),
@@ -331,6 +390,167 @@ impl MarketplaceService {
             install_type: install.install_type.clone(),
             resolved_commit,
             reload_required: true,
+            activation: MarketplaceActivation::SkillReload,
+        })
+    }
+
+    /// Install a package for a generic target (`dcc:maya`, `application:excel`,
+    /// `game:the-bazaar`, or `web:figma`). CUA profiles are delegated to the
+    /// independent `dcc-cua` CLI; Core never parses their profile schema.
+    pub async fn install_for_target(
+        &self,
+        name: String,
+        target: CatalogTarget,
+        explicit_sources: Vec<String>,
+        force: bool,
+        skip_validation: bool,
+    ) -> Result<MarketplaceInstallResult, MarketplaceError> {
+        if target.kind == CatalogTargetKind::Dcc {
+            return self
+                .install(
+                    name,
+                    Some(target.id),
+                    explicit_sources,
+                    force,
+                    skip_validation,
+                )
+                .await;
+        }
+        let hit = self
+            .resolve_install_hit_for_target(&name, &target, explicit_sources, skip_validation)
+            .await?;
+        ensure_entry_installable(&hit.entry)?;
+        let install = hit
+            .entry
+            .install
+            .clone()
+            .ok_or_else(|| MarketplaceError::MissingInstall(hit.entry.name.clone()))?;
+        let package = hit.entry.package.as_ref().ok_or_else(|| {
+            MarketplaceError::CommandFailed(
+                "generic target package requires package metadata".into(),
+            )
+        })?;
+        if package.format != CatalogPackageFormat::CuaProfile {
+            return Err(MarketplaceError::CommandFailed(format!(
+                "package '{}' uses {:?}; non-DCC targets require cua-profile",
+                hit.entry.name, package.format
+            )));
+        }
+        let package_name = path_component("package name", &hit.entry.name)?;
+        if !force
+            && self
+                .load_installed_state()?
+                .packages
+                .iter()
+                .any(|installed| installed.name == package_name && installed.target == target)
+        {
+            return Err(MarketplaceError::CommandFailed(format!(
+                "marketplace package '{package_name}' is already installed for target '{target}'"
+            )));
+        }
+        let target_root = self
+            .root
+            .join(".targets")
+            .join(target.kind.to_string())
+            .join(path_component("target id", &target.id)?);
+        fs::create_dir_all(&target_root).map_err(|error| {
+            MarketplaceError::ConfigIo(target_root.display().to_string(), error)
+        })?;
+        let staging = target_root.join(format!(".{package_name}.installing-{}", now_ms()));
+        if staging.exists() {
+            remove_path(&staging)?;
+        }
+        let fetched = match install.install_type.as_str() {
+            "git" => self.install_from_git(&install, &staging).await,
+            "path" => install_from_path_component(&install, &staging),
+            "zip" => self.install_from_zip(&install, &staging).await,
+            other => return Err(MarketplaceError::UnsupportedInstallType(other.into())),
+        };
+        if let Err(error) = fetched {
+            let _ = remove_path(&staging);
+            return Err(error);
+        }
+        let handler = handler_for(package.format)?;
+        let final_path = handler.install(InstallRequest {
+            staging: &staging,
+            destination: &target_root.join(&package_name),
+            target_root: &target_root,
+            package_name: &package_name,
+            target_id: &target.id,
+            skill_roots: install.skill_roots.as_deref(),
+            components: &package.components,
+            force,
+        });
+        let _ = remove_path(&staging);
+        let final_path = final_path?;
+        let installed = InstalledMarketplacePackage {
+            name: package_name.clone(),
+            dcc: String::new(),
+            target: target.clone(),
+            components: package.components.clone(),
+            package_format: Some(package.format),
+            version: hit.entry.version.clone(),
+            path: final_path.display().to_string(),
+            source_name: hit.source.name.clone(),
+            source_url: hit.source.url.clone(),
+            install_type: install.install_type.clone(),
+            install_url: install.url.clone(),
+            install_ref: install.ref_.clone(),
+            resolved_commit: None,
+            installed_at_ms: now_ms(),
+        };
+        self.upsert_installed(installed)?;
+        Ok(MarketplaceInstallResult {
+            installed: true,
+            name: package_name,
+            dcc: String::new(),
+            target,
+            version: hit.entry.version.clone(),
+            path: final_path.display().to_string(),
+            skill_search_path: String::new(),
+            source: hit.source,
+            entry: hit.entry,
+            install_type: install.install_type,
+            resolved_commit: None,
+            reload_required: false,
+            activation: MarketplaceActivation::None,
+        })
+    }
+
+    pub fn uninstall_for_target(
+        &self,
+        name: &str,
+        target: &CatalogTarget,
+    ) -> Result<MarketplaceUninstallResult, MarketplaceError> {
+        if target.kind == CatalogTargetKind::Dcc {
+            return self.uninstall(name, &target.id);
+        }
+        let name = path_component("package name", name)?;
+        let installed = self
+            .load_installed_state()?
+            .packages
+            .into_iter()
+            .find(|package| package.name == name && package.target == *target)
+            .ok_or_else(|| MarketplaceError::InstalledPackageNotFound(name.clone()))?;
+        let format = installed.package_format.ok_or_else(|| {
+            MarketplaceError::CommandFailed("installed package is missing package format".into())
+        })?;
+        handler_for(format)?.uninstall(UninstallRequest {
+            installed_path: Path::new(&installed.path),
+            target_root: &self.root,
+            components: &installed.components,
+        })?;
+        let removed_state = self.remove_installed_target(&name, target)?;
+        Ok(MarketplaceUninstallResult {
+            uninstalled: true,
+            name,
+            dcc: String::new(),
+            target: target.clone(),
+            path: installed.path,
+            removed_state,
+            removed_files: false,
+            reload_required: false,
+            activation: MarketplaceActivation::None,
         })
     }
 
@@ -341,15 +561,29 @@ impl MarketplaceService {
     ) -> Result<MarketplaceUninstallResult, MarketplaceError> {
         let name = path_component("package name", name)?;
         let dcc_root = self.dcc_dir(dcc);
-        let dest = self
+        let installed = self
             .load_installed_state()?
             .packages
             .into_iter()
-            .find(|package| package.name == name && package.dcc.eq_ignore_ascii_case(dcc))
-            .map(|package| PathBuf::from(package.path))
+            .find(|package| package.name == name && package.dcc.eq_ignore_ascii_case(dcc));
+        let dest = installed
+            .as_ref()
+            .map(|package| PathBuf::from(&package.path))
             .unwrap_or_else(|| dcc_root.join(&name));
         let removed_files = if dest.exists() {
-            remove_installed_path(&dcc_root, &dest)?;
+            let format = installed
+                .as_ref()
+                .and_then(|package| package.package_format)
+                .unwrap_or(CatalogPackageFormat::Skill);
+            let components = installed
+                .as_ref()
+                .map(|package| package.components.as_slice())
+                .unwrap_or_default();
+            handler_for(format)?.uninstall(UninstallRequest {
+                installed_path: &dest,
+                target_root: &dcc_root,
+                components,
+            })?;
             true
         } else {
             false
@@ -359,10 +593,15 @@ impl MarketplaceService {
             uninstalled: removed_files || removed_state,
             name,
             dcc: dcc.to_string(),
+            target: CatalogTarget {
+                kind: CatalogTargetKind::Dcc,
+                id: dcc.to_string(),
+            },
             path: dest.display().to_string(),
             removed_state,
             removed_files,
             reload_required: removed_files || removed_state,
+            activation: MarketplaceActivation::SkillReload,
         })
     }
 
@@ -393,6 +632,33 @@ impl MarketplaceService {
         }
     }
 
+    pub fn resolve_installed_target(
+        &self,
+        name: &str,
+        requested_target: Option<&CatalogTarget>,
+    ) -> Result<CatalogTarget, MarketplaceError> {
+        let name = path_component("package name", name)?;
+        if let Some(target) = requested_target {
+            return Ok(target.clone());
+        }
+        let mut targets = self
+            .load_installed_state()?
+            .packages
+            .into_iter()
+            .filter(|package| package.name == name)
+            .map(|package| package.target)
+            .collect::<Vec<_>>();
+        targets.sort_by_key(ToString::to_string);
+        targets.dedup();
+        match targets.as_slice() {
+            [target] => Ok(target.clone()),
+            [] => Err(MarketplaceError::InstalledPackageNotFound(name)),
+            _ => Err(MarketplaceError::CommandFailed(format!(
+                "installed package '{name}' targets multiple applications; pass --target"
+            ))),
+        }
+    }
+
     // ── installed state ──────────────────────────────────────────────────────
 
     pub fn list_installed(
@@ -405,6 +671,26 @@ impl MarketplaceService {
         }
         Ok(MarketplaceInstalledList {
             dcc: dcc.map(String::from),
+            target: dcc.map(|id| CatalogTarget {
+                kind: CatalogTargetKind::Dcc,
+                id: id.to_string(),
+            }),
+            count: packages.len(),
+            packages,
+        })
+    }
+
+    pub fn list_installed_for_target(
+        &self,
+        target: Option<&CatalogTarget>,
+    ) -> Result<MarketplaceInstalledList, MarketplaceError> {
+        let mut packages = self.load_installed_state()?.packages;
+        if let Some(target) = target {
+            packages.retain(|package| package.target == *target);
+        }
+        Ok(MarketplaceInstalledList {
+            dcc: None,
+            target: target.cloned(),
             count: packages.len(),
             packages,
         })
@@ -537,6 +823,12 @@ impl MarketplaceService {
                 self.upsert_installed(InstalledMarketplacePackage {
                     name: update_result.name.clone(),
                     dcc: update_result.dcc.clone(),
+                    target: CatalogTarget {
+                        kind: CatalogTargetKind::Dcc,
+                        id: update_result.dcc.clone(),
+                    },
+                    components: Vec::new(),
+                    package_format: None,
                     version: Some(vs.clone()),
                     path: update_result.path.clone(),
                     source_name: update_result.source_name.clone(),
@@ -651,6 +943,29 @@ impl MarketplaceService {
                 {
                     continue;
                 }
+                return Ok(MarketplaceHit { source, entry });
+            }
+        }
+        Err(MarketplaceError::NotFound(name.to_string()))
+    }
+
+    async fn resolve_install_hit_for_target(
+        &self,
+        name: &str,
+        target: &CatalogTarget,
+        explicit_sources: Vec<String>,
+        skip_validation: bool,
+    ) -> Result<MarketplaceHit, MarketplaceError> {
+        let sources = self.sources_for_query(explicit_sources)?;
+        for source in sources {
+            let entries = self
+                .load_source_entries_validated(&source, !skip_validation)
+                .await?;
+            if let Some(entry) = dcc_mcp_catalog::describe(&entries, name)
+                && entry_targets(&entry)
+                    .iter()
+                    .any(|candidate| candidate == target)
+            {
                 return Ok(MarketplaceHit { source, entry });
             }
         }
@@ -773,6 +1088,12 @@ impl MarketplaceService {
                 &InstalledMarketplacePackage {
                     name: pkg.name.clone(),
                     dcc: pkg.dcc.clone(),
+                    target: CatalogTarget {
+                        kind: CatalogTargetKind::Dcc,
+                        id: pkg.dcc.clone(),
+                    },
+                    components: Vec::new(),
+                    package_format: None,
                     version: pkg.installed_version.clone(),
                     path: pkg.path.clone(),
                     source_name: pkg.source_name.clone(),
@@ -878,13 +1199,14 @@ impl MarketplaceService {
         package: InstalledMarketplacePackage,
     ) -> Result<(), MarketplaceError> {
         let mut state = self.load_installed_state()?;
-        state
-            .packages
-            .retain(|existing| !(existing.name == package.name && existing.dcc == package.dcc));
+        state.packages.retain(|existing| {
+            !(existing.name == package.name && existing.target == package.target)
+        });
         state.packages.push(package);
         state.packages.sort_by(|a, b| {
-            a.dcc
-                .cmp(&b.dcc)
+            a.target
+                .to_string()
+                .cmp(&b.target.to_string())
                 .then_with(|| a.name.cmp(&b.name))
                 .then_with(|| a.path.cmp(&b.path))
         });
@@ -903,6 +1225,44 @@ impl MarketplaceService {
         }
         Ok(changed)
     }
+
+    fn remove_installed_target(
+        &self,
+        name: &str,
+        target: &CatalogTarget,
+    ) -> Result<bool, MarketplaceError> {
+        let mut state = self.load_installed_state()?;
+        let before = state.packages.len();
+        state
+            .packages
+            .retain(|package| !(package.name == name && package.target == *target));
+        let changed = state.packages.len() != before;
+        if changed {
+            self.save_installed_state(&state)?;
+        }
+        Ok(changed)
+    }
+}
+
+fn install_from_path_component(
+    install: &CatalogInstall,
+    destination: &Path,
+) -> Result<(), MarketplaceError> {
+    let source = install
+        .url
+        .as_deref()
+        .ok_or_else(|| MarketplaceError::MissingInstall("path.url".into()))?;
+    let source = source
+        .strip_prefix("file://")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(source));
+    if !source.is_dir() {
+        return Err(MarketplaceError::Read(
+            source.display().to_string(),
+            std::io::Error::new(std::io::ErrorKind::NotFound, "package directory not found"),
+        ));
+    }
+    copy_dir_recursive(&source, destination)
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
@@ -980,6 +1340,12 @@ mod tests {
         let pkg = InstalledMarketplacePackage {
             name: "test-skill".into(),
             dcc: "maya".into(),
+            target: CatalogTarget {
+                kind: CatalogTargetKind::Dcc,
+                id: "maya".into(),
+            },
+            components: Vec::new(),
+            package_format: None,
             version: Some("1.0.0".into()),
             path: "/tmp/test".into(),
             source_name: "dcc-mcp/marketplace".into(),

--- a/crates/dcc-mcp-marketplace/src/service_tests.rs
+++ b/crates/dcc-mcp-marketplace/src/service_tests.rs
@@ -4,6 +4,12 @@ fn installed_package(name: &str, dcc: &str) -> InstalledMarketplacePackage {
     InstalledMarketplacePackage {
         name: name.into(),
         dcc: dcc.into(),
+        target: CatalogTarget {
+            kind: CatalogTargetKind::Dcc,
+            id: dcc.into(),
+        },
+        components: Vec::new(),
+        package_format: None,
         version: Some("1.0.0".into()),
         path: format!("/tmp/{name}-{dcc}"),
         source_name: "local-test".into(),
@@ -44,6 +50,30 @@ fn resolve_installed_dcc_requires_a_host_for_ambiguous_packages() {
         service.resolve_installed_dcc("shared-tools", None),
         Err(MarketplaceError::AmbiguousInstalledDcc { name }) if name == "shared-tools"
     ));
+}
+
+#[test]
+fn installed_state_keys_packages_by_name_and_generic_target() {
+    let temp = tempfile::tempdir().unwrap();
+    let service = MarketplaceService::new(temp.path().to_path_buf());
+    for (kind, id) in [
+        (CatalogTargetKind::Game, "the-bazaar"),
+        (CatalogTargetKind::Application, "microsoft-excel"),
+    ] {
+        let mut package = installed_package("shared-profile", "");
+        package.target = CatalogTarget {
+            kind,
+            id: id.to_string(),
+        };
+        service.upsert_installed(package).unwrap();
+    }
+
+    assert_eq!(service.list_installed_for_target(None).unwrap().count, 2);
+    assert!(
+        service
+            .resolve_installed_target("shared-profile", None)
+            .is_err()
+    );
 }
 
 #[tokio::test]
@@ -112,6 +142,12 @@ async fn outdated_fetches_each_catalog_once() {
             .upsert_installed(InstalledMarketplacePackage {
                 name: name.into(),
                 dcc: "blender".into(),
+                target: CatalogTarget {
+                    kind: CatalogTargetKind::Dcc,
+                    id: "blender".into(),
+                },
+                components: Vec::new(),
+                package_format: None,
                 version: Some("1.0.0".into()),
                 path: temp.path().join(name).display().to_string(),
                 source_name: "local-test".into(),
@@ -140,6 +176,7 @@ fn pinned_git_revision_marks_unchanged_version_as_outdated() {
         name: "test-skill".into(),
         description: "desc".into(),
         dcc: vec!["maya".into()],
+        targets: vec![],
         url: None,
         tags: vec![],
         version: Some("1.0.0".into()),
@@ -167,6 +204,12 @@ fn pinned_git_revision_marks_unchanged_version_as_outdated() {
     let installed = InstalledMarketplacePackage {
         name: "test-skill".into(),
         dcc: "maya".into(),
+        target: CatalogTarget {
+            kind: CatalogTargetKind::Dcc,
+            id: "maya".into(),
+        },
+        components: Vec::new(),
+        package_format: None,
         version: Some("1.0.0".into()),
         path: "/tmp/test".into(),
         source_name: "official".into(),
@@ -220,6 +263,7 @@ fn core_version_gate_rejects_too_new_or_invalid_requirements() {
         name: "test-skill".into(),
         description: "desc".into(),
         dcc: vec!["maya".into()],
+        targets: vec![],
         url: None,
         tags: vec![],
         version: None,
@@ -255,6 +299,7 @@ fn install_policy_rejects_unavailable_entries() {
         name: "retired-skill".into(),
         description: "desc".into(),
         dcc: vec!["maya".into()],
+        targets: vec![],
         url: None,
         tags: vec![],
         version: None,

--- a/crates/dcc-mcp-marketplace/src/types.rs
+++ b/crates/dcc-mcp-marketplace/src/types.rs
@@ -3,7 +3,9 @@
 //! These are the canonical types used by both the CLI and the Gateway admin
 //! panel. The Gateway maps them to HTTP response types in its own adapter layer.
 
-use dcc_mcp_catalog::CatalogEntry;
+use dcc_mcp_catalog::{
+    CatalogComponent, CatalogEntry, CatalogPackageFormat, CatalogTarget, CatalogTargetKind,
+};
 use serde::{Deserialize, Serialize};
 
 // ── source ────────────────────────────────────────────────────────────────────
@@ -52,6 +54,8 @@ pub struct MarketplaceHit {
 pub struct MarketplaceSearchResult {
     pub query: Option<String>,
     pub dcc: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<CatalogTarget>,
     pub count: usize,
     pub hits: Vec<MarketplaceHit>,
 }
@@ -70,6 +74,7 @@ pub struct MarketplaceInstallResult {
     pub installed: bool,
     pub name: String,
     pub dcc: String,
+    pub target: CatalogTarget,
     pub version: Option<String>,
     pub path: String,
     pub skill_search_path: String,
@@ -80,6 +85,7 @@ pub struct MarketplaceInstallResult {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_commit: Option<String>,
     pub reload_required: bool,
+    pub activation: MarketplaceActivation,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -87,10 +93,20 @@ pub struct MarketplaceUninstallResult {
     pub uninstalled: bool,
     pub name: String,
     pub dcc: String,
+    pub target: CatalogTarget,
     pub path: String,
     pub removed_state: bool,
     pub removed_files: bool,
     pub reload_required: bool,
+    pub activation: MarketplaceActivation,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MarketplaceActivation {
+    None,
+    SkillReload,
+    Restart,
 }
 
 // ── installed state ──────────────────────────────────────────────────────────
@@ -99,6 +115,11 @@ pub struct MarketplaceUninstallResult {
 pub struct InstalledMarketplacePackage {
     pub name: String,
     pub dcc: String,
+    pub target: CatalogTarget,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub components: Vec<CatalogComponent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package_format: Option<CatalogPackageFormat>,
     pub version: Option<String>,
     pub path: String,
     pub source_name: String,
@@ -123,6 +144,8 @@ pub struct MarketplaceInstalledState {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MarketplaceInstalledList {
     pub dcc: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<CatalogTarget>,
     pub count: usize,
     pub packages: Vec<InstalledMarketplacePackage>,
 }
@@ -211,11 +234,49 @@ pub struct RepoInstallResult {
 /// `any` is the host-neutral wildcard used by Skills that can be loaded into a
 /// concrete adapter without owning a standalone DCC runtime.
 pub fn entry_targets_dcc(entry: &CatalogEntry, dcc: &str) -> bool {
+    entry_targets(entry)
+        .iter()
+        .any(|target| {
+            target.kind == CatalogTargetKind::Dcc
+                && (target.id.eq_ignore_ascii_case("any")
+                    || target.id.eq_ignore_ascii_case(dcc))
+        })
+}
+
+pub fn entry_targets(entry: &CatalogEntry) -> Vec<CatalogTarget> {
+    if !entry.targets.is_empty() {
+        return entry.targets.clone();
+    }
     entry
         .dcc
         .iter()
-        .any(|value| value.eq_ignore_ascii_case("any") || value.eq_ignore_ascii_case(dcc))
+        .map(|id| CatalogTarget {
+            kind: CatalogTargetKind::Dcc,
+            id: id.clone(),
+        })
+        .collect()
 }
+
+pub fn parse_target(value: &str) -> Result<CatalogTarget, MarketplaceTargetParseError> {
+    let (kind, id) = value.split_once(':').ok_or(MarketplaceTargetParseError)?;
+    if id.trim().is_empty() {
+        return Err(MarketplaceTargetParseError);
+    }
+    let kind = match kind {
+        "dcc" => CatalogTargetKind::Dcc,
+        "application" => CatalogTargetKind::Application,
+        "game" => CatalogTargetKind::Game,
+        "web" => CatalogTargetKind::Web,
+        _ => return Err(MarketplaceTargetParseError),
+    };
+    Ok(CatalogTarget {
+        kind,
+        id: id.to_string(),
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MarketplaceTargetParseError;
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
@@ -229,6 +290,7 @@ mod tests {
             name: "test".into(),
             description: "desc".into(),
             dcc: vec!["maya".into(), "blender".into()],
+            targets: vec![],
             url: None,
             tags: vec![],
             version: None,

--- a/crates/dcc-mcp-marketplace/src/types.rs
+++ b/crates/dcc-mcp-marketplace/src/types.rs
@@ -234,13 +234,10 @@ pub struct RepoInstallResult {
 /// `any` is the host-neutral wildcard used by Skills that can be loaded into a
 /// concrete adapter without owning a standalone DCC runtime.
 pub fn entry_targets_dcc(entry: &CatalogEntry, dcc: &str) -> bool {
-    entry_targets(entry)
-        .iter()
-        .any(|target| {
-            target.kind == CatalogTargetKind::Dcc
-                && (target.id.eq_ignore_ascii_case("any")
-                    || target.id.eq_ignore_ascii_case(dcc))
-        })
+    entry_targets(entry).iter().any(|target| {
+        target.kind == CatalogTargetKind::Dcc
+            && (target.id.eq_ignore_ascii_case("any") || target.id.eq_ignore_ascii_case(dcc))
+    })
 }
 
 pub fn entry_targets(entry: &CatalogEntry) -> Vec<CatalogTarget> {
@@ -315,6 +312,7 @@ mod tests {
             name: "host-neutral".into(),
             description: "desc".into(),
             dcc: vec!["ANY".into()],
+            targets: vec![],
             url: None,
             tags: vec![],
             version: None,

--- a/docs/guide/marketplace.md
+++ b/docs/guide/marketplace.md
@@ -1,4 +1,4 @@
-# Marketplace: Plugin, Bundle, and Skill Catalog
+# Marketplace: Typed Package Catalog
 
 The marketplace is a CLI-first discovery and installation system for official and
 community packages. It resolves human-readable names from one or more
@@ -75,7 +75,9 @@ Set `DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES=1` to disable the built-in source.
 | `marketplace search --query <q>`           | Fuzzy-rank entries across all sources; current builds also accept positional query words |
 | `marketplace inspect <name>`              | Show full entry metadata                       |
 | `marketplace install <name> --dcc <dcc> --reload` | Install a plugin, bundle, or Skill and refresh running adapters |
+| `marketplace install <name> --target <kind:id>` | Install a generic package such as a CUA Profile |
 | `marketplace list-installed --dcc <dcc>`  | List installed packages                        |
+| `marketplace list-installed --target <kind:id>` | List packages for an application target |
 | `marketplace uninstall <name> [--dcc <dcc>] [--reload]`| Remove an installed package and optionally refresh the adapter |
 | `marketplace outdated [name] --dcc <dcc>` | Check for newer versions                       |
 | `marketplace update [name] --all`         | Upgrade installed packages                     |
@@ -99,6 +101,30 @@ multiple `source.skillRoots`. In both cases `package.skills` provides the
 component names shown by the marketplace UI. DCC-MCP currently installs Skill
 components and ignores optional Agent Plugin `mcp.json` because DCC adapters
 already own the runtime MCP connection.
+
+Catalog v2 also supports generic `targets` and typed `components`. Target kinds
+are `dcc`, `application`, `game`, and `web`; package formats are `skill`,
+`skill-bundle`, `agent-plugin`, `cua-profile`, and `composite`. A CUA Profile
+entry has one `cua-profile` component with a package-relative root:
+
+```json
+{
+  "name": "the-bazaar-profile",
+  "description": "The Bazaar semantic profile",
+  "targets": [{"kind": "game", "id": "the-bazaar"}],
+  "package": {
+    "format": "cua-profile",
+    "components": [
+      {"kind": "cua-profile", "id": "the-bazaar", "root": "."}
+    ]
+  }
+}
+```
+
+The Marketplace delegates Profile validation, installation, and removal to
+`dcc-cua profile validate|install|uninstall` with exact process arguments. Core
+does not parse the Profile schema. `DCC_MCP_CUA_BINARY` may select an explicit
+binary; otherwise the CLI checks its sibling directory and then `PATH`.
 
 ## Installation Types
 
@@ -163,6 +189,19 @@ dcc-mcp-cli marketplace publish . \
   --catalog ../marketplace/marketplace.json \
   --install-url https://github.com/<owner>/<repo>/releases/download/v0.1.0/my-skill.zip \
   --sha256 sha256:<digest>
+```
+
+Publish a Profile package with explicit typed metadata:
+
+```bash
+dcc-mcp-cli marketplace publish . \
+  --catalog ../marketplace/marketplace.json \
+  --install-url https://example.com/the-bazaar-profile.zip \
+  --name the-bazaar-profile \
+  --description "The Bazaar semantic profile" \
+  --target game:the-bazaar \
+  --format cua-profile \
+  --component cua-profile:the-bazaar=.
 ```
 
 This is the recommended path for stable packages. Development packages can

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -473,6 +473,7 @@ For marketplace Skills, search first when the exact package ID is not known:
 dcc-mcp-cli marketplace search --query "maya rigging" --limit 20
 dcc-mcp-cli marketplace inspect <package_name>
 dcc-mcp-cli marketplace install <package_name> --dcc maya --reload
+dcc-mcp-cli marketplace install <profile_package_name> --target game:the-bazaar
 ```
 
 `--query "maya rigging"` remains supported for scripts. Search and inspect are

--- a/skills/dcc-mcp/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-mcp/references/CLI_CHEATSHEET.md
@@ -153,6 +153,7 @@ paths, or full tool payloads.
 | `dcc-mcp-cli marketplace search --query "maya rigging" --limit 20` | Find installable Skill packages with released and current CLI builds |
 | `dcc-mcp-cli marketplace inspect <package_name>` | Inspect the selected skill package metadata before installing |
 | `dcc-mcp-cli marketplace install <package_name> --dcc maya --reload` | Install an exact package ID and ask running Maya adapters to re-scan skill paths |
+| `dcc-mcp-cli marketplace install <package_name> --target game:the-bazaar` | Install a typed CUA Profile for a generic application target; no DCC reload is requested |
 | `dcc-mcp-cli reload-skills --dcc-type maya` | Ask running Maya adapters to re-scan installed skill paths |
 | `dcc-mcp-cli marketplace update <package_name> --dcc maya` | Update an installed skill package from the catalog |
 | `dcc-mcp-cli marketplace uninstall <package_name> --reload` | Remove an installed skill package; infer its DCC when it is installed for one DCC and refresh the adapter |


### PR DESCRIPTION
Add generic marketplace targets and typed components, then delegate CUA profile validation, installation, replacement, and removal to the verified dcc-cua sibling. Includes exact-argv E2E coverage and keeps Skill activation behavior unchanged.