### PR TITLE
fix: preserve immutable release artifacts

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: ""
+      reuse-release-assets:
+        description: "Reuse immutable dcc-mcp-core distributions from an existing GitHub Release"
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       checkout-ref:
@@ -24,6 +29,11 @@ on:
         required: false
         type: string
         default: ""
+      reuse-release-assets:
+        description: "Reuse immutable dcc-mcp-core distributions from an existing GitHub Release"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   # Scope by the resolved checkout target so a release-driven build for tag
@@ -39,6 +49,7 @@ jobs:
   # ── ABI3 builds (Python 3.8+) — one wheel works for all 3.8+ ──
 
   linux:
+    if: inputs.reuse-release-assets != true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -68,6 +79,7 @@ jobs:
           --platform linux-x86_64
           dist/*.whl
   windows:
+    if: inputs.reuse-release-assets != true
     runs-on: windows-latest
     permissions:
       contents: read
@@ -107,6 +119,7 @@ jobs:
   # from python/dcc_mcp_core without maturin, Rust, or just (just>=1.0 is
   # unavailable on Python 3.7 and previously blocked release PyPI publish).
   py37-lite:
+    if: inputs.reuse-release-assets != true
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -161,6 +174,7 @@ jobs:
   # Uses WHEEL_FEATURES_PY37 (no abi3-py38) via build-wheel action py37 branch.
 
   linux-py37:
+    if: inputs.reuse-release-assets != true
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -200,6 +214,7 @@ jobs:
             python -c "import dcc_mcp_core"
           fi
   windows-py37:
+    if: inputs.reuse-release-assets != true
     runs-on: windows-2022
     permissions:
       contents: read
@@ -239,6 +254,7 @@ jobs:
             python -c "import dcc_mcp_core"
           fi
   macos:
+    if: inputs.reuse-release-assets != true
     runs-on: macos-latest
     permissions:
       contents: read
@@ -268,6 +284,69 @@ jobs:
           --profile abi3
           --platform macos-universal2
           dist/*.whl
+
+  # Manual release backfills must publish the immutable bytes already archived
+  # on GitHub. Rebuilding can produce different wheel bytes for the same
+  # filename, while PyPI's skip-existing behavior preserves the first upload.
+  reuse-release-assets:
+    if: inputs.reuse-release-assets == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout immutable distribution verification tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .workflow-tools
+          sparse-checkout: |
+            compatibility
+            scripts/ci
+          persist-credentials: false
+
+      - name: Download dcc-mcp-core distributions from GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.release-tag-name }}
+          RELEASE_VERSION: ${{ inputs.release-tag-name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION="${RELEASE_VERSION#v}"
+          if [ -z "$RELEASE_TAG" ] || [ -z "$RELEASE_VERSION" ]; then
+            echo "::error::release-tag-name is required when reuse-release-assets is true"
+            exit 1
+          fi
+          mkdir -p dist
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir dist \
+            --pattern "dcc_mcp_core-${RELEASE_VERSION}-*" \
+            --pattern "dcc_mcp_core-${RELEASE_VERSION}.tar.gz"
+          gh release view "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json assets > release-assets.json
+
+      - name: Verify downloaded distributions against GitHub digests
+        env:
+          RELEASE_VERSION: ${{ inputs.release-tag-name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION="${RELEASE_VERSION#v}"
+          python .workflow-tools/scripts/ci/check_release_distribution_set.py \
+            --assets-json release-assets.json \
+            --dist-dir dist \
+            --version "$RELEASE_VERSION"
+
+      - name: Upload verified release distributions for PyPI backfill
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-release-backfill
+          path: dist/
+          retention-days: 30
+
   publish-release:
     needs:
       - linux
@@ -288,9 +367,9 @@ jobs:
           path: dist
           merge-multiple: true
       - name: Upload wheels to GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: >-
-          gh release upload "${{ inputs.release-tag-name }}" dist/*.whl
-          --repo "${{ github.repository }}" --clobber
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.release-tag-name }}
+          files: dist/*
+          overwrite_files: false
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Existing release tag to rebuild and publish, for example v0.15.4"
+        description: "Existing release tag for an immutable dcc-mcp-core-only PyPI backfill"
         required: false
         type: string
         default: ""
       release_version:
-        description: "Version for release_tag without the v prefix, for example 0.15.4"
+        description: "Core version for release_tag without the v prefix, for example 0.15.4"
         required: false
         type: string
         default: ""
@@ -108,7 +108,9 @@ jobs:
 
   build-admin-ui:
     needs: [release-please]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: |
+      needs.release-please.outputs.release_created == 'true' &&
+      !(github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -166,7 +168,9 @@ jobs:
   # at the same workspace.package.version as `dcc-mcp-core`.
   build-binaries:
     needs: [release-please, build-admin-ui]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: |
+      needs.release-please.outputs.release_created == 'true' &&
+      !(github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     strategy:
       fail-fast: false
       matrix:
@@ -363,6 +367,8 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
+          overwrite_files: false
+          fail_on_unmatched_files: true
           files: |
             ${{ matrix.artifact_name }}
             ${{ matrix.cli_artifact_name }}
@@ -390,7 +396,9 @@ jobs:
   # invocation.
   build-semantic-wheels:
     needs: [release-please]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: |
+      needs.release-please.outputs.release_created == 'true' &&
+      !(github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     strategy:
       fail-fast: false
       matrix:
@@ -546,6 +554,8 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
+          overwrite_files: false
+          fail_on_unmatched_files: true
           files: pkg/dcc-mcp-core-semantic/wheels/*.whl
 
   # ── Build and validate wheels when release-please creates a release ──
@@ -556,6 +566,7 @@ jobs:
     with:
       checkout-ref: ${{ needs.release-please.outputs.tag_name }}
       release-tag-name: ${{ needs.release-please.outputs.tag_name }}
+      reuse-release-assets: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag != '' }}
 
   # ── Validate release metadata once before publishing artefacts ──
   validate-release-version:
@@ -845,6 +856,8 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
+          overwrite_files: false
+          fail_on_unmatched_files: true
           files: |
             dist/*
             dist-server/*
@@ -870,20 +883,33 @@ jobs:
           server="${{ needs.publish-server-pypi.result }}"
           semantic="${{ needs.publish-semantic-pypi.result }}"
           release_assets="${{ needs.publish-github-release-assets.result }}"
+          core_backfill="${{ github.event_name == 'workflow_dispatch' && inputs.release_tag != '' }}"
 
           echo "PyPI dcc-mcp-core: ${core}"
           echo "PyPI dcc-mcp-server: ${server}"
           echo "PyPI dcc-mcp-core-semantic: ${semantic}"
           echo "GitHub Release assets: ${release_assets}"
+          echo "Core-only immutable backfill: ${core_backfill}"
 
           failed=0
-          if [ "$core" != "success" ] || [ "$server" != "success" ] || [ "$semantic" != "success" ]; then
-            echo "::error::PyPI upload failed (core=${core} server=${server} semantic=${semantic})."
-            failed=1
-          fi
-          if [ "$release_assets" != "success" ]; then
-            echo "::error::GitHub Release safety-net upload did not complete (result=${release_assets})."
-            failed=1
+          if [ "$core_backfill" = "true" ]; then
+            if [ "$core" != "success" ]; then
+              echo "::error::Core PyPI backfill failed (result=${core})."
+              failed=1
+            fi
+            if [ "$server" != "skipped" ] || [ "$semantic" != "skipped" ] || [ "$release_assets" != "skipped" ]; then
+              echo "::error::Core-only backfill unexpectedly ran another publication route."
+              failed=1
+            fi
+          else
+            if [ "$core" != "success" ] || [ "$server" != "success" ] || [ "$semantic" != "success" ]; then
+              echo "::error::PyPI upload failed (core=${core} server=${server} semantic=${semantic})."
+              failed=1
+            fi
+            if [ "$release_assets" != "success" ]; then
+              echo "::error::GitHub Release safety-net upload did not complete (result=${release_assets})."
+              failed=1
+            fi
           fi
           exit "$failed"
 

--- a/scripts/ci/check_release_distribution_set.py
+++ b/scripts/ci/check_release_distribution_set.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Verify an immutable dcc-mcp-core GitHub Release distribution set."""
+
+from __future__ import annotations
+
+import argparse
+from email.parser import Parser
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+import tarfile
+import zipfile
+
+try:
+    from .check_python_wheel import validate_wheel
+    from .python_support_contract import load_contract
+except ImportError:  # pragma: no cover - direct script execution
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from check_python_wheel import validate_wheel
+    from python_support_contract import load_contract
+
+
+class DistributionSetError(ValueError):
+    """Raised when archived Release distributions are incomplete or invalid."""
+
+
+_EXPECTED_WHEEL_CONTRACTS = {
+    "native_py37/linux-x86_64",
+    "native_py37/windows-x86_64",
+    "abi3/linux-x86_64",
+    "abi3/windows-x86_64",
+    "abi3/macos-universal2",
+    "lite_py37/any",
+}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _classify_wheel(filename: str, version: str) -> tuple[str, str]:
+    prefix = f"dcc_mcp_core-{version}-"
+    if not filename.startswith(prefix) or not filename.endswith(".whl"):
+        raise DistributionSetError(f"unexpected Core wheel filename {filename!r}")
+    tags = filename[len(prefix) : -4]
+    if tags == "py3-none-any":
+        return "lite_py37", "any"
+    if tags.startswith("cp37-cp37m-manylinux_"):
+        return "native_py37", "linux-x86_64"
+    if tags == "cp37-cp37m-win_amd64":
+        return "native_py37", "windows-x86_64"
+    if tags.startswith("cp38-abi3-manylinux_"):
+        return "abi3", "linux-x86_64"
+    if tags == "cp38-abi3-win_amd64":
+        return "abi3", "windows-x86_64"
+    if tags.startswith("cp38-abi3-macosx_") and "universal2" in tags:
+        return "abi3", "macos-universal2"
+    raise DistributionSetError(f"unexpected Core wheel tags in {filename!r}")
+
+
+def _single_metadata(archive: zipfile.ZipFile) -> str:
+    matches = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+    if len(matches) != 1:
+        raise DistributionSetError(f"wheel must contain exactly one METADATA file, found {len(matches)}")
+    return archive.read(matches[0]).decode("utf-8")
+
+
+def _validate_metadata(raw: str, version: str, filename: str) -> None:
+    metadata = Parser().parsestr(raw)
+    name = str(metadata.get("Name", "")).lower().replace("_", "-")
+    actual_version = str(metadata.get("Version", ""))
+    if name != "dcc-mcp-core":
+        raise DistributionSetError(f"{filename}: distribution name is {name!r}, expected 'dcc-mcp-core'")
+    if actual_version != version:
+        raise DistributionSetError(f"{filename}: metadata version is {actual_version!r}, expected {version!r}")
+
+
+def _validate_wheels(dist_dir: Path, version: str, wheel_names: set[str]) -> None:
+    observed_contracts = set()
+    contract = load_contract()
+    for filename in sorted(wheel_names):
+        profile, platform = _classify_wheel(filename, version)
+        contract_name = f"{profile}/{platform}"
+        if contract_name in observed_contracts:
+            raise DistributionSetError(f"duplicate wheel contract {contract_name!r}")
+        observed_contracts.add(contract_name)
+        path = dist_dir / filename
+        try:
+            with zipfile.ZipFile(path) as archive:
+                corrupt_member = archive.testzip()
+                if corrupt_member is not None:
+                    raise DistributionSetError(f"{filename}: corrupt ZIP member {corrupt_member!r}")
+                _validate_metadata(_single_metadata(archive), version, filename)
+        except (OSError, UnicodeDecodeError, zipfile.BadZipFile) as exc:
+            raise DistributionSetError(f"{filename}: cannot inspect wheel: {exc}") from exc
+        errors = validate_wheel(path, profile, platform, contract)
+        if errors:
+            raise DistributionSetError(f"{filename}: " + "; ".join(errors))
+
+    missing = sorted(_EXPECTED_WHEEL_CONTRACTS - observed_contracts)
+    unexpected = sorted(observed_contracts - _EXPECTED_WHEEL_CONTRACTS)
+    if missing or unexpected:
+        raise DistributionSetError(
+            f"Core wheel contract set is invalid; missing wheel contract(s)={missing}, unexpected={unexpected}"
+        )
+
+
+def _validate_sdist(path: Path, version: str) -> None:
+    root = f"dcc_mcp_core-{version}"
+    pkg_info_name = f"{root}/PKG-INFO"
+    try:
+        with tarfile.open(path, "r:gz") as archive:
+            members = archive.getmembers()
+            names = [member.name for member in members]
+            if names.count(pkg_info_name) != 1:
+                raise DistributionSetError(f"sdist must contain exactly one {pkg_info_name!r}")
+            invalid_names = [
+                name for name in names if name != root and (not name.startswith(f"{root}/") or ".." in Path(name).parts)
+            ]
+            if invalid_names:
+                raise DistributionSetError(f"sdist contains paths outside {root!r}: {invalid_names[:3]}")
+            pkg_info = ""
+            for member in members:
+                if not member.isfile():
+                    continue
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise DistributionSetError(f"sdist member {member.name!r} is unreadable")
+                data = stream.read()
+                if member.name == pkg_info_name:
+                    pkg_info = data.decode("utf-8")
+            _validate_metadata(pkg_info, version, path.name)
+    except (OSError, UnicodeDecodeError, tarfile.TarError) as exc:
+        raise DistributionSetError(f"{path.name}: cannot inspect sdist: {exc}") from exc
+
+
+def _release_assets(payload: dict, version: str) -> dict[str, dict]:
+    assets_payload = payload.get("assets") if isinstance(payload, dict) else None
+    if not isinstance(assets_payload, list) or any(not isinstance(item, dict) for item in assets_payload):
+        raise DistributionSetError("GitHub Release asset JSON is invalid")
+    prefix = f"dcc_mcp_core-{version}"
+    assets = {}
+    for asset in assets_payload:
+        name = asset.get("name")
+        if not isinstance(name, str) or not name.startswith(prefix):
+            continue
+        if Path(name).name != name or name in assets:
+            raise DistributionSetError(f"GitHub Release has an invalid or duplicate Core asset name {name!r}")
+        assets[name] = asset
+    return assets
+
+
+def verify_distribution_set(payload: dict, dist_dir: Path, version: str) -> dict[str, int]:
+    """Verify the exact seven-file Core distribution set and return evidence."""
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:[A-Za-z0-9.+-]*)", version):
+        raise DistributionSetError(f"invalid release version {version!r}")
+    if not dist_dir.is_dir():
+        raise DistributionSetError(f"distribution directory does not exist: {dist_dir}")
+    paths = [path for path in dist_dir.iterdir() if path.is_file()]
+    downloaded = {path.name: path for path in paths}
+    assets = _release_assets(payload, version)
+    if set(downloaded) != set(assets):
+        raise DistributionSetError(
+            "downloaded Core distributions do not match GitHub Release assets; "
+            f"missing={sorted(set(assets) - set(downloaded))}, extra={sorted(set(downloaded) - set(assets))}"
+        )
+
+    for name, path in downloaded.items():
+        asset = assets[name]
+        size = asset.get("size")
+        digest = asset.get("digest")
+        if not isinstance(size, int) or isinstance(size, bool) or size <= 0 or path.stat().st_size != size:
+            raise DistributionSetError(f"{name}: size mismatch with GitHub Release metadata")
+        if not isinstance(digest, str) or re.fullmatch(r"sha256:[0-9a-fA-F]{64}", digest) is None:
+            raise DistributionSetError(f"{name}: GitHub Release SHA-256 digest is invalid")
+        actual_digest = _sha256(path)
+        if actual_digest != digest.split(":", 1)[1].lower():
+            raise DistributionSetError(f"{name}: digest mismatch with GitHub Release metadata")
+
+    sdist_name = f"dcc_mcp_core-{version}.tar.gz"
+    wheel_names = {name for name in downloaded if name.endswith(".whl")}
+    if set(downloaded) != {*wheel_names, sdist_name}:
+        raise DistributionSetError("Core Release must contain six wheels and one exact-version sdist")
+    _validate_wheels(dist_dir, version, wheel_names)
+    _validate_sdist(dist_dir / sdist_name, version)
+    return {
+        "asset_count": len(downloaded),
+        "total_bytes": sum(path.stat().st_size for path in downloaded.values()),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate Release asset metadata and downloaded distributions."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--assets-json", type=Path, required=True)
+    parser.add_argument("--dist-dir", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args(argv)
+    try:
+        payload = json.loads(args.assets_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DistributionSetError(f"cannot read GitHub Release asset JSON: {exc}") from exc
+    evidence = verify_distribution_set(payload, args.dist_dir, args.version)
+    print(f"Verified {evidence['asset_count']} immutable Core distribution(s), {evidence['total_bytes']} byte(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except DistributionSetError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/release/pypi_cleanup.py
+++ b/scripts/release/pypi_cleanup.py
@@ -6,13 +6,22 @@ exact pins, and must be performed by a project Owner in the official PyPI
 management UI. This tool deliberately does not read browser credentials or
 submit private Warehouse forms. It inventories the public JSON API, applies a
 bounded selection policy, and optionally writes a manifest containing every
-selected file name, size, URL, and SHA-256 digest for operator review.
+selected file name, size, URL, and SHA-256 digest for operator review. When a
+GitHub repository is supplied, the tool fails closed unless every selected
+PyPI file has an exact-name GitHub Release asset with the same size and digest.
 
 Example:
     python scripts/release/pypi_cleanup.py --package dcc-mcp-core \
         --delete-below 0.19.90 \
         --keep-version 0.19.3 --keep-version 0.19.4 \
-        --keep-version 0.19.45 --output-json cleanup-plan.json
+        --keep-version 0.19.45 \
+        --max-deletes 83 --expect-selected-count 83 \
+        --expect-selected-total-bytes 9271523910 \
+        --github-repository dcc-mcp/dcc-mcp-core \
+        --output-json cleanup-plan.json
+
+Set GH_TOKEN or GITHUB_TOKEN only when GitHub's anonymous API rate limit is
+insufficient. Tokens are used for read-only Release metadata and never stored.
 
 """
 
@@ -21,7 +30,11 @@ from __future__ import annotations
 import argparse
 from dataclasses import asdict
 from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
+import hashlib
 import json
+import os
 from pathlib import Path
 import re
 import sys
@@ -30,7 +43,8 @@ import urllib.parse
 import urllib.request
 
 PYPI_URL = "https://pypi.org"
-USER_AGENT = "dcc-mcp-pypi-cleanup-plan/1.0 (+https://github.com/dcc-mcp/dcc-mcp-core)"
+GITHUB_API_URL = "https://api.github.com"
+USER_AGENT = "dcc-mcp-pypi-cleanup-plan/2.0 (+https://github.com/dcc-mcp/dcc-mcp-core)"
 
 
 class CleanupError(Exception):
@@ -112,27 +126,55 @@ def select_versions(
     return selected[:max_deletes] if max_deletes is not None else selected
 
 
-def _distribution_file(payload: dict) -> DistributionFile:
+def _distribution_file(version: str, payload: dict) -> DistributionFile:
     digests = payload.get("digests") or {}
-    return DistributionFile(
-        filename=str(payload.get("filename") or ""),
-        size=int(payload.get("size") or 0),
-        sha256=str(digests.get("sha256") or ""),
-        url=str(payload.get("url") or ""),
+    filename = payload.get("filename")
+    size = payload.get("size")
+    sha256 = digests.get("sha256") if isinstance(digests, dict) else None
+    url = payload.get("url")
+    parsed_url = urllib.parse.urlparse(url) if isinstance(url, str) else None
+    valid = (
+        isinstance(filename, str)
+        and bool(filename)
+        and Path(filename).name == filename
+        and isinstance(size, int)
+        and not isinstance(size, bool)
+        and size > 0
+        and isinstance(sha256, str)
+        and re.fullmatch(r"[0-9a-fA-F]{64}", sha256) is not None
+        and parsed_url is not None
+        and parsed_url.scheme == "https"
+        and parsed_url.hostname == "files.pythonhosted.org"
     )
+    if not valid:
+        raise CleanupError(f"release {version!r} has invalid file evidence")
+    return DistributionFile(
+        filename=filename,
+        size=size,
+        sha256=sha256.lower(),
+        url=url,
+    )
+
+
+def _utc_now() -> str:
+    """Return a compact UTC timestamp for manifest freshness evidence."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def parse_project_state(package: str, payload: dict) -> ProjectState:
     """Validate a project JSON payload and convert it into typed records."""
+    if not isinstance(payload, dict):
+        raise CleanupError("public PyPI response is missing release metadata")
     releases_payload = payload.get("releases")
-    latest = payload.get("info", {}).get("version")
+    info_payload = payload.get("info")
+    latest = info_payload.get("version") if isinstance(info_payload, dict) else None
     if not isinstance(releases_payload, dict) or not isinstance(latest, str) or not latest:
         raise CleanupError("public PyPI response is missing release metadata")
     releases = {}
     for version, files_payload in releases_payload.items():
-        if not isinstance(files_payload, list):
+        if not isinstance(files_payload, list) or any(not isinstance(item, dict) for item in files_payload):
             raise CleanupError(f"release {version!r} has an invalid files payload")
-        files = tuple(_distribution_file(item) for item in files_payload if isinstance(item, dict))
+        files = tuple(_distribution_file(str(version), item) for item in files_payload)
         releases[str(version)] = ReleaseRecord(version=str(version), files=files)
     return ProjectState(package=package, latest_version=latest, releases=releases)
 
@@ -152,6 +194,136 @@ def fetch_project_state(package: str) -> ProjectState:
     return parse_project_state(package, payload)
 
 
+def _github_repository_parts(repository: str) -> tuple[str, str]:
+    parts = repository.split("/")
+    if len(parts) != 2 or not all(re.fullmatch(r"[A-Za-z0-9_.-]+", part) for part in parts):
+        raise CleanupError("GitHub repository must use the OWNER/REPO form")
+    return parts[0], parts[1]
+
+
+def fetch_github_releases(repository: str) -> list[dict]:
+    """Read every public GitHub Release needed for backup verification."""
+    owner, repo = _github_repository_parts(repository)
+    releases = []
+    for page in range(1, 101):
+        url = (
+            f"{GITHUB_API_URL}/repos/{urllib.parse.quote(owner, safe='')}/"
+            f"{urllib.parse.quote(repo, safe='')}/releases?per_page=100&page={page}"
+        )
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": USER_AGENT,
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                payload = json.loads(response.read())
+        except (urllib.error.URLError, json.JSONDecodeError) as exc:
+            raise CleanupError(f"could not read public GitHub Releases for {repository!r}: {exc}") from exc
+        if not isinstance(payload, list) or any(not isinstance(item, dict) for item in payload):
+            raise CleanupError(f"public GitHub response for {repository!r} has invalid release metadata")
+        releases.extend(payload)
+        if len(payload) < 100:
+            return releases
+    raise CleanupError(f"public GitHub Releases for {repository!r} exceeded the 100-page safety bound")
+
+
+def verify_github_backup(plan: dict, repository: str, releases: list[dict]) -> dict:
+    """Fail closed unless every selected PyPI file has an identical GitHub asset."""
+    _github_repository_parts(repository)
+    releases_by_tag = {}
+    for release in releases:
+        tag = release.get("tag_name")
+        if isinstance(tag, str) and tag and tag not in releases_by_tag:
+            releases_by_tag[tag] = release
+
+    issues = []
+    release_evidence = []
+    verified_files = 0
+    for selected in plan["selected_releases"]:
+        tag = f"v{selected['version']}"
+        release = releases_by_tag.get(tag)
+        if release is None:
+            issues.append(f"{tag}: release is missing")
+            continue
+        if release.get("draft") is True:
+            issues.append(f"{tag}: release is still a draft")
+            continue
+        release_url = release.get("html_url")
+        assets_payload = release.get("assets")
+        if not isinstance(release_url, str) or not release_url.startswith("https://github.com/"):
+            issues.append(f"{tag}: release URL is invalid")
+            continue
+        if not isinstance(assets_payload, list) or any(not isinstance(item, dict) for item in assets_payload):
+            issues.append(f"{tag}: asset metadata is invalid")
+            continue
+
+        assets_by_name = {}
+        for asset in assets_payload:
+            name = asset.get("name")
+            if isinstance(name, str) and name and name not in assets_by_name:
+                assets_by_name[name] = asset
+
+        asset_evidence = []
+        for expected in selected["files"]:
+            filename = expected["filename"]
+            asset = assets_by_name.get(filename)
+            if asset is None:
+                issues.append(f"{tag}/{filename}: asset is missing")
+                continue
+            digest = asset.get("digest")
+            size = asset.get("size")
+            expected_digest = f"sha256:{expected['sha256']}"
+            if size != expected["size"]:
+                issues.append(f"{tag}/{filename}: size mismatch (PyPI {expected['size']}, GitHub {size!r})")
+                continue
+            if not isinstance(digest, str) or digest.lower() != expected_digest:
+                issues.append(f"{tag}/{filename}: digest mismatch (PyPI {expected_digest}, GitHub {digest!r})")
+                continue
+            asset_id = asset.get("id")
+            download_url = asset.get("browser_download_url")
+            if not isinstance(asset_id, int) or asset_id <= 0:
+                issues.append(f"{tag}/{filename}: asset id is invalid")
+                continue
+            if not isinstance(download_url, str) or not download_url.startswith("https://github.com/"):
+                issues.append(f"{tag}/{filename}: asset download URL is invalid")
+                continue
+            asset_evidence.append(
+                {
+                    "filename": filename,
+                    "asset_id": asset_id,
+                    "size": size,
+                    "sha256": expected["sha256"],
+                    "download_url": download_url,
+                }
+            )
+            verified_files += 1
+        release_evidence.append(
+            {
+                "version": selected["version"],
+                "tag": tag,
+                "release_url": release_url,
+                "assets": asset_evidence,
+            }
+        )
+
+    if issues:
+        raise CleanupError("GitHub backup verification failed: " + "; ".join(issues))
+    return {
+        "status": "verified",
+        "verified_at": _utc_now(),
+        "repository": repository,
+        "source": f"{GITHUB_API_URL}/repos/{repository}/releases",
+        "release_count": len(release_evidence),
+        "file_count": verified_files,
+        "releases": release_evidence,
+    }
+
+
 def build_plan(state: ProjectState, selected_versions: list[str], kept_versions: set[str]) -> dict:
     """Return a stable JSON-serializable cleanup manifest."""
     selected = []
@@ -166,7 +338,8 @@ def build_plan(state: ProjectState, selected_versions: list[str], kept_versions:
         )
     selected_bytes = sum(item["total_bytes"] for item in selected)
     return {
-        "schema_version": 1,
+        "schema_version": 2,
+        "generated_at": _utc_now(),
         "package": state.package,
         "source": f"{PYPI_URL}/pypi/{urllib.parse.quote(state.package, safe='')}/json",
         "management_url": f"{PYPI_URL}/manage/project/{urllib.parse.quote(state.package, safe='')}/releases/",
@@ -192,6 +365,12 @@ def _print_plan(plan: dict) -> None:
     print(f"Projected storage: {plan['projected_total_bytes']} byte(s)")
     if plan["kept_versions"]:
         print(f"Explicitly kept: {', '.join(plan['kept_versions'])}")
+    backup = plan.get("github_backup")
+    if backup:
+        print(
+            f"GitHub backup: {backup['file_count']} file(s) across "
+            f"{backup['release_count']} release(s) verified in {backup['repository']}"
+        )
     for release in selected:
         print(
             f"  - {release['version']} ({release['total_bytes']} bytes, {release['total_bytes'] / (1024**2):.2f} MiB)"
@@ -211,6 +390,23 @@ def main(argv: list[str] | None = None) -> int:
         "--keep-version", action="append", default=[], help="never select this exact version; repeatable"
     )
     parser.add_argument("--max-deletes", type=int, metavar="N", help="cap the number of selected releases")
+    parser.add_argument(
+        "--expect-selected-count",
+        type=int,
+        metavar="N",
+        help="fail unless the unbounded cleanup policy selects exactly N releases",
+    )
+    parser.add_argument(
+        "--expect-selected-total-bytes",
+        type=int,
+        metavar="N",
+        help="fail unless the selected releases contain exactly N stored bytes",
+    )
+    parser.add_argument(
+        "--github-repository",
+        metavar="OWNER/REPO",
+        help="fail unless every selected file has an identical public GitHub Release asset",
+    )
     parser.add_argument("--output-json", type=Path, metavar="PATH", help="write the complete cleanup manifest")
     args = parser.parse_args(argv)
 
@@ -218,31 +414,53 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("one of --delete-below / --delete-matching is required")
     if args.max_deletes is not None and args.max_deletes <= 0:
         parser.error("--max-deletes must be positive")
+    if args.expect_selected_count is not None and args.expect_selected_count <= 0:
+        parser.error("--expect-selected-count must be positive")
+    if args.expect_selected_total_bytes is not None and args.expect_selected_total_bytes <= 0:
+        parser.error("--expect-selected-total-bytes must be positive")
 
     state = fetch_project_state(args.package)
     kept_versions = set(args.keep_version)
     unknown_kept = sorted(kept_versions - set(state.releases), key=version_key)
     if unknown_kept:
         raise CleanupError(f"explicitly kept versions are absent from PyPI: {unknown_kept}")
-    selected = select_versions(
+    matching = select_versions(
         list(state.releases),
         delete_below=args.delete_below,
         delete_matching=args.delete_matching,
         exclude_matching=args.exclude_matching,
-        max_deletes=args.max_deletes,
+        max_deletes=None,
         keep_versions=kept_versions,
     )
+    if args.expect_selected_count is not None and len(matching) != args.expect_selected_count:
+        raise CleanupError(
+            f"expected {args.expect_selected_count} selected release(s), found {len(matching)} before the delete cap"
+        )
+    selected = matching[: args.max_deletes] if args.max_deletes is not None else matching
+    if args.expect_selected_count is not None and len(selected) != args.expect_selected_count:
+        raise CleanupError(
+            f"expected {args.expect_selected_count} selected release(s), but the delete cap retained {len(selected)}"
+        )
     if state.latest_version in selected:
         raise CleanupError(f"refusing to select current latest release {state.latest_version!r}")
     if not selected:
         print("Nothing matches the cleanup policy; nothing to do.")
         return 0
+    selected_bytes = sum(state.releases[version].total_bytes for version in selected)
+    if args.expect_selected_total_bytes is not None and selected_bytes != args.expect_selected_total_bytes:
+        raise CleanupError(f"expected {args.expect_selected_total_bytes} selected byte(s), found {selected_bytes}")
 
     plan = build_plan(state, selected, kept_versions)
+    if args.github_repository:
+        releases = fetch_github_releases(args.github_repository)
+        plan["github_backup"] = verify_github_backup(plan, args.github_repository, releases)
     _print_plan(plan)
     if args.output_json:
-        args.output_json.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        manifest_text = json.dumps(plan, indent=2, sort_keys=True) + "\n"
+        manifest_bytes = manifest_text.encode("utf-8")
+        args.output_json.write_bytes(manifest_bytes)
         print(f"Manifest written to: {args.output_json}")
+        print(f"Manifest SHA-256: {hashlib.sha256(manifest_bytes).hexdigest()}")
     return 0
 
 

--- a/tests/test_build_wheels_workflow.py
+++ b/tests/test_build_wheels_workflow.py
@@ -21,6 +21,40 @@ def _jobs() -> dict:
     return workflow["jobs"]
 
 
+def test_manual_backfill_reuses_verified_github_release_assets() -> None:
+    workflow = yaml_loads(BUILD_WHEELS_WORKFLOW.read_text(encoding="utf-8"))
+    reuse_input = workflow["on"]["workflow_call"]["inputs"]["reuse-release-assets"]
+    assert reuse_input == {
+        "description": "Reuse immutable dcc-mcp-core distributions from an existing GitHub Release",
+        "required": False,
+        "type": "boolean",
+        "default": False,
+    }
+
+    jobs = workflow["jobs"]
+    for job_id in BUILD_JOB_IDS:
+        assert jobs[job_id]["if"] == "inputs.reuse-release-assets != true"
+
+    reuse = jobs["reuse-release-assets"]
+    assert reuse["if"] == "inputs.reuse-release-assets == true"
+    assert reuse["permissions"] == {"contents": "read"}
+    commands = "\n".join(step.get("run", "") for step in reuse["steps"])
+    assert "gh release download" in commands
+    assert "dcc_mcp_core-${RELEASE_VERSION}-*" in commands
+    assert "dcc_mcp_core-${RELEASE_VERSION}.tar.gz" in commands
+    assert "check_release_distribution_set.py" in commands
+    checkout = next(step for step in reuse["steps"] if step.get("uses") == "actions/checkout@v6")
+    assert checkout["with"]["ref"] == "${{ github.workflow_sha }}"
+    assert "compatibility" in checkout["with"]["sparse-checkout"]
+    assert "scripts/ci" in checkout["with"]["sparse-checkout"]
+    upload = next(step for step in reuse["steps"] if step.get("uses") == "actions/upload-artifact@v7")
+    assert upload["with"] == {
+        "name": "wheels-release-backfill",
+        "path": "dist/",
+        "retention-days": 30,
+    }
+
+
 def test_release_wheels_are_uploaded_once_after_every_build() -> None:
     jobs = _jobs()
 
@@ -42,8 +76,10 @@ def test_release_wheels_are_uploaded_once_after_every_build() -> None:
     }
 
     upload = publish["steps"][1]
-    assert upload["env"] == {"GH_TOKEN": "${{ github.token }}"}
-    command = upload["run"]
-    assert 'gh release upload "${{ inputs.release-tag-name }}" dist/*.whl' in command
-    assert '--repo "${{ github.repository }}"' in command
-    assert command.endswith("--clobber")
+    assert upload["uses"] == "softprops/action-gh-release@v3"
+    assert upload["with"] == {
+        "tag_name": "${{ inputs.release-tag-name }}",
+        "files": "dist/*",
+        "overwrite_files": False,
+        "fail_on_unmatched_files": True,
+    }

--- a/tests/test_pypi_cleanup.py
+++ b/tests/test_pypi_cleanup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -71,6 +72,28 @@ def project_payload() -> dict:
     }
 
 
+def github_release_payload(sha256: str = "d" * 64) -> list[dict]:
+    """Return one GitHub Release whose asset mirrors the selected PyPI file."""
+    return [
+        {
+            "tag_name": "v0.19.89",
+            "html_url": "https://github.com/dcc-mcp/dcc-mcp-core/releases/tag/v0.19.89",
+            "draft": False,
+            "assets": [
+                {
+                    "id": 123,
+                    "name": "dcc_mcp_core-0.19.89.tar.gz",
+                    "size": 19,
+                    "digest": f"sha256:{sha256}",
+                    "browser_download_url": (
+                        "https://github.com/dcc-mcp/dcc-mcp-core/releases/download/v0.19.89/dcc_mcp_core-0.19.89.tar.gz"
+                    ),
+                }
+            ],
+        }
+    ]
+
+
 def test_parse_project_state_preserves_file_evidence() -> None:
     state = parse_project_state("dcc-mcp-core", project_payload())
     assert state.latest_version == "0.20.7"
@@ -84,6 +107,31 @@ def test_parse_project_state_preserves_file_evidence() -> None:
 def test_parse_project_state_rejects_missing_metadata() -> None:
     with pytest.raises(CleanupError, match="missing release metadata"):
         parse_project_state("dcc-mcp-core", {"info": {}, "releases": {}})
+    with pytest.raises(CleanupError, match="missing release metadata"):
+        parse_project_state("dcc-mcp-core", [])  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("filename", ""),
+        ("size", -1),
+        ("url", "http://example.invalid/archive.whl"),
+        ("digests", {"sha256": "not-a-sha256"}),
+    ],
+)
+def test_parse_project_state_rejects_invalid_file_evidence(field: str, value: object) -> None:
+    payload = project_payload()
+    payload["releases"]["0.19.89"][0][field] = value
+    with pytest.raises(CleanupError, match="invalid file evidence"):
+        parse_project_state("dcc-mcp-core", payload)
+
+
+def test_parse_project_state_rejects_non_object_file_entries() -> None:
+    payload = project_payload()
+    payload["releases"]["0.19.89"].append("not-an-object")
+    with pytest.raises(CleanupError, match="invalid files payload"):
+        parse_project_state("dcc-mcp-core", payload)
 
 
 def test_select_versions_delete_below_with_explicit_anchors() -> None:
@@ -122,6 +170,7 @@ def test_build_plan_includes_projected_storage_and_hashes() -> None:
     state = parse_project_state("dcc-mcp-core", project_payload())
     plan = build_plan(state, ["0.19.89"], {"0.19.3", "0.19.4", "0.19.45"})
     assert plan["selected_release_count"] == 1
+    assert plan["generated_at"].endswith("Z")
     assert plan["selected_total_bytes"] == 19
     assert plan["projected_total_bytes"] == 93
     assert plan["selected_releases"][0]["files"][0]["sha256"] == "d" * 64
@@ -156,6 +205,7 @@ def test_main_writes_auditable_manifest(monkeypatch: pytest.MonkeyPatch, tmp_pat
     stdout = capsys.readouterr().out
     assert "DRY RUN" in stdout
     assert "never deletes releases" in stdout
+    assert f"Manifest SHA-256: {hashlib.sha256(output.read_bytes()).hexdigest()}" in stdout
 
 
 def test_main_rejects_unknown_keep_anchor(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -172,6 +222,133 @@ def test_main_rejects_unknown_keep_anchor(monkeypatch: pytest.MonkeyPatch) -> No
                 "0.19.44",
             ]
         )
+
+
+def test_main_checks_expected_count_before_max_delete_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = parse_project_state("dcc-mcp-core", project_payload())
+    monkeypatch.setattr(pypi_cleanup, "fetch_project_state", lambda _package: state)
+    with pytest.raises(CleanupError, match=r"expected 1 selected release.*found 4"):
+        pypi_cleanup.main(
+            [
+                "--package",
+                "dcc-mcp-core",
+                "--delete-below",
+                "0.19.90",
+                "--max-deletes",
+                "1",
+                "--expect-selected-count",
+                "1",
+            ]
+        )
+
+
+def test_main_rejects_delete_cap_that_truncates_expected_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = parse_project_state("dcc-mcp-core", project_payload())
+    monkeypatch.setattr(pypi_cleanup, "fetch_project_state", lambda _package: state)
+    with pytest.raises(CleanupError, match=r"expected 4 selected release.*delete cap retained 1"):
+        pypi_cleanup.main(
+            [
+                "--package",
+                "dcc-mcp-core",
+                "--delete-below",
+                "0.19.90",
+                "--max-deletes",
+                "1",
+                "--expect-selected-count",
+                "4",
+            ]
+        )
+
+
+def test_main_rejects_unexpected_selected_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = parse_project_state("dcc-mcp-core", project_payload())
+    monkeypatch.setattr(pypi_cleanup, "fetch_project_state", lambda _package: state)
+    with pytest.raises(CleanupError, match=r"expected 20 selected byte.*found 19"):
+        pypi_cleanup.main(
+            [
+                "--package",
+                "dcc-mcp-core",
+                "--delete-below",
+                "0.19.90",
+                "--keep-version",
+                "0.19.3",
+                "--keep-version",
+                "0.19.4",
+                "--keep-version",
+                "0.19.45",
+                "--expect-selected-total-bytes",
+                "20",
+            ]
+        )
+
+
+def test_main_rejects_github_backup_digest_drift(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    state = parse_project_state("dcc-mcp-core", project_payload())
+    monkeypatch.setattr(pypi_cleanup, "fetch_project_state", lambda _package: state)
+    monkeypatch.setattr(
+        pypi_cleanup,
+        "fetch_github_releases",
+        lambda _repository: github_release_payload("0" * 64),
+        raising=False,
+    )
+    output = tmp_path / "cleanup-plan.json"
+
+    with pytest.raises(CleanupError, match=r"GitHub backup verification failed.*digest mismatch"):
+        pypi_cleanup.main(
+            [
+                "--package",
+                "dcc-mcp-core",
+                "--delete-below",
+                "0.19.90",
+                "--keep-version",
+                "0.19.3",
+                "--keep-version",
+                "0.19.4",
+                "--keep-version",
+                "0.19.45",
+                "--github-repository",
+                "dcc-mcp/dcc-mcp-core",
+                "--output-json",
+                str(output),
+            ]
+        )
+    assert not output.exists()
+
+
+def test_main_records_verified_github_backup_evidence(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    state = parse_project_state("dcc-mcp-core", project_payload())
+    monkeypatch.setattr(pypi_cleanup, "fetch_project_state", lambda _package: state)
+    monkeypatch.setattr(pypi_cleanup, "fetch_github_releases", lambda _repository: github_release_payload())
+    output = tmp_path / "cleanup-plan.json"
+
+    result = pypi_cleanup.main(
+        [
+            "--package",
+            "dcc-mcp-core",
+            "--delete-below",
+            "0.19.90",
+            "--keep-version",
+            "0.19.3",
+            "--keep-version",
+            "0.19.4",
+            "--keep-version",
+            "0.19.45",
+            "--github-repository",
+            "dcc-mcp/dcc-mcp-core",
+            "--output-json",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+    manifest = json.loads(output.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == 2
+    backup = manifest["github_backup"]
+    assert backup["status"] == "verified"
+    assert backup["verified_at"].endswith("Z")
+    assert backup["release_count"] == 1
+    assert backup["file_count"] == 1
+    assert backup["releases"][0]["assets"][0]["asset_id"] == 123
 
 
 def test_main_refuses_to_select_latest(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_release_distribution_set.py
+++ b/tests/test_release_distribution_set.py
@@ -1,0 +1,135 @@
+"""Tests for immutable Core release distribution verification."""
+
+from __future__ import annotations
+
+from email.generator import BytesGenerator
+from email.message import Message
+import hashlib
+import io
+import json
+from pathlib import Path
+import tarfile
+import zipfile
+
+import pytest
+from scripts.ci import check_release_distribution_set
+from scripts.ci.check_release_distribution_set import DistributionSetError
+from scripts.ci.check_release_distribution_set import verify_distribution_set
+
+VERSION = "0.20.8"
+WHEEL_NAMES = [
+    f"dcc_mcp_core-{VERSION}-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    f"dcc_mcp_core-{VERSION}-cp37-cp37m-win_amd64.whl",
+    (f"dcc_mcp_core-{VERSION}-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"),
+    f"dcc_mcp_core-{VERSION}-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    f"dcc_mcp_core-{VERSION}-cp38-abi3-win_amd64.whl",
+    f"dcc_mcp_core-{VERSION}-py3-none-any.whl",
+]
+SDIST_NAME = f"dcc_mcp_core-{VERSION}.tar.gz"
+
+
+def _metadata_bytes(name: str, version: str) -> bytes:
+    message = Message()
+    message["Metadata-Version"] = "2.1"
+    message["Name"] = name
+    message["Version"] = version
+    buffer = io.BytesIO()
+    BytesGenerator(buffer).flatten(message)
+    return buffer.getvalue()
+
+
+def _write_fixture_set(dist_dir: Path) -> None:
+    dist_dir.mkdir()
+    for name in WHEEL_NAMES:
+        with zipfile.ZipFile(dist_dir / name, "w") as archive:
+            archive.writestr(
+                f"dcc_mcp_core-{VERSION}.dist-info/METADATA",
+                _metadata_bytes("dcc-mcp-core", VERSION),
+            )
+    pkg_info = _metadata_bytes("dcc-mcp-core", VERSION)
+    with tarfile.open(dist_dir / SDIST_NAME, "w:gz") as archive:
+        member = tarfile.TarInfo(f"dcc_mcp_core-{VERSION}/PKG-INFO")
+        member.size = len(pkg_info)
+        archive.addfile(member, io.BytesIO(pkg_info))
+
+
+def _asset_payload(dist_dir: Path) -> dict:
+    assets = []
+    for path in sorted(dist_dir.iterdir()):
+        data = path.read_bytes()
+        assets.append(
+            {
+                "name": path.name,
+                "size": len(data),
+                "digest": f"sha256:{hashlib.sha256(data).hexdigest()}",
+            }
+        )
+    return {"assets": assets}
+
+
+def test_verify_distribution_set_requires_all_seven_contracts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    _write_fixture_set(dist_dir)
+    payload = _asset_payload(dist_dir)
+    monkeypatch.setattr(check_release_distribution_set, "validate_wheel", lambda *_args: [])
+    monkeypatch.setattr(check_release_distribution_set, "load_contract", lambda: {})
+
+    evidence = verify_distribution_set(payload, dist_dir, VERSION)
+
+    assert evidence == {"asset_count": 7, "total_bytes": sum(path.stat().st_size for path in dist_dir.iterdir())}
+
+
+def test_verify_distribution_set_rejects_incomplete_release(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    _write_fixture_set(dist_dir)
+    missing = dist_dir / WHEEL_NAMES[0]
+    missing.unlink()
+    payload = _asset_payload(dist_dir)
+    monkeypatch.setattr(check_release_distribution_set, "validate_wheel", lambda *_args: [])
+    monkeypatch.setattr(check_release_distribution_set, "load_contract", lambda: {})
+
+    with pytest.raises(DistributionSetError, match="missing wheel contract"):
+        verify_distribution_set(payload, dist_dir, VERSION)
+
+
+def test_verify_distribution_set_rejects_digest_drift(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    _write_fixture_set(dist_dir)
+    payload = _asset_payload(dist_dir)
+    payload["assets"][0]["digest"] = f"sha256:{'0' * 64}"
+    monkeypatch.setattr(check_release_distribution_set, "validate_wheel", lambda *_args: [])
+    monkeypatch.setattr(check_release_distribution_set, "load_contract", lambda: {})
+
+    with pytest.raises(DistributionSetError, match="digest mismatch"):
+        verify_distribution_set(payload, dist_dir, VERSION)
+
+
+def test_verify_distribution_set_runs_existing_wheel_contract(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    _write_fixture_set(dist_dir)
+    payload = _asset_payload(dist_dir)
+    monkeypatch.setattr(check_release_distribution_set, "load_contract", lambda: {})
+    monkeypatch.setattr(
+        check_release_distribution_set,
+        "validate_wheel",
+        lambda *_args: ["synthetic contract drift"],
+    )
+
+    with pytest.raises(DistributionSetError, match="synthetic contract drift"):
+        verify_distribution_set(payload, dist_dir, VERSION)
+
+
+def test_cli_reads_release_asset_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    _write_fixture_set(dist_dir)
+    assets_json = tmp_path / "assets.json"
+    assets_json.write_text(json.dumps(_asset_payload(dist_dir)), encoding="utf-8")
+    monkeypatch.setattr(check_release_distribution_set, "validate_wheel", lambda *_args: [])
+    monkeypatch.setattr(check_release_distribution_set, "load_contract", lambda: {})
+
+    assert (
+        check_release_distribution_set.main(
+            ["--assets-json", str(assets_json), "--dist-dir", str(dist_dir), "--version", VERSION]
+        )
+        == 0
+    )

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -7,6 +7,8 @@ from dcc_mcp_core import yaml_loads
 
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
 PYPI_ACTION = "pypa/gh-action-pypi-publish@release/v1"
+GITHUB_RELEASE_ACTION = "softprops/action-gh-release@v3"
+CORE_BACKFILL_EXPRESSION = "github.event_name == 'workflow_dispatch' && inputs.release_tag != ''"
 
 
 def _release_jobs() -> dict:
@@ -16,6 +18,38 @@ def _release_jobs() -> dict:
 
 def _pypi_steps(job: dict) -> list[dict]:
     return [step for step in job.get("steps", []) if step.get("uses") == PYPI_ACTION]
+
+
+def _github_release_steps(jobs: dict) -> list[dict]:
+    return [step for job in jobs.values() for step in job.get("steps", []) if step.get("uses") == GITHUB_RELEASE_ACTION]
+
+
+def test_release_workflow_preserves_existing_github_release_assets() -> None:
+    steps = _github_release_steps(_release_jobs())
+    assert len(steps) == 3
+    for step in steps:
+        assert step["with"]["overwrite_files"] is False
+        assert step["with"]["fail_on_unmatched_files"] is True
+
+
+def test_release_workflow_manual_backfill_reuses_core_release_assets() -> None:
+    build_wheels = _release_jobs()["build-wheels"]
+    assert build_wheels["with"]["reuse-release-assets"] == (
+        "${{ github.event_name == 'workflow_dispatch' && inputs.release_tag != '' }}"
+    )
+
+
+def test_manual_backfill_is_explicitly_core_only() -> None:
+    jobs = _release_jobs()
+    for job_id in ("build-admin-ui", "build-binaries", "build-semantic-wheels"):
+        condition = jobs[job_id]["if"]
+        assert f"!({CORE_BACKFILL_EXPRESSION})" in condition
+
+    summary = jobs["publish"]["steps"][0]["run"]
+    assert f'core_backfill="${{{{ {CORE_BACKFILL_EXPRESSION} }}}}"' in summary
+    assert 'server" != "skipped"' in summary
+    assert 'semantic" != "skipped"' in summary
+    assert 'release_assets" != "skipped"' in summary
 
 
 def test_release_workflow_publishes_each_pypi_project_in_its_own_job() -> None:


### PR DESCRIPTION
## Summary
- preserve existing GitHub Release assets and make manual dispatch an immutable Core-only PyPI backfill
- verify the exact six-wheel plus sdist contract before publishing archived assets
- fail PyPI cleanup planning unless exact scope and GitHub size/SHA-256 backup evidence match

## Validation
- 83 related tests passed
- `vx just lint-py`
- `vx actionlint .github/workflows/build-wheels.yml .github/workflows/release.yml`
- real v0.20.8 Core set verified: 7 files, 127,942,645 bytes
- live cleanup planner correctly rejected the six drifted v0.19.36 wheels

Skill guidance unchanged: release automation only; no public API, adapter wiring, or skill authoring contract changed.