### PR TITLE
fix(cua): accept standalone binary output path

### DIFF
--- a/python/dcc_mcp_core/cua_cli.py
+++ b/python/dcc_mcp_core/cua_cli.py
@@ -349,7 +349,9 @@ class CuaCliBridge:
     def _read_binary_output(self, response: Dict[str, Any]) -> bytes:
         if self._output_directory is None:
             raise CuaCliError("capture_failed", "The CUA binary output directory is unavailable.")
-        raw_path = response.get("_dcc_mcp_binary_output")
+        raw_path = response.get("_dcc_cua_binary_output")
+        if raw_path is None:
+            raw_path = response.get("_dcc_mcp_binary_output")
         if not isinstance(raw_path, str):
             raise CuaCliError("capture_failed", "dcc-cua returned no binary image output.")
         output_root = Path(self._output_directory.name).resolve()

--- a/tests/test_cua_cli.py
+++ b/tests/test_cua_cli.py
@@ -69,7 +69,7 @@ elif command == "host-jsonl":
                     "type": "snapshot",
                     "request_id": request["request_id"],
                     "image": {"encoding": "binary_frame", "length": len(data)},
-                    "_dcc_mcp_binary_output": str(output),
+                    "_dcc_cua_binary_output": str(output),
                 }
             else:
                 response = {
@@ -163,6 +163,22 @@ def test_cli_sibling_precedes_an_unrelated_path_cua(tmp_path: Path, monkeypatch:
 
 def test_binary_frame_fallback_reads_and_removes_cli_output(tmp_path: Path) -> None:
     bridge = CuaCliBridge(_fake_command(tmp_path), snapshot_transport="binary_frame")
+    try:
+        response = bridge.call("image")
+        output = Path(response["_dcc_cua_binary_output"])
+        assert bridge.read_image(response) == b"png"
+        assert not output.exists()
+    finally:
+        bridge.close()
+
+
+def test_binary_frame_fallback_accepts_the_legacy_core_output_field(tmp_path: Path) -> None:
+    script = tmp_path / "fake_legacy_cua.py"
+    script.write_text(
+        _FAKE_CLI.replace('"_dcc_cua_binary_output"', '"_dcc_mcp_binary_output"'),
+        encoding="utf-8",
+    )
+    bridge = CuaCliBridge([sys.executable, str(script)], snapshot_transport="binary_frame")
     try:
         response = bridge.call("image")
         output = Path(response["_dcc_mcp_binary_output"])


### PR DESCRIPTION
## Summary

- read the standalone `dcc-cua` binary-frame output field as the canonical path
- retain the previous Core field as a backward-compatible fallback
- cover both response shapes and verify that temporary image files are removed

## Context

This completes the fallback side of the snapshot transport contract exposed by dcc-mcp/dcc-cua#94. Shared memory remains the preferred transport; binary-frame must still work on supported fallback paths.

## Validation

- `vx uv run --frozen --with pytest python -m pytest tests/test_cua_cli.py -q` (9 passed, 1 environment-gated skip)
- `vx python@3.7 -m py_compile python/dcc_mcp_core/cua_cli.py`
- `vx ruff check python/dcc_mcp_core/cua_cli.py tests/test_cua_cli.py`
- `vx ruff format --check python/dcc_mcp_core/cua_cli.py tests/test_cua_cli.py`
- `vx git diff --check`

No public API, adapter wiring, skill schema, or agent workflow changed, so no creator Skill synchronization is required.