### PR TITLE
chore(catalog): update Shogun to 0.3.0

### DIFF
--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -397,12 +397,12 @@ entries:
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-touchdesigner/main/install.md"
 
   - name: "dcc-mcp-shogun"
-    description: "Vicon Shogun Post adapter with typed scene, file, timeline, and capability-gated processing workflows"
+    description: "Vicon Shogun Post adapter with 36 typed Scene, file, Timeline, and capability-gated Offline processing tools"
     dcc: ["shogun"]
     url: "https://github.com/dcc-mcp/dcc-mcp-shogun"
     tags: ["adapter", "shogun", "vicon", "official", "pip", "motion-capture", "timeline", "processing"]
-    version: "0.2.0"
-    min_core_version: "0.19.91"
+    version: "0.3.0"
+    min_core_version: "0.19.86"
     maintainer: "dcc-mcp"
     install:
       type: pip

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -30,7 +30,7 @@ submit a PR updating this matrix before the release PR merges.
 | FreeCAD | [dcc-mcp-freecad](https://github.com/dcc-mcp/dcc-mcp-freecad) | 0.1.2 | >=0.19.91,<1.0.0 | 1.0+ | External FreeCADCmd subprocess | 2026-08 |
 | Cinema 4D | [dcc-mcp-cinema4d](https://github.com/dcc-mcp/dcc-mcp-cinema4d) | 0.1.3 | >=0.19.91,<1.0.0 | R21+ | External headless c4dpy subprocess | 2026-08 |
 | ComfyUI | [dcc-mcp-comfyui](https://github.com/dcc-mcp/dcc-mcp-comfyui) | 0.1.0 | >=0.19.91,<1.0.0 | 0.31+ | Standalone sidecar + local REST workflow bridge | 2026-08 |
-| Shogun | [dcc-mcp-shogun](https://github.com/dcc-mcp/dcc-mcp-shogun) | 0.2.0 | >=0.19.91,<1.0.0 | Vicon Shogun Post | Typed scene and file workflows; Timeline and Offline processing are capability-gated | 2026-08 |
+| Shogun | [dcc-mcp-shogun](https://github.com/dcc-mcp/dcc-mcp-shogun) | 0.3.0 | >=0.19.86,<1.0.0 | Vicon Shogun Post | 36 typed Scene, file, Timeline, and Offline tools; newer SDK surfaces remain capability-gated | 2026-08 |
 | Mari | [dcc-mcp-mari](https://github.com/dcc-mcp/dcc-mcp-mari) | 0.2.1 | >=0.19.91,<1.0.0 | 5.0+ | Authenticated loopback sidecar + Qt UI timer | 2026-08 |
 | 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.40 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-08 |
 | Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.43 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-08 |


### PR DESCRIPTION
## Summary
- update the bundled Shogun adapter catalog pin from 0.2.0 to the published 0.3.0 release
- record the 36-tool official Scene, file, Timeline, and Offline surface
- keep capability-gating explicit in the compatibility matrix

## Validation
- public PyPI fresh install of `dcc-mcp-shogun==0.3.0`
- packaged resource count: 16 scene + 3 files + 8 timeline + 9 processing = 36 tools
- `vx cargo test -p dcc-mcp-catalog`: 34 passed
- `git diff --check`: passed