### PR TITLE
docs: register dcc-mcp-office + dcc-mcp-PowerPoint in ecosystem catalog

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -785,7 +785,7 @@ mod tests {
         let catalog = service.dcc_types(None).unwrap();
 
         assert!(catalog.custom_types_supported);
-        assert_eq!(catalog.dcc_types.len(), 34);
+        assert_eq!(catalog.dcc_types.len(), 35);
         for alias in ["after effects", "after-effects", "comfy-ui"] {
             assert!(
                 catalog
@@ -813,6 +813,7 @@ mod tests {
             ("mari", "dcc-mcp-mari"),
             ("material-maker", "dcc-mcp-material-maker"),
             ("openscad", "dcc-mcp-openscad"),
+            ("powerpoint", "dcc-mcp-PowerPoint"),
             ("renderdoc", "dcc-mcp-renderdoc"),
             ("sketchup", "dcc-mcp-sketchup"),
             ("shogun", "dcc-mcp-shogun"),

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -1739,7 +1739,7 @@ fn dcc_types_lists_release_catalog_without_a_gateway() {
 
     assert_eq!(value["custom_types_supported"], true);
     let types = value["dcc_types"].as_array().unwrap();
-    assert_eq!(types.len(), 34);
+    assert_eq!(types.len(), 35);
     for expected in [
         "aftereffects",
         "c4d",
@@ -1754,6 +1754,7 @@ fn dcc_types_lists_release_catalog_without_a_gateway() {
         "material-maker",
         "openusd",
         "openscad",
+        "powerpoint",
         "renderdoc",
         "shotgrid",
         "sketchup",

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -23,6 +23,21 @@ entries:
     url: "https://github.com/dcc-mcp/dcc-mcp-core"
     tags: ["core", "official", "rust", "python", "library"]
 
+  - name: "dcc-mcp-office"
+    description: "Office shared core for DCC-MCP — office-rpc/1 protocol, C# COM sidecar, Open XML worker, Microsoft Graph connector and Office skill packs"
+    dcc: ["office"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-office"
+    tags: ["office", "core", "official", "powerpoint", "word", "excel", "outlook"]
+
+  - name: "dcc-mcp-PowerPoint"
+    description: "PowerPoint adapter for DCC-MCP — deck generation (Deck IR → Open XML compile → COM render), slide composition and review decks"
+    dcc: ["powerpoint"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-PowerPoint"
+    tags: ["adapter", "powerpoint", "office", "official", "deck", "skills"]
+    version: "0.1.0"
+    min_core_version: "0.18.2"
+    maintainer: "dcc-mcp"
+
   - name: "dcc-mcp-maya"
     description: "Core Maya adapter for DCC-MCP — gateway-managed instance, mayapy-based MCP server"
     dcc: ["maya"]

--- a/llms.txt
+++ b/llms.txt
@@ -1102,6 +1102,8 @@ Full guide: `docs/guide/remote-server.md`. Per-module API: `docs/api/{auth,batch
 ## Related Projects
 
 - [dcc-mcp-maya](https://github.com/dcc-mcp/dcc-mcp-maya) — Maya MCP server implementation
+- [dcc-mcp-office](https://github.com/dcc-mcp/dcc-mcp-office) — Office shared core: office-rpc/1 protocol, C# COM sidecar, Open XML worker, Graph connector
+- [dcc-mcp-PowerPoint](https://github.com/dcc-mcp/dcc-mcp-PowerPoint) — PowerPoint adapter: deck generation (Deck IR → Open XML → COM render), review decks
 
 ---
 


### PR DESCRIPTION
## 内容

- dcc-mcp-catalog.yml 新增 dcc-mcp-office（Office 通用底座，基础设施条目）与 dcc-mcp-PowerPoint（PPT 适配器，含 version/min_core_version/maintainer）
- llms.txt Related Projects 同步

## 备注

- PowerPoint 包（dcc-mcp-powerpoint 0.1.0）尚未发布 PyPI，故暂未加 install 块；发布后补 type: pip + pip_package
- dcc-mcp-office 为 Rust + C# 底座，无 pip 包，不提供 install 块（同 dcc-mcp-core 惯例）