### PR TITLE
fix(marketplace): fetch GitHub archives from codeload

### DIFF
--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -1380,7 +1380,7 @@ mod tests {
 
         assert_eq!(
             github_archive_url(&install).as_deref(),
-            Some("https://github.com/dcc-mcp/dcc-mcp-maya-mgear/archive/main.zip")
+            Some("https://codeload.github.com/dcc-mcp/dcc-mcp-maya-mgear/zip/main")
         );
     }
 

--- a/crates/dcc-mcp-marketplace/src/service_internals.rs
+++ b/crates/dcc-mcp-marketplace/src/service_internals.rs
@@ -317,8 +317,12 @@ pub fn github_archive_url(install: &CatalogInstall) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or("HEAD");
+    // Fetch the archive directly from GitHub's archive host. The public
+    // github.com endpoint redirects here; avoiding that extra request prevents
+    // long downloads from being cut off when the redirect connection is
+    // closed before the response body completes.
     Some(format!(
-        "https://github.com/{owner}/{repo}/archive/{ref_}.zip"
+        "https://codeload.github.com/{owner}/{repo}/zip/{ref_}"
     ))
 }
 


### PR DESCRIPTION
## Summary
- resolve public GitHub repository archives directly through `codeload.github.com`
- avoid the `github.com/.../archive/...zip` redirect that can close before reqwest finishes the response body
- preserve SSH/private Git command fallback, immutable refs, SkillRoots selection, extraction safety, and installed-state behavior

## Reproduction
`dcc-mcp-cli 0.20.4 marketplace install dcc-mcp-cache-inspector --dcc blender` found the published catalog entry but failed twice while reading the redirected GitHub archive with `connection closed before message completed`. Direct codeload access was healthy.

## Validation
- `vx cargo test -p dcc-mcp-marketplace`: 51 passed
- `vx cargo fmt --all -- --check`: passed
- `git diff --check`: passed
- built `dcc-mcp-cli 0.20.4` with the patch
- installed published `dcc-mcp-cache-inspector` 0.3.0 from its immutable Marketplace source pin into an isolated concrete `blender` target
- resolved commit exactly matched `c961442fca498315361cd89df05bd27182a38833`
- installed only the `cache-inspection` Skill; no `any` target directory or adapter was created
- the installed Skill inspected real `.bgeo` and `.bgeo.sc` caches with identical bounded counts, bounds, primitive family, and attribute schema