### PR TITLE
docs(catalog): refresh recent adapter releases

### DIFF
--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -397,11 +397,11 @@ entries:
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-touchdesigner/main/install.md"
 
   - name: "dcc-mcp-shogun"
-    description: "Vicon Shogun Post adapter with 57 typed Scene, channel, camera, file, Timeline, production-context, and capability-gated Offline processing tools"
+    description: "Vicon Shogun Post adapter with 61 typed Scene, channel, camera, file, Timeline, production-context, and capability-gated Offline processing tools"
     dcc: ["shogun"]
     url: "https://github.com/dcc-mcp/dcc-mcp-shogun"
     tags: ["adapter", "shogun", "vicon", "official", "pip", "motion-capture", "timeline", "processing"]
-    version: "0.6.0"
+    version: "0.7.0"
     min_core_version: "0.19.86"
     maintainer: "dcc-mcp"
     install:

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -397,11 +397,11 @@ entries:
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-touchdesigner/main/install.md"
 
   - name: "dcc-mcp-shogun"
-    description: "Vicon Shogun Post adapter with 48 typed Scene, channel, camera, file, Timeline, and capability-gated Offline processing tools"
+    description: "Vicon Shogun Post adapter with 57 typed Scene, channel, camera, file, Timeline, production-context, and capability-gated Offline processing tools"
     dcc: ["shogun"]
     url: "https://github.com/dcc-mcp/dcc-mcp-shogun"
     tags: ["adapter", "shogun", "vicon", "official", "pip", "motion-capture", "timeline", "processing"]
-    version: "0.4.0"
+    version: "0.6.0"
     min_core_version: "0.19.86"
     maintainer: "dcc-mcp"
     install:
@@ -429,7 +429,7 @@ entries:
     dcc: ["material-maker"]
     url: "https://github.com/dcc-mcp/dcc-mcp-material-maker"
     tags: ["adapter", "material-maker", "official", "pip", "procedural-materials", "ptex", "lookdev"]
-    version: "0.3.0"
+    version: "0.3.1"
     min_core_version: "0.19.38"
     maintainer: "dcc-mcp"
     install:
@@ -443,7 +443,7 @@ entries:
     dcc: ["wwise"]
     url: "https://github.com/dcc-mcp/dcc-mcp-wwise"
     tags: ["adapter", "wwise", "official", "pip", "waapi", "game-audio", "soundbank"]
-    version: "0.1.1"
+    version: "0.1.2"
     min_core_version: "0.19.86"
     maintainer: "dcc-mcp"
     install:

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -30,7 +30,7 @@ submit a PR updating this matrix before the release PR merges.
 | FreeCAD | [dcc-mcp-freecad](https://github.com/dcc-mcp/dcc-mcp-freecad) | 0.1.2 | >=0.19.91,<1.0.0 | 1.0+ | External FreeCADCmd subprocess | 2026-08 |
 | Cinema 4D | [dcc-mcp-cinema4d](https://github.com/dcc-mcp/dcc-mcp-cinema4d) | 0.1.3 | >=0.19.91,<1.0.0 | R21+ | External headless c4dpy subprocess | 2026-08 |
 | ComfyUI | [dcc-mcp-comfyui](https://github.com/dcc-mcp/dcc-mcp-comfyui) | 0.1.0 | >=0.19.91,<1.0.0 | 0.31+ | Standalone sidecar + local REST workflow bridge | 2026-08 |
-| Shogun | [dcc-mcp-shogun](https://github.com/dcc-mcp/dcc-mcp-shogun) | 0.6.0 | >=0.19.86,<1.0.0 | Vicon Shogun Post | 57 typed Scene, channel, camera, file, Timeline, production-context, and Offline tools; SDK-dependent surfaces remain capability-gated | 2026-08 |
+| Shogun | [dcc-mcp-shogun](https://github.com/dcc-mcp/dcc-mcp-shogun) | 0.7.0 | >=0.19.86,<1.0.0 | Vicon Shogun Post | 61 typed Scene, channel, camera, file, Timeline, production-context, and Offline tools; SDK-dependent surfaces remain capability-gated | 2026-08 |
 | Mari | [dcc-mcp-mari](https://github.com/dcc-mcp/dcc-mcp-mari) | 0.2.1 | >=0.19.91,<1.0.0 | 5.0+ | Authenticated loopback sidecar + Qt UI timer | 2026-08 |
 | 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.40 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-08 |
 | Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.43 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-08 |

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -30,7 +30,7 @@ submit a PR updating this matrix before the release PR merges.
 | FreeCAD | [dcc-mcp-freecad](https://github.com/dcc-mcp/dcc-mcp-freecad) | 0.1.2 | >=0.19.91,<1.0.0 | 1.0+ | External FreeCADCmd subprocess | 2026-08 |
 | Cinema 4D | [dcc-mcp-cinema4d](https://github.com/dcc-mcp/dcc-mcp-cinema4d) | 0.1.3 | >=0.19.91,<1.0.0 | R21+ | External headless c4dpy subprocess | 2026-08 |
 | ComfyUI | [dcc-mcp-comfyui](https://github.com/dcc-mcp/dcc-mcp-comfyui) | 0.1.0 | >=0.19.91,<1.0.0 | 0.31+ | Standalone sidecar + local REST workflow bridge | 2026-08 |
-| Shogun | [dcc-mcp-shogun](https://github.com/dcc-mcp/dcc-mcp-shogun) | 0.4.0 | >=0.19.86,<1.0.0 | Vicon Shogun Post | 48 typed Scene, channel, camera, file, Timeline, and Offline tools; newer SDK surfaces remain capability-gated | 2026-08 |
+| Shogun | [dcc-mcp-shogun](https://github.com/dcc-mcp/dcc-mcp-shogun) | 0.6.0 | >=0.19.86,<1.0.0 | Vicon Shogun Post | 57 typed Scene, channel, camera, file, Timeline, production-context, and Offline tools; SDK-dependent surfaces remain capability-gated | 2026-08 |
 | Mari | [dcc-mcp-mari](https://github.com/dcc-mcp/dcc-mcp-mari) | 0.2.1 | >=0.19.91,<1.0.0 | 5.0+ | Authenticated loopback sidecar + Qt UI timer | 2026-08 |
 | 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.40 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-08 |
 | Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.43 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-08 |
@@ -48,8 +48,8 @@ submit a PR updating this matrix before the release PR merges.
 | SketchUp | [dcc-mcp-sketchup](https://github.com/dcc-mcp/dcc-mcp-sketchup) | 0.1.0 | >=0.19.91,<1.0.0 | 2021+ | Authenticated Ruby main-thread bridge + sidecar | 2026-08 |
 | TouchDesigner | [dcc-mcp-touchdesigner](https://github.com/dcc-mcp/dcc-mcp-touchdesigner) | 0.1.0 | >=0.19.91,<1.0.0 | 2025 official build | In-process HTTP runtime + `td.run()` main-thread dispatcher | — |
 | Tiled | [dcc-mcp-tiled](https://github.com/dcc-mcp/dcc-mcp-tiled) | 0.3.0 | >=0.19.38,<1.0.0 | 1.10+ | Standalone service + fixed JavaScript driver through `tiled --evaluate` | 2026-08 |
-| Material Maker | [dcc-mcp-material-maker](https://github.com/dcc-mcp/dcc-mcp-material-maker) | 0.3.0 | >=0.19.38,<1.0.0 | 1.7 | Standalone `.ptex` parser + native CLI exporter | — |
-| Wwise | [dcc-mcp-wwise](https://github.com/dcc-mcp/dcc-mcp-wwise) | 0.1.1 | >=0.19.86,<1.0.0 | 2024.1+ | External WAAPI client + host PID binding | 2026-07 |
+| Material Maker | [dcc-mcp-material-maker](https://github.com/dcc-mcp/dcc-mcp-material-maker) | 0.3.1 | >=0.19.38,<1.0.0 | 1.7 | Standalone `.ptex` parser + native CLI exporter | 2026-08 |
+| Wwise | [dcc-mcp-wwise](https://github.com/dcc-mcp/dcc-mcp-wwise) | 0.1.2 | >=0.19.86,<1.0.0 | 2024.1+ | External WAAPI client + host PID binding | 2026-08 |
 | Katana | [dcc-mcp-katana](https://github.com/dcc-mcp/dcc-mcp-katana) | 0.4.0 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
 | MotionBuilder | [dcc-mcp-mobu](https://github.com/dcc-mcp/dcc-mcp-mobu) | 0.3.0 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
 | RenderDoc | [dcc-mcp-renderdoc](https://github.com/dcc-mcp/dcc-mcp-renderdoc) | 0.3.0 | >=0.19.45,<1.0.0 | — | Headless CLI adapter | 2026-07 |

--- a/tests/test_public_adapter_catalog.py
+++ b/tests/test_public_adapter_catalog.py
@@ -16,14 +16,14 @@ def _entries() -> list:
 def test_recent_adapter_releases_are_current() -> None:
     entries = {entry["name"]: entry for entry in _entries()}
     expected_versions = {
-        "dcc-mcp-shogun": "0.6.0",
+        "dcc-mcp-shogun": "0.7.0",
         "dcc-mcp-tiled": "0.3.0",
         "dcc-mcp-material-maker": "0.3.1",
         "dcc-mcp-wwise": "0.1.2",
     }
 
     assert {name: entries[name]["version"] for name in expected_versions} == expected_versions
-    assert "57 typed" in entries["dcc-mcp-shogun"]["description"]
+    assert "61 typed" in entries["dcc-mcp-shogun"]["description"]
 
 
 def test_skill_only_packages_are_not_pip_adapters() -> None:

--- a/tests/test_public_adapter_catalog.py
+++ b/tests/test_public_adapter_catalog.py
@@ -1,0 +1,34 @@
+"""Public first-party adapter catalog boundary tests."""
+
+from __future__ import annotations
+
+from conftest import REPO_ROOT
+from dcc_mcp_core import yaml_loads
+
+CATALOG = REPO_ROOT / "dcc-mcp-catalog.yml"
+
+
+def _entries() -> list:
+    document = yaml_loads(CATALOG.read_text(encoding="utf-8"))
+    return document["entries"]
+
+
+def test_recent_adapter_releases_are_current() -> None:
+    entries = {entry["name"]: entry for entry in _entries()}
+    expected_versions = {
+        "dcc-mcp-shogun": "0.6.0",
+        "dcc-mcp-tiled": "0.3.0",
+        "dcc-mcp-material-maker": "0.3.1",
+        "dcc-mcp-wwise": "0.1.2",
+    }
+
+    assert {name: entries[name]["version"] for name in expected_versions} == expected_versions
+    assert "57 typed" in entries["dcc-mcp-shogun"]["description"]
+
+
+def test_skill_only_packages_are_not_pip_adapters() -> None:
+    entry_names = {entry["name"] for entry in _entries()}
+
+    # Cache Inspector is distributed through marketplace.json as a Skill pack.
+    # It intentionally has no PyPI project or first-party adapter catalog entry.
+    assert "dcc-mcp-cache-inspector" not in entry_names


### PR DESCRIPTION
## Summary
- refresh Shogun, Material Maker, and Wwise release metadata in the public adapter catalog and compatibility matrix
- record Shogun 0.6.0's 57 typed tools
- add a regression test that keeps Skill-only `dcc-mcp-cache-inspector` out of the PyPI adapter catalog

## Validation
- `uv run --no-sync pytest -q tests/test_public_adapter_catalog.py` (2 passed)
- `uv run --no-sync ruff check tests/test_public_adapter_catalog.py`
- `uv run --no-sync ruff format --check tests/test_public_adapter_catalog.py`
- YAML catalog contract smoke
- `git diff --check`