### PR TITLE
fix(ci): gate PyPI publish on project size budget preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -634,6 +634,30 @@ jobs:
       - name: List dcc-mcp-core artefacts
         run: ls -la dist/
 
+      # PyPI caps each project's TOTAL storage (10 GB by default); once the
+      # budget is exhausted the upload fails mid-stream and leaves the release
+      # partially published (v0.19.0 and v0.20.6 both reached PyPI with only
+      # the cp37 wheels). Preflight the budget before touching PyPI so a
+      # release either publishes completely or fails loudly up front.
+      # Backfills publish tagged source, but the preflight belongs to the
+      # workflow revision being executed - fetch it from the workflow ref
+      # like the other compatibility tooling.
+      - name: Checkout workflow compatibility tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .workflow-tools
+          sparse-checkout: |
+            scripts/ci
+          persist-credentials: false
+
+      - name: Check PyPI project size budget
+        shell: bash
+        run: >-
+          python .workflow-tools/scripts/ci/check_pypi_project_size.py
+          --package dcc-mcp-core
+          --dist-dir dist
+
       - name: Upload dcc-mcp-core to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -667,6 +691,24 @@ jobs:
 
       - name: List dcc-mcp-server artefacts
         run: ls -la dist-server/
+
+      # Same PyPI total-size budget gate as publish-core-pypi - fail before
+      # upload instead of leaving a partially published release.
+      - name: Checkout workflow compatibility tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .workflow-tools
+          sparse-checkout: |
+            scripts/ci
+          persist-credentials: false
+
+      - name: Check PyPI project size budget
+        shell: bash
+        run: >-
+          python .workflow-tools/scripts/ci/check_pypi_project_size.py
+          --package dcc-mcp-server
+          --dist-dir dist-server
 
       # The PyPI project must have a Trusted Publisher for:
       # Owner = dcc-mcp, Repo = dcc-mcp-core, Workflow = release.yml,
@@ -704,6 +746,24 @@ jobs:
 
       - name: List dcc-mcp-core-semantic artefacts
         run: ls -la dist-semantic/
+
+      # Same PyPI total-size budget gate as publish-core-pypi - fail before
+      # upload instead of leaving a partially published release.
+      - name: Checkout workflow compatibility tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .workflow-tools
+          sparse-checkout: |
+            scripts/ci
+          persist-credentials: false
+
+      - name: Check PyPI project size budget
+        shell: bash
+        run: >-
+          python .workflow-tools/scripts/ci/check_pypi_project_size.py
+          --package dcc-mcp-core-semantic
+          --dist-dir dist-semantic
 
       # The PyPI project must have a Trusted Publisher for:
       # Owner = dcc-mcp, Repo = dcc-mcp-core, Workflow = release.yml,

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -1067,6 +1067,7 @@ When adding a Rust type/function that needs to be callable from Python:
 - Python 3.8–3.14 gate: a representative PR matrix, plus the full Linux / macOS / Windows matrix on the scheduled workflow
 - Versioning: Release Please (Conventional Commits) — never manually bump
 - PyPI: Trusted Publishing (no tokens) — **each** of `dcc-mcp-core`, `dcc-mcp-server`, and `dcc-mcp-core-semantic` needs its own PyPI Trusted Publisher; see [PyPI Trusted Publishers](https://docs.pypi.org/trusted-publishers/)
+- PyPI size budget: each project has a 10 GB total-storage limit. The publish jobs run `scripts/ci/check_pypi_project_size.py` before uploading, so a release either publishes completely or fails loudly up front — never a partial upload. When the budget is exhausted, free storage by deleting old releases at `https://pypi.org/manage/project/<name>/releases/` (PyPI has no deletion API, so this is a maintainer web-UI action) or request a limit increase per [PyPI storage limits](https://docs.pypi.org/project-management/storage-limits/), then re-run the Release workflow — the publish step's `skip-existing` resumes the partial upload
 - Every PR emits the stable required statuses, including documentation-only changes
 - Squash merge convention for PRs
 

--- a/scripts/ci/check_pypi_project_size.py
+++ b/scripts/ci/check_pypi_project_size.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Gate a PyPI publish on the project's total-size budget.
+
+PyPI enforces a default 10 GB total-size limit per project
+(https://docs.pypi.org/project-management/storage-limits). When a project
+is at the limit, the upload fails MID-STREAM: twine uploads distributions
+one by one, so the release is left partially published. Both v0.19.0 and
+v0.20.6 of dcc-mcp-core shipped only the cp37 wheels to PyPI this way; the
+macOS abi3 wheel was rejected with '400 Project size too large', which
+broke downstream consumers that resolve platform wheels from PyPI (for
+example dcc-mcp-blender's addon packaging).
+
+This preflight mirrors the 'skip-existing: true' behaviour of
+pypa/gh-action-pypi-publish: artifacts whose filenames already exist on
+PyPI are treated as skipped, and everything else counts against the budget.
+It runs BEFORE the upload so a release either publishes completely or fails
+loudly without touching PyPI at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Mapping
+import urllib.request
+
+DEFAULT_LIMIT_GB = 10
+DEFAULT_WARN_HEADROOM_GB = 1.0
+DEFAULT_JSON_URL = "https://pypi.org/pypi/{package}/json"
+STORAGE_LIMITS_DOC = "https://docs.pypi.org/project-management/storage-limits"
+MANAGE_RELEASES_URL = "https://pypi.org/manage/project/{package}/releases/"
+GIB = 1024**3
+
+
+class Artifact:
+    """A single local distribution file that the publish step would upload."""
+
+    def __init__(self, filename: str, size_bytes: int) -> None:
+        self.filename = filename
+        self.size_bytes = size_bytes
+
+
+class SizeBudgetReport:
+    """Projected PyPI storage state after the pending publish."""
+
+    def __init__(
+        self, package, limit_bytes, current_bytes, already_present, to_add, projected_bytes, warn_headroom_bytes
+    ):
+        self.package = package
+        self.limit_bytes = limit_bytes
+        self.current_bytes = current_bytes
+        self.already_present = already_present
+        self.to_add = to_add
+        self.projected_bytes = projected_bytes
+        self.warn_headroom_bytes = warn_headroom_bytes
+
+    @property
+    def over_budget(self) -> bool:
+        return self.projected_bytes > self.limit_bytes
+
+    @property
+    def near_budget(self) -> bool:
+        headroom = self.limit_bytes - self.projected_bytes
+        return not self.over_budget and headroom <= self.warn_headroom_bytes
+
+
+def parse_gb(value: str) -> float:
+    """Parse a fractional gigabyte limit for argparse."""
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a number of gigabytes, got {value!r}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("limit must be greater than zero")
+    return parsed
+
+
+def fetch_pypi_files(package: str, json_url: str) -> dict:
+    """Return {filename: size_bytes} for every file of *package* on PyPI."""
+    url = json_url.format(package=package)
+    try:
+        with urllib.request.urlopen(url, timeout=60) as response:
+            payload = json.loads(response.read())
+    except Exception as exc:  # pragma: no cover - network path
+        raise RuntimeError(f"could not fetch PyPI metadata for {package!r} from {url}: {exc}") from exc
+    files = {}
+    for release_files in payload.get("releases", {}).values():
+        for file_info in release_files:
+            name = str(file_info.get("filename", ""))
+            size = int(file_info.get("size", 0))
+            if name:
+                files[name] = size
+    return files
+
+
+def collect_dist_artifacts(dist_dir: Path) -> list:
+    """Return the wheels and sdists in *dist_dir* that twine would upload."""
+    if not dist_dir.is_dir():
+        raise FileNotFoundError(f"dist directory not found: {dist_dir}")
+    artifacts = []
+    for path in sorted(dist_dir.iterdir()):
+        if not path.is_file():
+            continue
+        if not (path.name.endswith(".whl") or path.name.endswith(".tar.gz")):
+            continue
+        artifacts.append(Artifact(filename=path.name, size_bytes=path.stat().st_size))
+    return artifacts
+
+
+def build_report(
+    package: str,
+    pypi_files: Mapping[str, int],
+    artifacts: list,
+    limit_bytes: int,
+    warn_headroom_bytes: int,
+) -> SizeBudgetReport:
+    """Project the storage state after uploading artifacts not yet on PyPI."""
+    current_bytes = sum(pypi_files.values())
+    already_present = []
+    to_add = []
+    for artifact in artifacts:
+        if artifact.filename in pypi_files:
+            already_present.append(artifact.filename)
+        else:
+            to_add.append(artifact)
+    projected_bytes = current_bytes + sum(a.size_bytes for a in to_add)
+    return SizeBudgetReport(
+        package=package,
+        limit_bytes=limit_bytes,
+        current_bytes=current_bytes,
+        already_present=already_present,
+        to_add=to_add,
+        projected_bytes=projected_bytes,
+        warn_headroom_bytes=warn_headroom_bytes,
+    )
+
+
+def format_gib(size_bytes: int) -> str:
+    """Format a byte count as a human-readable GiB value."""
+    return f"{size_bytes / GIB:.2f} GiB"
+
+
+def render_summary(report: SizeBudgetReport) -> list:
+    """Return human-readable log lines describing the size projection."""
+    lines = [
+        f"PyPI project size budget: {report.package}",
+        f"  limit:     {format_gib(report.limit_bytes)}",
+        f"  current:   {format_gib(report.current_bytes)}",
+        f"  already on PyPI (skipped): {len(report.already_present)} file(s)",
+    ]
+    for name in report.already_present:
+        lines.append(f"    - {name}")
+    lines.append(f"  adding:    {len(report.to_add)} file(s)")
+    for artifact in report.to_add:
+        lines.append(f"    - {artifact.filename} ({format_gib(artifact.size_bytes)})")
+    lines.append(f"  projected: {format_gib(report.projected_bytes)}")
+    if not report.to_add:
+        lines.append("  nothing new to upload; PyPI already has every artifact")
+    return lines
+
+
+def render_failure(report: SizeBudgetReport) -> str:
+    """Return the actionable ::error:: message for an over-budget publish."""
+    projected = format_gib(report.projected_bytes)
+    limit = format_gib(report.limit_bytes)
+    manage = MANAGE_RELEASES_URL.format(package=report.package)
+    return (
+        f"::error::PyPI project {report.package!r} has no room for the pending "
+        f"artifacts: projected {projected} exceeds the {limit} project size "
+        "limit. Refusing to upload so the release is not left partially "
+        f"published. Remediation: (1) free storage by deleting old releases at "
+        f"{manage} (PyPI exposes no deletion API, so this is a maintainer "
+        f"web-UI action) or request a limit increase per {STORAGE_LIMITS_DOC}; "
+        "(2) re-run the Release workflow for the affected tag - the publish "
+        "step uses skip-existing, so already-published files are skipped and "
+        "only the missing distributions are uploaded."
+    )
+
+
+def render_warning(report: SizeBudgetReport) -> str:
+    """Return the ::warning:: message for a publish that fits but is tight."""
+    headroom = format_gib(report.limit_bytes - report.projected_bytes)
+    limit = format_gib(report.limit_bytes)
+    projected = format_gib(report.projected_bytes)
+    return (
+        f"::warning::PyPI project {report.package!r} will be within {headroom} "
+        f"of its {limit} size limit after this publish (projected {projected}). "
+        f"Plan to free storage or request a limit increase soon "
+        f"({STORAGE_LIMITS_DOC})."
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser for the preflight check."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--package", required=True, help="PyPI project name to check")
+    parser.add_argument("--dist-dir", required=True, help="directory holding the artifacts to publish")
+    parser.add_argument(
+        "--limit-gb",
+        type=parse_gb,
+        default=DEFAULT_LIMIT_GB,
+        help="PyPI total-size limit in GiB (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--warn-headroom-gb",
+        type=parse_gb,
+        default=DEFAULT_WARN_HEADROOM_GB,
+        help="warn when projected headroom is at most this many GiB (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--pypi-json-url",
+        default=DEFAULT_JSON_URL,
+        help="PyPI JSON API URL template with {package} placeholder",
+    )
+    return parser
+
+
+def main(argv: list | None = None) -> int:
+    """Run the preflight and exit 1 when the publish would exceed the budget."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    limit_bytes = int(args.limit_gb * GIB)
+    warn_headroom_bytes = int(args.warn_headroom_gb * GIB)
+
+    try:
+        pypi_files = fetch_pypi_files(args.package, args.pypi_json_url)
+        artifacts = collect_dist_artifacts(Path(args.dist_dir))
+    except Exception as exc:  # pragma: no cover - network/fs error path
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    report = build_report(
+        package=args.package,
+        pypi_files=pypi_files,
+        artifacts=artifacts,
+        limit_bytes=limit_bytes,
+        warn_headroom_bytes=warn_headroom_bytes,
+    )
+    for line in render_summary(report):
+        print(line)
+
+    if report.over_budget:
+        print(render_failure(report), file=sys.stderr)
+        return 1
+    if report.near_budget:
+        print(render_warning(report), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pypi_project_size.py
+++ b/tests/test_pypi_project_size.py
@@ -1,0 +1,174 @@
+"""Regression tests for the PyPI project size budget preflight."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+from scripts.ci.check_pypi_project_size import GIB
+from scripts.ci.check_pypi_project_size import MANAGE_RELEASES_URL
+from scripts.ci.check_pypi_project_size import STORAGE_LIMITS_DOC
+from scripts.ci.check_pypi_project_size import Artifact
+from scripts.ci.check_pypi_project_size import build_report
+from scripts.ci.check_pypi_project_size import collect_dist_artifacts
+from scripts.ci.check_pypi_project_size import parse_gb
+from scripts.ci.check_pypi_project_size import render_failure
+from scripts.ci.check_pypi_project_size import render_summary
+from scripts.ci.check_pypi_project_size import render_warning
+
+
+def _report(pypi_files, artifacts, limit_bytes=10 * GIB, warn_headroom_bytes=GIB):
+    return build_report(
+        package="dcc-mcp-core",
+        pypi_files=pypi_files,
+        artifacts=artifacts,
+        limit_bytes=limit_bytes,
+        warn_headroom_bytes=warn_headroom_bytes,
+    )
+
+
+def test_collect_dist_artifacts_ignores_non_distribution_files(tmp_path: Path) -> None:
+    wheel = tmp_path / "pkg-1.0.0-cp38-abi3-win_amd64.whl"
+    wheel.write_bytes(b"x" * 10)
+    sdist = tmp_path / "pkg-1.0.0.tar.gz"
+    sdist.write_bytes(b"y" * 20)
+    (tmp_path / "pkg-1.0.0.tar.gz.publish.attestation").write_bytes(b"z" * 30)
+    (tmp_path / "notes.txt").write_bytes(b"w" * 40)
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "nested" / "pkg-2.0.0-py3-none-any.whl").write_bytes(b"v" * 50)
+
+    artifacts = collect_dist_artifacts(tmp_path)
+
+    assert [(a.filename, a.size_bytes) for a in artifacts] == [
+        ("pkg-1.0.0-cp38-abi3-win_amd64.whl", 10),
+        ("pkg-1.0.0.tar.gz", 20),
+    ]
+
+
+def test_collect_dist_artifacts_missing_dir_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        collect_dist_artifacts(tmp_path / "missing")
+
+
+def test_build_report_skips_files_already_on_pypi() -> None:
+    report = _report(
+        pypi_files={"a.whl": 100},
+        artifacts=[Artifact("a.whl", 999), Artifact("b.whl", 100)],
+    )
+
+    assert report.current_bytes == 100
+    assert report.already_present == ["a.whl"]
+    assert [a.filename for a in report.to_add] == ["b.whl"]
+    assert report.projected_bytes == 200
+    assert not report.over_budget
+
+
+def test_build_report_over_budget_when_projection_exceeds_limit() -> None:
+    report = _report(
+        pypi_files={"existing.whl": 9 * GIB},
+        artifacts=[Artifact("new.whl", 2 * GIB)],
+    )
+
+    assert report.over_budget
+    assert not report.near_budget
+
+
+def test_build_report_warns_when_headroom_within_threshold() -> None:
+    report = _report(
+        pypi_files={"existing.whl": int(9.5 * GIB)},
+        artifacts=[Artifact("new.whl", GIB // 4)],
+        warn_headroom_bytes=GIB,
+    )
+
+    assert not report.over_budget
+    assert report.near_budget
+
+
+def test_build_report_ok_with_ample_headroom() -> None:
+    report = _report(
+        pypi_files={"existing.whl": GIB},
+        artifacts=[Artifact("new.whl", GIB)],
+        warn_headroom_bytes=GIB,
+    )
+
+    assert not report.over_budget
+    assert not report.near_budget
+
+
+def test_v0206_incident_shape_is_over_budget() -> None:
+    """The v0.20.6 publish left PyPI at ~9.98 GiB; the remaining five files
+    (macos abi3, linux abi3, windows abi3, py3-none-any, sdist) could not fit.
+    """
+    pypi_files = {"incumbent.whl": 10_714_226_066}
+    missing = [
+        Artifact(
+            "dcc_mcp_core-0.20.6-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl",
+            36 * GIB // 1000,
+        ),
+        Artifact("dcc_mcp_core-0.20.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", 19 * GIB // 1000),
+        Artifact("dcc_mcp_core-0.20.6-cp38-abi3-win_amd64.whl", 19 * GIB // 1000),
+        Artifact("dcc_mcp_core-0.20.6-py3-none-any.whl", GIB // 2000),
+        Artifact("dcc_mcp_core-0.20.6.tar.gz", 8 * GIB // 1000),
+    ]
+
+    report = _report(pypi_files, missing)
+
+    assert report.over_budget
+    assert len(report.to_add) == 5
+
+
+def test_render_failure_points_at_remediation_paths() -> None:
+    report = _report(
+        pypi_files={"existing.whl": 10 * GIB},
+        artifacts=[Artifact("new.whl", GIB)],
+    )
+
+    message = render_failure(report)
+
+    assert message.startswith("::error::")
+    assert "dcc-mcp-core" in message
+    assert STORAGE_LIMITS_DOC in message
+    assert MANAGE_RELEASES_URL.format(package="dcc-mcp-core") in message
+    assert "skip-existing" in message
+
+
+def test_render_warning_reports_headroom() -> None:
+    report = _report(
+        pypi_files={"existing.whl": int(9.5 * GIB)},
+        artifacts=[Artifact("new.whl", GIB // 4)],
+        warn_headroom_bytes=GIB,
+    )
+
+    message = render_warning(report)
+
+    assert message.startswith("::warning::")
+    assert "dcc-mcp-core" in message
+    assert STORAGE_LIMITS_DOC in message
+
+
+def test_render_summary_lists_skipped_and_added_files() -> None:
+    report = _report(
+        pypi_files={"a.whl": 100},
+        artifacts=[Artifact("a.whl", 999), Artifact("b.whl", 100)],
+    )
+
+    lines = render_summary(report)
+
+    joined = "\n".join(lines)
+    assert "already on PyPI (skipped): 1 file(s)" in joined
+    assert "a.whl" in joined
+    assert "b.whl" in joined
+    assert "projected:" in joined
+
+
+def test_parse_gb_rejects_invalid_values() -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_gb("abc")
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_gb("0")
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_gb("-1")
+
+    assert parse_gb("10") == 10.0
+    assert parse_gb("0.5") == 0.5


### PR DESCRIPTION
## Problem

The v0.20.6 release is partially published on PyPI: only the two cp37 wheels
(`dcc_mcp_core-0.20.6-cp37-cp37m-*`) made it, and the macOS abi3 wheel was
rejected with:

```text
400 Project size too large. Limit for project 'dcc-mcp-core' total size is 10 GB.
```

`dcc-mcp-core` is at ~9.98/10 GiB (609 files). The GitHub Release has the full
wheel set, but downstream consumers that resolve platform wheels from PyPI
break — dcc-mcp-blender's addon packaging fails with
`No dcc-mcp-core wheel for platform='macos' at version '0.20.6'`.
Same failure mode as #1758 (v0.19.0).

## Changes

- Add `scripts/ci/check_pypi_project_size.py`: a stdlib-only preflight that
  mirrors the publish step's `skip-existing` semantics — artifacts whose
  filenames already exist on PyPI are treated as skipped — and fails with an
  actionable `::error::` (remediation steps + docs links) when the projected
  project size would exceed the limit. Emits a `::warning::` when headroom is
  tight (default 1 GiB).
- Wire the preflight into `publish-core-pypi`, `publish-server-pypi`, and
  `publish-semantic-pypi` before the upload step, so a release either
  publishes completely or fails loudly up front — never a partial upload.
- Document the gate and recovery runbook in the CI & Release section of
  `docs/guide/agents-reference.md`.
- Regression tests in `tests/test_pypi_project_size.py` (11 tests), including
  the v0.20.6 incident shape.

## Validation

- `python -m pytest tests/test_pypi_project_size.py` — 11 passed
- `ruff check` + `ruff format --check` on the new files — clean
- `actionlint .github/workflows/release.yml` — clean
- Live run against real PyPI data: current 9.98 GiB detected, skip-existing
  modeling verified (the real 0.20.6 cp37 wheel filename recognized as
  already present), over-limit path exits 1 with the remediation message
- No skill guidance updates needed (CI-only change)

## Required follow-up (maintainer ops, not code)

To unblock the v0.20.6 macOS wheel on PyPI:

1. Free storage by deleting old releases at
   <https://pypi.org/manage/project/dcc-mcp-core/releases/> (PyPI has no
   deletion API) and/or request a limit increase per
   <https://docs.pypi.org/project-management/storage-limits/>.
2. Re-run the Release workflow for the tag:

   ```sh
   gh workflow run release.yml -f release_tag=v0.20.6 -f release_version=0.20.6
   ```

   `skip-existing: true` resumes with only the missing distributions.
