### PR TITLE
feat(release): add auditable PyPI cleanup planner

### DIFF
--- a/scripts/release/pypi_cleanup.py
+++ b/scripts/release/pypi_cleanup.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Build an auditable PyPI release-cleanup plan from public metadata.
+
+PyPI has no supported deletion API. Deleting releases is permanent, can break
+exact pins, and must be performed by a project Owner in the official PyPI
+management UI. This tool deliberately does not read browser credentials or
+submit private Warehouse forms. It inventories the public JSON API, applies a
+bounded selection policy, and optionally writes a manifest containing every
+selected file name, size, URL, and SHA-256 digest for operator review.
+
+Example:
+    python scripts/release/pypi_cleanup.py --package dcc-mcp-core \
+        --delete-below 0.19.90 \
+        --keep-version 0.19.3 --keep-version 0.19.4 \
+        --keep-version 0.19.45 --output-json cleanup-plan.json
+
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+PYPI_URL = "https://pypi.org"
+USER_AGENT = "dcc-mcp-pypi-cleanup-plan/1.0 (+https://github.com/dcc-mcp/dcc-mcp-core)"
+
+
+class CleanupError(Exception):
+    """Fatal, user-facing cleanup planning failure."""
+
+
+@dataclass(frozen=True)
+class DistributionFile:
+    """One immutable distribution file reported by the PyPI JSON API."""
+
+    filename: str
+    size: int
+    sha256: str
+    url: str
+
+
+@dataclass(frozen=True)
+class ReleaseRecord:
+    """Public files and total storage for one release."""
+
+    version: str
+    files: tuple[DistributionFile, ...]
+
+    @property
+    def total_bytes(self) -> int:
+        """Return the release's total stored bytes."""
+        return sum(item.size for item in self.files)
+
+
+@dataclass(frozen=True)
+class ProjectState:
+    """Public PyPI project state used to construct a cleanup plan."""
+
+    package: str
+    latest_version: str
+    releases: dict[str, ReleaseRecord]
+
+    @property
+    def total_bytes(self) -> int:
+        """Return the project's total stored bytes."""
+        return sum(release.total_bytes for release in self.releases.values())
+
+
+def version_key(version: str) -> tuple:
+    """Return a deterministic ordering key for this project's release tags."""
+    head = re.split(r"[-+]", version)[0]
+    parts = [part for part in re.split(r"[._]", head) if part]
+    key = []
+    for part in parts:
+        key.append((0, int(part)) if part.isdigit() else (1, 0, part))
+    return tuple(key)
+
+
+def select_versions(
+    versions: list[str],
+    delete_below: str | None,
+    delete_matching: str | None,
+    exclude_matching: str | None,
+    max_deletes: int | None,
+    keep_versions: set[str] | None = None,
+) -> list[str]:
+    """Apply a cleanup policy and return selected versions in order."""
+    kept = keep_versions or set()
+    below_key = version_key(delete_below) if delete_below else None
+    match_re = re.compile(delete_matching) if delete_matching else None
+    exclude_re = re.compile(exclude_matching) if exclude_matching else None
+    selected = []
+    for version in versions:
+        if version in kept:
+            continue
+        if below_key is not None and version_key(version) >= below_key:
+            continue
+        if match_re is not None and not match_re.fullmatch(version):
+            continue
+        if exclude_re is not None and exclude_re.fullmatch(version):
+            continue
+        selected.append(version)
+    selected.sort(key=version_key)
+    return selected[:max_deletes] if max_deletes is not None else selected
+
+
+def _distribution_file(payload: dict) -> DistributionFile:
+    digests = payload.get("digests") or {}
+    return DistributionFile(
+        filename=str(payload.get("filename") or ""),
+        size=int(payload.get("size") or 0),
+        sha256=str(digests.get("sha256") or ""),
+        url=str(payload.get("url") or ""),
+    )
+
+
+def parse_project_state(package: str, payload: dict) -> ProjectState:
+    """Validate a project JSON payload and convert it into typed records."""
+    releases_payload = payload.get("releases")
+    latest = payload.get("info", {}).get("version")
+    if not isinstance(releases_payload, dict) or not isinstance(latest, str) or not latest:
+        raise CleanupError("public PyPI response is missing release metadata")
+    releases = {}
+    for version, files_payload in releases_payload.items():
+        if not isinstance(files_payload, list):
+            raise CleanupError(f"release {version!r} has an invalid files payload")
+        files = tuple(_distribution_file(item) for item in files_payload if isinstance(item, dict))
+        releases[str(version)] = ReleaseRecord(version=str(version), files=files)
+    return ProjectState(package=package, latest_version=latest, releases=releases)
+
+
+def fetch_project_state(package: str) -> ProjectState:
+    """Read the current project inventory from PyPI's public JSON API."""
+    encoded_package = urllib.parse.quote(package, safe="")
+    request = urllib.request.Request(
+        f"{PYPI_URL}/pypi/{encoded_package}/json",
+        headers={"User-Agent": USER_AGENT},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            payload = json.loads(response.read())
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise CleanupError(f"could not read public PyPI state for {package!r}: {exc}") from exc
+    return parse_project_state(package, payload)
+
+
+def build_plan(state: ProjectState, selected_versions: list[str], kept_versions: set[str]) -> dict:
+    """Return a stable JSON-serializable cleanup manifest."""
+    selected = []
+    for version in selected_versions:
+        release = state.releases[version]
+        selected.append(
+            {
+                "version": version,
+                "total_bytes": release.total_bytes,
+                "files": [asdict(item) for item in release.files],
+            }
+        )
+    selected_bytes = sum(item["total_bytes"] for item in selected)
+    return {
+        "schema_version": 1,
+        "package": state.package,
+        "source": f"{PYPI_URL}/pypi/{urllib.parse.quote(state.package, safe='')}/json",
+        "management_url": f"{PYPI_URL}/manage/project/{urllib.parse.quote(state.package, safe='')}/releases/",
+        "latest_version": state.latest_version,
+        "release_count": len(state.releases),
+        "current_total_bytes": state.total_bytes,
+        "selected_release_count": len(selected),
+        "selected_total_bytes": selected_bytes,
+        "projected_total_bytes": state.total_bytes - selected_bytes,
+        "kept_versions": sorted(kept_versions, key=version_key),
+        "selected_releases": selected,
+        "warning": "Deletion is permanent. Execute only in the official PyPI Owner management UI.",
+    }
+
+
+def _print_plan(plan: dict) -> None:
+    selected = plan["selected_releases"]
+    selected_bytes = plan["selected_total_bytes"]
+    print(
+        f"Package: {plan['package']} — {plan['release_count']} release(s), {plan['current_total_bytes']} stored byte(s)"
+    )
+    print(f"Selected: {len(selected)} release(s), {selected_bytes} byte(s) ({selected_bytes / (1024**3):.3f} GiB)")
+    print(f"Projected storage: {plan['projected_total_bytes']} byte(s)")
+    if plan["kept_versions"]:
+        print(f"Explicitly kept: {', '.join(plan['kept_versions'])}")
+    for release in selected:
+        print(
+            f"  - {release['version']} ({release['total_bytes']} bytes, {release['total_bytes'] / (1024**2):.2f} MiB)"
+        )
+    print(f"Review and execute manually: {plan['management_url']}")
+    print("DRY RUN — this tool never deletes releases or reads PyPI credentials.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Build and print a public-data-only cleanup plan."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--package", required=True, help="PyPI project name")
+    parser.add_argument("--delete-below", metavar="VERSION", help="select releases strictly older than VERSION")
+    parser.add_argument("--delete-matching", metavar="REGEX", help="select releases whose version fully matches REGEX")
+    parser.add_argument("--exclude-matching", metavar="REGEX", help="never select releases matching REGEX")
+    parser.add_argument(
+        "--keep-version", action="append", default=[], help="never select this exact version; repeatable"
+    )
+    parser.add_argument("--max-deletes", type=int, metavar="N", help="cap the number of selected releases")
+    parser.add_argument("--output-json", type=Path, metavar="PATH", help="write the complete cleanup manifest")
+    args = parser.parse_args(argv)
+
+    if not (args.delete_below or args.delete_matching):
+        parser.error("one of --delete-below / --delete-matching is required")
+    if args.max_deletes is not None and args.max_deletes <= 0:
+        parser.error("--max-deletes must be positive")
+
+    state = fetch_project_state(args.package)
+    kept_versions = set(args.keep_version)
+    unknown_kept = sorted(kept_versions - set(state.releases), key=version_key)
+    if unknown_kept:
+        raise CleanupError(f"explicitly kept versions are absent from PyPI: {unknown_kept}")
+    selected = select_versions(
+        list(state.releases),
+        delete_below=args.delete_below,
+        delete_matching=args.delete_matching,
+        exclude_matching=args.exclude_matching,
+        max_deletes=args.max_deletes,
+        keep_versions=kept_versions,
+    )
+    if state.latest_version in selected:
+        raise CleanupError(f"refusing to select current latest release {state.latest_version!r}")
+    if not selected:
+        print("Nothing matches the cleanup policy; nothing to do.")
+        return 0
+
+    plan = build_plan(state, selected, kept_versions)
+    _print_plan(plan)
+    if args.output_json:
+        args.output_json.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"Manifest written to: {args.output_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except CleanupError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/test_pypi_cleanup.py
+++ b/tests/test_pypi_cleanup.py
@@ -1,0 +1,204 @@
+"""Regression tests for the public-data-only PyPI cleanup planner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from scripts.release import pypi_cleanup
+from scripts.release.pypi_cleanup import CleanupError
+from scripts.release.pypi_cleanup import build_plan
+from scripts.release.pypi_cleanup import parse_project_state
+from scripts.release.pypi_cleanup import select_versions
+from scripts.release.pypi_cleanup import version_key
+
+
+def project_payload() -> dict:
+    """Return a compact PyPI JSON fixture with immutable file evidence."""
+    return {
+        "info": {"version": "0.20.7"},
+        "releases": {
+            "0.19.3": [
+                {
+                    "filename": "dcc_mcp_core-0.19.3.tar.gz",
+                    "size": 11,
+                    "url": "https://files.pythonhosted.org/0.19.3.tar.gz",
+                    "digests": {"sha256": "a" * 64},
+                }
+            ],
+            "0.19.4": [
+                {
+                    "filename": "dcc_mcp_core-0.19.4.tar.gz",
+                    "size": 13,
+                    "url": "https://files.pythonhosted.org/0.19.4.tar.gz",
+                    "digests": {"sha256": "b" * 64},
+                }
+            ],
+            "0.19.45": [
+                {
+                    "filename": "dcc_mcp_core-0.19.45.tar.gz",
+                    "size": 17,
+                    "url": "https://files.pythonhosted.org/0.19.45.tar.gz",
+                    "digests": {"sha256": "c" * 64},
+                }
+            ],
+            "0.19.89": [
+                {
+                    "filename": "dcc_mcp_core-0.19.89.tar.gz",
+                    "size": 19,
+                    "url": "https://files.pythonhosted.org/0.19.89.tar.gz",
+                    "digests": {"sha256": "d" * 64},
+                }
+            ],
+            "0.19.90": [
+                {
+                    "filename": "dcc_mcp_core-0.19.90.tar.gz",
+                    "size": 23,
+                    "url": "https://files.pythonhosted.org/0.19.90.tar.gz",
+                    "digests": {"sha256": "e" * 64},
+                }
+            ],
+            "0.20.7": [
+                {
+                    "filename": "dcc_mcp_core-0.20.7.tar.gz",
+                    "size": 29,
+                    "url": "https://files.pythonhosted.org/0.20.7.tar.gz",
+                    "digests": {"sha256": "f" * 64},
+                }
+            ],
+        },
+    }
+
+
+def test_parse_project_state_preserves_file_evidence() -> None:
+    state = parse_project_state("dcc-mcp-core", project_payload())
+    assert state.latest_version == "0.20.7"
+    assert state.total_bytes == 112
+    release = state.releases["0.19.89"]
+    assert release.total_bytes == 19
+    assert release.files[0].filename == "dcc_mcp_core-0.19.89.tar.gz"
+    assert release.files[0].sha256 == "d" * 64
+
+
+def test_parse_project_state_rejects_missing_metadata() -> None:
+    with pytest.raises(CleanupError, match="missing release metadata"):
+        parse_project_state("dcc-mcp-core", {"info": {}, "releases": {}})
+
+
+def test_select_versions_delete_below_with_explicit_anchors() -> None:
+    versions = ["0.19.3", "0.19.4", "0.19.45", "0.19.89", "0.19.90", "0.20.7"]
+    selected = select_versions(
+        versions,
+        delete_below="0.19.90",
+        delete_matching=None,
+        exclude_matching=None,
+        max_deletes=None,
+        keep_versions={"0.19.3", "0.19.4", "0.19.45"},
+    )
+    assert selected == ["0.19.89"]
+
+
+def test_select_versions_matching_exclude_and_cap() -> None:
+    versions = ["0.19.7", "0.19.45", "0.19.89", "0.20.0"]
+    selected = select_versions(
+        versions,
+        delete_below=None,
+        delete_matching=r"0\.19\..*",
+        exclude_matching=r"0\.19\.45",
+        max_deletes=1,
+    )
+    assert selected == ["0.19.7"]
+
+
+def test_version_key_orders_numeric_segments() -> None:
+    assert version_key("0.19.7") < version_key("0.19.94")
+    assert version_key("0.19.9") < version_key("0.19.10")
+    assert version_key("0.20.0") > version_key("0.19.94")
+    assert version_key("0.19.94.post1") > version_key("0.19.94")
+
+
+def test_build_plan_includes_projected_storage_and_hashes() -> None:
+    state = parse_project_state("dcc-mcp-core", project_payload())
+    plan = build_plan(state, ["0.19.89"], {"0.19.3", "0.19.4", "0.19.45"})
+    assert plan["selected_release_count"] == 1
+    assert plan["selected_total_bytes"] == 19
+    assert plan["projected_total_bytes"] == 93
+    assert plan["selected_releases"][0]["files"][0]["sha256"] == "d" * 64
+    assert plan["management_url"].endswith("/manage/project/dcc-mcp-core/releases/")
+
+
+def test_main_writes_auditable_manifest(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys) -> None:
+    state = parse_project_state("dcc-mcp-core", project_payload())
+    monkeypatch.setattr(pypi_cleanup, "fetch_project_state", lambda _package: state)
+    output = tmp_path / "cleanup-plan.json"
+
+    result = pypi_cleanup.main(
+        [
+            "--package",
+            "dcc-mcp-core",
+            "--delete-below",
+            "0.19.90",
+            "--keep-version",
+            "0.19.3",
+            "--keep-version",
+            "0.19.4",
+            "--keep-version",
+            "0.19.45",
+            "--output-json",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+    manifest = json.loads(output.read_text(encoding="utf-8"))
+    assert [item["version"] for item in manifest["selected_releases"]] == ["0.19.89"]
+    stdout = capsys.readouterr().out
+    assert "DRY RUN" in stdout
+    assert "never deletes releases" in stdout
+
+
+def test_main_rejects_unknown_keep_anchor(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = parse_project_state("dcc-mcp-core", project_payload())
+    monkeypatch.setattr(pypi_cleanup, "fetch_project_state", lambda _package: state)
+    with pytest.raises(CleanupError, match="absent from PyPI"):
+        pypi_cleanup.main(
+            [
+                "--package",
+                "dcc-mcp-core",
+                "--delete-below",
+                "0.19.90",
+                "--keep-version",
+                "0.19.44",
+            ]
+        )
+
+
+def test_main_refuses_to_select_latest(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = parse_project_state("dcc-mcp-core", project_payload())
+    monkeypatch.setattr(pypi_cleanup, "fetch_project_state", lambda _package: state)
+    with pytest.raises(CleanupError, match="current latest release"):
+        pypi_cleanup.main(
+            [
+                "--package",
+                "dcc-mcp-core",
+                "--delete-below",
+                "1.0.0",
+            ]
+        )
+
+
+def test_cli_has_no_execute_or_credential_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = parse_project_state("dcc-mcp-core", project_payload())
+    monkeypatch.setattr(pypi_cleanup, "fetch_project_state", lambda _package: state)
+    with pytest.raises(SystemExit) as exc_info:
+        pypi_cleanup.main(
+            [
+                "--package",
+                "dcc-mcp-core",
+                "--delete-below",
+                "0.19.90",
+                "--execute",
+            ]
+        )
+    assert exc_info.value.code == 2


### PR DESCRIPTION
## Summary
- replace private Warehouse and browser-cookie automation with a public PyPI JSON cleanup planner
- record selected filenames, sizes, URLs, SHA-256 digests, and projected storage
- fail closed on unknown keep anchors or selection of the latest release

Supersedes #2177.

## Validation
- `21 passed` for cleanup planner and PyPI size preflight tests
- `vx just lint`
- live dry run selected 83 releases and projected 9,271,523,910 bytes freed

Skill guidance update: not needed; this changes maintainer release operations only.