### PR TITLE
fix(cua): route restore through exact target operation

### DIFF
--- a/python/dcc_mcp_core/skills/ui-control/scripts/_cua_cli_host_client.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_cua_cli_host_client.py
@@ -86,13 +86,17 @@ class UiControlHostClient:
         return self._call("get_window_state", self._authority(), "window_state")
 
     def change_window_state(self, operation: str) -> Dict[str, Any]:
-        """Activate the exact target; CUA intentionally exposes no restore/show aliases."""
-        if operation != "activate":
-            raise UiControlHostError("unsupported", "dcc-cua only supports exact-window activation.")
+        """Activate or explicitly restore the exact target through CUA."""
+        host_operation = "restore_activate" if operation == "restore" else operation
+        if host_operation not in {"activate", "restore_activate"}:
+            raise UiControlHostError(
+                "unsupported",
+                "dcc-cua supports exact-window activation and restore-activation.",
+            )
         try:
             return self._call(
                 "change_window_state",
-                {**self._authority(), "operation": operation},
+                {**self._authority(), "operation": host_operation},
                 "window_state_changed",
             )
         finally:

--- a/tests/test_cua_cli_host_client.py
+++ b/tests/test_cua_cli_host_client.py
@@ -75,6 +75,11 @@ class FakeBridge:
                 "action_id": "action-1",
                 "target_closed": False,
             }
+        if method == "change_window_state":
+            return {
+                "type": "window_state_changed",
+                "state": {"minimized": False, "foreground": True},
+            }
         if method == "recording_start":
             return {
                 "type": "recording_started",
@@ -155,6 +160,33 @@ def test_cua_host_adapter_preserves_exact_grant_snapshot_and_action_fences() -> 
 
     assert client.stop()["cleanup_pending"] is False
     assert bridge.closed is True
+
+
+def test_restore_window_uses_cua_restore_activate_contract() -> None:
+    client_module = _load(_CLIENT_PATH, "_test_cua_restore_activate")
+    bridge = FakeBridge()
+    client = client_module.UiControlHostClient(
+        session_id="maya",
+        task_grant_id="grant-1",
+        dcc_type="maya",
+        process_id=42,
+        window_handle=500,
+        allow_raw_input=False,
+        bridge=bridge,
+    )
+
+    result = client.change_window_state("restore")
+
+    assert result["state"]["foreground"] is True
+    assert bridge.calls[-1] == (
+        "change_window_state",
+        {
+            "session_id": "maya",
+            "task_grant_id": "grant-1",
+            "window_capability": "cua-window-1",
+            "operation": "restore_activate",
+        },
+    )
 
 
 def test_cua_backend_passes_cua_element_token_not_legacy_control_id() -> None:


### PR DESCRIPTION
## Summary
- translate the stable Core restore_window action to dcc-cua's restore_activate operation
- keep activate_window unchanged and reject unsupported show aliases
- cover the exact session/grant/window-capability payload with a regression test

## Validation
- PYTHONPATH=python python -m pytest tests/test_cua_cli_host_client.py -q (4 passed)
- ruff check affected files