### PR TITLE
test(http): keep pumping cancelled main-thread jobs

### DIFF
--- a/crates/dcc-mcp-http-server/src/thread_routed_invoker.rs
+++ b/crates/dcc-mcp-http-server/src/thread_routed_invoker.rs
@@ -260,11 +260,18 @@ mod tests {
         .expect("job reaches the host queue");
 
         jobs.cancel(&pending.job_id).expect("cancel running job");
-        tokio::task::yield_now().await;
-        let _ = deferred.poll_pending();
-
         tokio::time::timeout(Duration::from_secs(2), async {
-            while jobs.get(&pending.job_id).expect("job").read().status != JobStatus::Cancelled {
+            loop {
+                // `DccExecutorHandle::pending` is intentionally an approximate
+                // observability counter: submit records the enqueue before it
+                // hands the task to the mpsc channel. Mirror a real DCC event
+                // loop by pumping until the execution lane acknowledges the
+                // cancellation instead of assuming one poll is sufficient.
+                let _ = deferred.poll_pending();
+                assert!(!ran.load(Ordering::Acquire));
+                if jobs.get(&pending.job_id).expect("job").read().status == JobStatus::Cancelled {
+                    break;
+                }
                 tokio::task::yield_now().await;
             }
         })


### PR DESCRIPTION
## Summary
- make the REST main-thread cancellation regression test mirror the recurring DCC event-loop pump
- avoid treating the executor's documented approximate `pending()` counter as proof that the mpsc task is already visible
- keep asserting on every pump that the cancelled handler never executes

## Root cause
The test observed `pending() > 0` and then polled exactly once. `submit_deferred` records its enqueue statistic before handing the task to the mpsc channel, so under load the single poll could run in that narrow gap and drain zero tasks. The test then stopped pumping and timed out even though production DCC hosts poll continuously.

## Validation
- exact regression test passed
- exact regression test passed 100 consecutive iterations
- adjacent `thread_routed_invoker` tests passed
- adjacent `job_aware_invoker` tests passed
- `vx cargo fmt --all -- --check`
- `git diff --check`