### PR TITLE
docs(catalog): refresh ComfyUI TouchDesigner and Shogun

### DIFF
--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -357,11 +357,11 @@ entries:
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-cinema4d/main/README.md"
 
   - name: "dcc-mcp-comfyui"
-    description: "ComfyUI adapter for typed API-format workflow validation, bounded queue execution, status, and artifact retrieval"
+    description: "ComfyUI adapter with 17 typed workflow, catalog, queue, and artifact tools"
     dcc: ["comfyui", "comfy-ui"]
     url: "https://github.com/dcc-mcp/dcc-mcp-comfyui"
     tags: ["adapter", "comfyui", "official", "pip", "node-graph", "image-generation"]
-    version: "0.1.0"
+    version: "0.1.1"
     min_core_version: "0.19.91"
     maintainer: "dcc-mcp"
     install:
@@ -398,11 +398,11 @@ entries:
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-sketchup/main/README.md"
 
   - name: "dcc-mcp-touchdesigner"
-    description: "TouchDesigner adapter with typed operator graphs, parameters, project saves, TOP capture, and main-thread-safe execution"
+    description: "TouchDesigner adapter with 19 typed operator graph, parameter, DAT, timeline, capture, and project tools dispatched on the main thread"
     dcc: ["touchdesigner"]
     url: "https://github.com/dcc-mcp/dcc-mcp-touchdesigner"
     tags: ["adapter", "touchdesigner", "official", "pip", "node-graph", "real-time", "interactive-media"]
-    version: "0.1.0"
+    version: "0.1.1"
     min_core_version: "0.19.91"
     maintainer: "dcc-mcp"
     install:
@@ -412,11 +412,11 @@ entries:
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-touchdesigner/main/install.md"
 
   - name: "dcc-mcp-shogun"
-    description: "Vicon Shogun Post adapter with 61 typed Scene, channel, camera, file, Timeline, production-context, and capability-gated Offline processing tools"
+    description: "Vicon Shogun Post adapter with 66 typed Scene, channel, camera, file, Timeline, editing, production-context, and capability-gated Offline processing tools"
     dcc: ["shogun"]
     url: "https://github.com/dcc-mcp/dcc-mcp-shogun"
     tags: ["adapter", "shogun", "vicon", "official", "pip", "motion-capture", "timeline", "processing"]
-    version: "0.7.0"
+    version: "0.8.1"
     min_core_version: "0.19.86"
     maintainer: "dcc-mcp"
     install:

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -29,8 +29,8 @@ submit a PR updating this matrix before the release PR merges.
 | OpenSCAD | [dcc-mcp-openscad](https://github.com/dcc-mcp/dcc-mcp-openscad) | 0.1.2 | >=0.19.91,<1.0.0 | 2021.01+ | External OpenSCAD CLI subprocess | 2026-08 |
 | FreeCAD | [dcc-mcp-freecad](https://github.com/dcc-mcp/dcc-mcp-freecad) | 0.1.2 | >=0.19.91,<1.0.0 | 1.0+ | External FreeCADCmd subprocess | 2026-08 |
 | Cinema 4D | [dcc-mcp-cinema4d](https://github.com/dcc-mcp/dcc-mcp-cinema4d) | 0.1.3 | >=0.19.91,<1.0.0 | R21+ | External headless c4dpy subprocess | 2026-08 |
-| ComfyUI | [dcc-mcp-comfyui](https://github.com/dcc-mcp/dcc-mcp-comfyui) | 0.1.0 | >=0.19.91,<1.0.0 | 0.31+ | Standalone sidecar + local REST workflow bridge | 2026-08 |
-| Shogun | [dcc-mcp-shogun](https://github.com/dcc-mcp/dcc-mcp-shogun) | 0.7.0 | >=0.19.86,<1.0.0 | Vicon Shogun Post | 61 typed Scene, channel, camera, file, Timeline, production-context, and Offline tools; SDK-dependent surfaces remain capability-gated | 2026-08 |
+| ComfyUI | [dcc-mcp-comfyui](https://github.com/dcc-mcp/dcc-mcp-comfyui) | 0.1.1 | >=0.19.91,<1.0.0 | 0.31+ | 17 typed workflow, catalog, queue, and artifact tools over the local REST bridge | 2026-08 |
+| Shogun | [dcc-mcp-shogun](https://github.com/dcc-mcp/dcc-mcp-shogun) | 0.8.1 | >=0.19.86,<1.0.0 | Vicon Shogun Post | 66 typed Scene, channel, camera, file, Timeline, editing, production-context, and Offline tools; SDK-dependent surfaces remain capability-gated | 2026-08 |
 | Mari | [dcc-mcp-mari](https://github.com/dcc-mcp/dcc-mcp-mari) | 0.2.1 | >=0.19.91,<1.0.0 | 5.0+ | Authenticated loopback sidecar + Qt UI timer | 2026-08 |
 | 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.40 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-08 |
 | Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.43 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-08 |
@@ -46,7 +46,7 @@ submit a PR updating this matrix before the release PR merges.
 | GIMP | [dcc-mcp-gimp](https://github.com/dcc-mcp/dcc-mcp-gimp) | 0.3.0 | >=0.19.38,<1.0.0 | 3.0+ | Authenticated JSON-lines bridge + GLib main-thread dispatcher | — |
 | Krita | [dcc-mcp-krita](https://github.com/dcc-mcp/dcc-mcp-krita) | 0.3.0 | >=0.19.38,<1.0.0 | — | Authenticated JSON-lines bridge + UI main-thread queue | — |
 | SketchUp | [dcc-mcp-sketchup](https://github.com/dcc-mcp/dcc-mcp-sketchup) | 0.1.0 | >=0.19.91,<1.0.0 | 2021+ | Authenticated Ruby main-thread bridge + sidecar | 2026-08 |
-| TouchDesigner | [dcc-mcp-touchdesigner](https://github.com/dcc-mcp/dcc-mcp-touchdesigner) | 0.1.0 | >=0.19.91,<1.0.0 | 2025 official build | In-process HTTP runtime + `td.run()` main-thread dispatcher | — |
+| TouchDesigner | [dcc-mcp-touchdesigner](https://github.com/dcc-mcp/dcc-mcp-touchdesigner) | 0.1.1 | >=0.19.91,<1.0.0 | 2025 official build | 19 typed operator graph, parameter, DAT, timeline, capture, and project tools through the in-process HTTP runtime + `td.run()` main-thread dispatcher | 2026-08 |
 | Tiled | [dcc-mcp-tiled](https://github.com/dcc-mcp/dcc-mcp-tiled) | 0.3.0 | >=0.19.38,<1.0.0 | 1.10+ | Standalone service + fixed JavaScript driver through `tiled --evaluate` | 2026-08 |
 | Material Maker | [dcc-mcp-material-maker](https://github.com/dcc-mcp/dcc-mcp-material-maker) | 0.3.1 | >=0.19.38,<1.0.0 | 1.7 | Standalone `.ptex` parser + native CLI exporter | 2026-08 |
 | Wwise | [dcc-mcp-wwise](https://github.com/dcc-mcp/dcc-mcp-wwise) | 0.1.2 | >=0.19.86,<1.0.0 | 2024.1+ | External WAAPI client + host PID binding | 2026-08 |

--- a/tests/test_public_adapter_catalog.py
+++ b/tests/test_public_adapter_catalog.py
@@ -16,14 +16,19 @@ def _entries() -> list:
 def test_recent_adapter_releases_are_current() -> None:
     entries = {entry["name"]: entry for entry in _entries()}
     expected_versions = {
-        "dcc-mcp-shogun": "0.7.0",
+        "dcc-mcp-comfyui": "0.1.1",
+        "dcc-mcp-touchdesigner": "0.1.1",
+        "dcc-mcp-shogun": "0.8.1",
         "dcc-mcp-tiled": "0.3.0",
         "dcc-mcp-material-maker": "0.3.1",
         "dcc-mcp-wwise": "0.1.2",
     }
 
     assert {name: entries[name]["version"] for name in expected_versions} == expected_versions
-    assert "61 typed" in entries["dcc-mcp-shogun"]["description"]
+    assert entries["dcc-mcp-comfyui"]["min_core_version"] == "0.19.91"
+    assert "17 typed" in entries["dcc-mcp-comfyui"]["description"]
+    assert "19 typed" in entries["dcc-mcp-touchdesigner"]["description"]
+    assert "66 typed" in entries["dcc-mcp-shogun"]["description"]
 
 
 def test_skill_only_packages_are_not_pip_adapters() -> None:


### PR DESCRIPTION
## Summary

- sync the first-party catalog and compatibility matrix to public ComfyUI 0.1.1, TouchDesigner 0.1.1, and Shogun 0.8.1 releases
- record the actual public-wheel typed-tool counts: 17, 19, and 66 respectively
- record ComfyUI 0.1.1's published minimum `dcc-mcp-core>=0.19.91` requirement
- extend the catalog regression test while preserving the Cache Inspector Skill-only boundary

## Validation

- `python -m pytest tests/test_public_adapter_catalog.py -q` — 2 passed
- `python -m ruff check tests/test_public_adapter_catalog.py`
- `python -m ruff format --check tests/test_public_adapter_catalog.py`
- `markdownlint-cli2 docs/guide/adapter-compatibility-matrix.md`
- parsed `dcc-mcp-catalog.yml` and verified 36 unique entry names
- `git diff --check`
- fresh public PyPI install of ComfyUI 0.1.1 — 4 Skills / 17 typed tools with Core 0.20.5 and Server 0.20.6

The release versions, dependency lower bounds, and tool counts were read from each adapter's current public `main`, GitHub release, PyPI metadata, and installed wheel resources. The already validated ComfyUI 0.1.2 candidate adds the eighteenth tool and raises the Core floor; that future public release will receive a separate catalog update. No Skill guidance update is needed because this PR changes only catalog release metadata and its documentation.
