### PR TITLE
fix: unify tool result envelope contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,7 +339,7 @@ Gateway resources/prompts:
 | Skill validation | `validate_skill(skill_dir)` → `SkillValidationReport` |
 | Zero-dep JSON/YAML | `json_dumps/loads` / `yaml_dumps/loads` (Rust-powered) |
 | Canonical MCP/REST call envelopes | Rust `dcc-mcp-wire::{decode_call_tool, decode_rest_call, normalize_arguments, normalize_meta}`; Python wrappers `dcc_mcp_core.host.normalize_tool_arguments()` / `normalize_tool_meta()` |
-| Typed handler return envelope | `ToolResult.ok("msg", **ctx).to_dict()` / `ToolResult.fail("msg", error="code").to_dict()` from `dcc_mcp_core.result_envelope` — note the underscored aliases `success_`/`error_`; `success`/`error` are dataclass fields, **not** factories (#487) |
+| Typed handler return envelope | `ToolResultEnvelope.ok("msg", **ctx).to_dict()` / `ToolResultEnvelope.fail("msg", error="code").to_dict()` from `dcc_mcp_core.result_envelope`; `dcc_mcp_core.ToolResult` is the distinct Rust runtime model. Tool errors use a string code and structured details under `_meta["dcc.error"]` (#2183) |
 | Centralised metadata keys | `from dcc_mcp_core import METADATA_*, LAYER_*, CATEGORY_*` — re-exported at top level; also available from `dcc_mcp_core.constants`. Never inline `"dcc-mcp.recipes"` etc. (#487) |
 | Custom JSON-RPC method (Rust) | `MethodRouter::register(method, Arc::new(handler))` — implement `MethodHandler` trait (#492) |
 | Custom action validation (Rust) | implement `ValidationStrategy` and return it from `select_strategy(...)` (#493) |
@@ -443,7 +443,7 @@ restarts because the field is `#[serde(default)]`.
 4. **Register ALL handlers BEFORE `server.start()`** — server reads registry at startup
 5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** → sibling files, never top-level keys (v0.15+ / #356)
 6. **Use `dcc_mcp_core.METADATA_*` / `LAYER_*` / `CATEGORY_*`** → re-exported at top level (also in `constants` sub-module); no inline `"dcc-mcp.recipes"` / `"thin-harness"` literals (#487)
-7. **Return `ToolResult` from Python tool handlers** → `ToolResult.ok("...", **ctx).to_dict()` (or `success_(...)`); `success`/`error` are dataclass *fields*, the factories are `success_`/`error_` / `ok`/`fail` (#487)
+7. **Return `ToolResultEnvelope` from Python tool handlers** → `ToolResultEnvelope.ok("...", **ctx).to_dict()` (or `success_(...)`); `error` is a string code and structured diagnostics belong under namespaced `_meta` entries (#2183)
 8. **Gateway REST `/v1/call` / `/v1/call_batch` payloads accept only `tool_slug`, `arguments`, and `meta`** → put backend fields (`code`, `file_path`, `radius`, …) inside `arguments`; use `dcc-mcp-wire` / `dcc_mcp_core.host.normalize_tool_arguments()` for shared normalization
 9. **Lifecycle hooks — policy events propagate `HookDeny`, observation events swallow it** → `BEFORE_SKILL_LOAD`, `BEFORE_TOOL_CALL`, `BEFORE_SEARCH` are policy; all others are observation-only. Raising `HookDeny` from an observation event is silently logged (#1337)
 10. **Lifecycle hooks — `off()` removes by identity (`is`), not equality** → store the handler reference; `hooks.off(event, lambda ctx: ...)` never matches (#1337)
@@ -589,7 +589,7 @@ If a split is genuinely out-of-scope for the current PR:
 ```
 crates/          # Rust workspace; package membership comes from Cargo.toml
 python/dcc_mcp_core/__init__.py  # ← top-level Python public re-exports
-python/dcc_mcp_core/result_envelope.py  # ← typed ToolResult dataclass (#487)
+python/dcc_mcp_core/result_envelope.py  # ← typed ToolResultEnvelope wire builder (#2183)
 python/dcc_mcp_core/constants.py        # ← metadata key / layer / category constants (#487)
 python/dcc_mcp_core/_server/            # ← DccServerBase collaborators (observability, skill_query, window_resolver) (#486)
 tests/           # integration/regression tests
@@ -604,7 +604,7 @@ docs/            # human-readable guides + API reference
 ### Do ✅
 - Use `create_skill_server()` — Skills-First entry point
 - Use `success_result("msg", count=5)` — kwargs become context
-- Use `ToolResult.ok("...", **ctx).to_dict()` (or `.success_(...)`) from `result_envelope`; `.fail(msg, error="...")` for errors; `.not_found("Skill", name)` / `.invalid_input(msg)` for the common error codes (#487)
+- Use `ToolResultEnvelope.ok("...", **ctx).to_dict()` (or `.success_(...)`) from `result_envelope`; `.fail(msg, error="...")` for string error codes; structured details belong under `_meta` (#2183)
 - Import metadata strings from `dcc_mcp_core` (`METADATA_*`, `LAYER_*`, `CATEGORY_*` re-exported at top level; `dcc_mcp_core.constants.*` also works) (#487)
 - Use `ToolAnnotations` — safety hints for AI clients
 - Use `search_skills(query)` — don't guess tool names
@@ -622,7 +622,7 @@ docs/            # human-readable guides + API reference
 - Don't use `context=` kwarg in `success_result()` → **pass kwargs directly**
 - Don't call `ToolDispatcher.call()` → **use `.dispatch(name, json_str)`**
 - Don't put SKILL.md extensions at top level → **use `metadata.dcc-mcp.<feature>` + sibling file**
-- Don't hand-roll `{"success": ..., "context": ...}` dicts in handlers → **return `ToolResult.ok(...).to_dict()`** (the factory is `ok`/`success_`, NOT `success`) (#487)
+- Don't hand-roll `{"success": ..., "context": ...}` dicts in handlers → **return `ToolResultEnvelope.ok(...).to_dict()`** (the factory is `ok`/`success_`, not `success`) (#2183)
 - Don't write inline `"dcc-mcp.recipes"` / `"thin-harness"` literals → **import from `dcc_mcp_core`** (constants re-exported at top level) (#487)
 - Don't pass raw `&str` DCC names through Rust APIs → **`DccName::parse(s)` at the boundary** (#491)
 - Don't hardcode Maya as the default/example for generic core behavior → **use generic DCC examples or at least two DCCs in tests**

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -413,9 +413,11 @@ skills, skipped = scan_and_load(dcc_name="maya")
 for skill in scan_and_load(...):  # BREAKS - returns tuple, not list
 ```
 
-### 2. ToolResult Structure
+### 2. Tool Result Structures
 
-Always use the provided factories (`success_result`, `error_result`) — never hand-roll dicts:
+Server code uses the Rust-backed `ToolResult` factories. Dependency-light
+Python handlers use the distinct `ToolResultEnvelope` builder. Never hand-roll
+either structure:
 
 ```python
 from dcc_mcp_core import success_result, error_result
@@ -423,6 +425,14 @@ from dcc_mcp_core import success_result, error_result
 # ✓ CORRECT - use factories
 result = success_result("Created sphere", prompt="Add material next", count=5)
 # result.to_dict() -> {"success": True, "message": "...", "context": {"count": 5}}
+
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
+
+wire_result = ToolResultEnvelope.fail(
+    "Sphere creation failed",
+    error="invalid_radius",
+    _meta={"dcc.error": {"message": "radius must be positive"}},
+).to_dict()
 
 # ✗ WRONG - hand-rolled dict
 result = {"success": True, "message": "..."}  # Missing context, not forward-compatible
@@ -575,7 +585,7 @@ If you are uncertain whether a change affects py37 compatibility, ask. Never ass
 5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** → sibling files, never top-level extension keys
 6. **Use `dcc_mcp_core.METADATA_*` / `LAYER_*` / `CATEGORY_*`** → re-exported at top level
 7. **Gateway wrappers accept only `tool_slug`, `arguments`, `meta`** → backend inputs go inside `arguments`
-8. **Return `ToolResult` from Python tool handlers** → `ToolResult.ok("...", **ctx).to_dict()`
+8. **Return `ToolResultEnvelope` from Python tool handlers** → `ToolResultEnvelope.ok("...", **ctx).to_dict()`; use string error codes and `_meta["dcc.error"]` for details
 9. **Lifecycle hooks: policy events veto, observation events don't** → `BEFORE_*` events propagate `HookDeny`; `AFTER_*` events swallow it
 10. **Agent memory: `install()` is mandatory** → `MemoryRecorder` does nothing until wired to `LifecycleHooks` via `.install(hooks)`
 

--- a/crates/dcc-mcp-host-rpc/src/qtserver.rs
+++ b/crates/dcc-mcp-host-rpc/src/qtserver.rs
@@ -568,6 +568,25 @@ mod tests {
     }
 
     #[test]
+    fn interpret_envelope_keeps_domain_error_inside_result() {
+        let domain_result = json!({
+            "success": false,
+            "error": "RuntimeError",
+            "_meta": {
+                "dcc.error": {
+                    "type": "RuntimeError",
+                    "message": "host stopped",
+                },
+            },
+        });
+        let env = json!({"id": "req-domain-error", "result": domain_result.clone()});
+
+        let value = interpret_envelope(env, "maya_scene__create_sphere").unwrap();
+
+        assert_eq!(value, domain_result);
+    }
+
+    #[test]
     fn interpret_envelope_maps_dispatcher_error_to_transport_error() {
         let env = json!({
             "id": "req-2",

--- a/crates/dcc-mcp-models/src/action_result.rs
+++ b/crates/dcc-mcp-models/src/action_result.rs
@@ -104,7 +104,11 @@ pub enum SerializeFormat {
     MsgPack,
 }
 
-/// Internal Rust data representation (serde-friendly).
+/// Rust data representation (serde-friendly).
+///
+/// The public field layout is intentionally stable for downstream struct
+/// literals. Python-only top-level metadata is stored by [`ActionResultModel`]
+/// rather than adding a source-breaking field here.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ActionResultModelData {
@@ -115,7 +119,7 @@ pub struct ActionResultModelData {
     /// Optional prompt/hint for the next user action.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
-    /// Optional error message when `success` is `false`.
+    /// Stable machine-readable error code when `success` is `false`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     /// Arbitrary key-value context data (e.g. traceback, error_type).
@@ -209,6 +213,22 @@ impl ActionResultModelData {
     }
 }
 
+#[derive(Serialize)]
+struct ActionResultWireRef<'a> {
+    #[serde(flatten)]
+    data: &'a ActionResultModelData,
+    #[serde(rename = "_meta", skip_serializing_if = "HashMap::is_empty")]
+    meta: &'a HashMap<String, serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct ActionResultWireOwned {
+    #[serde(flatten)]
+    data: ActionResultModelData,
+    #[serde(rename = "_meta", default)]
+    meta: HashMap<String, serde_json::Value>,
+}
+
 /// Python-facing ToolResult.
 #[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
 #[cfg_attr(
@@ -218,19 +238,71 @@ impl ActionResultModelData {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ActionResultModel {
     pub(crate) inner: ActionResultModelData,
+    pub(crate) meta: HashMap<String, serde_json::Value>,
 }
 
 impl ActionResultModel {
     /// Create a `ToolResult` from raw data.
     #[must_use]
     pub fn from_data(data: ActionResultModelData) -> Self {
-        Self { inner: data }
+        Self {
+            inner: data,
+            meta: HashMap::new(),
+        }
+    }
+
+    /// Create a `ToolResult` from raw data and top-level metadata.
+    #[must_use]
+    pub fn from_data_with_meta(
+        data: ActionResultModelData,
+        meta: HashMap<String, serde_json::Value>,
+    ) -> Self {
+        Self { inner: data, meta }
     }
 
     /// Access the underlying data.
     #[must_use]
     pub fn data(&self) -> &ActionResultModelData {
         &self.inner
+    }
+
+    /// Access top-level `_meta` values without mixing them into context.
+    #[must_use]
+    pub fn meta(&self) -> &HashMap<String, serde_json::Value> {
+        &self.meta
+    }
+
+    /// Serialize the complete model, including top-level `_meta`.
+    pub fn to_bytes(&self, fmt: SerializeFormat) -> Result<Vec<u8>, String> {
+        let wire = ActionResultWireRef {
+            data: &self.inner,
+            meta: &self.meta,
+        };
+        match fmt {
+            SerializeFormat::Json => serde_json::to_vec(&wire).map_err(|e| e.to_string()),
+            SerializeFormat::MsgPack => rmp_serde::to_vec_named(&wire).map_err(|e| e.to_string()),
+        }
+    }
+
+    /// Deserialize the complete model, including top-level `_meta`.
+    pub fn from_bytes(data: &[u8], fmt: SerializeFormat) -> Result<Self, String> {
+        let wire: ActionResultWireOwned = match fmt {
+            SerializeFormat::Json => serde_json::from_slice(data).map_err(|e| e.to_string())?,
+            SerializeFormat::MsgPack => rmp_serde::from_slice(data).map_err(|e| e.to_string())?,
+        };
+        Ok(Self::from_data_with_meta(wire.data, wire.meta))
+    }
+
+    /// Serialize to compact JSON while applying the historical context limit.
+    pub fn to_json_string(&self) -> Result<String, String> {
+        let mut compacted = self.clone();
+        compacted.inner.context = compacted
+            .inner
+            .context
+            .iter()
+            .map(|(k, v)| (k.clone(), compact_json_value(v, 0, 3)))
+            .collect();
+        String::from_utf8(compacted.to_bytes(SerializeFormat::Json)?).map_err(|e| e.to_string())
     }
 }
 

--- a/crates/dcc-mcp-models/src/action_result_tests.rs
+++ b/crates/dcc-mcp-models/src/action_result_tests.rs
@@ -126,6 +126,8 @@ fn test_action_result_serialization() {
     assert!(json.contains("\"prompt\":\"next step\""));
     // Optional None fields are skipped
     assert!(!json.contains("\"error\""));
+    // Empty metadata does not change the legacy wire shape.
+    assert!(!json.contains("\"_meta\""));
 }
 
 #[test]
@@ -150,6 +152,68 @@ fn test_action_result_deserialize_minimal_json() {
     assert!(data.success); // default = true
     assert_eq!(data.message, "hello");
     assert!(data.error.is_none());
+}
+
+#[test]
+fn test_action_result_meta_round_trips_json_and_msgpack() {
+    let meta = HashMap::from([
+        (
+            "dcc.error".to_string(),
+            serde_json::json!({
+                "type": "RuntimeError",
+                "message": "host stopped",
+                "details": {"adapter": "maya", "retryable": false}
+            }),
+        ),
+        (
+            "vendor.trace".to_string(),
+            serde_json::json!(["frame-1", {"frame": 2}]),
+        ),
+    ]);
+    let model = ActionResultModel::from_data_with_meta(
+        ActionResultModelData {
+            success: false,
+            message: "Execution failed".to_string(),
+            error: Some("execution_error".to_string()),
+            context: HashMap::from([(
+                "action_name".to_string(),
+                serde_json::json!("create_sphere"),
+            )]),
+            ..Default::default()
+        },
+        meta.clone(),
+    );
+
+    for format in [SerializeFormat::Json, SerializeFormat::MsgPack] {
+        let encoded = model.to_bytes(format).unwrap();
+        let decoded = ActionResultModel::from_bytes(&encoded, format).unwrap();
+        assert_eq!(decoded, model);
+        assert_eq!(decoded.meta(), &meta);
+    }
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&model.to_bytes(SerializeFormat::Json).unwrap()).unwrap();
+    assert_eq!(json["_meta"], serde_json::json!(meta));
+    assert!(json.get("meta").is_none());
+}
+
+#[test]
+fn test_action_result_json_string_does_not_compact_meta() {
+    let deeply_nested = serde_json::json!({
+        "level_1": {"level_2": {"level_3": {"level_4": [1, 2, 3]}}}
+    });
+    let model = ActionResultModel::from_data_with_meta(
+        ActionResultModelData {
+            message: "metadata fidelity".to_string(),
+            context: HashMap::from([("deep".to_string(), deeply_nested.clone())]),
+            ..Default::default()
+        },
+        HashMap::from([("dcc.error".to_string(), deeply_nested.clone())]),
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&model.to_json_string().unwrap()).unwrap();
+    assert_eq!(json["_meta"]["dcc.error"], deeply_nested);
+    assert_ne!(json["context"]["deep"], deeply_nested);
 }
 
 // ── Context ─────────────────────────────────────────────────────────────────

--- a/crates/dcc-mcp-models/src/python/action_result.rs
+++ b/crates/dcc-mcp-models/src/python/action_result.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 #[cfg(feature = "stub-gen")]
-use pyo3_stub_gen_derive::gen_stub_pymethods;
+use pyo3_stub_gen_derive::{gen_stub_pyfunction, gen_stub_pymethods};
 
 use dcc_mcp_pybridge::py_json::{
     json_value_to_bound_py, py_any_to_json_value, py_dict_to_json_map,
@@ -25,7 +25,9 @@ const CTX_KEY_ERROR_TYPE: &str = "error_type";
 const CTX_KEY_TRACEBACK: &str = "traceback";
 const CTX_KEY_VALUE: &str = "value";
 const CTX_KEY_POSSIBLE_SOLUTIONS: &str = "possible_solutions";
-const ACTION_RESULT_KNOWN_KEYS: &[&str] = &["success", "message", "prompt", "error", "context"];
+const META_KEY_DCC_ERROR: &str = "dcc.error";
+const ACTION_RESULT_KNOWN_KEYS: &[&str] =
+    &["success", "message", "prompt", "error", "context", "_meta"];
 
 #[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
 #[pymethods]
@@ -38,29 +40,31 @@ impl SerializeFormat {
     }
 }
 
+#[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
 #[pymethods]
 impl ActionResultModel {
     #[new]
-    #[pyo3(signature = (success=true, message="".to_string(), prompt=None, error=None, context=None))]
+    #[pyo3(signature = (success=true, message="".to_string(), prompt=None, error=None, context=None, *, _meta=None))]
     fn new(
         success: bool,
         message: String,
         prompt: Option<String>,
         error: Option<String>,
         context: Option<&Bound<'_, PyDict>>,
+        _meta: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Self> {
-        let ctx = if let Some(dict) = context {
-            py_dict_to_json_map(dict)?
-        } else {
-            HashMap::new()
-        };
-        Ok(Self::from_data(ActionResultModelData {
-            success,
-            message,
-            prompt,
-            error,
-            context: ctx,
-        }))
+        let ctx = extract_context(context)?;
+        let meta = extract_context(_meta)?;
+        Ok(Self::from_data_with_meta(
+            ActionResultModelData {
+                success,
+                message,
+                prompt,
+                error,
+                context: ctx,
+            },
+            meta,
+        ))
     }
 
     #[getter]
@@ -97,6 +101,15 @@ impl ActionResultModel {
         Ok(dict)
     }
 
+    #[getter]
+    fn _meta<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        for (k, v) in self.meta() {
+            dict.set_item(k, json_value_to_bound_py(py, v)?)?;
+        }
+        Ok(dict)
+    }
+
     /// Create a new instance with error information.
     #[allow(clippy::double_must_use)]
     #[must_use]
@@ -104,7 +117,7 @@ impl ActionResultModel {
         let mut data = self.data().clone();
         data.success = false;
         data.error = Some(error);
-        Self::from_data(data)
+        Self::from_data_with_meta(data, self.meta().clone())
     }
 
     /// Create a new instance with updated context.
@@ -120,7 +133,7 @@ impl ActionResultModel {
                 data.context.insert(key, val);
             }
         }
-        Ok(Self::from_data(data))
+        Ok(Self::from_data_with_meta(data, self.meta().clone()))
     }
 
     /// Convert to dictionary.
@@ -131,32 +144,40 @@ impl ActionResultModel {
         dict.set_item("prompt", self.data().prompt.as_deref())?;
         dict.set_item("error", self.data().error.as_deref())?;
         dict.set_item("context", self.context(py)?)?;
+        if !self.meta().is_empty() {
+            dict.set_item("_meta", self._meta(py)?)?;
+        }
         Ok(dict)
     }
 
     /// Serialize to a JSON string.
     fn to_json(&self) -> PyResult<String> {
-        self.data()
-            .to_json_string()
+        self.to_json_string()
             .map_err(pyo3::exceptions::PyValueError::new_err)
     }
 
     /// Iterate over key-value pairs (mapping protocol).
-    fn __iter__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, pyo3::types::PyIterator>> {
+    fn __iter__(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = self.to_dict(py)?;
-        pyo3::types::PyIterator::from_object(&dict.into_any())
+        Ok(pyo3::types::PyIterator::from_object(&dict.into_any())?
+            .into_any()
+            .unbind())
     }
 
     /// Return the list of field names (part of the mapping protocol).
     fn keys<'py>(&self, py: Python<'py>) -> PyResult<Vec<String>> {
         let _ = py;
-        Ok(vec![
+        let mut keys = vec![
             "success".to_string(),
             "message".to_string(),
             "prompt".to_string(),
             "error".to_string(),
             "context".to_string(),
-        ])
+        ];
+        if !self.meta().is_empty() {
+            keys.push("_meta".to_string());
+        }
+        Ok(keys)
     }
 
     fn __repr__(&self) -> String {
@@ -202,6 +223,84 @@ fn insert_possible_solutions(
     }
 }
 
+fn insert_error_meta(
+    meta: &mut HashMap<String, serde_json::Value>,
+    error_type: &str,
+    message: &str,
+    traceback: Option<String>,
+) {
+    let mut details = serde_json::Map::from_iter([
+        (
+            "type".to_string(),
+            serde_json::Value::String(error_type.to_string()),
+        ),
+        (
+            "message".to_string(),
+            serde_json::Value::String(message.to_string()),
+        ),
+    ]);
+    if let Some(traceback) = traceback {
+        details.insert(
+            "traceback".to_string(),
+            serde_json::Value::String(traceback),
+        );
+    }
+    meta.insert(
+        META_KEY_DCC_ERROR.to_string(),
+        serde_json::Value::Object(details),
+    );
+}
+
+fn truncate_utf8_at_byte_limit(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
+}
+
+fn is_exception_error_code(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    let has_valid_syntax = (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'));
+    if !has_valid_syntax {
+        return false;
+    }
+
+    let leaf = value.rsplit('.').next().unwrap_or(value);
+    value.contains('_')
+        || value.contains('-')
+        || leaf.ends_with("Error")
+        || leaf.ends_with("Exception")
+        || matches!(
+            leaf,
+            "KeyboardInterrupt"
+                | "SystemExit"
+                | "GeneratorExit"
+                | "StopIteration"
+                | "StopAsyncIteration"
+        )
+}
+
+fn split_exception_message(error_message: &str) -> (String, String) {
+    if let Some((candidate, detail)) = error_message.split_once(':') {
+        let candidate = candidate.trim();
+        let detail = detail.trim();
+        if is_exception_error_code(candidate) && !detail.starts_with("//") {
+            return (candidate.to_string(), detail.to_string());
+        }
+    }
+
+    (DEFAULT_ERROR_TYPE.to_string(), error_message.to_string())
+}
+
 fn extract_bool_field(dict: &Bound<'_, PyDict>, key: &str, default: bool) -> PyResult<bool> {
     dict.get_item(key)?
         .map(|v| {
@@ -241,16 +340,19 @@ fn extract_optional_string_field(dict: &Bound<'_, PyDict>, key: &str) -> PyResul
         .map(|opt| opt.flatten())
 }
 
-fn extract_context_field(dict: &Bound<'_, PyDict>) -> PyResult<HashMap<String, serde_json::Value>> {
-    dict.get_item("context")?
+fn extract_dict_field(
+    dict: &Bound<'_, PyDict>,
+    key: &str,
+) -> PyResult<HashMap<String, serde_json::Value>> {
+    dict.get_item(key)?
         .map(|v| {
             if v.is_none() {
                 Ok(HashMap::new())
             } else {
-                let context = v.cast::<PyDict>().map_err(|_| {
-                    pyo3::exceptions::PyTypeError::new_err("'context' field must be a dict")
+                let value = v.cast::<PyDict>().map_err(|_| {
+                    pyo3::exceptions::PyTypeError::new_err(format!("'{key}' field must be a dict"))
                 })?;
-                py_dict_to_json_map(context)
+                py_dict_to_json_map(value)
             }
         })
         .transpose()
@@ -263,7 +365,8 @@ fn validate_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<ActionResultModel> {
     let prompt = extract_optional_string_field(dict, "prompt")?;
     let error = extract_optional_string_field(dict, "error")?;
 
-    let mut ctx = extract_context_field(dict)?;
+    let mut ctx = extract_dict_field(dict, "context")?;
+    let meta = extract_dict_field(dict, "_meta")?;
     for (k, v) in dict.iter() {
         if let Ok(key) = k.extract::<String>()
             && !ACTION_RESULT_KNOWN_KEYS.contains(&key.as_str())
@@ -272,94 +375,108 @@ fn validate_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<ActionResultModel> {
         }
     }
 
-    Ok(ActionResultModel::from_data(ActionResultModelData {
-        success,
-        message,
-        prompt,
-        error,
-        context: ctx,
-    }))
-}
-
-#[pyfunction]
-#[pyo3(name = "success_result")]
-#[pyo3(signature = (message, prompt=None, **context))]
-pub fn py_success_result(
-    message: String,
-    prompt: Option<String>,
-    context: Option<&Bound<'_, PyDict>>,
-) -> PyResult<ActionResultModel> {
-    let ctx = extract_context(context)?;
-    Ok(ActionResultModel::from_data(
-        ActionResultModelData::success(message, prompt, ctx),
+    Ok(ActionResultModel::from_data_with_meta(
+        ActionResultModelData {
+            success,
+            message,
+            prompt,
+            error,
+            context: ctx,
+        },
+        meta,
     ))
 }
 
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
+#[pyfunction]
+#[pyo3(name = "success_result")]
+#[pyo3(signature = (message, prompt=None, *, _meta=None, **context))]
+pub fn py_success_result(
+    message: String,
+    prompt: Option<String>,
+    _meta: Option<&Bound<'_, PyDict>>,
+    context: Option<&Bound<'_, PyDict>>,
+) -> PyResult<ActionResultModel> {
+    let ctx = extract_context(context)?;
+    let data = ActionResultModelData::success(message, prompt, ctx);
+    Ok(ActionResultModel::from_data_with_meta(
+        data,
+        extract_context(_meta)?,
+    ))
+}
+
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
 #[pyfunction]
 #[pyo3(name = "error_result")]
-#[pyo3(signature = (message, error, prompt=None, possible_solutions=None, **context))]
+#[pyo3(signature = (message, error, prompt=None, possible_solutions=None, *, _meta=None, **context))]
 pub fn py_error_result(
     message: String,
     error: String,
     prompt: Option<String>,
     possible_solutions: Option<Vec<String>>,
+    _meta: Option<&Bound<'_, PyDict>>,
     context: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<ActionResultModel> {
     let mut ctx = extract_context(context)?;
     insert_possible_solutions(&mut ctx, possible_solutions);
-    Ok(ActionResultModel::from_data(
-        ActionResultModelData::failure(message, Some(error), prompt, ctx),
+    let data = ActionResultModelData::failure(message, Some(error), prompt, ctx);
+    Ok(ActionResultModel::from_data_with_meta(
+        data,
+        extract_context(_meta)?,
     ))
 }
 
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
 #[pyfunction]
 #[pyo3(name = "from_exception")]
-#[pyo3(signature = (error_message, message=None, prompt=None, include_traceback=true, possible_solutions=None, **context))]
+#[pyo3(signature = (error_message, message=None, prompt=None, include_traceback=true, possible_solutions=None, *, _meta=None, **context))]
 pub fn py_from_exception(
     error_message: String,
     message: Option<String>,
     prompt: Option<String>,
     include_traceback: bool,
     possible_solutions: Option<Vec<String>>,
+    _meta: Option<&Bound<'_, PyDict>>,
     context: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<ActionResultModel> {
     let mut ctx = extract_context(context)?;
-    let error_type = error_message
-        .split_once(':')
-        .map(|(t, _)| t.trim().to_string())
-        .unwrap_or_else(|| DEFAULT_ERROR_TYPE.to_string());
-    ctx.insert(
-        CTX_KEY_ERROR_TYPE.to_string(),
-        serde_json::Value::String(error_type),
-    );
+    let (error_type, error_detail) = split_exception_message(&error_message);
     let msg = message.unwrap_or_else(|| format!("Error: {error_message}"));
-    if include_traceback {
-        let truncated_traceback = if error_message.len() > 1024 {
+    let traceback = include_traceback.then(|| {
+        if error_message.len() > 1024 {
             let trace_id = format!("err-{}", uuid::Uuid::new_v4());
             format!(
                 "{}... (truncated, see trace_id: {})",
-                &error_message[..1000.min(error_message.len())],
+                truncate_utf8_at_byte_limit(&error_message, 1000),
                 trace_id
             )
         } else {
             error_message.clone()
-        };
+        }
+    });
+    ctx.insert(
+        CTX_KEY_ERROR_TYPE.to_string(),
+        serde_json::Value::String(error_type.clone()),
+    );
+    if let Some(traceback) = &traceback {
         ctx.insert(
             CTX_KEY_TRACEBACK.to_string(),
-            serde_json::Value::String(truncated_traceback),
+            serde_json::Value::String(traceback.clone()),
         );
     }
     insert_possible_solutions(&mut ctx, possible_solutions);
-    Ok(ActionResultModel::from_data(
-        ActionResultModelData::failure(
-            msg,
-            Some(error_message),
-            Some(prompt.unwrap_or_else(|| DEFAULT_ERROR_PROMPT.to_string())),
-            ctx,
-        ),
-    ))
+    let data = ActionResultModelData::failure(
+        msg,
+        Some(error_type.clone()),
+        Some(prompt.unwrap_or_else(|| DEFAULT_ERROR_PROMPT.to_string())),
+        ctx,
+    );
+    let mut meta = extract_context(_meta)?;
+    insert_error_meta(&mut meta, &error_type, &error_detail, traceback);
+    Ok(ActionResultModel::from_data_with_meta(data, meta))
 }
 
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
 #[pyfunction]
 #[pyo3(name = "validate_action_result")]
 pub fn py_validate_action_result(result: &Bound<'_, PyAny>) -> PyResult<ActionResultModel> {
@@ -380,6 +497,7 @@ pub fn py_validate_action_result(result: &Bound<'_, PyAny>) -> PyResult<ActionRe
 }
 
 /// Serialize a `ToolResult` to a string (JSON) or bytes (MsgPack).
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
 #[pyfunction]
 #[pyo3(name = "serialize_result")]
 #[pyo3(signature = (result, format = SerializeFormat::Json))]
@@ -389,7 +507,6 @@ pub fn py_serialize_result(
     format: SerializeFormat,
 ) -> PyResult<Py<PyAny>> {
     let bytes = result
-        .data()
         .to_bytes(format)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;
     match format {
@@ -403,6 +520,7 @@ pub fn py_serialize_result(
 }
 
 /// Deserialize a `str` (JSON) or `bytes` (MsgPack) into a `ToolResult`.
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
 #[pyfunction]
 #[pyo3(name = "deserialize_result")]
 #[pyo3(signature = (data, format = SerializeFormat::Json))]
@@ -419,7 +537,191 @@ pub fn py_deserialize_result(
             "data must be str (JSON) or bytes (MsgPack)",
         ));
     };
-    let data = ActionResultModelData::from_bytes(&raw, format)
+    let data = ActionResultModel::from_bytes(&raw, format)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;
-    Ok(ActionResultModel::from_data(data))
+    Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::exceptions::PyTypeError;
+    use std::sync::Once;
+
+    fn initialize_python() {
+        static INITIALIZE: Once = Once::new();
+        INITIALIZE.call_once(Python::initialize);
+    }
+
+    #[test]
+    fn test_validate_to_dict_and_serialize_preserve_top_level_meta() {
+        initialize_python();
+        Python::attach(|py| -> PyResult<()> {
+            let error_details = PyDict::new(py);
+            error_details.set_item("type", "RuntimeError")?;
+            error_details.set_item("message", "host stopped")?;
+
+            let meta = PyDict::new(py);
+            meta.set_item("dcc.error", &error_details)?;
+
+            let context = PyDict::new(py);
+            context.set_item("action_name", "create_sphere")?;
+
+            let payload = PyDict::new(py);
+            payload.set_item("success", false)?;
+            payload.set_item("message", "Execution failed")?;
+            payload.set_item("error", "execution_error")?;
+            payload.set_item("context", &context)?;
+            payload.set_item("_meta", &meta)?;
+            payload.set_item("legacy_extra", 42)?;
+
+            let result = validate_from_dict(&payload)?;
+            assert_eq!(
+                result.meta()["dcc.error"],
+                serde_json::json!({"type": "RuntimeError", "message": "host stopped"})
+            );
+            assert!(!result.data().context.contains_key("_meta"));
+            assert_eq!(result.data().context["legacy_extra"], serde_json::json!(42));
+
+            let rendered = result.to_dict(py)?;
+            let rendered_json = py_dict_to_json_map(&rendered)?;
+            assert_eq!(
+                rendered_json["_meta"],
+                serde_json::json!({
+                    "dcc.error": {"type": "RuntimeError", "message": "host stopped"}
+                })
+            );
+            assert!(result.keys(py)?.contains(&"_meta".to_string()));
+
+            let serialized = py_serialize_result(py, &result, SerializeFormat::Json)?;
+            let serialized: String = serialized.bind(py).extract()?;
+            let serialized: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(serialized["_meta"], rendered_json["_meta"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_constructor_and_factory_keep_meta_outside_context() {
+        initialize_python();
+        Python::attach(|py| -> PyResult<()> {
+            let meta = PyDict::new(py);
+            meta.set_item("vendor.trace", "trace-42")?;
+
+            let constructed =
+                ActionResultModel::new(true, "Done".to_string(), None, None, None, Some(&meta))?;
+            assert_eq!(
+                constructed.meta()["vendor.trace"],
+                serde_json::json!("trace-42")
+            );
+            assert!(constructed.data().context.is_empty());
+
+            let failed = py_error_result(
+                "Execution failed".to_string(),
+                "execution_error".to_string(),
+                None,
+                None,
+                Some(&meta),
+                None,
+            )?;
+            assert_eq!(failed.meta(), constructed.meta());
+            assert!(failed.data().context.is_empty());
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_from_exception_uses_string_code_and_namespaced_meta() {
+        initialize_python();
+        Python::attach(|py| -> PyResult<()> {
+            let meta = PyDict::new(py);
+            meta.set_item("vendor.trace", "trace-42")?;
+
+            let result = py_from_exception(
+                "RuntimeError: host stopped".to_string(),
+                None,
+                None,
+                true,
+                None,
+                Some(&meta),
+                None,
+            )?;
+
+            assert_eq!(result.data().error.as_deref(), Some("RuntimeError"));
+            assert_eq!(
+                result.data().context[CTX_KEY_ERROR_TYPE],
+                serde_json::json!("RuntimeError")
+            );
+            assert_eq!(
+                result.data().context[CTX_KEY_TRACEBACK],
+                serde_json::json!("RuntimeError: host stopped")
+            );
+            assert_eq!(result.meta()["vendor.trace"], serde_json::json!("trace-42"));
+            assert_eq!(
+                result.meta()[META_KEY_DCC_ERROR],
+                serde_json::json!({
+                    "type": "RuntimeError",
+                    "message": "host stopped",
+                    "traceback": "RuntimeError: host stopped"
+                })
+            );
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_from_exception_truncates_utf8_on_character_boundary() {
+        initialize_python();
+        for (unit, count, expected_prefix_count) in [("错", 342, 333), ("🙂", 260, 250)] {
+            let result =
+                py_from_exception(unit.repeat(count), None, None, true, None, None, None).unwrap();
+
+            let traceback = result.data().context[CTX_KEY_TRACEBACK]
+                .as_str()
+                .expect("traceback must be a string");
+            assert!(traceback.starts_with(&format!("{}...", unit.repeat(expected_prefix_count))));
+            assert!(traceback.contains("truncated, see trace_id"));
+        }
+    }
+
+    #[test]
+    fn test_from_exception_rejects_human_text_and_windows_drive_as_error_codes() {
+        initialize_python();
+        for message in [
+            r"C:\scene.ma: access denied",
+            "C:scene.ma: access denied",
+            "https://example.invalid/file: failed",
+            "dcc-mcp://host/tool: failed",
+            "Could not open: file",
+        ] {
+            let result =
+                py_from_exception(message.to_string(), None, None, false, None, None, None)
+                    .unwrap();
+
+            assert_eq!(result.data().error.as_deref(), Some(DEFAULT_ERROR_TYPE));
+            assert_eq!(
+                result.meta()[META_KEY_DCC_ERROR]["message"],
+                serde_json::json!(message)
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_non_dict_meta() {
+        initialize_python();
+        Python::attach(|py| -> PyResult<()> {
+            let payload = PyDict::new(py);
+            payload.set_item("success", false)?;
+            payload.set_item("_meta", "not-a-dict")?;
+
+            let error = validate_from_dict(&payload).unwrap_err();
+            assert!(error.is_instance_of::<PyTypeError>(py));
+            assert!(error.to_string().contains("'_meta' field must be a dict"));
+            Ok(())
+        })
+        .unwrap();
+    }
 }

--- a/docs/adr/022-canonical-tool-result-envelope.md
+++ b/docs/adr/022-canonical-tool-result-envelope.md
@@ -1,0 +1,71 @@
+# Canonical Tool Result Envelope
+
+Status: Accepted
+
+## Context
+
+Python tool handlers exposed three incompatible result shapes. The pure-Python
+builder used a string `error` and omitted empty fields, skill helpers used a
+string `error` and retained empty fields, while in-process execution returned a
+mapping in `error`. The public name `ToolResult` also referred both to the
+Rust-backed runtime model and to the unrelated pure-Python wire builder.
+
+Consumers therefore could not safely interpret `error`, and native validation
+moved an otherwise valid top-level `_meta` object into `context` while the
+source-only Python path preserved it.
+
+## Decision
+
+- `dcc_mcp_core.ToolResult` remains the Rust-backed runtime model.
+- The pure-Python wire builder is named `ToolResultEnvelope`. The legacy
+  `dcc_mcp_core.result_envelope.ToolResult` import remains as a deprecated,
+  behavior-compatible wrapper for one migration window.
+- Every domain tool result uses the same fields: `success`, `message`, `error`,
+  `prompt`, `context`, and optional `_meta`.
+- `error` is either a stable string code or `None`. Structured error details
+  use the namespaced `_meta["dcc.error"]` object; raw call diagnostics continue
+  to use `_meta["dcc.raw_trace"]`.
+- The Rust model preserves `_meta` during validation and JSON/MessagePack
+  serialization without changing the public `ActionResultModelData` struct
+  layout. Skill subprocesses use the dependency-light normalizer and standard
+  library JSON in every installation so native and source-only projections are
+  identical, including tuples and integers outside the serde 64-bit range.
+- Field presence is a projection concern. The general builder omits empty
+  fields by default, while released skill helpers retain their historical
+  fixed-key projection for compatibility.
+- Exception helpers mirror their released diagnostic context keys for one
+  migration window, but `_meta["dcc.error"]` is the canonical structured
+  location for new consumers.
+- JSON-RPC and host-RPC transport errors remain separate outer envelopes. A
+  domain tool result may be nested under a transport `result`, but it must not
+  replace the transport's `{result}` / `{error}` contract.
+
+## Consequences
+
+- Consumers may always treat a non-null `error` as a string and inspect `_meta`
+  only when structured diagnostics are needed.
+- Existing skill scripts that index `error`, `prompt`, or `context` directly
+  keep working.
+- Existing Rust callers may continue constructing `ActionResultModelData` with
+  exhaustive struct literals; metadata is held privately by `ActionResultModel`.
+  Existing JSON and MessagePack payloads remain compatible.
+- New code must use the unambiguous `ToolResultEnvelope` name for wire
+  dictionaries.
+
+## Alternatives considered
+
+### Keep structured mappings in `error`
+
+Rejected because it preserves the consumer ambiguity that prompted the
+decision and conflicts with the established Rust and skill-helper contracts.
+
+### Normalize only in the pure-Python serializer
+
+Rejected because native validation would still relocate `_meta`, leaving two
+wire contracts depending on whether the compiled extension is installed.
+
+### Rename the Rust-backed `ToolResult`
+
+Rejected because it is the established top-level public API and the return type
+of runtime factories and deserializers. Renaming the smaller pure-Python surface
+has a bounded compatibility path.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,7 @@ Decision / Consequences / Alternatives considered.
 | 019 | [Build reproducible agent experiments on the session timeline](./019-reproducible-agent-experiments.md) | Proposed |
 | 020 | [Consume application control through standalone dcc-cua](./020-external-cua-runtime.md) | Accepted |
 | 021 | [Use content-addressed revisions for cross-DCC asset sync](./021-content-addressed-asset-sync.md) | Accepted |
+| 022 | [Canonical Tool Result Envelope](./022-canonical-tool-result-envelope.md) | Accepted |
 
 > Numbering is strictly sequential and never reused. ADR 001 is reserved for
 > the first historical record; filling it in is tracked separately from any

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -11,8 +11,9 @@ Standardized result for all action executions. Backed by a Rust struct via PyO3.
 | `success` | `bool` | `True` | Whether the execution was successful |
 | `message` | `str` | `""` | Human-readable result description |
 | `prompt` | `Optional[str]` | `None` | Suggestion for AI about next steps |
-| `error` | `Optional[str]` | `None` | Error message when `success` is `False` |
+| `error` | `Optional[str]` | `None` | Stable string error code when `success` is `False` |
 | `context` | `Dict[str, Any]` | `{}` | Additional context data |
+| `_meta` | `Dict[str, Any]` | `{}` | Namespaced structured metadata such as `dcc.error` |
 
 ### Methods
 
@@ -52,11 +53,16 @@ json_str = serialize_result(result)
 from dcc_mcp_core import success_result, error_result, from_exception, validate_action_result, ToolResult
 
 # Success result with context
-result = success_result("Created 5 spheres", prompt="Use modify_spheres next", count=5)
+result = success_result(
+    "Created 5 spheres",
+    prompt="Use modify_spheres next",
+    _meta={"vendor.trace": {"id": "42"}},
+    count=5,
+)
 
 # Error result with possible solutions
 error = error_result(
-    "Failed", "File not found",
+    "Failed", "file_not_found",
     prompt="Check path",
     possible_solutions=["Verify file exists", "Check permissions"],
     path="/bad/path",
@@ -68,6 +74,8 @@ exc_result = from_exception(
     message="Import failed",
     include_traceback=True,
 )
+# exc_result.error == "ValueError"
+# exc_result._meta["dcc.error"]["message"] == "bad input"
 
 # Validate/normalize any value to ToolResult
 validate_action_result(result)                          # pass-through
@@ -79,9 +87,9 @@ validate_action_result("hello")                         # wrap as success
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `success_result` | `(message, prompt=None, **context) -> ToolResult` | Create a successful result |
-| `error_result` | `(message, error, prompt=None, possible_solutions=None, **context) -> ToolResult` | Create a failed result |
-| `from_exception` | `(error_message, message=None, prompt=None, include_traceback=True, possible_solutions=None, **context) -> ToolResult` | Wrap an exception as a result |
+| `success_result` | `(message, prompt=None, *, _meta=None, **context) -> ToolResult` | Create a successful result |
+| `error_result` | `(message, error, prompt=None, possible_solutions=None, *, _meta=None, **context) -> ToolResult` | Create a failed result |
+| `from_exception` | `(error_message, message=None, prompt=None, include_traceback=True, possible_solutions=None, *, _meta=None, **context) -> ToolResult` | Wrap an exception as a result |
 | `validate_action_result` | `(result: Any) -> ToolResult` | Normalize dict/str/None/ToolResult → ToolResult |
 
 ## SkillMetadata

--- a/docs/api/skills.md
+++ b/docs/api/skills.md
@@ -751,6 +751,7 @@ skill_success(
     message: str,
     *,
     prompt: str | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context,
 ) -> dict
 ```
@@ -761,6 +762,7 @@ Return a success result dict.
 |-----------|------|-------------|
 | `message` | `str` | Human-readable summary of what was accomplished |
 | `prompt` | `str \| None` | Optional hint for the agent's next action |
+| `_meta` | `Mapping[str, Any] \| None` | Optional namespaced top-level metadata |
 | `**context` | `Any` | Arbitrary key/value pairs attached to `context` |
 
 ```python
@@ -783,6 +785,7 @@ skill_error(
     *,
     prompt: str | None = None,
     possible_solutions: list[str] | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context,
 ) -> dict
 ```
@@ -792,14 +795,15 @@ Return a failure result dict.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `message` | `str` | User-facing description of what went wrong |
-| `error` | `str` | Technical error string (exception repr, code …) |
+| `error` | `str` | Stable machine-readable error code; put exception details under `_meta["dcc.error"]` |
 | `prompt` | `str \| None` | Recovery hint; defaults to a generic message |
 | `possible_solutions` | `list[str] \| None` | Actionable suggestions in `context["possible_solutions"]` |
+| `_meta` | `Mapping[str, Any] \| None` | Optional namespaced top-level metadata |
 
 ```python
 return skill_error(
     "Maya is not available",
-    "ImportError: No module named 'maya'",
+    "import_error",
     prompt="Ensure Maya is running before calling this skill.",
     possible_solutions=["Start Maya", "Check DCC_MCP_MAYA_SKILL_PATHS"],
 )
@@ -815,6 +819,7 @@ skill_warning(
     *,
     warning: str = "",
     prompt: str | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context,
 ) -> dict
 ```
@@ -842,12 +847,16 @@ skill_exception(
     prompt: str | None = None,
     include_traceback: bool = True,
     possible_solutions: list[str] | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context,
 ) -> dict
 ```
 
-Return a failure result built from an exception. Captures `error_type` and optionally
-the formatted traceback in `context`.
+Return a failure result built from an exception. The string `error` is the
+exception type; the message and optional formatted traceback are stored in
+`_meta["dcc.error"]`. Caller metadata is merged by namespace. The legacy
+`context.error_type` and `context.traceback` mirrors remain for one migration
+window.
 
 ```python
 try:
@@ -1021,17 +1030,17 @@ assert roundtrip.context["frame_count"] == 240
 
 ### How `run_main` uses serialization
 
-`run_main()` automatically uses `serialize_result` when `_core` is available,
-falling back to `json.dumps` in pure-Python environments:
+`run_main()` always normalizes through the dependency-light
+`ToolResultEnvelope` and emits JSON with the standard library. Using one path
+keeps native-wheel and source-only skill subprocess payloads identical:
 
 ```
 result dict
-    ↓ validate_action_result()  (type-safe validation)
-ToolResult
-    ↓ serialize_result(arm, SerializeFormat.Json)   (Rust JSON writer)
+    ↓ ToolResultEnvelope.from_dict()  (schema validation)
+canonical mapping
+    ↓ json.dumps(..., allow_nan=False)
 JSON string → stdout
 ```
 
-To switch to MessagePack in a future release, only `_serialize_result()` in
-`skill.py` needs updating — the `serialize_result` / `deserialize_result` API
-remains stable.
+The Rust-backed `serialize_result` / `deserialize_result` functions remain the
+explicit JSON/MessagePack API for runtime `ToolResult` objects.

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -158,17 +158,23 @@ print(result.context)   # {"object_name": "sphere1", "position": [0, 0, 0]}
 # Error
 result = error_result(
     message="Failed to create sphere",
-    error="Maya API error: object already exists",
+    error="object_already_exists",
+    _meta={
+        "dcc.error": {
+            "type": "MayaApiError",
+            "message": "object already exists",
+        }
+    },
     object_name="sphere1",
 )
 print(result.success)  # False
-print(result.error)    # "Maya API error: object already exists"
+print(result.error)    # "object_already_exists"
 
 # From exception
 try:
     raise RuntimeError("connection refused")
-except Exception:
-    result = from_exception("Connection to Maya lost")
+except Exception as exc:
+    result = from_exception(f"{type(exc).__name__}: {exc}")
     print(result.success)  # False
 ```
 

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -223,30 +223,34 @@ tools with `execution: async` and poll `jobs_get_status`.
 This includes `register_diagnostic_mcp_tools(...)` for instance-bound diagnostics —
 register them before calling `server.start()`, never after.
 
-**Return `ToolResult` from Python tool handlers (#487) — never hand-roll the dict:**
+**Return `ToolResultEnvelope` from Python tool handlers (#2183) — never hand-roll the dict:**
 ```python
-from dcc_mcp_core.result_envelope import ToolResult
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 # ✓ typed envelope; serialises to the same wire shape clients already see.
 # Factory methods are `success_` / `error_` (trailing underscore avoids
 # shadowing the dataclass fields), with shorter aliases `ok` / `fail`.
-return ToolResult.ok("Loaded skill", name=name).to_dict()
-return ToolResult.fail("Skill missing", error="not_found",
-                       prompt="Try `recipes__list`.").to_dict()
-# `ToolResult.not_found("Skill", name)` and `ToolResult.invalid_input(msg)`
+return ToolResultEnvelope.ok("Loaded skill", name=name).to_dict()
+return ToolResultEnvelope.fail("Skill missing", error="not_found",
+                               prompt="Try `recipes__list`.").to_dict()
+# `ToolResultEnvelope.not_found("Skill", name)` and
+# `ToolResultEnvelope.invalid_input(msg)`
 # are convenience constructors for the two most common error codes.
 
 # ✗ ad-hoc dict — no field validation, drifts when the wire shape evolves
 return {"success": True, "message": "...", "context": {"name": name}}
 ```
-The dataclass mirrors the Rust `ToolResult` model; empty fields are pruned
-by `.to_dict()` so feature-flag toggles do not perturb the JSON envelope.
+The dataclass shares the Rust `ToolResult` wire schema but is a distinct,
+dependency-light builder. Empty fields are pruned by `.to_dict()` by default;
+skill helpers intentionally retain their historical fixed-key projection.
+`error` is a string code; structured details belong under `_meta["dcc.error"]`.
 
-> **Trap (#487):** there is no `ToolResult.success(...)` / `ToolResult.error(...)`
+> **Trap (#2183):** there is no `ToolResultEnvelope.success(...)` /
+> `ToolResultEnvelope.error(...)`
 > classmethod — `success` and `error` are *dataclass fields*, so the factories
 > are spelled `success_` / `error_` (or the cleaner aliases `ok` / `fail`).
-> Calling `ToolResult.success("...")` raises
-> `AttributeError: type object 'ToolResult' has no attribute 'success'`.
+> Top-level `dcc_mcp_core.ToolResult` is the Rust runtime model, not this wire
+> builder.
 
 **Import metadata key strings from `constants.py` (#487):**
 ```python
@@ -375,7 +379,8 @@ annotations = ToolAnnotations(
     deferred_hint=None,        # full schema deferred until load_skill (set by server, not user)
 )
 # Design tools around user workflows, not raw API calls.
-# Return human-readable errors via error_result("msg", "specific error").
+# Put human-readable detail in message/_meta and pass a stable code as error.
+# Example: error_result("File was not found", "file_not_found").
 # Use notifications/tools/list_changed when the tool set changes.
 ```
 
@@ -787,7 +792,8 @@ Strict input/output schemas, explicit side effects, documented errors.
 
 - Every tool MUST have an `input_schema` (JSON Schema) with per-parameter
   descriptions (≤100 chars each).
-- Every tool handler MUST return `ToolResult` — never raw dicts.
+- Every Python tool handler MUST return a `ToolResultEnvelope` mapping (usually
+  through `skill_success` / `skill_error`) — never a hand-rolled dict.
 - Every error MUST include an actionable `prompt` suggesting a recovery step.
 
 ### Safety Annotations
@@ -848,17 +854,17 @@ description: "Create geometry."
 Every tool should provide structured error recovery:
 
 ```python
-from dcc_mcp_core import error_result, ToolResult
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 # ✓ Good — specific error code + actionable prompt
-return ToolResult.fail(
+return ToolResultEnvelope.fail(
     "Sphere creation failed",
     error="invalid_radius",
     prompt="Radius must be positive. Try create_sphere with radius=1.0.",
 ).to_dict()
 
 # ✗ Bad — generic error, no guidance
-return ToolResult.fail("Error", error="failed").to_dict()
+return ToolResultEnvelope.fail("Error", error="failed").to_dict()
 ```
 
 ### Stateless by Default
@@ -962,7 +968,10 @@ return client.call(params["service"], **params.get("arguments", {}))
 ```python
 hint = params.get("_meta", {}).get("permission_hint", "read-write")
 if hint == "read-only" and params.get("action") == "delete":
-    return error_result("action 'delete' denied: permission_hint is 'read-only'")
+    return error_result(
+        "Action 'delete' denied: permission_hint is 'read-only'",
+        "permission_denied",
+    )
 ```
 
 **Pattern 3: Project-scoped data isolation** — filter results by

--- a/docs/guide/capabilities.md
+++ b/docs/guide/capabilities.md
@@ -158,11 +158,15 @@ tool context:
 ```python
 def import_usd(path: str, _workspace_roots=None):
     if _workspace_roots is None:
-        return error_result("import_usd", "no workspace roots advertised")
+        return error_result("No workspace roots advertised", "missing_workspace_roots")
     try:
         resolved = _workspace_roots.resolve(path)
     except ValueError as e:
-        return error_result("import_usd", str(e))
+        return error_result(
+            "Import path is invalid",
+            "invalid_path",
+            _meta={"dcc.error": {"type": type(e).__name__, "message": str(e)}},
+        )
     # ...continue with `resolved` as an absolute PathBuf-equivalent
 ```
 

--- a/docs/guide/custom-actions.md
+++ b/docs/guide/custom-actions.md
@@ -68,7 +68,11 @@ def create_sphere(radius: float = 1.0, name: str | None = None):
             radius=radius,
         )
     except Exception as e:
-        return error_result("Failed to create sphere", str(e))
+        return error_result(
+            "Failed to create sphere",
+            "sphere_creation_failed",
+            _meta={"dcc.error": {"type": type(e).__name__, "message": str(e)}},
+        )
 ```
 
 ### Step 3: Register via Environment Variable and Start

--- a/docs/guide/dcc-thread-safety.md
+++ b/docs/guide/dcc-thread-safety.md
@@ -347,7 +347,7 @@ for the planned cooperative-cancellation primitive.
 ```python
 for batch in chunks(primitives, size=500):
     if job.check_cancelled():           # #329
-        return skill_error("Cancelled by user")
+        return skill_error("Cancelled by user", "cancelled")
     create_primitives(batch)
     # control returns to DCC between batches
 ```

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -114,7 +114,7 @@ print(result.success)   # True
 print(result.context)   # {"name": "sphere1"}
 
 # Error
-result = error_result("Failed to create sphere", error="No active scene")
+result = error_result("Failed to create sphere", error="no_active_scene")
 print(result.success)   # False
 
 # From exception

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -246,7 +246,7 @@ print(result.success)  # True
 print(result.message)  # "Created 5 spheres"
 print(result.context)  # {"count": 5}
 
-err = error_result("Failed", "File not found", prompt="Check path")
+err = error_result("Failed", "file_not_found", prompt="Check path")
 print(err.success)  # False
 ```
 
@@ -403,7 +403,7 @@ When building tools for AI agents to consume:
 
 1. **Design around user workflows**, not raw API calls. A tool called `create_character` is better than three separate calls to `create_joint`, `bind_skin`, `apply_animation`.
 2. **Use `ToolAnnotations`** to signal safety properties — `read_only_hint=True`, `destructive_hint=False`, `idempotent_hint=True` — so AI clients make informed choices.
-3. **Return human-readable errors** via `error_result("msg", "specific error")` with actionable suggestions in `prompt`.
+3. **Return stable error codes** via `error_result("human-readable message", "machine_code")`, put structured diagnostics in `_meta`, and provide actionable suggestions in `prompt`.
 4. **Use `next-tools`** inside sibling `tools.yaml` declarations to guide AI agents to follow-up tools (e.g. `on-failure: [dcc_diagnostics__screenshot]`).
 5. **Keep `tools/list` small** by using tool groups with `default_active=false` for power-user features. Agents activate groups on demand.
 6. **Validate all AI-provided inputs** with `ToolValidator.from_schema_json()` before execution — never trust LLM output blindly.
@@ -419,7 +419,7 @@ Before registering a new tool, verify:
 - [ ] **Single responsibility**: Tool does one clear thing (not a kitchen-sink endpoint)
 - [ ] **Descriptive name**: Follows `{skill}__{action}` naming; self-explanatory action
 - [ ] **Input schema**: JSON Schema with per-parameter descriptions (≤100 chars each)
-- [ ] **Output schema**: Returns `ToolResult` via `ToolResult.ok()` / `ToolResult.fail()` — never raw dicts
+- [ ] **Output schema**: Python handlers return `ToolResultEnvelope` via `.ok()` / `.fail()` (or `skill_success` / `skill_error`) — never hand-rolled dicts
 - [ ] **ToolAnnotations**: Set `read_only_hint`, `destructive_hint`, `idempotent_hint`, `open_world_hint`
 - [ ] **Error taxonomy**: Document error codes in `error_result()` with actionable `prompt` suggestions
 - [ ] **Follow-up guidance**: `next-tools.on-success` for the logical next step; `next-tools.on-failure` pointing to diagnostics

--- a/docs/guide/thin-harness.md
+++ b/docs/guide/thin-harness.md
@@ -115,7 +115,7 @@ tools:
 ```python
 from __future__ import annotations
 
-from dcc_mcp_core import skill_entry, skill_success, skill_error
+from dcc_mcp_core import skill_entry, skill_success, skill_error_with_trace
 
 
 @skill_entry
@@ -137,10 +137,11 @@ def execute_python(code: str, timeout_secs: int = 30) -> dict:
         output = local_ns.get("result", None)
         return skill_success("Script executed", output=output)
     except Exception as exc:  # noqa: BLE001
-        return skill_error(
+        return skill_error_with_trace(
             f"Script raised {type(exc).__name__}: {exc}",
+            "script_execution_failed",
             underlying_call=code[:200],
-            traceback=traceback.format_exc(),
+            tb=traceback.format_exc(),
         )
 ```
 

--- a/docs/guide/what-is-dcc-mcp-core.md
+++ b/docs/guide/what-is-dcc-mcp-core.md
@@ -118,7 +118,7 @@ dcc-mcp-core/
     └── dcc_mcp_core/
         ├── __init__.py              # public API re-exports from _core
         ├── constants.py             # METADATA_*, LAYER_*, CATEGORY_* (#487)
-        ├── result_envelope.py       # ToolResult factories (#487)
+        ├── result_envelope.py       # dependency-light ToolResultEnvelope builder
         ├── _server/                 # DccServerBase collaborators (#486)
         └── _core.pyi                # type stubs for every public API
 ```

--- a/docs/zh/api/models.md
+++ b/docs/zh/api/models.md
@@ -11,8 +11,9 @@
 | `success` | `bool` | `True` | 执行是否成功 |
 | `message` | `str` | `""` | 人类可读的结果描述 |
 | `prompt` | `Optional[str]` | `None` | 给 AI 的下一步建议 |
-| `error` | `Optional[str]` | `None` | `success` 为 `False` 时的错误消息 |
+| `error` | `Optional[str]` | `None` | `success` 为 `False` 时的稳定字符串错误代码 |
 | `context` | `Dict[str, Any]` | `{}` | 附加上下文数据 |
+| `_meta` | `Dict[str, Any]` | `{}` | 命名空间化的结构化元数据，例如 `dcc.error` |
 
 ### 方法
 
@@ -49,14 +50,19 @@ json_str = serialize_result(result)
 ### 工厂函数
 
 ```python
-from dcc_mcp_core import success_result, error_result, from_exception, validate_action_result
+from dcc_mcp_core import success_result, error_result, from_exception, validate_action_result, ToolResult
 
 # 带上下文的成功结果
-result = success_result("创建了 5 个球体", prompt="使用 modify_spheres", count=5)
+result = success_result(
+    "创建了 5 个球体",
+    prompt="使用 modify_spheres",
+    _meta={"vendor.trace": {"id": "42"}},
+    count=5,
+)
 
 # 带可能解决方案的错误结果
 error = error_result(
-    "失败", "文件未找到",
+    "失败", "file_not_found",
     prompt="检查路径",
     possible_solutions=["确认文件存在", "检查权限"],
     path="/bad/path",
@@ -68,6 +74,8 @@ exc_result = from_exception(
     message="导入失败",
     include_traceback=True,
 )
+# exc_result.error == "ValueError"
+# exc_result._meta["dcc.error"]["message"] == "bad input"
 
 # 验证/规范化任意值为 ToolResult
 validate_action_result(result)                          # 直接通过
@@ -79,9 +87,9 @@ validate_action_result("hello")                         # 包装为成功结果
 
 | 函数 | 签名 | 说明 |
 |------|------|------|
-| `success_result` | `(message, prompt=None, **context) -> ToolResult` | 创建成功结果 |
-| `error_result` | `(message, error, prompt=None, possible_solutions=None, **context) -> ToolResult` | 创建失败结果 |
-| `from_exception` | `(error_message, message=None, prompt=None, include_traceback=True, possible_solutions=None, **context) -> ToolResult` | 将异常包装为结果 |
+| `success_result` | `(message, prompt=None, *, _meta=None, **context) -> ToolResult` | 创建成功结果 |
+| `error_result` | `(message, error, prompt=None, possible_solutions=None, *, _meta=None, **context) -> ToolResult` | 创建失败结果 |
+| `from_exception` | `(error_message, message=None, prompt=None, include_traceback=True, possible_solutions=None, *, _meta=None, **context) -> ToolResult` | 将异常包装为结果 |
 | `validate_action_result` | `(result: Any) -> ToolResult` | 规范化 dict/str/None/ARM → ToolResult |
 
 ## SkillMetadata

--- a/docs/zh/api/skills.md
+++ b/docs/zh/api/skills.md
@@ -621,6 +621,7 @@ skill_success(
     message: str,
     *,
     prompt: str | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context,
 ) -> dict
 ```
@@ -631,6 +632,7 @@ skill_success(
 |------|------|------|
 | `message` | `str` | 人类可读的执行摘要 |
 | `prompt` | `str \| None` | Agent 下一步操作的提示（可选）|
+| `_meta` | `Mapping[str, Any] \| None` | 可选的命名空间化顶层元数据 |
 | `**context` | `Any` | 附加到 `context` 的任意键值对 |
 
 ```python
@@ -653,6 +655,7 @@ skill_error(
     *,
     prompt: str | None = None,
     possible_solutions: list[str] | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context,
 ) -> dict
 ```
@@ -662,14 +665,15 @@ skill_error(
 | 参数 | 类型 | 说明 |
 |------|------|------|
 | `message` | `str` | 面向用户的错误描述 |
-| `error` | `str` | 技术错误字符串（异常 repr、错误码等）|
+| `error` | `str` | 稳定、机器可读的错误码；异常详情放在 `_meta["dcc.error"]` 下 |
 | `prompt` | `str \| None` | 恢复提示；默认为通用消息 |
 | `possible_solutions` | `list[str] \| None` | 可操作建议，存储在 `context["possible_solutions"]` 中 |
+| `_meta` | `Mapping[str, Any] \| None` | 可选的命名空间化顶层元数据 |
 
 ```python
 return skill_error(
     "Maya 环境不可用",
-    "ImportError: No module named 'maya'",
+    "import_error",
     prompt="请确保 Maya 已启动再调用此 Skill。",
     possible_solutions=["启动 Maya", "检查 DCC_MCP_MAYA_SKILL_PATHS"],
 )
@@ -685,6 +689,7 @@ skill_warning(
     *,
     warning: str = "",
     prompt: str | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context,
 ) -> dict
 ```
@@ -712,11 +717,14 @@ skill_exception(
     prompt: str | None = None,
     include_traceback: bool = True,
     possible_solutions: list[str] | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context,
 ) -> dict
 ```
 
-从异常构建失败结果 dict。自动捕获 `error_type` 和完整堆栈跟踪（可选）存入 `context`。
+从异常构建失败结果 dict。字符串 `error` 为异常类型；异常消息和可选完整堆栈存入
+`_meta["dcc.error"]`，调用方元数据按命名空间合并。
+为兼容现有调用方，`context.error_type` 与 `context.traceback` 会镜像保留一个迁移周期。
 
 ```python
 try:
@@ -886,14 +894,16 @@ assert roundtrip.context["frame_count"] == 240
 
 ### `run_main` 的序列化流程
 
-`run_main()` 在 `_core` 可用时自动使用 `serialize_result`，在纯 Python 环境中回退到 `json.dumps`：
+`run_main()` 始终通过轻依赖 `ToolResultEnvelope` 规范化结果，并使用标准库输出 JSON。
+单一路径保证原生 wheel 与仅源码的 skill 子进程产生相同 payload：
 
 ```
 result dict
-    ↓ validate_action_result()  （类型安全验证）
-ToolResult
-    ↓ serialize_result(arm, SerializeFormat.Json)   （Rust JSON 写入器）
+    ↓ ToolResultEnvelope.from_dict()  （schema 校验）
+canonical mapping
+    ↓ json.dumps(..., allow_nan=False)
 JSON 字符串 → stdout
 ```
 
-未来切换到 MessagePack 时，只需修改 `skill.py` 中的 `_serialize_result()`——`serialize_result` / `deserialize_result` API 保持稳定。
+Rust 后端的 `serialize_result` / `deserialize_result` 仍是运行时 `ToolResult`
+对象显式使用的 JSON/MessagePack API。

--- a/docs/zh/guide/actions.md
+++ b/docs/zh/guide/actions.md
@@ -158,17 +158,23 @@ print(result.context)   # {"object_name": "sphere1", "position": [0, 0, 0]}
 # 错误
 result = error_result(
     message="Failed to create sphere",
-    error="Maya API error: object already exists",
+    error="object_already_exists",
+    _meta={
+        "dcc.error": {
+            "type": "MayaApiError",
+            "message": "object already exists",
+        }
+    },
     object_name="sphere1",
 )
 print(result.success)  # False
-print(result.error)    # "Maya API error: object already exists"
+print(result.error)    # "object_already_exists"
 
 # 从异常创建
 try:
     raise RuntimeError("connection refused")
-except Exception:
-    result = from_exception("Connection to Maya lost")
+except Exception as exc:
+    result = from_exception(f"{type(exc).__name__}: {exc}")
     print(result.success)  # False
 ```
 

--- a/docs/zh/guide/agents-reference.md
+++ b/docs/zh/guide/agents-reference.md
@@ -157,6 +157,28 @@ from dcc_mcp_core._core import DeferredExecutor   # 需要直接导入
 这包括 `register_diagnostic_mcp_tools(...)` 用于实例绑定的诊断工具 —
 在调用 `server.start()` 之前注册，绝不在之后。
 
+**Python 工具处理器返回 `ToolResultEnvelope`（#2183），不要手写字典：**
+```python
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
+
+# ✓ 类型化 envelope；序列化后的 wire shape 与现有客户端契约一致。
+return ToolResultEnvelope.ok("Loaded skill", name=name).to_dict()
+return ToolResultEnvelope.fail(
+    "Skill missing",
+    error="not_found",
+    prompt="Try `recipes__list`.",
+).to_dict()
+
+# ✗ 临时拼装的字典不会校验字段，wire shape 演进时容易漂移。
+return {"success": True, "message": "...", "context": {"name": name}}
+```
+`ToolResultEnvelope` 与 Rust `ToolResult` 共享 wire schema，但它是独立的轻依赖构建器。
+`.to_dict()` 默认裁剪空字段；skill helpers 为兼容历史调用方保留固定键投影。
+`error` 必须是字符串代码；结构化详情放在 `_meta["dcc.error"]` 下。
+工厂方法使用 `success_` / `error_`（或别名 `ok` / `fail`），因为
+`success` 与 `error` 本身是 dataclass 字段。顶层 `dcc_mcp_core.ToolResult`
+是 Rust 运行时模型，不是这个 wire builder。
+
 **`Capturer.new_auto()` vs `.new_window_auto()`：**
 ```python
 # ✓ 全屏 / 显示捕获（Windows 上 DXGI，Linux 上 X11）
@@ -215,7 +237,8 @@ annotations = ToolAnnotations(
     deferred_hint=None,        # 完整 schema 延迟到 load_skill（由服务器设置，非用户）
 )
 # 围绕用户工作流设计工具，而非原始 API 调用。
-# 通过 error_result("msg", "specific error") 返回人类可读的错误。
+# 人类可读详情放在 message/_meta 中，error 使用稳定错误码。
+# 示例：error_result("File was not found", "file_not_found")。
 # 当工具集变更时使用 notifications/tools/list_changed。
 ```
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -396,7 +396,7 @@ dependencies = [
 python/dcc_mcp_core/
 ├── __init__.py     # 顶层公开重导出
 ├── skill.py        # 纯 Python Skill 脚本辅助（无 _core 依赖）
-├── result_envelope.py # Typed ToolResult helpers
+├── result_envelope.py # 轻依赖 ToolResultEnvelope 构建器
 └── py.typed        # PEP 561 标记
 
 # _core.pyi 是 stub-gen/dev 构建后的生成产物，不是手写源码

--- a/docs/zh/guide/capabilities.md
+++ b/docs/zh/guide/capabilities.md
@@ -155,11 +155,15 @@ URI scheme，服务器针对会话的第一个根目录解析它。
 ```python
 def import_usd(path: str, _workspace_roots=None):
     if _workspace_roots is None:
-        return error_result("import_usd", "no workspace roots advertised")
+        return error_result("No workspace roots advertised", "missing_workspace_roots")
     try:
         resolved = _workspace_roots.resolve(path)
     except ValueError as e:
-        return error_result("import_usd", str(e))
+        return error_result(
+            "Import path is invalid",
+            "invalid_path",
+            _meta={"dcc.error": {"type": type(e).__name__, "message": str(e)}},
+        )
     # ...继续使用 `resolved` 作为绝对 PathBuf 等效物
 ```
 

--- a/docs/zh/guide/custom-actions.md
+++ b/docs/zh/guide/custom-actions.md
@@ -67,7 +67,11 @@ def create_sphere(radius: float = 1.0, name: str | None = None):
             radius=radius,
         )
     except Exception as e:
-        return error_result("创建球体失败", str(e))
+        return error_result(
+            "创建球体失败",
+            "sphere_creation_failed",
+            _meta={"dcc.error": {"type": type(e).__name__, "message": str(e)}},
+        )
 ```
 
 ### 第三步：通过环境变量注册并启动

--- a/docs/zh/guide/dcc-thread-safety.md
+++ b/docs/zh/guide/dcc-thread-safety.md
@@ -133,7 +133,7 @@ bpy.app.timers.register(render_next)
 ```python
 for batch in chunks(primitives, size=500):
     if job.check_cancelled():           # #329
-        return skill_error("被用户取消")
+        return skill_error("被用户取消", "cancelled")
     create_primitives(batch)
     # 在 batch 之间控制权会回到 DCC
 ```

--- a/docs/zh/guide/faq.md
+++ b/docs/zh/guide/faq.md
@@ -132,7 +132,7 @@ print(result.success)   # True
 print(result.context)   # {"name": "sphere1"}
 
 # 错误
-result = error_result("创建球体失败", error="没有活动场景")
+result = error_result("创建球体失败", error="no_active_scene")
 print(result.success)   # False
 
 # 从异常创建

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -191,7 +191,7 @@ print(result.success)  # True
 print(result.message)  # "创建了 5 个球体"
 print(result.context)  # {"count": 5}
 
-err = error_result("失败", "文件未找到", prompt="检查路径")
+err = error_result("失败", "file_not_found", prompt="检查路径")
 print(err.success)  # False
 ```
 

--- a/docs/zh/guide/thin-harness.md
+++ b/docs/zh/guide/thin-harness.md
@@ -116,7 +116,7 @@ tools:
 ```python
 from __future__ import annotations
 
-from dcc_mcp_core import skill_entry, skill_success, skill_error
+from dcc_mcp_core import skill_entry, skill_success, skill_error_with_trace
 
 
 @skill_entry
@@ -138,10 +138,11 @@ def execute_python(code: str, timeout_secs: int = 30) -> dict:
         output = local_ns.get("result", None)
         return skill_success("Script executed", output=output)
     except Exception as exc:  # noqa: BLE001
-        return skill_error(
+        return skill_error_with_trace(
             f"Script raised {type(exc).__name__}: {exc}",
+            "script_execution_failed",
             underlying_call=code[:200],
-            traceback=traceback.format_exc(),
+            tb=traceback.format_exc(),
         )
 ```
 

--- a/docs/zh/guide/what-is-dcc-mcp-core.md
+++ b/docs/zh/guide/what-is-dcc-mcp-core.md
@@ -117,7 +117,7 @@ dcc-mcp-core/
     └── dcc_mcp_core/
         ├── __init__.py              # 从 _core 重导出公共 API
         ├── constants.py             # METADATA_*, LAYER_*, CATEGORY_*（#487）
-        ├── result_envelope.py       # ToolResult 工厂（#487）
+        ├── result_envelope.py       # 轻依赖 ToolResultEnvelope 构建器
         ├── _server/                 # DccServerBase 协作者（#486）
         └── _core.pyi                # 所有公开 API 的类型桩
 ```

--- a/examples/remote-server/skills/hello-world/scripts/greet.py
+++ b/examples/remote-server/skills/hello-world/scripts/greet.py
@@ -12,7 +12,7 @@ from dcc_mcp_core.skills_helper import skill_success
 def main(name: str = "World"):
     """Return a bounded greeting for connectivity validation."""
     if not isinstance(name, str) or not name.strip():
-        return skill_error("Invalid name", "Name must be a non-empty string.")
+        return skill_error("Invalid name", "invalid_name")
     return skill_success(
         f"Hello, {name.strip()}! (from the internal MCP service)",
         name=name.strip(),

--- a/examples/skills/cancellable-loop/scripts/count.py
+++ b/examples/skills/cancellable-loop/scripts/count.py
@@ -51,8 +51,14 @@ def count(iterations: int = 10, sleep_ms: int = 100, **_: object) -> dict:
     except CancelledError as exc:
         return skill_error(
             f"Cancelled after {completed} iteration(s)",
-            repr(exc),
+            "cancelled",
             prompt="The client cancelled the request; no cleanup needed.",
+            _meta={
+                "dcc.error": {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                }
+            },
             iterations_completed=completed,
         )
     return skill_success(

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -153,15 +153,16 @@ hints for the LLM. Immutable snapshot — use `with_error()`/`with_context()` to
 
 **Constructor:**
 ```python
-ToolResult(success=True, message="", prompt=None, error=None, context=None)
+ToolResult(success=True, message="", prompt=None, error=None, context=None, *, _meta=None)
 ```
 
 **Properties (read-only except `message`):**
 - `success: bool` — Whether the execution was successful
 - `message: str` — Human-readable result description (settable)
 - `prompt: Optional[str]` — Suggestion for AI about next steps ← **use this for AI guidance**
-- `error: Optional[str]` — Error message when success is False
+- `error: Optional[str]` — Stable string error code when success is False
 - `context: dict` — Additional context data (returns a new dict each access)
+- `_meta: dict` — Namespaced structured metadata such as `dcc.error`
 
 **Methods:**
 - `with_error(error: str) -> ToolResult` — Copy with error info (sets success=False)
@@ -176,17 +177,21 @@ ToolResult(success=True, message="", prompt=None, error=None, context=None)
 from dcc_mcp_core import success_result, error_result, from_exception, validate_action_result
 
 # success_result: positional message, optional prompt, remaining kwargs → context
-result = success_result("Created 5 spheres", prompt="Use modify_spheres next", count=5)
+result = success_result("Created 5 spheres", prompt="Use modify_spheres next", _meta={"vendor.trace": {"id": "42"}}, count=5)
 # result.context == {"count": 5}
 
 # error_result: message, error string, optional prompt+solutions
-error = error_result("Failed", "File not found", prompt="Check path", possible_solutions=["fix A", "fix B"])
+error = error_result("Failed", "file_not_found", prompt="Check path", possible_solutions=["fix A", "fix B"])
 
 # from_exception: wrap an exception string (not the exception object itself)
 try:
     risky_op()
 except Exception as e:
-    exc_result = from_exception(str(e), message="Import failed", include_traceback=True)
+    exc_result = from_exception(
+        f"{type(e).__name__}: {e}",
+        message="Import failed",
+        include_traceback=True,
+    )
 
 # validate_action_result: normalize any type to ToolResult
 validated = validate_action_result({"success": True, "message": "ok"})  # dict → ToolResult
@@ -738,7 +743,7 @@ manifest = get_skill_version_manifest("/path/to/skill-dir")
 from dcc_mcp_core import skill_error_with_trace, skill_warning, skill_exception
 
 # Error with automatic traceback capture
-result = skill_error_with_trace("Export failed", error="File not found", prompt="Check path")
+result = skill_error_with_trace("Export failed", error="file_not_found", prompt="Check path")
 
 # Warning-level result (success=True with warning note)
 result = skill_warning("Export completed", prompt="Review normals", warning="Some UVs overlap")
@@ -746,8 +751,8 @@ result = skill_warning("Export completed", prompt="Review normals", warning="Som
 # Exception wrapper (captures current exception info)
 try:
     risky_op()
-except Exception:
-    result = skill_exception("Operation failed", prompt="Retry with different params")
+except Exception as exc:
+    result = skill_exception(exc, message="Operation failed", prompt="Retry with different params")
 ```
 
 ### run_main
@@ -999,17 +1004,17 @@ All helpers return a plain `dict` compatible with `ToolResult`.
 
 ```python
 # Success
-skill_success(message, *, prompt=None, **context) -> dict
+skill_success(message, *, prompt=None, _meta=None, **context) -> dict
 
 # Failure — explicit error string
-skill_error(message, error, *, prompt=None, possible_solutions=None, **context) -> dict
+skill_error(message, error, *, prompt=None, possible_solutions=None, _meta=None, **context) -> dict
 
 # Success with a warning note in context["warning"]
-skill_warning(message, *, warning="", prompt=None, **context) -> dict
+skill_warning(message, *, warning="", prompt=None, _meta=None, **context) -> dict
 
-# Failure built from a caught exception (captures traceback in context)
+# Failure built from a caught exception (details in _meta["dcc.error"])
 skill_exception(exc, *, message=None, prompt=None, include_traceback=True,
-                possible_solutions=None, **context) -> dict
+                possible_solutions=None, _meta=None, **context) -> dict
 ```
 
 ### @skill_entry decorator
@@ -1109,11 +1114,12 @@ assert arm3.context["count"] == 3
 
 ### How run_main serializes
 
-`run_main()` in `dcc_mcp_core.skill` uses this Rust path when `_core` is available:
+`run_main()` in `dcc_mcp_core.skill` uses one dependency-light path in every environment:
 ```
-dict → validate_action_result() → ToolResult → serialize_result() → JSON str → stdout
+dict → ToolResultEnvelope.from_dict() → canonical mapping → stdlib JSON → stdout
 ```
-Falls back to `json.dumps` in pure-Python DCC environments (no `_core` installed).
+This keeps native-wheel and source-only subprocess payloads identical. Use
+`serialize_result()` explicitly for Rust-backed `ToolResult` JSON or MessagePack.
 
 ### Rust API (for crate authors)
 
@@ -2981,7 +2987,11 @@ try:
         output = reply.body.decode()
         r = success_result(output, prompt="Objects listed. You can now select one to modify.")
     else:  # Err (msg_type=3)
-        r = error_result("DCC script failed", reply.body.decode())
+        r = error_result(
+            "DCC script failed",
+            "dcc_script_failed",
+            _meta={"dcc.error": {"message": reply.body.decode()}},
+        )
 finally:
     client.shutdown()
 ```
@@ -3187,7 +3197,11 @@ for skill in skills:
                 proc = subprocess.run(["python", sp], capture_output=True, text=True, timeout=30)
                 if proc.returncode == 0:
                     return success_result(proc.stdout.strip(), prompt="Script finished successfully.")
-                return error_result("Script failed", proc.stderr.strip())
+                return error_result(
+                    "Script failed",
+                    "script_failed",
+                    _meta={"dcc.error": {"message": proc.stderr.strip()}},
+                )
             return handler
         dispatcher.register_handler(action_name, make_handler(script_path))
 

--- a/llms.txt
+++ b/llms.txt
@@ -172,7 +172,7 @@ next CLI launch and does not replace a running server.
 | Skill warning / exception helpers | `skill_warning()` / `skill_exception()` |
 | Disable accumulated/evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |
 | Make skill discovery hermetic | `DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS=1` omits implicit operator-owned roots (local/platform defaults, marketplace installs, and Admin custom paths) while preserving explicit, bundled, and `DCC_MCP_*_SKILL_PATHS` paths |
-| Typed Python tool handler return | `from dcc_mcp_core.result_envelope import ToolResult` → `ToolResult.ok("msg", **ctx).to_dict()` / `ToolResult.fail("msg", error="code").to_dict()` (also `success_`/`error_`, plus `not_found(entity_type, name)` / `invalid_input(msg)` shortcuts). **Note**: `success`/`error` are dataclass fields, not factories; calling `ToolResult.success(...)` raises `AttributeError` (#487) |
+| Typed Python tool handler return | `from dcc_mcp_core.result_envelope import ToolResultEnvelope` → `ToolResultEnvelope.ok("msg", **ctx).to_dict()` / `ToolResultEnvelope.fail("msg", error="code").to_dict()` (also `success_`/`error_`, plus `not_found(entity_type, name)` / `invalid_input(msg)`). `error` is a string code; put structured details in `_meta["dcc.error"]`. Top-level `dcc_mcp_core.ToolResult` is the distinct Rust runtime model (#2183) |
 | Centralised metadata key constants | `from dcc_mcp_core import METADATA_RECIPES_KEY, METADATA_LAYER_KEY, LAYER_THIN_HARNESS, CATEGORY_DIAGNOSTICS, ...` — re-exported at top level; also `from dcc_mcp_core.constants import ...`. Every `"dcc-mcp.<feature>"` string lives here. Available constants: `METADATA_DCC_MCP`, `METADATA_RECIPES_KEY`, `METADATA_WORKFLOWS_KEY`, `METADATA_LAYER_KEY`, `METADATA_DCC_KEY`, `METADATA_VERSION_KEY`, `METADATA_TOOLS_KEY`, `METADATA_GROUPS_KEY`, `METADATA_SEARCH_HINT_KEY`, `METADATA_TAGS_KEY`, `METADATA_EXTERNAL_DEPS_KEY`, `LAYER_THIN_HARNESS`, `LAYER_DOMAIN`, `LAYER_INFRASTRUCTURE`, `LAYER_EXAMPLE`, `CATEGORY_DIAGNOSTICS`, `CATEGORY_FEEDBACK`, `CATEGORY_INTROSPECT`, `CATEGORY_RECIPES`, `CATEGORY_WORKFLOWS`, `CATEGORY_DOCS`, `CATEGORY_GENERAL` (#487) |
 | Custom JSON-RPC method (Rust) | `dcc_mcp_http::handler::{MethodRouter, MethodHandler, HandlerFuture}` — `router.register("ping", Arc::new(handler))`; capability gating lives in the handler, not the router (#492) |
 | Custom action validation (Rust) | `dcc_mcp_actions::validation_strategy::{ValidationStrategy, ValidationOutcome, NoOpValidator, SchemaValidator, select_strategy}` — adding a flavour does not touch `dispatch()` (#493) |
@@ -209,7 +209,7 @@ meta = reg.get_action("create_sphere")
 
 # Structured results (always use factories, never raw dicts)
 result = dcc_mcp_core.success_result("Created sphere", prompt="Add materials next", count=1)
-error = dcc_mcp_core.error_result("Failed", "File not found")
+error = dcc_mcp_core.error_result("Failed", "file_not_found")
 
 # Event bus
 bus = dcc_mcp_core.EventBus()
@@ -337,12 +337,12 @@ Pure-Python modules: `cancellation`, `checkpoint`, `constants` (#487), `result_e
 - `VersionConstraint.parse(">=1.0.0")` — Version constraint expression
 
 **Result Factories:**
-- `success_result(message, prompt=None, **context) -> ToolResult`
-- `error_result(message, error, prompt=None, possible_solutions=None, **context) -> ToolResult`
-- `from_exception(error_message, message=None, include_traceback=False, ...) -> ToolResult`
+- `success_result(message, prompt=None, *, _meta=None, **context) -> ToolResult`
+- `error_result(message, error, prompt=None, possible_solutions=None, *, _meta=None, **context) -> ToolResult`
+- `from_exception(error_message, message=None, prompt=None, include_traceback=True, possible_solutions=None, *, _meta=None, **context) -> ToolResult`
 - `validate_action_result(result) -> ToolResult` — normalize dict/str/None → ToolResult
 
-**ToolResult fields:** `.success`, `.message`, `.prompt`, `.error`, `.context`, `.to_dict()`, `.to_json()`, `.with_error(err)`, `.with_context(**kw)`
+**ToolResult fields:** `.success`, `.message`, `.prompt`, `.error`, `.context`, `._meta`, `.to_dict()`, `.to_json()`, `.with_error(err)`, `.with_context(**kw)`
 
 **Skills:**
 - `SkillScanner` — `.scan(extra_paths=None, dcc_name=None, force_refresh=False) -> List[str]`
@@ -361,11 +361,11 @@ Pure-Python modules: `cancellation`, `checkpoint`, `constants` (#487), `result_e
 - `validate_dependencies(skills) -> List[str]` — returns error messages
 - `get_skill_paths_from_env() -> List[str]` — reads `DCC_MCP_SKILL_PATHS` env var
 - `get_app_skill_paths_from_env(app_name: str) -> List[str]` — reads `DCC_MCP_{APP}_SKILL_PATHS` env var
-- `skill_error(message, error, prompt=None, possible_solutions=None, **context) -> dict` — zero-boilerplate error result for skill scripts
-- `skill_error_with_trace(message, error=None, prompt=None, **context) -> dict` — same as `skill_error` but includes traceback
-- `skill_warning(message, prompt=None, **context) -> dict` — warning-level result
-- `skill_exception(message, exc_info=None, prompt=None, **context) -> dict` — exception-style result
-- `run_main(skill_dir, params=None) -> dict` — convenience entry point for standalone skill script execution
+- `skill_error(message, error, *, prompt=None, possible_solutions=None, _meta=None, **context) -> dict` — zero-boilerplate result using a stable string error code; structured diagnostics belong in `_meta["dcc.error"]`
+- `skill_error_with_trace(message, error, *, ..., _meta=None, **context) -> dict` — same as `skill_error` with `_meta["dcc.raw_trace"]`
+- `skill_warning(message, *, warning="", prompt=None, _meta=None, **context) -> dict` — warning-level result
+- `skill_exception(exc, *, message=None, prompt=None, include_traceback=True, possible_solutions=None, _meta=None, **context) -> dict` — exception code plus `_meta["dcc.error"]`
+- `run_main(main_fn, argv=None) -> None` — standalone skill entry point; writes JSON and exits from the normalized envelope status
 - `SkillFeedback` — feedback data model
 - `get_skill_feedback(skill_name) -> List[SkillFeedback]`
 - `record_skill_feedback(skill_name, feedback)`

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -146,8 +146,11 @@ __all__ = [
     "atomic_write_text",
     "bytes_digest_sha256",
     "correct_python_executable",
+    "deserialize_result",
     "ensure_within_root",
+    "error_result",
     "file_digest_sha256",
+    "from_exception",
     "gc_orphans",
     "init_default_telemetry",
     "is_gui_executable",
@@ -165,10 +168,13 @@ __all__ = [
     "scan_and_load_user_lenient",
     "scan_skill_paths",
     "scene_info_json_to_stage",
+    "serialize_result",
     "shutdown_telemetry",
     "stage_to_scene_info_json",
+    "success_result",
     "units_to_mpu",
     "validate_action_id",
+    "validate_action_result",
     "validate_tool_name",
 ]
 
@@ -3555,7 +3561,48 @@ class ToolResult:
     r"""
     Python-facing ToolResult.
     """
+    @property
+    def success(self) -> builtins.bool: ...
+    @property
+    def message(self) -> builtins.str: ...
+    @message.setter
+    def message(self, value: builtins.str) -> None: ...
+    @property
+    def prompt(self) -> typing.Optional[builtins.str]: ...
+    @property
+    def error(self) -> typing.Optional[builtins.str]: ...
+    @property
+    def context(self) -> dict: ...
+    @property
+    def _meta(self) -> dict: ...
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
+    def __new__(cls, success: builtins.bool = True, message: builtins.str = '', prompt: typing.Optional[builtins.str] = None, error: typing.Optional[builtins.str] = None, context: typing.Optional[dict] = None, *, _meta: typing.Optional[dict] = None) -> ToolResult: ...
+    def with_error(self, error: builtins.str) -> ToolResult:
+        r"""
+        Create a new instance with error information.
+        """
+    def with_context(self, **kwargs: typing.Any) -> ToolResult:
+        r"""
+        Create a new instance with updated context.
+        """
+    def to_dict(self) -> dict:
+        r"""
+        Convert to dictionary.
+        """
+    def to_json(self) -> builtins.str:
+        r"""
+        Serialize to a JSON string.
+        """
+    def __iter__(self) -> typing.Any:
+        r"""
+        Iterate over key-value pairs (mapping protocol).
+        """
+    def keys(self) -> builtins.list[builtins.str]:
+        r"""
+        Return the list of field names (part of the mapping protocol).
+        """
+    def __repr__(self) -> builtins.str: ...
+    def __str__(self) -> builtins.str: ...
 
 @typing.final
 class ToolValidator:
@@ -4387,15 +4434,24 @@ def correct_python_executable(path: builtins.str) -> pathlib.Path:
     Convenience for one-shot fixing of `DCC_MCP_PYTHON_EXECUTABLE`.
     """
 
+def deserialize_result(data: typing.Any, format: SerializeFormat = SerializeFormat.Json) -> ToolResult:
+    r"""
+    Deserialize a `str` (JSON) or `bytes` (MsgPack) into a `ToolResult`.
+    """
+
 def ensure_within_root(root: builtins.str, path: builtins.str, must_exist: builtins.bool = False) -> builtins.str:
     r"""
     Resolve ``path`` under ``root`` and reject paths that escape the root.
     """
 
+def error_result(message: builtins.str, error: builtins.str, prompt: typing.Optional[builtins.str] = None, possible_solutions: typing.Optional[typing.Sequence[builtins.str]] = None, *, _meta: typing.Optional[dict] = None, **context: typing.Any) -> ToolResult: ...
+
 def file_digest_sha256(path: builtins.str, max_bytes: typing.Optional[builtins.int] = None) -> builtins.str:
     r"""
     Stream-hash a file with SHA-256 and return the lowercase hex digest.
     """
+
+def from_exception(error_message: builtins.str, message: typing.Optional[builtins.str] = None, prompt: typing.Optional[builtins.str] = None, include_traceback: builtins.bool = True, possible_solutions: typing.Optional[typing.Sequence[builtins.str]] = None, *, _meta: typing.Optional[dict] = None, **context: typing.Any) -> ToolResult: ...
 
 def gc_orphans(max_age_secs: builtins.float) -> builtins.int:
     r"""
@@ -4510,6 +4566,11 @@ def scene_info_json_to_stage(scene_info_json: builtins.str, dcc_type: builtins.s
         A ``UsdStage`` containing the converted scene.
     """
 
+def serialize_result(result: ToolResult, format: SerializeFormat = SerializeFormat.Json) -> typing.Any:
+    r"""
+    Serialize a `ToolResult` to a string (JSON) or bytes (MsgPack).
+    """
+
 def shutdown_telemetry() -> None:
     r"""
     Shut down the global telemetry provider, flushing all pending data.
@@ -4519,6 +4580,8 @@ def stage_to_scene_info_json(stage: UsdStage) -> builtins.str:
     r"""
     Convert a ``UsdStage`` to a JSON string representing ``SceneInfo``.
     """
+
+def success_result(message: builtins.str, prompt: typing.Optional[builtins.str] = None, *, _meta: typing.Optional[dict] = None, **context: typing.Any) -> ToolResult: ...
 
 def units_to_mpu(units: builtins.str) -> builtins.float:
     r"""
@@ -4531,6 +4594,8 @@ def validate_action_id(name: builtins.str) -> None:
 
     Raises ``ValueError`` on any violation; returns ``None`` on success.
     """
+
+def validate_action_result(result: typing.Any) -> ToolResult: ...
 
 def validate_tool_name(name: builtins.str) -> None:
     r"""

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -149,6 +149,7 @@ _LAZY: dict[str, str] = {
     "ToolRecorder": "dcc_mcp_core._core",
     "ToolRegistry": "dcc_mcp_core._core",
     "ToolResult": "dcc_mcp_core._core",
+    "ToolResultEnvelope": "dcc_mcp_core.result_envelope",
     "ToolValidator": "dcc_mcp_core.skills_helper",
     "TransportAddress": "dcc_mcp_core._core",
     "TransportScheme": "dcc_mcp_core._core",

--- a/python/dcc_mcp_core/_server/_inprocess_contracts.py
+++ b/python/dcc_mcp_core/_server/_inprocess_contracts.py
@@ -11,6 +11,7 @@ from typing import Callable
 
 from dcc_mcp_core._typing_compat import Protocol
 from dcc_mcp_core._typing_compat import runtime_checkable
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 logger = logging.getLogger(__name__)
 
@@ -119,15 +120,13 @@ def sandbox_denied_envelope(exc: BaseException, *, action_name: str = "") -> dic
     """Structured denial envelope when :class:`SandboxContext` rejects an action."""
     msg = str(exc)
     detail = f"Sandbox denied action '{action_name}': {msg}" if action_name else f"Sandbox denied action: {msg}"
-    return {
-        "success": False,
-        "message": detail,
-        "error": {
-            "type": "SandboxDenied",
-            "message": msg,
-            "action": action_name or None,
-        },
-    }
+    context = {"action_name": action_name} if action_name else {}
+    return ToolResultEnvelope.fail(
+        detail,
+        error="SandboxDenied",
+        _meta={"dcc.error": {"type": "SandboxDenied", "message": msg}},
+        **context,
+    ).to_dict()
 
 
 def resolve_sandbox_action_name(action_name: str, script_path: str) -> str:
@@ -145,22 +144,26 @@ def exception_to_error_envelope(exc: BaseException, *, message: str | None = Non
     the same ``success: false`` heuristic without any extra string
     parsing on the client side.
 
-    The traceback is folded into ``error.traceback`` (single string,
-    pre-formatted) so MCP clients can render it inline. Skill authors
-    catching exceptions inside ``main`` can reuse this helper to keep
-    the envelope shape consistent across in-process and subprocess
+    ``error`` is the stable exception-type string. Structured details are
+    folded into ``_meta["dcc.error"]`` so MCP clients can render them without
+    forcing consumers to support two incompatible ``error`` field types.
+    Skill authors catching exceptions inside ``main`` can reuse this helper
+    to keep the envelope shape consistent across in-process and subprocess
     execution.
     """
     msg = message if message is not None else f"Execution failed: {exc}"
-    return {
-        "success": False,
-        "message": msg,
-        "error": {
-            "type": type(exc).__name__,
-            "message": str(exc),
-            "traceback": "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+    error_type = type(exc).__name__
+    return ToolResultEnvelope.fail(
+        msg,
+        error=error_type,
+        _meta={
+            "dcc.error": {
+                "type": error_type,
+                "message": str(exc),
+                "traceback": "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+            }
         },
-    }
+    ).to_dict()
 
 
 def attach_deferred_streams(result: Any, deferred: DeferredToolResult) -> Any:

--- a/python/dcc_mcp_core/dcc_server.py
+++ b/python/dcc_mcp_core/dcc_server.py
@@ -64,7 +64,7 @@ from typing import Callable
 from dcc_mcp_core import json_dumps
 from dcc_mcp_core import json_loads
 from dcc_mcp_core.constants import CATEGORY_DIAGNOSTICS
-from dcc_mcp_core.result_envelope import ToolResult
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +153,7 @@ def _handle_get_audit_log(params_json: str) -> str:
 
     ctx = _get_sandbox_context()
     if ctx is None:
-        return ToolResult(success=False, message="SandboxContext not available.").to_json()
+        return ToolResultEnvelope(success=False, message="SandboxContext not available.").to_json()
 
     try:
         audit = ctx.audit_log
@@ -191,7 +191,7 @@ def _handle_get_audit_log(params_json: str) -> str:
         )
     except Exception as exc:
         logger.warning("get_audit_log handler error: %s", exc)
-        return ToolResult(success=False, message=str(exc)).to_json()
+        return ToolResultEnvelope(success=False, message=str(exc)).to_json()
 
 
 def _handle_get_tool_metrics(params_json: str) -> str:
@@ -205,7 +205,7 @@ def _handle_get_tool_metrics(params_json: str) -> str:
 
     recorder = _get_action_recorder()
     if recorder is None:
-        return ToolResult(success=False, message="ToolRecorder not available.").to_json()
+        return ToolResultEnvelope(success=False, message="ToolRecorder not available.").to_json()
 
     try:
         if action_name:
@@ -223,7 +223,7 @@ def _handle_get_tool_metrics(params_json: str) -> str:
         )
     except Exception as exc:
         logger.warning("get_tool_metrics handler error: %s", exc)
-        return ToolResult(success=False, message=str(exc)).to_json()
+        return ToolResultEnvelope(success=False, message=str(exc)).to_json()
 
 
 def _get_window_capturer() -> Any:
@@ -580,7 +580,7 @@ def _handle_dispatch_tool(params_json: str) -> str:
     try:
         params = json_loads(params_json) if params_json else {}
     except ValueError:
-        return ToolResult(success=False, message="Invalid JSON params.").to_json()
+        return ToolResultEnvelope(success=False, message="Invalid JSON params.").to_json()
 
     # The wire payload still uses the legacy field name ``action`` — that key
     # reflects the backward-compat Rust dispatch result shape (see PR #218);
@@ -589,11 +589,11 @@ def _handle_dispatch_tool(params_json: str) -> str:
     action_params = params.get("params", {})
 
     if not action:
-        return ToolResult(success=False, message="Missing 'action' field.").to_json()
+        return ToolResultEnvelope(success=False, message="Missing 'action' field.").to_json()
 
     dispatcher = _dispatcher_ref
     if dispatcher is None:
-        return ToolResult(success=False, message="Dispatcher not available.").to_json()
+        return ToolResultEnvelope(success=False, message="Dispatcher not available.").to_json()
 
     try:
         result = dispatcher.dispatch(action, json_dumps(action_params))
@@ -603,7 +603,7 @@ def _handle_dispatch_tool(params_json: str) -> str:
         return json_dumps(output)
     except Exception as exc:
         logger.warning("dispatch_tool handler error for '%s': %s", action, exc)
-        return ToolResult(success=False, message=str(exc)).to_json()
+        return ToolResultEnvelope(success=False, message=str(exc)).to_json()
 
 
 # ── public API ────────────────────────────────────────────────────────────
@@ -923,4 +923,4 @@ def _adapt_mcp_handler(handler: Callable[[str], str], params: Any) -> Any:
     try:
         return json_loads(result_str)
     except (TypeError, ValueError):
-        return ToolResult(success=False, message="Invalid handler output").to_dict()
+        return ToolResultEnvelope(success=False, message="Invalid handler output").to_dict()

--- a/python/dcc_mcp_core/feedback.py
+++ b/python/dcc_mcp_core/feedback.py
@@ -63,7 +63,7 @@ from dcc_mcp_core import json_loads
 from dcc_mcp_core._tool_registration import ToolSpec
 from dcc_mcp_core._tool_registration import register_tools
 from dcc_mcp_core.constants import CATEGORY_FEEDBACK
-from dcc_mcp_core.result_envelope import ToolResult
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +269,7 @@ def _handle_feedback_report(params: str) -> str:
         entry["tool_name"],
         entry["severity"],
     )
-    return ToolResult.ok("Feedback recorded.", feedback_id=entry["id"]).to_json()
+    return ToolResultEnvelope.ok("Feedback recorded.", feedback_id=entry["id"]).to_json()
 
 
 # ── Registration helper ────────────────────────────────────────────────────

--- a/python/dcc_mcp_core/introspect.py
+++ b/python/dcc_mcp_core/introspect.py
@@ -35,7 +35,7 @@ from dcc_mcp_core import json_loads
 from dcc_mcp_core._tool_registration import ToolSpec
 from dcc_mcp_core._tool_registration import register_tools
 from dcc_mcp_core.constants import CATEGORY_INTROSPECT
-from dcc_mcp_core.result_envelope import ToolResult
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 logger = logging.getLogger(__name__)
 
@@ -77,13 +77,13 @@ def introspect_list_module(module_name: str, *, limit: int = _MAX_NAMES) -> dict
     """
     mod, err = _import_module(module_name)
     if err:
-        return ToolResult(success=False, message=err).to_dict()
+        return ToolResultEnvelope(success=False, message=err).to_dict()
 
     names = list(mod.__all__) if hasattr(mod, "__all__") else [n for n in dir(mod) if not n.startswith("_")]
 
     names.sort()
     truncated = len(names) > limit
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         f"{len(names)} names in {module_name}" + (" (truncated)" if truncated else ""),
         module=module_name,
         names=names[:limit],
@@ -115,11 +115,11 @@ def introspect_signature(qualname: str) -> dict[str, Any]:
 
     mod, err = _import_module(module_name)
     if err:
-        return ToolResult(success=False, message=err).to_dict()
+        return ToolResultEnvelope(success=False, message=err).to_dict()
 
     obj = getattr(mod, attr, None)
     if obj is None:
-        return ToolResult(success=False, message=f"'{attr}' not found in '{module_name}'").to_dict()
+        return ToolResultEnvelope(success=False, message=f"'{attr}' not found in '{module_name}'").to_dict()
 
     # Signature
     sig_str = ""
@@ -139,7 +139,7 @@ def introspect_signature(qualname: str) -> dict[str, Any]:
     with contextlib.suppress(TypeError, OSError):
         source_file = inspect.getfile(obj)
 
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         f"Signature for {qualname}",
         qualname=qualname,
         signature=sig_str,
@@ -175,11 +175,11 @@ def introspect_search(
     try:
         regex = re.compile(pattern, re.IGNORECASE)
     except re.error as exc:
-        return ToolResult(success=False, message=f"Invalid regex '{pattern}': {exc}").to_dict()
+        return ToolResultEnvelope(success=False, message=f"Invalid regex '{pattern}': {exc}").to_dict()
 
     mod, err = _import_module(module_name)
     if err:
-        return ToolResult(success=False, message=err).to_dict()
+        return ToolResultEnvelope(success=False, message=err).to_dict()
 
     all_names: list[str] = list(getattr(mod, "__all__", None) or [n for n in dir(mod) if not n.startswith("_")])
     hits: list[dict[str, str]] = []
@@ -197,7 +197,7 @@ def introspect_search(
         if len(hits) >= limit:
             break
 
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         f"{len(hits)} matches for '{pattern}' in '{module_name}'",
         pattern=pattern,
         module=module_name,
@@ -232,7 +232,7 @@ def introspect_eval(expression: str) -> dict[str, Any]:
     _BANNED = ("import ", "=", "def ", "class ", "for ", "while ", "exec(", "eval(", "__import__")
     for banned in _BANNED:
         if banned in stripped:
-            return ToolResult(
+            return ToolResultEnvelope(
                 success=False,
                 message=f"Expression contains disallowed construct: '{banned}'",
             ).to_dict()
@@ -244,13 +244,13 @@ def introspect_eval(expression: str) -> dict[str, Any]:
             repr_str = repr_str[:_REPR_MAX_CHARS] + "...(truncated)"
     except Exception:
         tb = traceback.format_exc()
-        return ToolResult(
+        return ToolResultEnvelope(
             success=False,
             message=f"Evaluation failed: {tb.splitlines()[-1]}",
             context={"traceback": tb},
         ).to_dict()
 
-    return ToolResult.ok("Expression evaluated.", expression=expression, repr=repr_str).to_dict()
+    return ToolResultEnvelope.ok("Expression evaluated.", expression=expression, repr=repr_str).to_dict()
 
 
 # ── JSON schemas for MCP tools ─────────────────────────────────────────────

--- a/python/dcc_mcp_core/recipes.py
+++ b/python/dcc_mcp_core/recipes.py
@@ -76,7 +76,7 @@ from dcc_mcp_core._tool_registration import register_tools
 from dcc_mcp_core.constants import CATEGORY_RECIPES
 from dcc_mcp_core.constants import METADATA_DCC_MCP
 from dcc_mcp_core.constants import METADATA_RECIPES_KEY
-from dcc_mcp_core.result_envelope import ToolResult
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 logger = logging.getLogger(__name__)
 
@@ -528,14 +528,14 @@ def _recipes_handle_list(skill_map: dict[str, Any], params: Any) -> Any:
     skill_name = args.get("skill", "")
     skill_md = skill_map.get(skill_name)
     if skill_md is None:
-        return ToolResult(
+        return ToolResultEnvelope(
             success=False,
             message=f"Skill '{skill_name}' not found.",
             context={"skill": skill_name, "anchors": []},
         ).to_dict()
     rp = get_recipes_path(skill_md)
     if not rp:
-        return ToolResult.ok(
+        return ToolResultEnvelope.ok(
             f"Skill '{skill_name}' has no recipes file.",
             skill=skill_name,
             anchors=[],
@@ -544,7 +544,7 @@ def _recipes_handle_list(skill_map: dict[str, Any], params: Any) -> Any:
         ).to_dict()
     entries = list_recipe_entries(skill_md)
     anchors = [entry["name"] for entry in entries if entry.get("provenance", {}).get("format") == "markdown-anchor"]
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         f"Found {len(entries)} recipes.",
         skill=skill_name,
         anchors=anchors,
@@ -560,13 +560,13 @@ def _recipes_handle_get(skill_map: dict[str, Any], params: Any) -> Any:
     anchor = args.get("anchor", "")
     skill_md = skill_map.get(skill_name)
     if skill_md is None:
-        return ToolResult(success=False, message=f"Skill '{skill_name}' not found.").to_dict()
+        return ToolResultEnvelope(success=False, message=f"Skill '{skill_name}' not found.").to_dict()
     rp = get_recipes_path(skill_md)
     if not rp:
-        return ToolResult(success=False, message=f"Skill '{skill_name}' has no recipes file.").to_dict()
+        return ToolResultEnvelope(success=False, message=f"Skill '{skill_name}' has no recipes file.").to_dict()
     recipe = find_recipe_entry(skill_md, anchor)
     if recipe and recipe.get("provenance", {}).get("format") == "recipe-pack":
-        return ToolResult.ok(
+        return ToolResultEnvelope.ok(
             f"Recipe '{anchor}'",
             skill=skill_name,
             anchor=anchor,
@@ -576,12 +576,12 @@ def _recipes_handle_get(skill_map: dict[str, Any], params: Any) -> Any:
     content_path = str(recipe.get("provenance", {}).get("path") or rp) if recipe else rp
     content = get_recipe_content(content_path, anchor)
     if content is None:
-        return ToolResult(
+        return ToolResultEnvelope(
             success=False,
             message=f"Anchor '{anchor}' not found in {rp}.",
             context={"available_anchors": [entry["name"] for entry in list_recipe_entries(skill_md)]},
         ).to_dict()
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         f"Recipe '{anchor}'",
         skill=skill_name,
         anchor=anchor,
@@ -614,7 +614,7 @@ def _recipes_handle_search(skills: list[Any], params: Any) -> Any:
             if dcc_filter and str(entry.get("dcc") or "").lower() != dcc_filter:
                 continue
             matches.append(entry)
-    return ToolResult.ok(f"Found {len(matches)} matching recipes.", query=query, recipes=matches).to_dict()
+    return ToolResultEnvelope.ok(f"Found {len(matches)} matching recipes.", query=query, recipes=matches).to_dict()
 
 
 def _recipes_handle_validate(skill_map: dict[str, Any], params: Any) -> Any:
@@ -625,12 +625,12 @@ def _recipes_handle_validate(skill_map: dict[str, Any], params: Any) -> Any:
     inputs = args.get("inputs") or {}
     skill_md = skill_map.get(skill_name)
     if skill_md is None:
-        return ToolResult.not_found("Skill", skill_name).to_dict()
+        return ToolResultEnvelope.not_found("Skill", skill_name).to_dict()
     recipe = find_recipe_entry(skill_md, recipe_name)
     if recipe is None:
-        return ToolResult.not_found("Recipe", recipe_name).to_dict()
+        return ToolResultEnvelope.not_found("Recipe", recipe_name).to_dict()
     errors = validate_recipe_inputs(recipe, inputs if isinstance(inputs, dict) else {})
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         "Recipe inputs are valid." if not errors else "Recipe inputs are invalid.",
         valid=not errors,
         errors=errors,
@@ -647,16 +647,18 @@ def _recipes_handle_apply(skill_map: dict[str, Any], params: Any) -> Any:
     inputs = args.get("inputs") or {}
     skill_md = skill_map.get(skill_name)
     if skill_md is None:
-        return ToolResult.not_found("Skill", skill_name).to_dict()
+        return ToolResultEnvelope.not_found("Skill", skill_name).to_dict()
     recipe = find_recipe_entry(skill_md, recipe_name)
     if recipe is None:
-        return ToolResult.not_found("Recipe", recipe_name).to_dict()
+        return ToolResultEnvelope.not_found("Recipe", recipe_name).to_dict()
     if recipe.get("provenance", {}).get("format") != "recipe-pack":
-        return ToolResult.invalid_input("recipes__apply requires a structured YAML recipe pack entry.").to_dict()
+        return ToolResultEnvelope.invalid_input(
+            "recipes__apply requires a structured YAML recipe pack entry."
+        ).to_dict()
     errors = validate_recipe_inputs(recipe, inputs if isinstance(inputs, dict) else {})
     if errors:
-        return ToolResult.invalid_input("Recipe inputs are invalid.", errors=errors).to_dict()
-    return ToolResult.ok(
+        return ToolResultEnvelope.invalid_input("Recipe inputs are invalid.", errors=errors).to_dict()
+    return ToolResultEnvelope.ok(
         f"Recipe '{recipe_name}' application plan ready.",
         skill=skill_name,
         recipe=recipe_name,

--- a/python/dcc_mcp_core/result_envelope.py
+++ b/python/dcc_mcp_core/result_envelope.py
@@ -1,99 +1,246 @@
-"""Typed result envelope for Python MCP tool handlers (#487).
+"""Dependency-light wire envelope for Python MCP tool handlers.
 
-Replaces the ad-hoc ``{"success": ..., "message": ..., "context": ...}``
-dicts that previously appeared inline in every handler in ``recipes.py``,
-``feedback.py``, ``introspect.py``, ``docs_resources.py``,
-``workflow_yaml.py``, and ``dcc_server.py``.
-
-The wire format is preserved: :meth:`ToolResult.to_dict` produces the
-same JSON shape that existing clients receive today, including the
-""empty fields are pruned"" convention that makes the envelope stable
-across feature flags.
+``dcc_mcp_core.ToolResult`` is the Rust-backed runtime model. This module owns
+the distinct JSON-compatible wire builder, :class:`ToolResultEnvelope`, used by
+pure-Python skill scripts and handler code. Keeping the names distinct avoids
+the historical collision where two unrelated classes were both called
+``ToolResult`` (issue #2183).
 
 Typical usage::
 
-    from dcc_mcp_core.result_envelope import ToolResult
+    from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
-    return ToolResult.ok("Loaded skill", name="recipe.x").to_dict()
+    return ToolResultEnvelope.ok("Loaded skill", name="recipe.x").to_dict()
 
-    return ToolResult.fail(
+    return ToolResultEnvelope.fail(
         "Failed to load skill",
         error="not_found",
         prompt="Try `recipes__list` to see available skills.",
         skill_name=name,
     ).to_dict()
+
+The deprecated ``result_envelope.ToolResult`` name remains available through a
+module-level compatibility shim for one migration window. New code must use
+``ToolResultEnvelope`` or the top-level Rust-backed ``ToolResult`` explicitly.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+import json
+from typing import TYPE_CHECKING
 from typing import Any
+from typing import Mapping
+import warnings
 
-from dcc_mcp_core import json_dumps
+_KNOWN_KEYS = frozenset({"success", "message", "error", "prompt", "context", "_meta"})
 
 
 @dataclass
-class ToolResult:
-    """Typed envelope for MCP tool return values.
+class ToolResultEnvelope:
+    """JSON-compatible envelope for MCP tool return values.
 
-    Attributes
-    ----------
-    success:
-        ``True`` if the tool succeeded, ``False`` otherwise.
-    message:
-        Short human-readable summary suitable for surfacing to an AI agent.
-    error:
-        Stable, machine-readable error code (e.g. ``"not_found"``,
-        ``"invalid_input"``). ``None`` on success.
-    prompt:
-        Optional next-step suggestion shown to the agent (e.g. ``"Try
-        `recipes__list` to see available skills."``).
-    context:
-        Free-form structured data carried alongside the message. Empty
-        contexts are pruned by :meth:`to_dict` to keep the wire format
-        stable with the historical hand-rolled dicts.
+    ``error`` is always a string when present. Structured diagnostics belong
+    under namespaced ``_meta`` entries such as ``dcc.error`` or
+    ``dcc.raw_trace``; they must never replace the string error field.
 
+    Empty optional fields are pruned by default. Callers that expose a legacy
+    fixed-key mapping may pass ``prune_empty=False`` to :meth:`to_dict` while
+    retaining the same schema and field types.
     """
 
     success: bool
     message: str = ""
     error: str | None = None
-    prompt: str = ""
+    prompt: str | None = None
     context: dict[str, Any] = field(default_factory=dict)
+    _meta: dict[str, Any] = field(default_factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
-        """Render to the JSON-compatible dict shape clients expect.
+    def __post_init__(self) -> None:
+        """Enforce the wire schema on every construction path."""
+        if not isinstance(self.success, bool):
+            raise TypeError("'success' field must be a bool")
+        if not isinstance(self.message, str):
+            raise TypeError("'message' field must be a string")
+        if self.error is not None and not isinstance(self.error, str):
+            raise TypeError("'error' field must be a string or None")
+        if self.prompt is not None and not isinstance(self.prompt, str):
+            raise TypeError("'prompt' field must be a string or None")
+        if not isinstance(self.context, Mapping):
+            raise TypeError("'context' field must be a mapping")
+        if not isinstance(self._meta, Mapping):
+            raise TypeError("'_meta' field must be a mapping")
+        self.context = dict(self.context)
+        self._meta = dict(self._meta)
 
-        Empty optional fields (``error=None``, ``prompt=""``,
-        ``context={}``) are pruned so the wire format matches what the
-        previous hand-rolled dicts produced.
+    def to_dict(self, *, prune_empty: bool = True) -> dict[str, Any]:
+        """Render the canonical JSON-compatible mapping.
+
+        Args:
+            prune_empty: Omit empty optional fields when ``True``. Skill helper
+                compatibility paths use ``False`` so released scripts can keep
+                indexing ``prompt``, ``error``, and ``context`` directly.
+
         """
         out: dict[str, Any] = {"success": self.success}
-        if self.message:
+        if self.message or not prune_empty:
             out["message"] = self.message
-        if self.error is not None:
+        if self.error is not None or not prune_empty:
             out["error"] = self.error
-        if self.prompt:
+        if self.prompt not in (None, "") or not prune_empty:
             out["prompt"] = self.prompt
-        if self.context:
+        if self.context or not prune_empty:
             out["context"] = self.context
+        if self._meta:
+            out["_meta"] = self._meta
         return out
 
-    def to_json(self) -> str:
-        """Render to the JSON string form used by JSON-RPC handlers."""
-        return json_dumps(self.to_dict())
-
-    # ── Factory helpers ────────────────────────────────────────────────────
+    def to_json(self, *, prune_empty: bool = True) -> str:
+        """Render the envelope as dependency-free UTF-8 JSON."""
+        return json.dumps(
+            self.to_dict(prune_empty=prune_empty),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        )
 
     @classmethod
-    def success_(cls, message: str = "", **context: Any) -> ToolResult:
-        """Build a success envelope. Keyword arguments become ``context``.
+    def from_dict(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        strict: bool = True,
+    ) -> ToolResultEnvelope:
+        """Validate and normalize a result mapping.
 
-        Named with a trailing underscore to avoid shadowing
-        ``unittest.TestCase.success`` and similar builtins on intermixed
-        usage. Use :meth:`ok` as a shorter alias.
+        Unknown top-level keys are rejected in strict mode. ``strict=False``
+        preserves the historical runtime behavior by folding them into
+        ``context``; :func:`dcc_mcp_core.skill._serialize_result` uses that
+        compatibility mode for released skill scripts.
         """
+        if not isinstance(payload, Mapping):
+            raise TypeError("tool result envelope must be a mapping")
+
+        success = payload.get("success")
+        if not isinstance(success, bool):
+            raise TypeError("'success' field must be a bool")
+
+        message = payload.get("message", "")
+        if not isinstance(message, str):
+            raise TypeError("'message' field must be a string")
+
+        error = payload.get("error")
+        if error is not None and not isinstance(error, str):
+            raise TypeError("'error' field must be a string or None")
+
+        prompt = payload.get("prompt")
+        if prompt is not None and not isinstance(prompt, str):
+            raise TypeError("'prompt' field must be a string or None")
+
+        raw_context = payload.get("context")
+        if raw_context is None:
+            context: dict[str, Any] = {}
+        elif isinstance(raw_context, Mapping):
+            context = dict(raw_context)
+        else:
+            raise TypeError("'context' field must be a mapping or None")
+
+        raw_meta = payload.get("_meta")
+        if raw_meta is None:
+            meta: dict[str, Any] = {}
+        elif isinstance(raw_meta, Mapping):
+            meta = dict(raw_meta)
+        else:
+            raise TypeError("'_meta' field must be a mapping or None")
+
+        extras = {key: value for key, value in payload.items() if key not in _KNOWN_KEYS}
+        if extras and strict:
+            names = ", ".join(sorted(str(key) for key in extras))
+            raise ValueError(f"unknown tool result envelope fields: {names}")
+        context.update(extras)
+
+        return cls(
+            success=success,
+            message=message,
+            error=error,
+            prompt=prompt,
+            context=context,
+            _meta=meta,
+        )
+
+    from_mapping = from_dict
+
+    @classmethod
+    def success_(
+        cls,
+        message: str = "",
+        *,
+        prompt: str | None = None,
+        _meta: Mapping[str, Any] | None = None,
+        **context: Any,
+    ) -> ToolResultEnvelope:
+        """Build a success envelope; keyword arguments become context."""
+        return cls(
+            success=True,
+            message=message,
+            prompt=prompt,
+            context=dict(context),
+            _meta=dict(_meta or {}),
+        )
+
+    ok = success_
+
+    @classmethod
+    def error_(
+        cls,
+        message: str,
+        error: str = "error",
+        prompt: str | None = None,
+        *,
+        _meta: Mapping[str, Any] | None = None,
+        **context: Any,
+    ) -> ToolResultEnvelope:
+        """Build an error envelope with a string code and optional metadata."""
+        return cls(
+            success=False,
+            message=message,
+            error=error,
+            prompt=prompt,
+            context=dict(context),
+            _meta=dict(_meta or {}),
+        )
+
+    fail = error_
+
+    @classmethod
+    def not_found(
+        cls,
+        entity_type: str,
+        entity_name: str,
+        **context: Any,
+    ) -> ToolResultEnvelope:
+        """Build a ``not_found`` envelope for a missing entity."""
+        return cls.error_(
+            message=f"{entity_type} not found: {entity_name}",
+            error="not_found",
+            **context,
+        )
+
+    @classmethod
+    def invalid_input(cls, message: str, **context: Any) -> ToolResultEnvelope:
+        """Build an ``invalid_input`` envelope for caller-side validation."""
+        return cls.error_(message=message, error="invalid_input", **context)
+
+
+@dataclass
+class _LegacyToolResultEnvelope(ToolResultEnvelope):
+    """Behavior-compatible implementation of the deprecated class name."""
+
+    prompt: str | None = ""
+
+    @classmethod
+    def success_(cls, message: str = "", **context: Any) -> _LegacyToolResultEnvelope:
         return cls(success=True, message=message, context=dict(context))
 
     ok = success_
@@ -105,12 +252,7 @@ class ToolResult:
         error: str = "error",
         prompt: str = "",
         **context: Any,
-    ) -> ToolResult:
-        """Build an error envelope with a stable error code and optional prompt.
-
-        Named with a trailing underscore to avoid shadowing the dataclass
-        ``error`` field.
-        """
+    ) -> _LegacyToolResultEnvelope:
         return cls(
             success=False,
             message=message,
@@ -121,24 +263,27 @@ class ToolResult:
 
     fail = error_
 
-    @classmethod
-    def not_found(
-        cls,
-        entity_type: str,
-        entity_name: str,
-        **context: Any,
-    ) -> ToolResult:
-        """Build a ``not_found`` envelope for missing entities."""
-        return cls.error_(
-            message=f"{entity_type} not found: {entity_name}",
-            error="not_found",
-            **context,
+
+if TYPE_CHECKING:
+    ToolResult = _LegacyToolResultEnvelope
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve the legacy pure-Python class name with a deprecation warning."""
+    if name == "ToolResult":
+        warnings.warn(
+            "dcc_mcp_core.result_envelope.ToolResult is deprecated; use "
+            "ToolResultEnvelope for wire dictionaries or dcc_mcp_core.ToolResult "
+            "for the Rust-backed runtime model.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-
-    @classmethod
-    def invalid_input(cls, message: str, **context: Any) -> ToolResult:
-        """Build an ``invalid_input`` envelope for caller-side validation errors."""
-        return cls.error_(message=message, error="invalid_input", **context)
+        return _LegacyToolResultEnvelope
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["ToolResult"]
+def __dir__() -> list[str]:
+    return sorted([*globals(), "ToolResult"])
+
+
+__all__ = ["ToolResult", "ToolResultEnvelope"]

--- a/python/dcc_mcp_core/script_execution.py
+++ b/python/dcc_mcp_core/script_execution.py
@@ -28,7 +28,7 @@ from typing import Any
 from typing import Sequence
 from typing import TextIO
 
-from dcc_mcp_core.result_envelope import ToolResult
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 from dcc_mcp_core.script_materialization import MaterializedScript
 from dcc_mcp_core.script_materialization import cleanup_materialized_scripts
 from dcc_mcp_core.script_materialization import default_script_materialization_root
@@ -506,7 +506,7 @@ class ScriptExecutionResult:
                 repr_fallback=use_repr,
             )
         except ScriptExecutionSerializationError as exc:
-            return ToolResult.fail(
+            return ToolResultEnvelope.fail(
                 str(exc),
                 error="non_serializable_result",
                 stdout=stdout,
@@ -520,7 +520,7 @@ class ScriptExecutionResult:
         }
         if materialized_script is not None:
             context["materialized_script"] = _materialized_script_context(materialized_script)
-        return ToolResult.ok(message, **context).to_dict()
+        return ToolResultEnvelope.ok(message, **context).to_dict()
 
     @staticmethod
     def from_exception(
@@ -531,14 +531,23 @@ class ScriptExecutionResult:
         message: str | None = None,
     ) -> dict[str, Any]:
         """Return a structured failure envelope with traceback and captured output."""
-        return ToolResult.fail(
+        error_type = type(exc).__name__
+        formatted_traceback = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        return ToolResultEnvelope.fail(
             message or f"Script execution failed: {exc}",
             error="script_execution_error",
+            _meta={
+                "dcc.error": {
+                    "type": error_type,
+                    "message": str(exc),
+                    "traceback": formatted_traceback,
+                }
+            },
             stdout=stdout,
             stderr=stderr,
-            exception_type=type(exc).__name__,
+            exception_type=error_type,
             exception_message=str(exc),
-            traceback="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+            traceback=formatted_traceback,
         ).to_dict()
 
 

--- a/python/dcc_mcp_core/skill.py
+++ b/python/dcc_mcp_core/skill.py
@@ -40,7 +40,7 @@ You can also call the helpers directly without the decorator:
             cmds.playbackOptions(min=start_frame, max=end_frame)
             return skill_success("Timeline updated", start=start_frame, end=end_frame)
         except ImportError:
-            return skill_error("Maya not available", "ImportError: maya.cmds not found")
+            return skill_error("Maya not available", "import_error")
         except Exception as exc:
             return skill_exception(exc)
 
@@ -58,7 +58,10 @@ import traceback
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import Mapping
 from typing import TypeVar
+
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 __all__ = [
     "get_bundled_skill_paths",
@@ -179,6 +182,7 @@ def skill_success(
     message: str,
     *,
     prompt: str | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context: Any,
 ) -> ResultDict:
     """Return a success result dict compatible with ``ToolResult``.
@@ -190,6 +194,8 @@ def skill_success(
     prompt:
         Optional hint for the agent's next action (e.g.
         ``"Inspect the viewport to verify the result."``).
+    _meta:
+        Optional namespaced top-level metadata.
     **context:
         Arbitrary key/value pairs attached to ``context``.  Use these to
         return structured data (object names, frame counts, file paths …).
@@ -212,13 +218,7 @@ def skill_success(
         )
 
     """
-    return {
-        "success": True,
-        "message": message,
-        "prompt": prompt,
-        "error": None,
-        "context": context,
-    }
+    return ToolResultEnvelope.ok(message, prompt=prompt, _meta=_meta, **context).to_dict(prune_empty=False)
 
 
 def skill_error(
@@ -227,6 +227,7 @@ def skill_error(
     *,
     prompt: str | None = None,
     possible_solutions: list[str] | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context: Any,
 ) -> ResultDict:
     """Return a failure result dict compatible with ``ToolResult``.
@@ -236,13 +237,16 @@ def skill_error(
     message:
         User-facing description of what went wrong.
     error:
-        Technical error string (exception repr, error code …).
+        Stable machine-readable error code. Put exception type, message, and
+        traceback details under ``_meta["dcc.error"]``.
     prompt:
         Optional hint for recovery (defaults to a generic "check the error"
         message).
     possible_solutions:
         Optional list of actionable suggestions stored under
         ``context["possible_solutions"]``.
+    _meta:
+        Optional namespaced top-level metadata.
     **context:
         Additional key/value pairs attached to ``context``.
 
@@ -252,7 +256,7 @@ def skill_error(
 
         return skill_error(
             "Failed to create object",
-            "NameError: 'polyCube' is not defined",
+            "missing_command",
             prompt="Ensure the Maya plugin is loaded.",
             possible_solutions=["Load plugin: loadPlugin('polyCube')"],
         )
@@ -260,13 +264,13 @@ def skill_error(
     """
     if possible_solutions:
         context.setdefault("possible_solutions", possible_solutions)
-    return {
-        "success": False,
-        "message": message,
-        "prompt": prompt or "Check the error details and try again.",
-        "error": error,
-        "context": context,
-    }
+    return ToolResultEnvelope.fail(
+        message,
+        error=error,
+        prompt=prompt or "Check the error details and try again.",
+        _meta=_meta,
+        **context,
+    ).to_dict(prune_empty=False)
 
 
 def _build_raw_trace(
@@ -314,6 +318,7 @@ def skill_error_with_trace(
     tb: str | None = None,
     prompt: str | None = None,
     possible_solutions: list[str] | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context: Any,
 ) -> ResultDict:
     """Return a failure result dict enriched with a diagnostic ``_meta.dcc.raw_trace`` block.
@@ -332,7 +337,8 @@ def skill_error_with_trace(
     message:
         User-facing description of what went wrong.
     error:
-        Technical error string (exception repr, error code …).
+        Stable machine-readable error code. Put exception type and message
+        under ``_meta["dcc.error"]`` when they are available.
     underlying_call:
         The raw DCC API call that failed (e.g.
         ``"maya.cmds.polySphere(name='mySphere', radius=-1.0)"``).
@@ -351,6 +357,8 @@ def skill_error_with_trace(
         Optional recovery hint for the agent.
     possible_solutions:
         Optional list of actionable suggestions.
+    _meta:
+        Optional namespaced metadata merged with ``dcc.raw_trace``.
     **context:
         Additional key/value pairs attached to ``context``.
 
@@ -384,7 +392,7 @@ def skill_error_with_trace(
         except Exception as exc:
             return skill_error_with_trace(
                 "Failed to create sphere",
-                str(exc),
+                "sphere_creation_failed",
                 underlying_call=f"maya.cmds.polySphere(name='mySphere', radius={radius})",
                 recipe_hint="references/RECIPES.md#create_sphere",
                 introspect_hint="dcc_introspect__signature(qualname='maya.cmds.polySphere')",
@@ -395,17 +403,17 @@ def skill_error_with_trace(
     if possible_solutions:
         context.setdefault("possible_solutions", possible_solutions)
 
-    result: ResultDict = {
-        "success": False,
-        "message": message,
-        "prompt": prompt or "Check the error details and try again.",
-        "error": error,
-        "context": context,
-    }
     raw_trace = _build_raw_trace(underlying_call, recipe_hint, introspect_hint, tb)
+    meta = dict(_meta or {})
     if raw_trace:
-        result["_meta"] = {"dcc.raw_trace": raw_trace}
-    return result
+        meta["dcc.raw_trace"] = raw_trace
+    return ToolResultEnvelope.fail(
+        message,
+        error=error,
+        prompt=prompt or "Check the error details and try again.",
+        _meta=meta or None,
+        **context,
+    ).to_dict(prune_empty=False)
 
 
 def skill_warning(
@@ -413,6 +421,7 @@ def skill_warning(
     *,
     warning: str = "",
     prompt: str | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context: Any,
 ) -> ResultDict:
     """Return a success-but-with-warning result dict.
@@ -428,6 +437,8 @@ def skill_warning(
         Description of the condition that should be noted.
     prompt:
         Optional follow-up hint for the agent.
+    _meta:
+        Optional namespaced top-level metadata.
     **context:
         Additional context key/value pairs.
 
@@ -444,13 +455,7 @@ def skill_warning(
 
     """
     context["warning"] = warning
-    return {
-        "success": True,
-        "message": message,
-        "prompt": prompt,
-        "error": None,
-        "context": context,
-    }
+    return ToolResultEnvelope.ok(message, prompt=prompt, _meta=_meta, **context).to_dict(prune_empty=False)
 
 
 def skill_exception(
@@ -460,12 +465,13 @@ def skill_exception(
     prompt: str | None = None,
     include_traceback: bool = True,
     possible_solutions: list[str] | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context: Any,
 ) -> ResultDict:
     """Return a failure result dict built from an exception.
 
-    Captures the exception type, repr, and optionally the full traceback
-    and stores them in ``context``.
+    Uses the exception type as the stable string error code. The exception
+    message and optional traceback are stored in ``_meta["dcc.error"]``.
 
     Parameters
     ----------
@@ -477,9 +483,11 @@ def skill_exception(
         Optional recovery hint.
     include_traceback:
         When ``True`` (default), attach the formatted traceback to
-        ``context["traceback"]``.
+        ``_meta["dcc.error"]["traceback"]``.
     possible_solutions:
         Optional list of actionable suggestions.
+    _meta:
+        Optional namespaced metadata merged with ``dcc.error``.
     **context:
         Additional context key/value pairs.
 
@@ -493,9 +501,8 @@ def skill_exception(
             return skill_exception(exc, possible_solutions=["Check file path"])
 
     """
-    error_str = repr(exc)
     error_type = type(exc).__name__
-    context["error_type"] = error_type
+    error_details = {"type": error_type, "message": str(exc)}
     if include_traceback:
         # Use format_exception with explicit exc.__traceback__ so the full
         # stack frames are preserved even when called across thread
@@ -503,16 +510,21 @@ def skill_exception(
         # (e.g. through a DCC main-thread dispatcher). format_exc() relies
         # on sys.exc_info() which is thread-local and can return
         # (None, None, None) outside an active except block. (issue #860)
-        context["traceback"] = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        formatted_traceback = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        error_details["traceback"] = formatted_traceback
+        context["traceback"] = formatted_traceback
+    context["error_type"] = error_type
     if possible_solutions:
         context.setdefault("possible_solutions", possible_solutions)
-    return {
-        "success": False,
-        "message": message or f"Error: {exc}",
-        "prompt": prompt or "Check the error details and try again.",
-        "error": error_str,
-        "context": context,
-    }
+    meta = dict(_meta or {})
+    meta["dcc.error"] = error_details
+    return ToolResultEnvelope.fail(
+        message or f"Error: {exc}",
+        error=error_type,
+        prompt=prompt or "Check the error details and try again.",
+        _meta=meta,
+        **context,
+    ).to_dict(prune_empty=False)
 
 
 # ---------------------------------------------------------------------------
@@ -559,16 +571,28 @@ def skill_entry(func: _F) -> _F:
             dcc_name = _guess_dcc_from_import_error(exc)
             return skill_error(
                 f"{dcc_name} is not available in this environment",
-                repr(exc),
+                "import_error",
                 prompt=f"Ensure {dcc_name} is running and the plugin is loaded.",
+                _meta={
+                    "dcc.error": {
+                        "type": type(exc).__name__,
+                        "message": str(exc),
+                    }
+                },
             )
         except Exception as exc:
             return skill_exception(exc)
         except BaseException as exc:
             return skill_error(
                 "Skill execution was interrupted",
-                repr(exc),
+                "interrupted",
                 prompt="The skill was forcibly stopped; retry if needed.",
+                _meta={
+                    "dcc.error": {
+                        "type": type(exc).__name__,
+                        "message": str(exc),
+                    }
+                },
             )
 
     # Attach a `main` name alias so callers can use `main(**kwargs)` pattern.
@@ -608,12 +632,9 @@ def run_main(main_fn: Callable[..., ResultDict], argv: list[str] | None = None) 
 
     Notes
     -----
-    * Serialization uses the Rust ``serialize_result()`` implementation when
-      the compiled ``_core`` extension is available.  This is type-safe,
-      format-agnostic (JSON now, MessagePack in the future), and validates the
-      result through ``ToolResult``.
-    * Falls back to ``json.dumps`` in DCC environments where only the pure-Python
-      wheel is installed.
+    * Serialization uses the dependency-light ``ToolResultEnvelope`` validator
+      and standard-library JSON in every installation, so native and source-only
+      DCC environments emit the same payload.
     * The function currently ignores *argv* (no CLI arg parser is bundled).
         The subprocess executor's complete stdin JSON payload is authoritative.
     * Exit code ``0`` on success, ``1`` on failure (``result["success"] is False``).
@@ -636,10 +657,10 @@ def run_main(main_fn: Callable[..., ResultDict], argv: list[str] | None = None) 
     except Exception as exc:
         result = skill_exception(exc)
 
-    output = _serialize_result(result)
+    output, success = _serialize_result_with_status(result)
     sys.stdout.write(output + "\n")
     sys.stdout.flush()
-    sys.exit(0 if result.get("success", False) else 1)
+    sys.exit(0 if success else 1)
 
 
 # ---------------------------------------------------------------------------
@@ -647,13 +668,57 @@ def run_main(main_fn: Callable[..., ResultDict], argv: list[str] | None = None) 
 # ---------------------------------------------------------------------------
 
 
-def _serialize_result(result: ResultDict) -> str:
+def _normalize_result(result: Any) -> ToolResultEnvelope:
+    """Return the canonical envelope emitted by a skill subprocess."""
+    try:
+        return ToolResultEnvelope.from_dict(result, strict=False)
+    except (TypeError, ValueError) as exc:
+        return ToolResultEnvelope.fail(
+            "Failed to normalize result",
+            error="invalid_result_envelope",
+            _meta={
+                "dcc.error": {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                }
+            },
+        )
+
+
+def _serialize_result_with_status(result: Any) -> tuple[str, bool]:
+    """Serialize the actual emitted envelope and return its success state."""
+    envelope = _normalize_result(result)
+    payload = envelope.to_dict(prune_empty=False)
+    payload = {key: value for key, value in payload.items() if not (key in {"error", "prompt"} and value is None)}
+
+    try:
+        output = json.dumps(
+            payload,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        envelope = ToolResultEnvelope.fail(
+            "Failed to serialize result",
+            error="non_serializable_result",
+            _meta={
+                "dcc.error": {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                }
+            },
+        )
+        output = envelope.to_json(prune_empty=False)
+    return output, envelope.success
+
+
+def _serialize_result(result: Any) -> str:
     """Serialize a result dict to a JSON string.
 
-    Tries the Rust ``serialize_result()`` path first (type-safe, validates via
-    ``ToolResult``, format-extensible).  Falls back to ``json.dumps``
-    when the compiled ``_core`` extension is not available (e.g. standalone
-    DCC environment with only this module installed).
+    Normalizes through :class:`ToolResultEnvelope` and serializes with the
+    standard library in every installation. This keeps native and source-only
+    skill environments byte-for-byte consistent for JSON values.
 
     Parameters
     ----------
@@ -667,44 +732,7 @@ def _serialize_result(result: ResultDict) -> str:
         JSON-encoded result string (no trailing newline).
 
     """
-    try:
-        # Import lazily so skill.py itself has no hard _core dependency.
-        from dcc_mcp_core._core import SerializeFormat
-        from dcc_mcp_core._core import serialize_result
-        from dcc_mcp_core._core import validate_action_result
-
-        arm = validate_action_result(result)
-        return serialize_result(arm, SerializeFormat.Json)
-    except ImportError:
-        pass  # _core not available — fall back to pure Python
-
-    dumps = _json_dumps_for_fallback()
-
-    # Fallback path: handles any extra keys in context gracefully.
-    try:
-        return dumps(result, ensure_ascii=False)
-    except (TypeError, ValueError) as exc:
-        return dumps(
-            skill_error("Failed to serialize result", repr(exc)),
-            ensure_ascii=False,
-        )
-
-
-def _json_dumps_for_fallback() -> Callable[..., str]:
-    """Return the fastest JSON dumper available without a top-level _core dependency."""
-    try:
-        # Lazy import: source-only DCC environments may not have the compiled extension.
-        from dcc_mcp_core import json_dumps as core_json_dumps
-    except (AttributeError, ImportError):
-        return json.dumps
-
-    def dumps(payload: Any, **kwargs: Any) -> str:
-        try:
-            return core_json_dumps(payload, **kwargs)
-        except ImportError:
-            return json.dumps(payload, **kwargs)
-
-    return dumps
+    return _serialize_result_with_status(result)[0]
 
 
 _DCC_IMPORT_LABELS = {

--- a/python/dcc_mcp_core/skill_reference_docs.py
+++ b/python/dcc_mcp_core/skill_reference_docs.py
@@ -20,7 +20,7 @@ from dcc_mcp_core._tool_registration import register_tools
 from dcc_mcp_core.constants import CATEGORY_DOCS
 from dcc_mcp_core.constants import METADATA_DCC_MCP
 from dcc_mcp_core.constants import METADATA_SKILL_REFERENCE_DOCS_KEY
-from dcc_mcp_core.result_envelope import ToolResult
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 logger = logging.getLogger(__name__)
 
@@ -173,23 +173,23 @@ def _handle_list(skill_map: dict[str, Any], params: Any) -> dict[str, Any]:
     skill_name = str(args.get("skill") or "")
     md = skill_map.get(skill_name)
     if md is None:
-        return ToolResult(success=False, message=f"Skill '{skill_name}' not found.").to_dict()
+        return ToolResultEnvelope(success=False, message=f"Skill '{skill_name}' not found.").to_dict()
     skill_path = getattr(md, "skill_path", "") or ""
     if not skill_path:
-        return ToolResult.fail("Skill has no skill_path.", error="invalid_skill").to_dict()
+        return ToolResultEnvelope.fail("Skill has no skill_path.", error="invalid_skill").to_dict()
     root = Path(skill_path)
     if not root.is_dir():
-        return ToolResult.fail(f"Skill directory missing: {skill_path}", error="invalid_skill").to_dict()
+        return ToolResultEnvelope.fail(f"Skill directory missing: {skill_path}", error="invalid_skill").to_dict()
     globs = _skill_reference_doc_globs(md)
     if not globs:
-        return ToolResult.ok(
+        return ToolResultEnvelope.ok(
             f"Skill '{skill_name}' has no reference-doc globs and no references/ directory.",
             skill=skill_name,
             globs=[],
             files=[],
         ).to_dict()
     files = _collect_reference_files(root, globs)
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         f"Found {len(files)} reference file(s) for '{skill_name}'.",
         skill=skill_name,
         globs=globs,
@@ -203,43 +203,43 @@ def _handle_read(skill_map: dict[str, Any], params: Any) -> dict[str, Any]:
     rel_path = str(args.get("path") or "")
     md = skill_map.get(skill_name)
     if md is None:
-        return ToolResult(success=False, message=f"Skill '{skill_name}' not found.").to_dict()
+        return ToolResultEnvelope(success=False, message=f"Skill '{skill_name}' not found.").to_dict()
     skill_path = getattr(md, "skill_path", "") or ""
     root = Path(skill_path)
     if not root.is_dir():
-        return ToolResult.fail(f"Skill directory missing: {skill_path}", error="invalid_skill").to_dict()
+        return ToolResultEnvelope.fail(f"Skill directory missing: {skill_path}", error="invalid_skill").to_dict()
 
     target = _resolve_safe_path(root, rel_path)
     if target is None:
-        return ToolResult.invalid_input(
+        return ToolResultEnvelope.invalid_input(
             "Invalid path — use a relative path from skill_refs__list with no '..'.",
         ).to_dict()
 
     suf = target.suffix.lower()
     if suf not in _TEXT_SUFFIXES:
-        return ToolResult.invalid_input("Only text reference types are readable (.md, .txt, …).").to_dict()
+        return ToolResultEnvelope.invalid_input("Only text reference types are readable (.md, .txt, …).").to_dict()
 
     allowed = {e["path"] for e in _collect_reference_files(root, _skill_reference_doc_globs(md))}
     rel_posix = target.resolve().relative_to(root.resolve()).as_posix()
     if rel_posix not in allowed:
-        return ToolResult.invalid_input(
+        return ToolResultEnvelope.invalid_input(
             "Path is not among indexed reference files; call skill_refs__list first.",
         ).to_dict()
 
     try:
         raw = target.read_bytes()
     except OSError as exc:
-        return ToolResult.fail(f"Cannot read file: {exc}", error="io_error").to_dict()
+        return ToolResultEnvelope.fail(f"Cannot read file: {exc}", error="io_error").to_dict()
     if len(raw) > _MAX_READ_BYTES:
-        return ToolResult.invalid_input(
+        return ToolResultEnvelope.invalid_input(
             f"File exceeds max read size ({_MAX_READ_BYTES} bytes).",
         ).to_dict()
     try:
         text = raw.decode("utf-8")
     except UnicodeDecodeError:
-        return ToolResult.invalid_input("File is not valid UTF-8.").to_dict()
+        return ToolResultEnvelope.invalid_input("File is not valid UTF-8.").to_dict()
 
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         f"Read '{rel_posix}'",
         skill=skill_name,
         path=rel_posix,

--- a/python/dcc_mcp_core/skills/qt_ui_inspector.py
+++ b/python/dcc_mcp_core/skills/qt_ui_inspector.py
@@ -24,7 +24,7 @@ from typing import Any
 from dcc_mcp_core import json_loads
 from dcc_mcp_core._tool_registration import ToolSpec
 from dcc_mcp_core._tool_registration import register_tools
-from dcc_mcp_core.result_envelope import ToolResult
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ def _load_qt() -> _QtBinding:
 
 
 def _binding_unavailable(exc: _BindingUnavailable) -> dict[str, Any]:
-    return ToolResult.fail(
+    return ToolResultEnvelope.fail(
         str(exc),
         error="qt-binding-unavailable",
         hint=(
@@ -72,7 +72,7 @@ def _binding_unavailable(exc: _BindingUnavailable) -> dict[str, Any]:
 
 
 def _no_application() -> dict[str, Any]:
-    return ToolResult.fail(
+    return ToolResultEnvelope.fail(
         "QApplication.instance() returned None — host has no running Qt event loop.",
         error="qt-no-application",
         hint="this tool must run inside a Qt host (Maya/Houdini/Nuke/Substance/Katana/etc.)",
@@ -192,7 +192,7 @@ def qt_list_windows(*, include_hidden: bool = False, max_results: int = 64) -> d
                 break
         except Exception as exc:
             windows.append({"widget_id": None, "class": w.__class__.__name__, "error": str(exc)})
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         "listed Qt top-level windows",
         binding=binding.name,
         window_count=len(windows),
@@ -212,7 +212,7 @@ def qt_find_widgets(
 ) -> dict[str, Any]:
     """Search Qt widgets by object name and/or class name with a bounded result count."""
     if object_name is None and class_name is None:
-        return ToolResult.invalid_input("supply at least one of object_name or class_name").to_dict()
+        return ToolResultEnvelope.invalid_input("supply at least one of object_name or class_name").to_dict()
     cap = max(1, min(int(max_results), 1024))
     try:
         binding = _load_qt()
@@ -235,7 +235,7 @@ def qt_find_widgets(
                 break
         except Exception:
             continue
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         "found matching Qt widgets",
         binding=binding.name,
         match_count=len(hits),
@@ -247,7 +247,7 @@ def qt_find_widgets(
 def qt_describe_widget(*, widget_id: str) -> dict[str, Any]:
     """Return a single Qt widget's structured state and bounded property snapshot."""
     if not widget_id:
-        return ToolResult.invalid_input("widget_id is required").to_dict()
+        return ToolResultEnvelope.invalid_input("widget_id is required").to_dict()
     try:
         binding = _load_qt()
     except _BindingUnavailable as exc:
@@ -257,7 +257,7 @@ def qt_describe_widget(*, widget_id: str) -> dict[str, Any]:
         return _no_application()
     widget = _find_by_id(app, widget_id)
     if widget is None:
-        return ToolResult.not_found("Widget", widget_id).to_dict()
+        return ToolResultEnvelope.not_found("Widget", widget_id).to_dict()
     summary = _widget_summary(widget)
     properties: dict[str, Any] = {}
     try:
@@ -279,7 +279,7 @@ def qt_describe_widget(*, widget_id: str) -> dict[str, Any]:
         properties = {}
     summary["properties"] = properties
     summary["properties_truncated"] = len(properties) >= _PROPERTY_CAP
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         "described Qt widget",
         binding=binding.name,
         widget=summary,
@@ -326,7 +326,7 @@ def qt_snapshot_tree(
     budget = [cap]
     if root_widget_id is None:
         trees = [_walk(w, 0, depth, budget) for w in app.topLevelWidgets() if budget[0] > 0]
-        return ToolResult.ok(
+        return ToolResultEnvelope.ok(
             "snapshotted Qt top-level widget trees",
             binding=binding.name,
             root_widget_id=None,
@@ -336,9 +336,9 @@ def qt_snapshot_tree(
         ).to_dict()
     root = _find_by_id(app, root_widget_id)
     if root is None:
-        return ToolResult.not_found("Widget", root_widget_id).to_dict()
+        return ToolResultEnvelope.not_found("Widget", root_widget_id).to_dict()
     tree = _walk(root, 0, depth, budget)
-    return ToolResult.ok(
+    return ToolResultEnvelope.ok(
         "snapshotted Qt widget tree",
         binding=binding.name,
         root_widget_id=root_widget_id,
@@ -391,7 +391,7 @@ def qt_wait_for_widget(
 ) -> dict[str, Any]:
     """Poll for a Qt widget matching the criteria within a bounded timeout."""
     if object_name is None and class_name is None:
-        return ToolResult.invalid_input("supply at least one of object_name or class_name").to_dict()
+        return ToolResultEnvelope.invalid_input("supply at least one of object_name or class_name").to_dict()
     timeout = max(0, min(int(timeout_ms), 60_000)) / 1000.0
     poll = max(25, int(poll_interval_ms)) / 1000.0
     try:
@@ -415,7 +415,7 @@ def qt_wait_for_widget(
                     continue
                 if enabled and not w.isEnabled():
                     continue
-                return ToolResult.ok(
+                return ToolResultEnvelope.ok(
                     "Qt widget appeared",
                     binding=binding.name,
                     polls=polls,
@@ -425,7 +425,7 @@ def qt_wait_for_widget(
             except Exception:
                 continue
         if time.monotonic() >= deadline:
-            return ToolResult.fail(
+            return ToolResultEnvelope.fail(
                 "timed out waiting for matching widget",
                 error="timeout",
                 polls=polls,

--- a/python/dcc_mcp_core/skills_helper.py
+++ b/python/dcc_mcp_core/skills_helper.py
@@ -15,6 +15,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 import json as _json
 from pathlib import Path
+import traceback as _traceback
 from typing import Any
 
 from dcc_mcp_core._lazy import lazy_dir
@@ -607,15 +608,27 @@ def skill_error_from_exception(
     message: str | None = None,
     error: str | None = None,
     prompt: str | None = None,
+    _meta: Mapping[str, Any] | None = None,
     **context: Any,
 ) -> dict[str, Any]:
-    """Convert an exception into the standard skill error dictionary shape."""
+    """Convert an exception into the standard skill error dictionary shape.
+
+    The exception type and message are preserved under ``_meta["dcc.error"]``.
+    Caller metadata is retained, but cannot override those canonical details.
+    """
     from dcc_mcp_core.skill import skill_error
 
+    meta = dict(_meta or {})
+    meta["dcc.error"] = {
+        "type": type(exc).__name__,
+        "message": str(exc),
+        "traceback": "".join(_traceback.format_exception(type(exc), exc, exc.__traceback__)),
+    }
     return skill_error(
         message or str(exc) or type(exc).__name__,
         error or type(exc).__name__,
         prompt=prompt,
+        _meta=meta,
         **context,
     )
 

--- a/python/dcc_mcp_core/workflow_yaml.py
+++ b/python/dcc_mcp_core/workflow_yaml.py
@@ -65,7 +65,7 @@ from dcc_mcp_core._tool_registration import register_tools
 from dcc_mcp_core.constants import CATEGORY_WORKFLOWS
 from dcc_mcp_core.constants import METADATA_DCC_MCP
 from dcc_mcp_core.constants import METADATA_WORKFLOWS_KEY
-from dcc_mcp_core.result_envelope import ToolResult
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 logger = logging.getLogger(__name__)
 
@@ -404,7 +404,7 @@ def register_workflow_yaml_tools(
 
     def _handle_list(_params: Any) -> Any:
         summaries = [wf.to_summary_dict() for wf in workflow_map.values()]
-        return ToolResult.ok(
+        return ToolResultEnvelope.ok(
             f"{len(summaries)} workflow(s) available.",
             workflows=summaries,
             count=len(summaries),
@@ -416,12 +416,12 @@ def register_workflow_yaml_tools(
         wf = workflow_map.get(name)
         if wf is None:
             available = list(workflow_map.keys())
-            return ToolResult(
+            return ToolResultEnvelope(
                 success=False,
                 message=f"Workflow '{name}' not found.",
                 context={"available": available},
             ).to_dict()
-        return ToolResult(
+        return ToolResultEnvelope(
             success=True,
             message=f"Workflow '{name}': {wf.goal}",
             context=wf.to_summary_dict(),

--- a/skills/asset-source/scripts/search_assets.py
+++ b/skills/asset-source/scripts/search_assets.py
@@ -187,7 +187,7 @@ def search_assets(query: str, limit: int = 10) -> dict:
     """
     query = query.strip()
     if not query:
-        return skill_error("Empty query", "query must not be empty")
+        return skill_error("Empty query", "invalid_query")
 
     limit = max(1, min(limit, 50))
 

--- a/skills/dcc-mcp-creator/references/HOST_PATTERN_MATRIX.md
+++ b/skills/dcc-mcp-creator/references/HOST_PATTERN_MATRIX.md
@@ -40,7 +40,11 @@ Use this table when choosing adapter runtime wiring for a new DCC.
   cannot safely interrupt a DCC-native API call or an uncooperative hot loop
   already executing on the host thread; use typed, bounded operations and
   return control to the pump between chunks.
-- Every bridge path must normalize arguments and return structured envelopes.
+- Every bridge path must normalize arguments and return the canonical domain
+  result envelope: `error` is a string code and structured details belong under
+  namespaced `_meta` entries. `HostExecutionBridge` and in-process dispatchers
+  must not return a JSON-RPC-style error object in the domain `error` field.
+  Keep outer host-RPC `{result}` / `{error}` transport envelopes separate.
 
 ## Dispatcher Smoke Tests
 

--- a/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
+++ b/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
@@ -120,7 +120,11 @@ host process.
 Import shared helper APIs from `dcc_mcp_core.skills_helper` before adding small
 dependencies or local utility modules. That namespace is the preferred path for
 JSON/YAML codecs, bounded HTTP requests, safe file/path helpers, validation,
-result envelopes, argument normalization, and cancellation checks. Keep
+argument normalization, and cancellation checks. Use `skill_success` /
+`skill_error` from this preferred namespace for result envelopes; the lazy
+exports delegate to the canonical implementation in `dcc_mcp_core.skill`.
+Failures carry a string error code and structured details under namespaced
+`_meta`. Keep
 `requests`, PyYAML, custom HTTP/file helpers, or SDK-specific libraries only
 when they provide behavior `skills_helper` intentionally does not cover, such
 as sessions, streaming, multipart upload, custom retry/auth flows, or rich

--- a/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
+++ b/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
@@ -22,6 +22,26 @@ permissive `{"type": "object"}` instead of importing or executing the script.
 If you derive schemas from Python annotations, do it while authoring and write
 the result into `tools.yaml`.
 
+## Result Envelope
+
+Python skill scripts should return `skill_success(...)`, `skill_error(...)`,
+or another helper from `dcc_mcp_core.skill`. Lower-level handlers may use
+`ToolResultEnvelope` from `dcc_mcp_core.result_envelope`. Do not hand-roll a
+result mapping.
+
+The canonical fields are `success`, `message`, `error`, `prompt`, `context`,
+and optional `_meta`. A failure's `error` must be a stable string code (for
+example `invalid_input`, `RuntimeError`, or `SandboxDenied`), never an object.
+Put structured exception details under `_meta["dcc.error"]` and raw DCC call
+diagnostics under `_meta["dcc.raw_trace"]`. Keep ordinary tool outputs and
+identifiers in `context`.
+
+The general builder may omit empty optional fields. Skill helpers intentionally
+retain their historical fixed-key shape, so consumers should rely on field
+types and semantics rather than treating omission and `None` as different
+outcomes. Top-level `dcc_mcp_core.ToolResult` is the distinct Rust-backed
+runtime model; use `ToolResultEnvelope` when building a Python wire mapping.
+
 A zero-argument tool must not use that permissive fallback. Declare the closed
 empty-object contract explicitly:
 

--- a/skills/spatial-interchange/scripts/plan_conversion.py
+++ b/skills/spatial-interchange/scripts/plan_conversion.py
@@ -27,8 +27,14 @@ def main(
     except (KeyError, TypeError, ValueError) as exc:
         return skill_error(
             "Spatial conversion could not be planned",
-            str(exc),
+            "invalid_spatial_conversion",
             prompt="Inspect the live source and target axes and units, then provide three distinct signed axes.",
+            _meta={
+                "dcc.error": {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                }
+            },
         )
     return skill_success("Spatial conversion planned", **plan)
 

--- a/tests/test_envelope_contract.py
+++ b/tests/test_envelope_contract.py
@@ -1,0 +1,189 @@
+"""Cross-producer contract tests for issue #2183."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from dcc_mcp_core import SerializeFormat
+from dcc_mcp_core import from_exception
+from dcc_mcp_core import serialize_result
+from dcc_mcp_core import validate_action_result
+from dcc_mcp_core._server.inprocess_executor import exception_to_error_envelope
+from dcc_mcp_core._server.inprocess_executor import sandbox_denied_envelope
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
+from dcc_mcp_core.script_execution import ScriptExecutionResult
+from dcc_mcp_core.skill import skill_entry
+from dcc_mcp_core.skill import skill_error
+from dcc_mcp_core.skill import skill_error_with_trace
+from dcc_mcp_core.skill import skill_exception
+from dcc_mcp_core.skill import skill_success
+from dcc_mcp_core.skill import skill_warning
+from dcc_mcp_core.skills_helper import skill_error_from_exception
+
+_CANONICAL_KEYS = {"success", "message", "error", "prompt", "context", "_meta"}
+
+
+def _assert_canonical(payload: dict[str, Any]) -> None:
+    assert set(payload) <= _CANONICAL_KEYS
+    assert isinstance(payload["success"], bool)
+    if "message" in payload:
+        assert isinstance(payload["message"], str)
+    if payload.get("error") is not None:
+        assert isinstance(payload["error"], str)
+    if payload.get("prompt") is not None:
+        assert isinstance(payload["prompt"], str)
+    if "context" in payload:
+        assert isinstance(payload["context"], dict)
+    if "_meta" in payload:
+        assert isinstance(payload["_meta"], dict)
+    normalized = ToolResultEnvelope.from_dict(payload).to_dict(prune_empty=False)
+    for key, value in payload.items():
+        assert normalized[key] == value
+    assert ToolResultEnvelope.from_dict(normalized).to_dict(prune_empty=False) == normalized
+
+
+def _captured_exception() -> RuntimeError:
+    try:
+        raise RuntimeError("host stopped")
+    except RuntimeError as exc:
+        return exc
+
+
+def test_all_python_result_producers_share_one_envelope_schema() -> None:
+    exc = _captured_exception()
+
+    @skill_entry
+    def missing_host(**_: Any) -> dict[str, Any]:
+        raise ImportError("No module named 'zbrush'", name="zbrush")
+
+    @skill_entry
+    def interrupted(**_: Any) -> dict[str, Any]:
+        raise KeyboardInterrupt("artist cancelled")
+
+    payloads = [
+        ToolResultEnvelope.ok("done", object_name="cube").to_dict(),
+        ToolResultEnvelope.fail("failed", error="invalid_input").to_dict(),
+        skill_success("done", object_name="cube"),
+        skill_error("failed", "invalid_input"),
+        skill_error_with_trace("failed", "execution_error", tb="Traceback: host stopped"),
+        skill_warning("done with warning", warning="slow"),
+        skill_exception(exc),
+        skill_error_from_exception(exc, operation="inspect_scene"),
+        from_exception("RuntimeError: host stopped").to_dict(),
+        ScriptExecutionResult.from_exception(exc),
+        exception_to_error_envelope(exc),
+        sandbox_denied_envelope(PermissionError("blocked"), action_name="execute_python"),
+        missing_host(),
+        interrupted(),
+    ]
+
+    for payload in payloads:
+        _assert_canonical(payload)
+
+
+def test_inprocess_exception_uses_string_code_and_structured_meta() -> None:
+    payload = exception_to_error_envelope(_captured_exception())
+
+    assert payload["error"] == "RuntimeError"
+    assert payload["_meta"]["dcc.error"]["type"] == "RuntimeError"
+    assert payload["_meta"]["dcc.error"]["message"] == "host stopped"
+    assert "Traceback" in payload["_meta"]["dcc.error"]["traceback"]
+
+
+def test_exception_producers_keep_diagnostics_in_namespaced_meta() -> None:
+    exc = _captured_exception()
+    payloads = [
+        skill_exception(exc),
+        skill_error_from_exception(exc),
+        from_exception("RuntimeError: host stopped").to_dict(),
+        ScriptExecutionResult.from_exception(exc),
+    ]
+
+    for payload in payloads:
+        assert isinstance(payload["error"], str)
+        assert payload["_meta"]["dcc.error"]["type"] == "RuntimeError"
+        assert payload["_meta"]["dcc.error"]["message"] == "host stopped"
+        assert payload["_meta"]["dcc.error"]["traceback"]
+
+
+@pytest.mark.parametrize(
+    ("unit", "count", "expected_prefix_count"),
+    [("错", 342, 333), ("🙂", 260, 250)],
+)
+def test_runtime_from_exception_truncates_utf8_on_character_boundary(
+    unit: str,
+    count: int,
+    expected_prefix_count: int,
+) -> None:
+    payload = from_exception(unit * count).to_dict()
+    traceback = payload["_meta"]["dcc.error"]["traceback"]
+
+    assert traceback.startswith((unit * expected_prefix_count) + "...")
+    assert "truncated, see trace_id" in traceback
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        r"C:\scene.ma: access denied",
+        "C:scene.ma: access denied",
+        "https://example.invalid/file: failed",
+        "dcc-mcp://host/tool: failed",
+        "Could not open: file",
+    ],
+)
+def test_runtime_from_exception_rejects_unstable_error_code_prefixes(message: str) -> None:
+    payload = from_exception(message).to_dict()
+
+    assert payload["error"] == "Exception"
+    assert payload["_meta"]["dcc.error"]["message"] == message
+
+
+def test_trace_helpers_merge_caller_meta_without_allowing_contract_override() -> None:
+    caller_meta = {
+        "vendor.trace": {"id": "trace-42"},
+        "dcc.error": {"type": "Spoofed"},
+        "dcc.raw_trace": {"underlying_call": "spoofed()"},
+    }
+    traced = skill_error_with_trace(
+        "failed",
+        "execution_error",
+        underlying_call="maya.cmds.polyCube()",
+        _meta=caller_meta,
+    )
+    caught = skill_exception(_captured_exception(), _meta=caller_meta)
+
+    assert traced["_meta"]["vendor.trace"] == {"id": "trace-42"}
+    assert traced["_meta"]["dcc.raw_trace"]["underlying_call"] == "maya.cmds.polyCube()"
+    assert caught["_meta"]["vendor.trace"] == {"id": "trace-42"}
+    assert caught["_meta"]["dcc.error"]["type"] == "RuntimeError"
+
+
+def test_runtime_tool_result_preserves_meta_during_json_round_trip() -> None:
+    payload = exception_to_error_envelope(_captured_exception())
+
+    runtime_result = validate_action_result(payload)
+    runtime_payload = runtime_result.to_dict()
+    serialized_payload = json.loads(serialize_result(runtime_result, SerializeFormat.Json))
+
+    assert runtime_payload["_meta"] == payload["_meta"]
+    assert serialized_payload["_meta"] == payload["_meta"]
+    assert "_meta" not in runtime_payload["context"]
+
+
+@pytest.mark.parametrize(
+    ("dcc_type", "asset_name"),
+    [("maya", "hero_mesh"), ("photoshop", "beauty_comp")],
+)
+def test_envelope_context_is_host_agnostic(dcc_type: str, asset_name: str) -> None:
+    payload = ToolResultEnvelope.ok(
+        "Asset inspected",
+        dcc_type=dcc_type,
+        asset_name=asset_name,
+    ).to_dict()
+
+    _assert_canonical(payload)
+    assert payload["context"] == {"dcc_type": dcc_type, "asset_name": asset_name}

--- a/tests/test_inprocess_executor.py
+++ b/tests/test_inprocess_executor.py
@@ -475,9 +475,9 @@ def test_executor_dispatcher_exception_becomes_error_envelope(tmp_path: Path) ->
     assert isinstance(result, dict)
     assert result["success"] is False
     assert "UI thread shutdown" in result["message"]
-    assert result["error"]["type"] == "RuntimeError"
-    assert result["error"]["message"] == "UI thread shutdown"
-    assert "Traceback" in result["error"]["traceback"]
+    assert result["error"] == "RuntimeError"
+    assert result["_meta"]["dcc.error"]["message"] == "UI thread shutdown"
+    assert "Traceback" in result["_meta"]["dcc.error"]["traceback"]
 
 
 def test_executor_inline_exception_becomes_error_envelope(tmp_path: Path) -> None:
@@ -489,9 +489,9 @@ def test_executor_inline_exception_becomes_error_envelope(tmp_path: Path) -> Non
     result = executor(str(p), {})
     assert isinstance(result, dict)
     assert result["success"] is False
-    assert result["error"]["type"] == "ValueError"
-    assert result["error"]["message"] == "bad input"
-    assert "Traceback" in result["error"]["traceback"]
+    assert result["error"] == "ValueError"
+    assert result["_meta"]["dcc.error"]["message"] == "bad input"
+    assert "Traceback" in result["_meta"]["dcc.error"]["traceback"]
 
 
 def test_exception_to_error_envelope_overrides_message() -> None:
@@ -502,13 +502,16 @@ def test_exception_to_error_envelope_overrides_message() -> None:
     assert envelope == {
         "success": False,
         "message": "custom summary",
-        "error": {
-            "type": "KeyError",
-            "message": "'missing'",
-            "traceback": envelope["error"]["traceback"],
+        "error": "KeyError",
+        "_meta": {
+            "dcc.error": {
+                "type": "KeyError",
+                "message": "'missing'",
+                "traceback": envelope["_meta"]["dcc.error"]["traceback"],
+            }
         },
     }
-    assert "KeyError" in envelope["error"]["traceback"]
+    assert "KeyError" in envelope["_meta"]["dcc.error"]["traceback"]
 
 
 def test_executor_uses_custom_runner() -> None:
@@ -645,7 +648,7 @@ def test_host_execution_bridge_connects_cooperative_cancel_token(tmp_path: Path)
         result = call.result(timeout=2)
 
     assert result["success"] is False
-    assert result["error"]["type"] == "CancelledError"
+    assert result["error"] == "CancelledError"
     assert current_job_id() is None
 
 
@@ -776,7 +779,7 @@ def test_hot_reload_invalidates_an_already_dispatched_call(
         result = call.result(timeout=1)
 
     assert result["success"] is False
-    assert result["error"]["type"] == "RuntimeError"
+    assert result["error"] == "RuntimeError"
     assert not cleaned.exists()
     assert bridge.shutdown_script_execution() == 0
     assert not cleaned.exists()
@@ -1048,7 +1051,7 @@ def test_deferred_tool_result_timeout_becomes_error_envelope() -> None:
     )
 
     assert result["success"] is False
-    assert result["error"]["type"] == "TimeoutError"
+    assert result["error"] == "TimeoutError"
     assert result["_meta"]["dcc.deferred"]["stderr"] == "still rendering"
 
 

--- a/tests/test_inprocess_sandbox.py
+++ b/tests/test_inprocess_sandbox.py
@@ -43,7 +43,7 @@ def test_denied_action_records_audit_without_importing_script(tmp_path: Path) ->
 
     mocked.assert_not_called()
     assert result["success"] is False
-    assert result["error"]["type"] == "SandboxDenied"
+    assert result["error"] == "SandboxDenied"
     denials = ctx.audit_log.denials()
     assert len(denials) == 1
     assert denials[0].action == "execute_python"
@@ -92,8 +92,8 @@ def test_sandbox_uses_script_stem_when_action_name_missing(tmp_path: Path) -> No
 
     mocked.assert_not_called()
     assert result["success"] is False
-    assert result["error"]["type"] == "SandboxDenied"
-    assert result["error"]["action"] == "execute_python"
+    assert result["error"] == "SandboxDenied"
+    assert result["context"]["action_name"] == "execute_python"
     denials = ctx.audit_log.denials()
     assert len(denials) == 1
     assert denials[0].action == "execute_python"
@@ -143,8 +143,8 @@ def test_register_inprocess_executor_attaches_configured_sandbox(tmp_path: Path)
     )
     result = captured[0](str(script), {})
     assert result["success"] is False
-    assert result["error"]["type"] == "SandboxDenied"
-    assert result["error"]["action"] == "execute_python"
+    assert result["error"] == "SandboxDenied"
+    assert result["context"]["action_name"] == "execute_python"
     assert base._execution_bridge is not None
     assert base._execution_bridge.sandbox_context is not None
 
@@ -174,5 +174,5 @@ def test_register_host_execution_bridge_attaches_configured_sandbox(tmp_path: Pa
     )
     result = captured[0](str(script), {})
     assert result["success"] is False
-    assert result["error"]["type"] == "SandboxDenied"
-    assert result["error"]["action"] == "execute_python"
+    assert result["error"] == "SandboxDenied"
+    assert result["context"]["action_name"] == "execute_python"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -155,10 +155,13 @@ class TestFactoryFunctions:
     def test_from_exception_minimal(self) -> None:
         r = dcc_mcp_core.from_exception("ValueError: bad")
         assert r.success is False
-        assert "ValueError" in r.error
+        assert r.error == "ValueError"
         assert r.prompt is not None  # has default prompt
-        assert "error_type" in r.context
-        assert "traceback" in r.context  # include_traceback=True by default
+        assert r._meta["dcc.error"]["type"] == "ValueError"
+        assert r._meta["dcc.error"]["message"] == "bad"
+        assert r._meta["dcc.error"]["traceback"]  # include_traceback=True by default
+        assert r.context["error_type"] == "ValueError"
+        assert r.context["traceback"]
 
     def test_from_exception_with_message(self) -> None:
         r = dcc_mcp_core.from_exception("err", message="Custom msg")
@@ -170,7 +173,7 @@ class TestFactoryFunctions:
 
     def test_from_exception_no_traceback(self) -> None:
         r = dcc_mcp_core.from_exception("err", include_traceback=False)
-        assert "traceback" not in r.context
+        assert "traceback" not in r._meta["dcc.error"]
 
     def test_from_exception_with_solutions(self) -> None:
         r = dcc_mcp_core.from_exception("err", possible_solutions=["sol1", "sol2"])

--- a/tests/test_protocols_scene_skill_serialize_deep.py
+++ b/tests/test_protocols_scene_skill_serialize_deep.py
@@ -577,7 +577,7 @@ class TestSkillException:
             raise ValueError("bad input")
         except Exception as e:
             r = skill_exception(e)
-        assert "ValueError" in r["error"] or "bad input" in r["error"]
+        assert r["error"] == "ValueError"
 
     def test_custom_message(self):
         try:
@@ -591,8 +591,7 @@ class TestSkillException:
             raise ValueError("oops")
         except Exception as e:
             r = skill_exception(e, include_traceback=True)
-        # traceback info should be in context
-        assert "traceback" in r.get("context", {}) or "error" in r
+        assert "traceback" in r["_meta"]["dcc.error"]
 
     def test_no_traceback_by_default_still_ok(self):
         try:
@@ -640,6 +639,8 @@ class TestSkillEntryDecorator:
 
         r = my_func()
         assert r["success"] is False
+        assert r["error"] == "import_error"
+        assert r["_meta"]["dcc.error"]["type"] == "ImportError"
 
     def test_exception_caught(self):
         @skill_entry
@@ -648,6 +649,19 @@ class TestSkillEntryDecorator:
 
         r = my_func()
         assert r["success"] is False
+
+    def test_base_exception_uses_stable_code_and_structured_meta(self):
+        @skill_entry
+        def my_func(**kwargs):
+            raise KeyboardInterrupt("artist cancelled")
+
+        r = my_func()
+        assert r["success"] is False
+        assert r["error"] == "interrupted"
+        assert r["_meta"]["dcc.error"] == {
+            "type": "KeyboardInterrupt",
+            "message": "artist cancelled",
+        }
 
     def test_returns_dict_always(self):
         @skill_entry

--- a/tests/test_result_envelope.py
+++ b/tests/test_result_envelope.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import json
 
-from dcc_mcp_core.result_envelope import ToolResult
+import pytest
+
+import dcc_mcp_core
+from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 
 def test_tool_result_ok_puts_kwargs_in_context() -> None:
-    result = ToolResult.ok("Loaded skill", name="recipe.x").to_dict()
+    result = ToolResultEnvelope.ok("Loaded skill", name="recipe.x").to_dict()
 
     assert result == {
         "success": True,
@@ -18,7 +21,7 @@ def test_tool_result_ok_puts_kwargs_in_context() -> None:
 
 
 def test_tool_result_fail_sets_error_prompt_and_context() -> None:
-    result = ToolResult.fail(
+    result = ToolResultEnvelope.fail(
         "Unknown tool",
         error="not_found",
         prompt="Call search_tools first.",
@@ -33,12 +36,12 @@ def test_tool_result_fail_sets_error_prompt_and_context() -> None:
 
 
 def test_tool_result_shortcut_factories() -> None:
-    assert ToolResult.not_found("Skill", "missing").to_dict() == {
+    assert ToolResultEnvelope.not_found("Skill", "missing").to_dict() == {
         "success": False,
         "message": "Skill not found: missing",
         "error": "not_found",
     }
-    assert ToolResult.invalid_input("Bad radius", radius=-1).to_dict() == {
+    assert ToolResultEnvelope.invalid_input("Bad radius", radius=-1).to_dict() == {
         "success": False,
         "message": "Bad radius",
         "error": "invalid_input",
@@ -47,6 +50,56 @@ def test_tool_result_shortcut_factories() -> None:
 
 
 def test_tool_result_json_uses_pruned_wire_shape() -> None:
-    payload = json.loads(ToolResult.ok("Done").to_json())
+    payload = json.loads(ToolResultEnvelope.ok("Done").to_json())
 
     assert payload == {"success": True, "message": "Done"}
+
+
+def test_tool_result_envelope_preserves_namespaced_meta() -> None:
+    payload = ToolResultEnvelope.fail(
+        "Execution failed",
+        error="execution_error",
+        _meta={"dcc.error": {"type": "RuntimeError", "message": "boom"}},
+    ).to_dict()
+
+    assert payload["error"] == "execution_error"
+    assert payload["_meta"]["dcc.error"]["type"] == "RuntimeError"
+
+
+def test_tool_result_envelope_round_trips_canonical_shape() -> None:
+    payload = {
+        "success": False,
+        "message": "Execution failed",
+        "error": "execution_error",
+        "prompt": "Retry after inspecting the error details.",
+        "context": {"action_name": "create_sphere"},
+        "_meta": {"dcc.error": {"type": "RuntimeError", "message": "boom"}},
+    }
+
+    assert ToolResultEnvelope.from_dict(payload).to_dict() == payload
+
+
+def test_legacy_module_tool_result_alias_is_deprecated() -> None:
+    from dcc_mcp_core import result_envelope
+
+    with pytest.warns(DeprecationWarning, match="ToolResultEnvelope"):
+        legacy = result_envelope.ToolResult
+
+    assert legacy is not ToolResultEnvelope
+    assert issubclass(legacy, ToolResultEnvelope)
+    assert legacy(True).prompt == ""
+    assert legacy.ok("Done", prompt="Inspect").to_dict() == {
+        "success": True,
+        "message": "Done",
+        "context": {"prompt": "Inspect"},
+    }
+
+
+def test_runtime_model_and_wire_envelope_have_distinct_public_names() -> None:
+    assert dcc_mcp_core.ToolResultEnvelope is ToolResultEnvelope
+    assert dcc_mcp_core.ToolResult is not ToolResultEnvelope
+
+
+def test_tool_result_envelope_rejects_object_error_on_direct_construction() -> None:
+    with pytest.raises(TypeError, match=r"error.*string"):
+        ToolResultEnvelope.fail("failed", error={"type": "RuntimeError"})  # type: ignore[arg-type]

--- a/tests/test_sandbox_audit_recorder_usd_capturer.py
+++ b/tests/test_sandbox_audit_recorder_usd_capturer.py
@@ -769,7 +769,8 @@ class TestFromException:
 
     def test_error_contains_message(self) -> None:
         r = dcc_mcp_core.from_exception("connection timeout")
-        assert "connection timeout" in r.error
+        assert r.error == "Exception"
+        assert r._meta["dcc.error"]["message"] == "connection timeout"
 
     def test_returns_action_result_model(self) -> None:
         r = dcc_mcp_core.from_exception("err")
@@ -797,4 +798,5 @@ class TestFromException:
     def test_include_traceback_false(self) -> None:
         r = dcc_mcp_core.from_exception("err", include_traceback=False)
         assert r.success is False
-        assert "err" in r.error
+        assert r.error == "Exception"
+        assert "traceback" not in r._meta["dcc.error"]

--- a/tests/test_script_execution.py
+++ b/tests/test_script_execution.py
@@ -250,6 +250,9 @@ def test_from_exception_includes_traceback_and_captured_output() -> None:
     assert result["error"] == "script_execution_error"
     assert result["context"]["stdout"] == "out"
     assert result["context"]["stderr"] == "err"
+    assert result["_meta"]["dcc.error"]["type"] == "RuntimeError"
+    assert result["_meta"]["dcc.error"]["message"] == "boom"
+    assert "Traceback" in result["_meta"]["dcc.error"]["traceback"]
     assert result["context"]["exception_type"] == "RuntimeError"
     assert result["context"]["exception_message"] == "boom"
     assert "Traceback" in result["context"]["traceback"]

--- a/tests/test_serialize_result_roundtrip.py
+++ b/tests/test_serialize_result_roundtrip.py
@@ -12,8 +12,8 @@ Covers:
 - Long message and Unicode content
 - deserialize_result TypeError on wrong input type
 - deserialize_result ValueError on corrupt data
-- _serialize_result helper in skill.py falls back when _core unavailable
-- run_main in skill.py uses Rust path when _core available
+- _serialize_result helper uses one dependency-light standard-library path
+- run_main emits the same normalized JSON with or without _core
 """
 
 from __future__ import annotations
@@ -506,91 +506,70 @@ class TestSkillSerializeResult:
         assert parsed["success"] is False
         assert parsed["error"] == "RuntimeError: boom"
 
-    def test_serialize_result_fallback_without_core(self, monkeypatch):
-        """When _core cannot be imported, fall back to json.dumps."""
-        import builtins
-        import importlib
-
-        original_import = builtins.__import__
-
-        def mock_import(name, *args, **kwargs):
-            if name == "dcc_mcp_core._core":
-                raise ImportError("simulated missing _core")
-            return original_import(name, *args, **kwargs)
-
-        # Reload skill module to get a fresh copy
+    def test_serialize_result_is_independent_of_native_json_helpers(self, monkeypatch):
+        """Skill JSON projection is identical when native helpers are unavailable."""
         import dcc_mcp_core.skill as skill_mod
 
-        importlib.reload(skill_mod)
-
+        result = {
+            "success": False,
+            "message": "Maya command failed",
+            "prompt": None,
+            "error": "RuntimeError",
+            "context": {"dcc_type": "maya", "action_name": "create_sphere"},
+            "_meta": {
+                "dcc.error": {
+                    "type": "RuntimeError",
+                    "message": "host stopped",
+                }
+            },
+        }
+        native_available = skill_mod._serialize_result(result)
         with monkeypatch.context() as mp:
-            mp.setattr(builtins, "__import__", mock_import)
-            # Import _serialize_result after patching
-            result = {"success": True, "message": "fallback", "prompt": None, "error": None, "context": {}}
-            # Call directly to exercise the fallback branch
-            output = skill_mod._serialize_result(result)
-        assert isinstance(output, str)
-        parsed = json.loads(output)
-        assert parsed["message"] == "fallback"
+            mp.setattr(
+                dcc_mcp_core,
+                "json_dumps",
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("native JSON helper used")),
+                raising=False,
+            )
+            source_only = skill_mod._serialize_result(result)
 
-    def test_serialize_result_fallback_prefers_core_json_dumps(self, monkeypatch):
-        """When validation is unavailable but json_dumps is importable, prefer it over stdlib JSON."""
-        import builtins
-        import importlib
+        assert native_available == source_only
+        parsed = json.loads(source_only)
+        assert parsed["_meta"] == result["_meta"]
+        assert "_meta" not in parsed["context"]
 
-        original_import = builtins.__import__
-        calls = []
+    def test_serialize_result_preserves_json_tuple_and_large_integer_semantics(self):
+        from dcc_mcp_core.skill import _serialize_result
 
-        def mock_import(name, globals=None, locals=None, fromlist=(), level=0):
-            if name == "dcc_mcp_core._core":
-                raise ImportError("simulated missing validation path")
-            return original_import(name, globals, locals, fromlist, level)
+        large_integer = 2**80 + 1
+        parsed = json.loads(
+            _serialize_result(
+                {
+                    "success": True,
+                    "message": "done",
+                    "context": {"coordinates": (1, 2), "asset_id": large_integer},
+                }
+            )
+        )
 
-        def fake_json_dumps(payload, **kwargs):
-            calls.append((payload, kwargs))
-            return json.dumps(payload, **kwargs)
+        assert parsed["context"]["coordinates"] == [1, 2]
+        assert parsed["context"]["asset_id"] == large_integer
 
-        import dcc_mcp_core.skill as skill_mod
+    def test_serialize_result_replaces_non_json_context_with_failure(self):
+        from dcc_mcp_core.skill import _serialize_result
 
-        importlib.reload(skill_mod)
+        parsed = json.loads(
+            _serialize_result(
+                {
+                    "success": True,
+                    "message": "done",
+                    "context": {"host_object": object()},
+                }
+            )
+        )
 
-        with monkeypatch.context() as mp:
-            mp.setattr(builtins, "__import__", mock_import)
-            mp.setattr(dcc_mcp_core, "json_dumps", fake_json_dumps, raising=False)
-            result = {"success": True, "message": "fast", "prompt": None, "error": None, "context": {}}
-
-            output = skill_mod._serialize_result(result)
-
-        assert calls
-        assert json.loads(output)["message"] == "fast"
-
-    def test_serialize_result_fallback_handles_lazy_core_json_missing(self, monkeypatch):
-        """If top-level json_dumps resolves but needs _core at call time, use stdlib JSON."""
-        import builtins
-        import importlib
-
-        original_import = builtins.__import__
-
-        def mock_import(name, globals=None, locals=None, fromlist=(), level=0):
-            if name == "dcc_mcp_core._core":
-                raise ImportError("simulated missing validation path")
-            return original_import(name, globals, locals, fromlist, level)
-
-        def unavailable_json_dumps(_payload, **_kwargs):
-            raise ModuleNotFoundError("No module named 'dcc_mcp_core._core'")
-
-        import dcc_mcp_core.skill as skill_mod
-
-        importlib.reload(skill_mod)
-
-        with monkeypatch.context() as mp:
-            mp.setattr(builtins, "__import__", mock_import)
-            mp.setattr(dcc_mcp_core, "json_dumps", unavailable_json_dumps, raising=False)
-            result = {"success": True, "message": "source-only", "prompt": None, "error": None, "context": {}}
-
-            output = skill_mod._serialize_result(result)
-
-        assert json.loads(output)["message"] == "source-only"
+        assert parsed["success"] is False
+        assert parsed["error"] == "non_serializable_result"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shm_versioned_registry_result_deep.py
+++ b/tests/test_shm_versioned_registry_result_deep.py
@@ -699,7 +699,8 @@ class TestFromException:
 
     def test_error_field_set(self):
         r = from_exception("my error")
-        assert r.error == "my error"
+        assert r.error == "Exception"
+        assert r._meta["dcc.error"]["message"] == "my error"
 
     def test_message_field_default_none_or_str(self):
         r = from_exception("my error")
@@ -714,9 +715,9 @@ class TestFromException:
         r = from_exception("my error", include_traceback=False)
         assert r.success is False
 
-    def test_include_traceback_true_has_traceback_context(self):
+    def test_include_traceback_true_has_traceback_meta(self):
         r = from_exception("my error", include_traceback=True)
-        assert "traceback" in r.context
+        assert "traceback" in r._meta["dcc.error"]
 
     def test_context_kwargs_are_stored(self):
         r = from_exception("my error", foo="bar", baz=42)
@@ -732,9 +733,10 @@ class TestFromException:
         r = from_exception("my error", prompt="Try checking logs")
         assert r.prompt == "Try checking logs"
 
-    def test_context_contains_error_type(self):
+    def test_meta_contains_error_type(self):
         r = from_exception("my error", include_traceback=True)
-        assert "error_type" in r.context
+        assert r._meta["dcc.error"]["type"] == "Exception"
+        assert r.context["error_type"] == "Exception"
 
     def test_returns_action_result_model_type(self):
         from dcc_mcp_core import ToolResult

--- a/tests/test_skill_error_with_trace.py
+++ b/tests/test_skill_error_with_trace.py
@@ -136,6 +136,9 @@ def test_skill_entry_import_error_reports_actual_bridge_host(exc, expected_label
 
     assert result["success"] is False
     assert result["message"] == f"{expected_label} is not available in this environment"
+    assert result["error"] == "import_error"
+    assert result["_meta"]["dcc.error"]["type"] == "ImportError"
+    assert result["_meta"]["dcc.error"]["message"] == str(exc)
     assert f"{expected_label} is running" in result["prompt"]
     assert "Maya is not available" not in result["message"]
     assert "Maya" not in result["prompt"]
@@ -158,4 +161,6 @@ def test_run_main_emits_non_maya_bridge_error_json(capsys):
     payload = json.loads(capsys.readouterr().out)
     assert payload["success"] is False
     assert payload["message"] == "ZBrush is not available in this environment"
+    assert payload["error"] == "import_error"
+    assert payload["_meta"]["dcc.error"]["type"] == "ImportError"
     assert "Maya" not in payload["prompt"]

--- a/tests/test_skill_execute_real.py
+++ b/tests/test_skill_execute_real.py
@@ -264,8 +264,8 @@ class TestSkillScriptErrorPropagation:
             {"reason": "invalid input"},
         )
         assert result["success"] is False
-        assert result["error"]["type"] == "RuntimeError"
-        assert result["error"]["message"] == "skill failed: invalid input"
+        assert result["error"] == "RuntimeError"
+        assert result["_meta"]["dcc.error"]["message"] == "skill failed: invalid input"
 
     def test_dispatcher_errors_are_visible_to_caller(self, tmp_path: Path) -> None:
         """If the host dispatcher's UI thread fails (e.g. Maya viewport closed),
@@ -291,8 +291,8 @@ class TestSkillScriptErrorPropagation:
         executor = build_inprocess_executor(_BoomDispatcher())
         result = executor(str(skill_dir / "scripts" / "noop.py"), {})
         assert result["success"] is False
-        assert result["error"]["type"] == "RuntimeError"
-        assert result["error"]["message"] == "UI thread shutting down"
+        assert result["error"] == "RuntimeError"
+        assert result["_meta"]["dcc.error"]["message"] == "UI thread shutting down"
 
     def test_missing_main_callable_raises_attribute_error(self, tmp_path: Path) -> None:
         skill_dir = _write_skill(
@@ -305,8 +305,8 @@ class TestSkillScriptErrorPropagation:
         executor = build_inprocess_executor(None)
         result = executor(str(skill_dir / "scripts" / "module_only.py"), {})
         assert result["success"] is False
-        assert result["error"]["type"] == "AttributeError"
-        assert "`main` callable" in result["error"]["message"]
+        assert result["error"] == "AttributeError"
+        assert "`main` callable" in result["_meta"]["dcc.error"]["message"]
 
 
 # ── catalog ↔ executor wiring round-trip ───────────────────────────────────

--- a/tests/test_skill_run_main.py
+++ b/tests/test_skill_run_main.py
@@ -31,3 +31,35 @@ def test_run_main_forwards_stdin_json_to_skill(monkeypatch, capsys):
         "width": 1920,
         "layers": ["title", "subtitle"],
     }
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"success": "yes", "message": "malformed"},
+        {"message": "missing success"},
+        ["not", "a", "mapping"],
+    ],
+)
+def test_run_main_exits_from_normalized_failure(result, monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+
+    with pytest.raises(SystemExit) as exit_info:
+        run_main(lambda: result)
+
+    assert exit_info.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert payload["error"] == "invalid_result_envelope"
+
+
+def test_run_main_serialization_failure_exits_nonzero(monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+
+    with pytest.raises(SystemExit) as exit_info:
+        run_main(lambda: skill_success("done", value=object()))
+
+    assert exit_info.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert payload["error"] == "non_serializable_result"

--- a/tests/test_skills_helper.py
+++ b/tests/test_skills_helper.py
@@ -84,13 +84,24 @@ def test_skills_helper_reexports_skill_result_helpers() -> None:
 def test_skill_error_from_exception_uses_standard_skill_error_shape() -> None:
     exc = ValueError("bad radius")
 
-    result = skill_error_from_exception(exc, prompt="Use a positive radius.", radius=-1)
+    result = skill_error_from_exception(
+        exc,
+        prompt="Use a positive radius.",
+        _meta={"vendor.trace": {"id": "trace-42"}, "dcc.error": {"type": "Spoofed"}},
+        radius=-1,
+    )
 
     assert result["success"] is False
     assert result["message"] == "bad radius"
     assert result["error"] == "ValueError"
     assert result["prompt"] == "Use a positive radius."
     assert result["context"] == {"radius": -1}
+    assert result["_meta"]["vendor.trace"] == {"id": "trace-42"}
+    assert result["_meta"]["dcc.error"] == {
+        "type": "ValueError",
+        "message": "bad radius",
+        "traceback": "ValueError: bad radius\n",
+    }
 
 
 def test_skills_helper_reports_invalid_json_errors() -> None:
@@ -289,7 +300,11 @@ def test_http_error_can_raise_structured_status_error(http_server) -> None:
     assert err.status == 418
     assert err.response.status == 418
     assert err.kind == "http-status"
-    assert err.to_skill_error()["error"] == "http-status"
+    payload = err.to_skill_error(_meta={"vendor.http": {"attempt": 1}})
+    assert payload["error"] == "http-status"
+    assert payload["_meta"]["vendor.http"] == {"attempt": 1}
+    assert payload["_meta"]["dcc.error"]["type"] == "HttpStatusError"
+    assert payload["_meta"]["dcc.error"]["message"] == str(err)
 
 
 def test_http_timeout_raises_structured_http_error(http_server) -> None:


### PR DESCRIPTION
## Summary
- unify Python and Rust tool-result errors around string codes and namespaced metadata
- preserve legacy imports and native/source-only serialization compatibility
- document the canonical contract and add cross-producer regression coverage

## Validation
- vx just preflight
- vx just lint
- vx just check-python-support
- Python: 10096 passed, 134 skipped, 3 xfailed
- vx npm run docs:build

Skill guidance updated for the public envelope and in-process dispatcher contracts.

Closes #2183