### PR TITLE
fix(skills): preserve attached Python for subprocess scripts

### DIFF
--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -511,6 +511,40 @@ fn which_program(program: &str) -> bool {
     false
 }
 
+pub(super) fn is_python_cli_executable(path: &std::path::Path) -> bool {
+    let stem = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_default();
+    stem.starts_with("python")
+        || stem.starts_with("pypy")
+        || matches!(stem.as_str(), "mayapy" | "hython" | "c4dpy" | "3dsmaxpy")
+}
+
+#[cfg(feature = "python-bindings")]
+fn attached_python_executable() -> Option<String> {
+    use pyo3::prelude::*;
+
+    Python::try_attach(|py| {
+        let executable = py
+            .import("sys")
+            .ok()?
+            .getattr("executable")
+            .ok()?
+            .extract::<String>()
+            .ok()?;
+        let path = std::path::Path::new(&executable);
+        (path.is_file() && is_python_cli_executable(path)).then_some(executable)
+    })
+    .flatten()
+}
+
+#[cfg(not(feature = "python-bindings"))]
+fn attached_python_executable() -> Option<String> {
+    None
+}
+
 pub(crate) fn execute_script(
     script_path: &str,
     mut params: serde_json::Value,
@@ -533,10 +567,18 @@ pub(crate) fn execute_script(
 
     // Resolve the Python interpreter:
     // 1. DCC_MCP_PYTHON_EXECUTABLE env var (explicit override, e.g. mayapy)
-    // 2. Fall back to the Python that shipped the `python` command on PATH
+    // 2. The Python interpreter already attached through PyO3. This preserves
+    //    virtual-environment package visibility even when that environment is
+    //    not first on PATH.
+    // 3. Fall back to the `python` command on PATH for pure-Rust callers.
     let python_exe_override = std::env::var("DCC_MCP_PYTHON_EXECUTABLE").ok();
+    let attached_python_exe = python_exe_override
+        .is_none()
+        .then(attached_python_executable)
+        .flatten();
     let python_exe = python_exe_override
         .clone()
+        .or_else(|| attached_python_exe.clone())
         .unwrap_or_else(|| "python".to_string());
 
     // Optional: prepend a Python init snippet before running the skill script.
@@ -550,6 +592,7 @@ pub(crate) fn execute_script(
     // harnesses and the stub-based `python` DCC).
     if (ext == "py" || ext == "pyw")
         && python_exe_override.is_none()
+        && attached_python_exe.is_none()
         && init_snippet.is_none()
         && std::env::var("DCC_MCP_ALLOW_AMBIENT_PYTHON")
             .ok()

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -511,6 +511,7 @@ fn which_program(program: &str) -> bool {
     false
 }
 
+#[cfg(any(feature = "python-bindings", test))]
 pub(super) fn is_python_cli_executable(path: &std::path::Path) -> bool {
     let stem = path
         .file_stem()

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_env.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_env.rs
@@ -7,6 +7,12 @@
 use super::*;
 use dcc_mcp_test_utils::EnvVarsGuard;
 
+#[cfg(feature = "python-bindings")]
+use std::sync::Once;
+
+#[cfg(feature = "python-bindings")]
+static PYTHON_INIT: Once = Once::new();
+
 /// Clear the three Python-execution env vars and return a guard that restores
 /// them on drop. Tests that need a specific value should create their own
 /// `EnvVarsGuard::set(&[...])` that includes these three clears followed by
@@ -93,6 +99,101 @@ fn test_execute_script_allows_generic_python_dcc() {
         assert!(
             !err.contains("DCC_MCP_PYTHON_EXECUTABLE"),
             "generic 'python' dcc must not trigger the #231 check: got {err}"
+        );
+    }
+}
+
+#[cfg(feature = "python-bindings")]
+#[test]
+fn test_execute_script_uses_attached_python_when_path_lacks_python() {
+    use pyo3::types::PyAnyMethods;
+
+    const CHILD_ENV: &str = "DCC_MCP_TEST_ATTACHED_PYTHON_CHILD";
+    if std::env::var_os(CHILD_ENV).is_none() {
+        let output = std::process::Command::new(std::env::current_exe().expect("current test exe"))
+            .arg(
+                "catalog::tests::test_execute_script_env::test_execute_script_uses_attached_python_when_path_lacks_python",
+            )
+            .arg("--exact")
+            .arg("--nocapture")
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("run isolated attached-Python test");
+        assert!(
+            output.status.success(),
+            "isolated test failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        return;
+    }
+
+    let python_output = std::process::Command::new("python")
+        .args(["-c", "import sys; print(sys.executable)"])
+        .output()
+        .expect("resolve a Python interpreter before clearing PATH");
+    assert!(python_output.status.success());
+    let python_executable = String::from_utf8(python_output.stdout)
+        .expect("Python executable path is UTF-8")
+        .trim()
+        .to_string();
+
+    PYTHON_INIT.call_once(pyo3::Python::initialize);
+    pyo3::Python::attach(|py| {
+        py.import("sys")
+            .expect("import sys")
+            .setattr("executable", python_executable.as_str())
+            .expect("model an extension loaded by the active Python interpreter");
+    });
+
+    let empty_path = tempfile::tempdir().expect("create empty PATH root");
+    let script_dir = tempfile::tempdir().expect("create skill script root");
+    let script = script_dir.path().join("status.py");
+    std::fs::write(
+        &script,
+        "import json\nprint(json.dumps({'success': True, 'runtime': 'attached'}))\n",
+    )
+    .expect("write skill script");
+
+    let empty_path_value = empty_path.path().to_string_lossy().into_owned();
+    let _g = EnvVarsGuard::set(&[
+        ("DCC_MCP_PYTHON_EXECUTABLE", None),
+        ("DCC_MCP_PYTHON_INIT_SNIPPET", None),
+        ("DCC_MCP_ALLOW_AMBIENT_PYTHON", None),
+        ("PATH", Some(empty_path_value.as_str())),
+    ]);
+
+    let result = execute_script(
+        script.to_str().expect("UTF-8 script path"),
+        serde_json::json!({}),
+        Some("freecad"),
+    )
+    .expect("the attached Python interpreter must execute the skill");
+
+    assert_eq!(result["success"], true);
+    assert_eq!(result["runtime"], "attached");
+}
+
+#[test]
+fn test_attached_interpreter_filter_rejects_dcc_gui_binaries() {
+    for executable in [
+        "python.exe",
+        "python3.14",
+        "pythonw.exe",
+        "pypy3",
+        "mayapy.exe",
+        "hython",
+    ] {
+        assert!(
+            super::execute::is_python_cli_executable(std::path::Path::new(executable)),
+            "{executable} must be accepted as a Python CLI",
+        );
+    }
+
+    for executable in ["FreeCAD.exe", "openscad.exe", "blender.exe", "maya.exe"] {
+        assert!(
+            !super::execute::is_python_cli_executable(std::path::Path::new(executable)),
+            "{executable} must never be auto-selected as a Python interpreter",
         );
     }
 }

--- a/crates/dcc-mcp-skills/src/python/catalog.rs
+++ b/crates/dcc-mcp-skills/src/python/catalog.rs
@@ -81,15 +81,18 @@ impl SkillCatalog {
     /// the callable receives the script path and a params dict and must return
     /// a JSON-serialisable dict.
     ///
-    /// The callable signature must be::
+    /// The callable signature must be:
     ///
+    /// ```python
     ///     def executor(script_path: str, params: dict, *, action_name: str,
     ///                  skill_name: str | None, thread_affinity: str,
     ///                  execution: str, timeout_hint_secs: int | None) -> dict:
     ///         ...
+    /// ```
     ///
-    /// Example (Maya adapter)::
+    /// Example (Maya adapter):
     ///
+    /// ```python
     ///     def _maya_exec(script_path: str, params: dict) -> dict:
     ///         import importlib.util, sys
     ///         spec = importlib.util.spec_from_file_location("_skill_script", script_path)
@@ -99,6 +102,7 @@ impl SkillCatalog {
     ///         return getattr(mod, "__mcp_result__", {"success": True})
     ///
     ///     catalog.set_in_process_executor(_maya_exec)
+    /// ```
     ///
     /// Pass ``None`` to revert to subprocess execution.
     #[pyo3(name = "set_in_process_executor")]

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -1597,7 +1597,7 @@ automatically, so adapters using that path don't need a separate call.
 
 | Extension | Type | Execution |
 |-----------|------|-----------|
-| `.py` | Python | `python` interpreter |
+| `.py` | Python | resolved Python CLI, or the registered in-process executor |
 | `.sh`, `.bash` | Shell | `bash` |
 | `.bat`, `.cmd` | Batch | `cmd /C` |
 | `.mel` | MEL (Maya) | `python` wrapper |
@@ -1609,7 +1609,14 @@ automatically, so adapters using that path don't need a separate call.
 :::
 
 ::: warning script execution
-All scripts run as subprocesses. Input parameters are passed via stdin as JSON. The script should write a JSON result to stdout and exit with code 0 on success.
+Scripts use the execution route owned by the server. The default out-of-process
+route passes input parameters via stdin as JSON and expects one JSON result on
+stdout with exit code 0. Its Python priority is an explicit
+`DCC_MCP_PYTHON_EXECUTABLE`, then the active PyO3-attached `sys.executable` when
+that path is a Python CLI, then `python` on `PATH` for pure-Rust callers. Host
+GUI executables are never auto-selected. Embedded adapters should register the
+Core in-process executor through `HostExecutionBridge` when tools must stay in
+the DCC process.
 :::
 
 ## On-Demand Skill Discovery (MCP HTTP)

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -2469,15 +2469,18 @@ class SkillCatalog:
         the callable receives the script path and a params dict and must return
         a JSON-serialisable dict.
 
-        The callable signature must be::
+        The callable signature must be:
 
+        ```python
             def executor(script_path: str, params: dict, *, action_name: str,
                          skill_name: str | None, thread_affinity: str,
                          execution: str, timeout_hint_secs: int | None) -> dict:
                 ...
+        ```
 
-        Example (Maya adapter)::
+        Example (Maya adapter):
 
+        ```python
             def _maya_exec(script_path: str, params: dict) -> dict:
                 import importlib.util, sys
                 spec = importlib.util.spec_from_file_location("_skill_script", script_path)
@@ -2487,6 +2490,7 @@ class SkillCatalog:
                 return getattr(mod, "__mcp_result__", {"success": True})
 
             catalog.set_in_process_executor(_maya_exec)
+        ```
 
         Pass ``None`` to revert to subprocess execution.
         """

--- a/skills/dcc-mcp-creator/references/ADAPTER_WORKFLOW.md
+++ b/skills/dcc-mcp-creator/references/ADAPTER_WORKFLOW.md
@@ -94,6 +94,16 @@ Only eager-load the skills needed for discovery, diagnostics, and a first useful
 scene query. Leave authoring, render, export, and pipeline skills loadable on
 demand.
 
+For ordinary standalone Python adapters installed in a virtual environment,
+leave `DCC_MCP_PYTHON_EXECUTABLE` unset. The subprocess executor resolves an
+explicit override first, then the active PyO3-attached `sys.executable` when it
+is a real Python CLI, and finally `python` on `PATH` for pure-Rust callers. This
+keeps adapter and Core packages visible to Skill scripts even when the virtual
+environment is not first on `PATH`. Core does not auto-select host GUI binaries
+such as Blender, Maya, FreeCAD, or OpenSCAD. Embedded hosts should keep using an
+in-process `HostExecutionBridge`, or set an explicit vendor CLI such as
+`mayapy`, `hython`, or `c4dpy` only when subprocess execution is intentional.
+
 ## 4. Publish Adapter Context
 
 Prefer core-owned surfaces:


### PR DESCRIPTION
## Summary
- resolve Python Skill subprocesses from an explicit override, then the active PyO3 `sys.executable`, then `python` on `PATH`
- accept only real Python CLI executables for automatic attached-interpreter selection, never DCC GUI binaries
- document the standalone-adapter and embedded-host execution contracts

## Problem
Standalone Python adapters can be installed in a virtual environment while the process `PATH` still resolves another Python. Skill scripts were launched with that ambient interpreter and could not import the adapter or Core packages from the active environment.

## Validation
- `vx cargo test -p dcc-mcp-skills --features python-bindings` (363 tests + 5 doctests)
- `vx cargo clippy -p dcc-mcp-skills --features python-bindings --lib --no-deps -- -D warnings`
- `vx cargo fmt --all -- --check`
- VitePress production build
- built Windows CPython 3.11 and 3.12 wheels
- reproduced with standalone FreeCAD and OpenSCAD adapters installed in an isolated virtual environment; after the fix, typed status calls and an OpenSCAD → FreeCAD → Blender → Godot artifact handoff completed successfully