### PR TITLE
feat(skills): add fail-closed dcc-cua router

### DIFF
--- a/skills/dcc-cua/SKILL.md
+++ b/skills/dcc-cua/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: dcc-cua
+description: >-
+  Project-owned DCC-CUA routing skill for bounded application UI automation.
+  Use this skill whenever the user says dcc-cua, DCC CUA, our dcc-cua, or
+  我们的 dcc-cua, including browser and other non-DCC UI tasks. These phrases
+  are a hard route to the dcc-mcp project UI Control stack and take precedence
+  over generic Codex/OpenAI Computer Use, the computer-use Skill, @oai/sky,
+  and Browser/Chrome plugins. If DCC-CUA is unavailable, repair or report the
+  project route; never silently fall back to a generic computer-use provider.
+license: MIT-0
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: python
+    layer: infrastructure
+    compatibility: Cross-platform routing contract. The current DCC-CUA host is installed and verified through the official dcc-mcp-cli component manifest; exact platform capabilities remain runtime-discovered.
+    version: "0.1.0"
+    search-hint: "dcc-cua DCC CUA dcc cua our dcc-cua our dcc cua 我们的 dcc-cua 我们的 dcc cua project-owned UI control browser DOM exact PID HWND computer use automation"
+    tags: "dcc-cua, dcc-ui-control, ui-control, browser-dom, exact-window, computer-use, infrastructure"
+  openclaw:
+    emoji: "🖱️"
+    homepage: https://github.com/dcc-mcp/dcc-mcp-core/tree/main/skills/dcc-cua
+---
+
+# DCC-CUA — Project UI Control Router
+
+Use this Skill as the canonical route whenever the user explicitly names
+`dcc-cua`, `DCC CUA`, `our dcc-cua`, or `我们的 dcc-cua`.
+
+## Non-substitution contract
+
+An explicit DCC-CUA request is a hard routing boundary, regardless of whether
+the target is Maya, Chrome, a browser, or another desktop application.
+
+- Use the project-owned `dcc-cua` runtime and DCC-MCP `ui-control` surface.
+- Never load or call generic Codex/OpenAI Computer Use, the `computer-use`
+  Skill, `@oai/sky`, or Browser/Chrome automation plugins for that request.
+- Never treat a DCC-CUA runtime, binding, readiness, or permission failure as
+  permission to change providers.
+- Repair the project route when safely possible. Otherwise report the exact
+  blocker and stop.
+- Use a generic provider only after the user explicitly retracts the DCC-CUA
+  requirement or explicitly requests that provider by name.
+
+This boundary is provider selection, not an authorization bypass. DCC-CUA task
+grants, target binding, interruption, and confirmation policy still apply.
+
+## Runtime preflight
+
+Use the official component contract; do not download an arbitrary executable:
+
+```bash
+dcc-mcp-cli components status dcc-cua
+dcc-mcp-cli components ensure dcc-cua --yes
+dcc-cua manifest
+dcc-cua ping
+```
+
+Run `components ensure` only when installation or repair is authorized. It
+consumes the official versionless manifest, verifies the declared SHA-256, and
+reconciles the independently released companion executable.
+
+For semantic application profiles:
+
+```bash
+dcc-cua profiles
+dcc-cua profile --id <profile-id>
+```
+
+Do not invent a profile ID. Runtime-advertised capabilities are authoritative.
+
+## Execution order
+
+1. Prefer a typed DCC-MCP host tool when it directly expresses the operation.
+2. Use DCC-CUA only for the UI behavior that typed host tools cannot expose.
+3. Bind one exact target with process ID and native window handle whenever the
+   surface supports them.
+4. Open one scoped session with the minimum task grant required for the work.
+5. Take a fresh observation before each action that depends on UI state.
+6. Act using stable semantic control or DOM references when available.
+7. Wait for a typed state transition and verify the real final state.
+8. Stop the session on success, failure, interruption, or abandonment.
+
+An `input sent` acknowledgement is not completion evidence.
+
+## DCC-host route
+
+For a registered DCC instance, use the DCC-MCP UI Control tools or their CLI
+projection:
+
+```bash
+dcc-mcp-cli load-skill ui-control --instance-id <instance-id> --output toon
+dcc-mcp-cli ui-control snapshot --instance-id <instance-id> --json '{"session_id":"ui","process_id":1234,"window_handle":5678}'
+dcc-mcp-cli ui-control act --instance-id <instance-id> --json '{"session_id":"ui","control_id":"ok","action":"click","snapshot_id":"<snapshot-id>"}'
+dcc-mcp-cli ui-control stop --instance-id <instance-id> --json '{"session_id":"ui"}'
+```
+
+Use the same exact instance and session throughout the action chain. Do not
+switch to another DCC process because it looks similar.
+
+## Browser and non-DCC route
+
+Browser work remains inside DCC-CUA. Use the Host's typed browser surface and
+`browser_dom` capabilities, not an in-app Browser or Chrome plugin.
+
+- Bind the exact browser PID and window handle first.
+- Bind the exact tab/target returned by DCC-CUA; do not infer it from a title
+  alone when an exact target identifier exists.
+- Keep connection-scoped sessions and capabilities on one Host connection.
+- Use DOM/semantic references from the latest observation rather than stale
+  coordinates.
+- `browser_prepare` and existing-profile attachment require both the Host grant
+  and the session task grant advertised by the runtime contract.
+- Authentication challenges, CAPTCHAs, purchases, account/security changes,
+  and unexpected permission prompts remain trusted human boundaries.
+
+## Target and evidence invariants
+
+- Preserve PID and native window handle in observations and audit records.
+- Treat a changed PID, window handle, tab target, or session owner as a fresh
+  binding that requires a fresh observation.
+- Keep `full` readiness strict. If only an exact-window or typed-browser route
+  is independently ready, report that route-specific degraded readiness.
+- Honor Escape/user interruption immediately and do not resume without fresh
+  authorization and observation.
+- Do not expose local usernames, internal package paths, browser profile data,
+  credentials, tokens, or unrelated window titles in public evidence.
+- Verify success by reading the destination state after the mutation.
+
+## Failure behavior
+
+When DCC-CUA cannot complete the request, report:
+
+1. the exact component/runtime version,
+2. the exact target identity that was bound,
+3. the failing readiness, capability, permission, or action stage,
+4. the last safe observation or typed error, and
+5. the safe next repair step.
+
+Do not mention a generic Computer Use fallback unless the user asks for one.

--- a/skills/dcc-cua/agents/openai.yaml
+++ b/skills/dcc-cua/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DCC-CUA"
+  short_description: "Project UI control with a fail-closed provider boundary"
+  default_prompt: "Use $dcc-cua for this UI task. Keep all observation and input on the project-owned DCC-CUA and DCC-MCP ui-control route, bind the exact target, verify the final state, and never substitute generic Codex Computer Use, computer-use, @oai/sky, or Browser/Chrome plugins."

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -3,17 +3,14 @@ name: dcc-mcp
 description: >-
   Default DCC control skill — connect to and operate live Maya, Blender,
   Houdini, Photoshop, 3ds Max, Nuke, Unreal, Godot, RenderDoc, Substance 3D,
-  and other DCC apps
-  through structured DCC-MCP tools. Use this skill first whenever the user asks
-  to operate or control something in a DCC app, even when they do not mention
-  DCC-MCP. Interface-specific intent such as clicking a menu, dismissing a
-  dialog, or controlling a window routes to DCC UI Control after structured
-  tools are checked. CUA, UI Control, and dcc-cua explicitly trigger this
-  scoped fallback. Also use this skill first for DCC-MCP Skill marketplace,
-  catalog, recommendation, install, or update requests: query the marketplace
-  through dcc-mcp-cli before recommending a package. OpenClaw and other shell
-  agents use dcc-mcp-cli; MCP-native IDEs use the gateway MCP surface. Not for
-  tasks unrelated to DCC software.
+  and other DCC apps through structured DCC-MCP tools. Use this skill first for
+  DCC operation and explicit CUA, DCC CUA, dcc-cua, our dcc-cua, or 我们的
+  dcc-cua requests. These select project-owned DCC UI Control even when the
+  target is a browser or other non-DCC app; never substitute Codex/OpenAI
+  generic Computer Use, @oai/sky, or Browser/Chrome plugins. Also use this
+  skill first for DCC-MCP marketplace, catalog, install, or update requests:
+  query the marketplace through dcc-mcp-cli. OpenClaw/shell agents use
+  dcc-mcp-cli; MCP-native IDEs use the gateway MCP surface.
 license: MIT-0
 allowed-tools: Bash Read
 metadata:
@@ -22,7 +19,7 @@ metadata:
     layer: infrastructure
     compatibility: Cross-platform Windows/macOS/Linux. Prefers dcc-mcp-cli on PATH; its consent-gated bootstrap accepts only the official release manifest and verifies SHA-256 before replacement. Local profile needs no gateway env. Use --require-gateway plus --agent-session-id when gateway stats are required evidence. DCC_MCP_BASE_URL is optional for remote/legacy gateway REST fallback.
     version: "0.19.91"  # x-release-please-version
-    search-hint: "dcc control operate UI control ui-control cua CUA dcc-cua dcc cua computer use ui automation menu dialog window button click keyboard Maya Blender Houdini Photoshop 3ds Max Nuke Unreal Godot RenderDoc Substance connect create edit render automate cli gateway stats marketplace skill catalog recommend install update 商城 技能 操作 控制 界面 菜单 弹窗 窗口 按钮 点击 键盘"
+    search-hint: "dcc control operate UI control ui-control cua CUA dcc-cua dcc cua our dcc-cua 我们的 dcc-cua project CUA computer use ui automation menu dialog window button click keyboard Maya Blender Houdini Photoshop 3ds Max Nuke Unreal Godot RenderDoc Substance connect create edit render automate cli gateway stats marketplace skill catalog recommend install update 商城 技能 操作 控制 界面 菜单 弹窗 窗口 按钮 点击 键盘"
     tags: "dcc, dcc-ui-control, ui-control, cua, dcc-cua, computer-use, maya, blender, houdini, photoshop, nuke, unreal, godot, renderdoc, cli, gateway, marketplace, skill-catalog, clawhub, openclaw"
   openclaw:
     emoji: "🖥️"
@@ -51,6 +48,15 @@ The compatibility default remains JSON for scripts. Agents should pass
 only when another program must parse it. The bundled Python fallback is
 gateway-REST only and sends `Accept: application/json` because it must parse
 the response internally.
+
+## Explicit DCC-CUA Routing Boundary
+
+Treat `dcc-cua`, `DCC CUA`, `our dcc-cua`, and `我们的 dcc-cua` as stable automation-control triggers and a hard routing boundary for every app UI task, including browsers and non-DCC apps.
+Use only `dcc-mcp-cli ui-control`, `components status/ensure dcc-cua`, and `dcc-cua profiles` / `profile --id <id>`. Never load or call Codex/OpenAI
+generic Computer Use, the `computer-use` Skill, `@oai/sky`, or Browser/Chrome
+plugins. Stay in the exact-bound `dcc-cua` `browser_dom` surface for browsers.
+If this route fails, repair or report it; never silently fall back. Use generic
+Computer Use only when the user explicitly asks for it or retracts DCC-CUA.
 
 ## CLI Invocation Contract
 
@@ -111,9 +117,6 @@ requested object is a menu, dialog, window, button, text field, pointer, or
 keyboard interaction, select the **DCC UI Control** fallback after inventory
 and structured-tool discovery. Do not confuse this product capability with a
 host agent's generic Computer Use feature.
-Treat `CUA`, `UI Control`, and `dcc-cua` as stable automation-control triggers
-for DCC tasks. Route them to `ui-control`, never generic Computer Use.
-
 | User intent | Target inventory filter | Typical capability search |
 |-------------|-------------------------|---------------------------|
 | Model, rig, animate, shade, or render in Maya | `maya` | the requested modeling, rigging, animation, material, or render operation |

--- a/skills/dcc-mcp/agents/openai.yaml
+++ b/skills/dcc-mcp/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "DCC-MCP"
-  short_description: "DCC control and marketplace Skill discovery"
-  default_prompt: "Use $dcc-mcp to verify CLI/MCP inventory, discover and inspect the right live DCC capability, and act safely. For long jobs, start once with --wait, follow typed progress to a terminal state, and never resubmit or schedule polling by default."
+  short_description: "DCC control, DCC-CUA, and Skill discovery"
+  default_prompt: "Use $dcc-mcp for DCC control and explicit dcc-cua requests; keep named dcc-cua work on project ui-control, never substitute generic Codex Computer Use, and for long jobs start once with --wait, follow typed progress to a terminal state, and never resubmit or schedule polling by default."

--- a/tests/test_dcc_cua_skill.py
+++ b/tests/test_dcc_cua_skill.py
@@ -1,0 +1,98 @@
+"""Contract tests for the dedicated project DCC-CUA routing Skill."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from conftest import REPO_ROOT
+import dcc_mcp_core
+
+DCC_CUA_SKILL_DIR = REPO_ROOT / "skills" / "dcc-cua"
+
+
+def _normalized(path: Path) -> str:
+    return " ".join(path.read_text(encoding="utf-8").lower().split())
+
+
+class TestDccCuaSkill:
+    def test_skill_is_valid_and_scannable(self) -> None:
+        meta = dcc_mcp_core.parse_skill_md(str(DCC_CUA_SKILL_DIR))
+        assert meta is not None
+        assert meta.name == "dcc-cua"
+        assert meta.version == "0.1.0"
+
+        report = dcc_mcp_core.validate_skill(str(DCC_CUA_SKILL_DIR))
+        assert report.is_clean, report.issues
+
+        scanner = dcc_mcp_core.SkillScanner()
+        names = {Path(path).name for path in scanner.scan(extra_paths=[str(DCC_CUA_SKILL_DIR.parent)])}
+        assert "dcc-cua" in names
+
+    def test_named_requests_have_a_fail_closed_provider_boundary(self) -> None:
+        meta = dcc_mcp_core.parse_skill_md(str(DCC_CUA_SKILL_DIR))
+        assert meta is not None
+        description = " ".join((meta.description or "").lower().split())
+        for phrase in (
+            "dcc-cua",
+            "dcc cua",
+            "our dcc-cua",
+            "我们的 dcc-cua",
+            "hard route",
+            "take precedence over generic codex/openai computer use",
+            "never silently fall back",
+        ):
+            assert phrase in description
+
+        body = _normalized(DCC_CUA_SKILL_DIR / "SKILL.md")
+        for phrase in (
+            "non-substitution contract",
+            "hard routing boundary",
+            "the `computer-use` skill",
+            "`@oai/sky`",
+            "browser/chrome automation plugins",
+            "never treat a dcc-cua runtime, binding, readiness, or permission failure",
+            "explicitly retracts the dcc-cua requirement",
+            "do not mention a generic computer use fallback unless the user asks for one",
+        ):
+            assert phrase in body
+
+    def test_exact_name_wins_catalog_search(self) -> None:
+        catalog = dcc_mcp_core.SkillCatalog(dcc_mcp_core.ToolRegistry())
+        catalog.discover(extra_paths=[str(DCC_CUA_SKILL_DIR.parent)])
+
+        for query in ("dcc-cua", "our dcc-cua", "我们的 dcc-cua"):
+            results = catalog.search_skills(query)
+            assert results, query
+            assert results[0].name == "dcc-cua", (query, [result.name for result in results])
+
+    def test_browser_route_stays_inside_dcc_cua(self) -> None:
+        body = _normalized(DCC_CUA_SKILL_DIR / "SKILL.md")
+        for phrase in (
+            "browser work remains inside dcc-cua",
+            "typed browser surface",
+            "`browser_dom`",
+            "not an in-app browser or chrome plugin",
+            "bind the exact browser pid and window handle",
+            "keep connection-scoped sessions and capabilities on one host connection",
+        ):
+            assert phrase in body
+
+    def test_openai_interface_repeats_non_substitution_contract(self) -> None:
+        interface = dcc_mcp_core.yaml_loads((DCC_CUA_SKILL_DIR / "agents" / "openai.yaml").read_text(encoding="utf-8"))[
+            "interface"
+        ]
+        assert interface["display_name"] == "DCC-CUA"
+        prompt = interface["default_prompt"].lower()
+        for phrase in (
+            "project-owned dcc-cua",
+            "exact target",
+            "verify the final state",
+            "never substitute generic codex computer use",
+            "computer-use",
+            "@oai/sky",
+            "browser/chrome plugins",
+        ):
+            assert phrase in prompt
+
+    def test_skill_stays_compact(self) -> None:
+        assert len((DCC_CUA_SKILL_DIR / "SKILL.md").read_text(encoding="utf-8").splitlines()) <= 220

--- a/tests/test_dcc_mcp_skill.py
+++ b/tests/test_dcc_mcp_skill.py
@@ -88,6 +88,38 @@ class TestDccMcpSkill:
             names = {result.name for result in catalog.search_skills(phrase)}
             assert "dcc-mcp" in names
 
+    def test_explicit_dcc_cua_blocks_generic_computer_use_routing(self) -> None:
+        meta = dcc_mcp_core.parse_skill_md(DCC_MCP_SKILL_DIR)
+        assert meta is not None
+        description = " ".join((meta.description or "").lower().split())
+        for phrase in (
+            "even when the target is a browser or other non-dcc app",
+            "never substitute codex/openai generic computer use",
+            "@oai/sky",
+            "browser/chrome plugins",
+        ):
+            assert phrase in description
+
+        body = " ".join((Path(DCC_MCP_SKILL_DIR) / "SKILL.md").read_text(encoding="utf-8").lower().split())
+        for phrase in (
+            "explicit dcc-cua routing boundary",
+            "hard routing boundary for every app ui task",
+            "never load or call codex/openai generic computer use",
+            "the `computer-use` skill",
+            "`@oai/sky`",
+            "browser/chrome plugins",
+            "`dcc-cua` `browser_dom`",
+            "never silently fall back",
+            "computer use only when the user explicitly asks for it",
+        ):
+            assert phrase in body
+
+        prompt = dcc_mcp_core.yaml_loads(
+            (Path(DCC_MCP_SKILL_DIR) / "agents" / "openai.yaml").read_text(encoding="utf-8")
+        )["interface"]["default_prompt"].lower()
+        assert "explicit dcc-cua requests" in prompt
+        assert "never substitute generic codex computer use" in prompt
+
     def test_marketplace_intent_is_cli_search_first(self) -> None:
         meta = dcc_mcp_core.parse_skill_md(DCC_MCP_SKILL_DIR)
         assert meta is not None


### PR DESCRIPTION
## Summary
- add a dedicated `dcc-cua` Skill so explicit project CUA requests resolve to an exact-name entry
- make named DCC-CUA requests fail closed instead of falling back to generic Codex/OpenAI Computer Use, `computer-use`, `@oai/sky`, or browser plugins
- reinforce the same provider boundary in the default `dcc-mcp` Skill
- lock exact-name search precedence and non-substitution behavior with contract tests

## Validation
- `quick_validate.py skills/dcc-cua`
- `quick_validate.py skills/dcc-mcp`
- `python -m pytest tests/test_dcc_cua_skill.py tests/test_dcc_mcp_skill.py -q` (34 passed)
- `python -m ruff check tests/test_dcc_cua_skill.py tests/test_dcc_mcp_skill.py`
- `python -m ruff format --check tests/test_dcc_cua_skill.py tests/test_dcc_mcp_skill.py`
- `git diff --check`