### PR TITLE
fix(updater): require and reverify binary update digests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,9 @@ Start a new agent turn after installation.
   before running the local file.
 - Keep official builds current with `dcc-mcp-cli update check`, then
   `dcc-mcp-cli update apply`. The apply step stages the latest CLI for the next
-  launch; it does not replace a running `dcc-mcp-server`.
+  launch and re-verifies its mandatory SHA-256 before replacement. Legacy
+  unsigned staging is quarantined. It does not replace a running
+  `dcc-mcp-server`.
 
 ## Response Language
 

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -98,8 +98,11 @@ dcc-mcp-cli update check
 dcc-mcp-cli update apply
 ```
 
-`update apply` downloads and stages the latest CLI for the next launch. It does
-not update a running `dcc-mcp-server`; update that server in its own environment.
+`update apply` accepts only an available manifest entry with a valid SHA-256,
+downloads and verifies the exact asset, and stages it for the next launch. The
+next process re-verifies the installation-bound staged bytes before replacing
+and restarting the CLI; legacy unsigned staging is quarantined. It does not
+update a running `dcc-mcp-server`; update that server in its own environment.
 
 ### Computer Use is an agent-directed fallback
 

--- a/admin-ui/src/hooks/queries.ts
+++ b/admin-ui/src/hooks/queries.ts
@@ -117,6 +117,7 @@ function isInstanceUpdatePayload(value: unknown): value is InstanceUpdatePayload
       'not_configured',
       'stage_failed',
       'staged',
+      'target_environment_required',
       'up_to_date',
     ].includes(status);
 }

--- a/crates/dcc-mcp-cli/src/application/update.rs
+++ b/crates/dcc-mcp-cli/src/application/update.rs
@@ -38,17 +38,21 @@ impl UpdateService {
             }));
         }
 
-        // Download the update archive
-        let downloaded = self.updater.download_update(&info).await?;
+        // Download and verify the update binary.
+        let downloaded = self.updater.download_verified_update(&info).await?;
 
         // Stage it for replacement on next launch
-        Updater::stage_update(&downloaded, self.updater.binary_name())?;
+        Updater::stage_verified_update(
+            downloaded.path(),
+            self.updater.binary_name(),
+            downloaded.sha256(),
+        )?;
 
         Ok(serde_json::json!({
             "status": "staged",
             "current_version": info.current_version,
             "latest_version": info.latest_version,
-            "staged_at": downloaded.to_string_lossy(),
+            "staged_at": downloaded.path().to_string_lossy(),
             "message": "Update downloaded and staged. Restart the binary to apply.",
         }))
     }

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -507,18 +507,34 @@ enum GatewayDaemonAction {
 }
 
 pub async fn run() -> anyhow::Result<()> {
-    apply_staged_update();
+    if apply_staged_update() {
+        return restart_after_update();
+    }
     run_with_args(Args::parse()).await
 }
 
-fn apply_staged_update() {
+fn apply_staged_update() -> bool {
     // Apply any staged binary update before running commands (CLI restart
     // is the user's next invocation after `update apply`).
     match dcc_mcp_updater::Updater::apply_staged_update(env!("CARGO_PKG_NAME")) {
-        Ok(true) => eprintln!("info: staged binary update applied"),
-        Ok(false) => { /* no update was staged */ }
-        Err(e) => eprintln!("warning: failed to apply staged binary update: {e}"),
+        Ok(true) => {
+            eprintln!("info: staged binary update applied; restarting");
+            true
+        }
+        Ok(false) => false,
+        Err(e) => {
+            eprintln!("warning: failed to apply staged binary update: {e}");
+            false
+        }
     }
+}
+
+fn restart_after_update() -> anyhow::Result<()> {
+    let executable = std::env::current_exe()?;
+    std::process::Command::new(executable)
+        .args(std::env::args_os().skip(1))
+        .spawn()?;
+    Ok(())
 }
 
 async fn run_with_args(args: Args) -> anyhow::Result<()> {

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -1524,7 +1524,7 @@ fn update_check_auto_starts_builtin_local_gateway() {
 }
 
 #[test]
-fn staged_update_applies_before_version_short_circuit() {
+fn legacy_unsigned_update_is_quarantined_before_version_short_circuit() {
     let temp = TempDir::new().unwrap();
     let source = std::path::Path::new(env!("CARGO_BIN_EXE_dcc-mcp-cli"));
     let cli = temp.path().join(source.file_name().unwrap());
@@ -1561,8 +1561,23 @@ fn staged_update_applies_before_version_short_circuit() {
     );
     assert!(
         !marker.exists(),
-        "--version must apply a staged update before clap exits; stderr: {}",
+        "--version must quarantine a legacy staged update before clap exits; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::read(&cli).unwrap(),
+        std::fs::read(source).unwrap(),
+        "legacy unsigned bytes must never replace the CLI"
+    );
+    assert!(
+        std::fs::read_dir(&staging)
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|entry| entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("legacy-unsigned-")),
+        "legacy update should be retained in a quarantine directory"
     );
 }
 
@@ -1665,7 +1680,10 @@ fn update_check_supports_server_binary_versions() {
         update["download_url"],
         "https://example.invalid/dcc-mcp-server.zip"
     );
-    assert_eq!(update["sha256"], "abc123");
+    assert_eq!(
+        update["sha256"],
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
     assert_eq!(update["release_notes"], "Server update");
 }
 

--- a/crates/dcc-mcp-cli/tests/support/mod.rs
+++ b/crates/dcc-mcp-cli/tests/support/mod.rs
@@ -103,7 +103,7 @@ pub(crate) fn spawn_gateway_fixture() -> GatewayFixture {
                     "dcc-mcp-server": {
                         "version": "9.9.9",
                         "url": "https://example.invalid/dcc-mcp-server.zip",
-                        "sha256": "abc123",
+                        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                         "release_notes": "Fixture update"
                     }
                 }))
@@ -545,7 +545,7 @@ pub(crate) fn spawn_gateway_fixture() -> GatewayFixture {
                             "update_available": current != "0.19.0",
                             "latest_version": "0.19.0",
                             "download_url": "https://example.invalid/dcc-mcp-server.zip",
-                            "sha256": "abc123",
+                            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                             "release_notes": "Server update"
                         })),
                     )
@@ -566,7 +566,8 @@ pub(crate) fn spawn_gateway_fixture() -> GatewayFixture {
                 (
                     StatusCode::OK,
                     Json(json!({
-                        "download_url": "https://example.invalid/dcc-mcp-server.zip"
+                        "download_url": "https://example.invalid/dcc-mcp-server.zip",
+                        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                     })),
                 )
             }),

--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/handlers.rs
@@ -9,7 +9,6 @@ use axum::extract::{OriginalUri, Path, Query, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use dcc_mcp_gateway_core::naming::instance_short;
-use dcc_mcp_updater::{UpdateInfo, Updater};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
@@ -166,7 +165,7 @@ pub async fn handle_admin_instances(
     .into_response()
 }
 
-/// `POST /admin/api/instances/{instance_id}/update` — check and optionally stage a server update.
+/// `POST /admin/api/instances/{instance_id}/update` — check an instance update.
 pub async fn handle_admin_instance_update(
     State(s): State<AdminState>,
     Path(instance_filter): Path<String>,
@@ -179,7 +178,7 @@ pub async fn handle_admin_instance_update(
         .filter(|value| !value.is_empty())
         .unwrap_or("dcc-mcp-server")
         .to_string();
-    let apply = req.apply.unwrap_or(true);
+    let apply = req.apply.unwrap_or(false);
 
     let instance = match admin_find_instance_entry(&s, &instance_filter).await {
         Ok(entry) => entry,
@@ -284,6 +283,32 @@ pub async fn handle_admin_instance_update(
 
     let update_available =
         crate::gateway::is_newer_version(&manifest_entry.version, &current_version);
+    let verified_asset = if update_available {
+        match manifest_entry.require_asset(&binary_name) {
+            Ok(asset) => Some(asset),
+            Err(error) => {
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({
+                        "status": "manifest_error",
+                        "error": "invalid_update_manifest",
+                        "message": error.to_string(),
+                        "instance_id": instance_id,
+                        "instance_short": instance_short_id,
+                        "binary_name": binary_name,
+                        "current_version": displayed_current_version,
+                        "current_version_source": current_version_source,
+                        "latest_version": manifest_entry.version,
+                        "update_available": false,
+                        "requires_restart": false,
+                    })),
+                )
+                    .into_response();
+            }
+        }
+    } else {
+        None
+    };
     if !update_available || !apply {
         return Json(json!({
             "status": if update_available { "available" } else { "up_to_date" },
@@ -293,8 +318,10 @@ pub async fn handle_admin_instance_update(
             "current_version": displayed_current_version,
             "current_version_source": current_version_source,
             "latest_version": manifest_entry.version,
-            "download_url": manifest_entry.url,
-            "sha256": manifest_entry.sha256,
+            "download_url": verified_asset.as_ref().map(|asset| asset.url),
+            "sha256": verified_asset
+                .as_ref()
+                .map(|asset| asset.sha256.as_str()),
             "release_notes": manifest_entry.release_notes,
             "update_available": update_available,
             "requires_restart": false,
@@ -307,120 +334,35 @@ pub async fn handle_admin_instance_update(
         .into_response();
     }
 
-    // The gateway cannot prove that a selected instance uses its own current
-    // executable or installation root. Staging a server update here would let
-    // another local/remote instance consume a binary_name-only marker and,
-    // on Windows, could pair the server with the wrong sibling host. Keep
-    // Admin check-only and require apply from the exact target environment.
-    if binary_name == "dcc-mcp-server" {
-        return (
-            StatusCode::CONFLICT,
-            Json(json!({
-                "status": "target_environment_required",
-                "error": "server_update_target_unproven",
-                "message": "Server updates must be staged from the target installation. Run `dcc-mcp-server update apply` in that server environment.",
-                "instance_id": instance_id,
-                "instance_short": instance_short_id,
-                "binary_name": binary_name,
-                "current_version": displayed_current_version,
-                "current_version_source": current_version_source,
-                "latest_version": manifest_entry.version,
-                "update_available": true,
-                "requires_restart": false,
-            })),
-        )
-            .into_response();
-    }
-
-    if manifest_entry.url.is_none() {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({
-                "status": "download_failed",
-                "error": "download_url_not_configured",
-                "message": format!("No download URL is configured for binary '{binary_name}'."),
-                "instance_id": instance_id,
-                "instance_short": instance_short_id,
-                "binary_name": binary_name,
-                "current_version": displayed_current_version,
-                "current_version_source": current_version_source,
-                "latest_version": manifest_entry.version,
-                "update_available": true,
-                "requires_restart": false,
-            })),
-        )
-            .into_response();
-    }
-
-    let info = UpdateInfo {
-        update_available,
-        current_version: current_version.clone(),
-        latest_version: manifest_entry.version.clone(),
-        download_url: manifest_entry.url.clone(),
-        sha256: manifest_entry.sha256.clone(),
-        release_notes: manifest_entry.release_notes.clone(),
-    };
-    let updater = Updater::new("http://127.0.0.1", &binary_name, &current_version);
-    let downloaded = match updater.download_update(&info).await {
-        Ok(path) => path,
-        Err(err) => {
-            return (
-                StatusCode::BAD_GATEWAY,
-                Json(json!({
-                    "status": "download_failed",
-                    "error": "update_download_failed",
-                    "message": err.to_string(),
-                    "instance_id": instance_id,
-                    "instance_short": instance_short_id,
-                    "binary_name": binary_name,
-                    "current_version": displayed_current_version,
-                    "current_version_source": current_version_source,
-                    "latest_version": manifest_entry.version,
-                    "update_available": true,
-                    "requires_restart": false,
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    if let Err(err) = Updater::stage_update(&downloaded, &binary_name) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({
-                "status": "stage_failed",
-                "error": "update_stage_failed",
-                "message": err.to_string(),
-                "instance_id": instance_id,
-                "instance_short": instance_short_id,
-                "binary_name": binary_name,
-                "current_version": displayed_current_version,
-                "current_version_source": current_version_source,
-                "latest_version": manifest_entry.version,
-                "update_available": true,
-                "requires_restart": false,
-            })),
-        )
-            .into_response();
-    }
-
-    Json(json!({
-        "status": "staged",
-        "instance_id": instance_id,
-        "instance_short": instance_short_id,
-        "binary_name": binary_name,
-        "current_version": displayed_current_version,
-        "current_version_source": current_version_source,
-        "latest_version": manifest_entry.version,
-        "download_url": manifest_entry.url,
-        "sha256": manifest_entry.sha256,
-        "release_notes": manifest_entry.release_notes,
-        "staged_at": downloaded.to_string_lossy(),
-        "update_available": true,
-        "requires_restart": true,
-        "message": "Update downloaded and staged. Restart the binary to apply.",
-    }))
-    .into_response()
+    // The gateway cannot prove which executable installation should consume
+    // a staged update. Keep Admin check-only for every binary and require the
+    // updater to run inside the exact target environment.
+    (
+        StatusCode::CONFLICT,
+        Json(json!({
+            "status": "target_environment_required",
+            "error": "update_target_unproven",
+            "message": format!(
+                "Updates for '{binary_name}' must be staged from the exact target installation."
+            ),
+            "instance_id": instance_id,
+            "instance_short": instance_short_id,
+            "binary_name": binary_name,
+            "current_version": displayed_current_version,
+            "current_version_source": current_version_source,
+            "latest_version": manifest_entry.version,
+            "download_url": verified_asset
+                .as_ref()
+                .map(|asset| asset.url),
+            "sha256": verified_asset
+                .as_ref()
+                .map(|asset| asset.sha256.as_str()),
+            "release_notes": manifest_entry.release_notes,
+            "update_available": true,
+            "requires_restart": false,
+        })),
+    )
+        .into_response()
 }
 
 async fn admin_find_instance_entry(

--- a/crates/dcc-mcp-gateway/src/gateway/admin/instance_update_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/instance_update_tests.rs
@@ -48,22 +48,17 @@ impl ScopedUpdateDataDir {
         self.dir.path()
     }
 
-    fn pending_marker(&self, binary_name: &str) -> std::path::PathBuf {
+    fn update_root(&self) -> std::path::PathBuf {
         #[cfg(target_os = "macos")]
         {
             self.root()
                 .join("Library")
                 .join("Application Support")
                 .join("update")
-                .join(binary_name)
-                .join("pending.marker")
         }
         #[cfg(not(target_os = "macos"))]
         {
-            self.root()
-                .join("update")
-                .join(binary_name)
-                .join("pending.marker")
+            self.root().join("update")
         }
     }
 }
@@ -188,18 +183,22 @@ async fn spawn_update_manifest(manifest: Value) -> (String, oneshot::Sender<()>)
 }
 
 async fn spawn_update_manifest_with_binary(
+    binary_name: &'static str,
     version: &'static str,
     binary_body: &'static [u8],
 ) -> (String, oneshot::Sender<()>) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
-    let download_url = format!("http://127.0.0.1:{port}/dcc-mcp-server.bin");
+    let download_url = format!("http://127.0.0.1:{port}/binary.bin");
+    let digest_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(digest_file.path(), binary_body).unwrap();
+    let sha256 = dcc_mcp_updater::sha256_file(digest_file.path()).unwrap();
     let manifest = json!({
-        "dcc-mcp-server": {
+        binary_name: {
             "version": version,
             "url": download_url,
-            "sha256": null,
-            "release_notes": "Server update"
+            "sha256": sha256,
+            "release_notes": "Binary update"
         }
     });
     let app = Router::new()
@@ -211,7 +210,7 @@ async fn spawn_update_manifest_with_binary(
             }),
         )
         .route(
-            "/dcc-mcp-server.bin",
+            "/binary.bin",
             axum::routing::get(move || {
                 let body = binary_body.to_vec();
                 async move { ([(header::CONTENT_TYPE, "application/octet-stream")], body) }
@@ -393,7 +392,7 @@ async fn test_admin_instance_update_checks_manifest_without_manual_cli() {
 }
 
 #[tokio::test]
-async fn test_admin_instance_update_requires_target_environment_before_server_download() {
+async fn test_admin_instance_update_rejects_available_manifest_without_asset_integrity() {
     let (manifest_url, shutdown) = spawn_update_manifest(json!({
         "dcc-mcp-server": {
             "version": "999.0.0",
@@ -424,21 +423,21 @@ async fn test_admin_instance_update_requires_target_environment_before_server_do
     .await;
     let _ = shutdown.send(());
 
-    assert_eq!(status, StatusCode::CONFLICT);
-    assert_eq!(body["status"], "target_environment_required");
-    assert_eq!(body["error"], "server_update_target_unproven");
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+    assert_eq!(body["status"], "manifest_error");
+    assert_eq!(body["error"], "invalid_update_manifest");
     assert_eq!(body["binary_name"], "dcc-mcp-server");
     assert_eq!(body["current_version"], "0.18.0");
     assert_eq!(body["current_version_source"], "request");
     assert_eq!(body["latest_version"], "999.0.0");
-    assert_eq!(body["update_available"], true);
+    assert_eq!(body["update_available"], false);
     assert_eq!(body["requires_restart"], false);
 }
 
 #[tokio::test]
 async fn test_admin_instance_update_can_check_without_staging() {
     let (manifest_url, shutdown) =
-        spawn_update_manifest_with_binary("999.0.0", b"server-binary").await;
+        spawn_update_manifest_with_binary("dcc-mcp-server", "999.0.0", b"server-binary").await;
 
     let mut gs = make_gateway_state();
     gs.update_manifest_url = Some(manifest_url);
@@ -475,7 +474,7 @@ async fn test_admin_instance_update_never_stages_unbound_server_binary() {
     let _guard = UPDATE_ENV_LOCK.lock();
     let data_dir = ScopedUpdateDataDir::new();
     let (manifest_url, shutdown) =
-        spawn_update_manifest_with_binary("999.0.0", b"server-binary").await;
+        spawn_update_manifest_with_binary("dcc-mcp-server", "999.0.0", b"server-binary").await;
 
     let mut gs = make_gateway_state();
     gs.update_manifest_url = Some(manifest_url);
@@ -499,7 +498,7 @@ async fn test_admin_instance_update_never_stages_unbound_server_binary() {
 
     assert_eq!(status, StatusCode::CONFLICT);
     assert_eq!(body["status"], "target_environment_required");
-    assert_eq!(body["error"], "server_update_target_unproven");
+    assert_eq!(body["error"], "update_target_unproven");
     assert_eq!(body["binary_name"], "dcc-mcp-server");
     assert_eq!(body["current_version"], "0.18.0");
     assert_eq!(body["current_version_source"], "request");
@@ -507,8 +506,51 @@ async fn test_admin_instance_update_never_stages_unbound_server_binary() {
     assert_eq!(body["update_available"], true);
     assert_eq!(body["requires_restart"], false);
     assert!(
-        !data_dir.pending_marker("dcc-mcp-server").exists(),
-        "Admin must not write an installation-unbound server marker"
+        !data_dir.update_root().exists(),
+        "Admin must not write installation-unbound update state"
+    );
+}
+
+#[tokio::test]
+async fn test_admin_instance_update_is_check_only_for_non_server_binaries() {
+    let _guard = UPDATE_ENV_LOCK.lock();
+    let data_dir = ScopedUpdateDataDir::new();
+
+    for binary_name in ["dcc-mcp-cli", "studio-custom-tool"] {
+        let (manifest_url, shutdown) =
+            spawn_update_manifest_with_binary(binary_name, "999.0.0", b"binary").await;
+        let mut gs = make_gateway_state();
+        gs.update_manifest_url = Some(manifest_url);
+        let instance_id = {
+            let reg = gs.registry.write().await;
+            let entry = make_service_entry("photoshop", "127.0.0.1", 18814, Some(4243));
+            let instance_id = entry.instance_id.to_string();
+            reg.register(entry).unwrap();
+            instance_id
+        };
+
+        let router = build_admin_router(AdminState::new(gs));
+        let (status, body) = post_json(
+            router,
+            &format!("/api/instances/{instance_id}/update"),
+            json!({
+                "binary": binary_name,
+                "apply": true,
+                "current_version": "0.18.0"
+            }),
+        )
+        .await;
+        let _ = shutdown.send(());
+
+        assert_eq!(status, StatusCode::CONFLICT, "{binary_name}: {body}");
+        assert_eq!(body["status"], "target_environment_required");
+        assert_eq!(body["error"], "update_target_unproven");
+        assert_eq!(body["binary_name"], binary_name);
+    }
+
+    assert!(
+        !data_dir.update_root().exists(),
+        "Admin must remain check-only for every binary"
     );
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -685,7 +685,7 @@ async fn gateway_update_check_and_download_use_configured_manifest() {
         "dcc-mcp-server": {
             "version": "0.19.0",
             "url": "https://example.invalid/dcc-mcp-server.zip",
-            "sha256": "abc123",
+            "sha256": "a".repeat(64),
             "release_notes": "Server update"
         }
     }))
@@ -715,7 +715,7 @@ async fn gateway_update_check_and_download_use_configured_manifest() {
         body["download_url"],
         "https://example.invalid/dcc-mcp-server.zip"
     );
-    assert_eq!(body["sha256"], "abc123");
+    assert_eq!(body["sha256"], "a".repeat(64));
     assert_eq!(body["release_notes"], "Server update");
 
     let response = app
@@ -736,10 +736,11 @@ async fn gateway_update_check_and_download_use_configured_manifest() {
         body["download_url"],
         "https://example.invalid/dcc-mcp-server.zip"
     );
+    assert_eq!(body["sha256"], "a".repeat(64));
 }
 
 #[tokio::test]
-async fn gateway_update_download_reports_missing_url_as_structured_payload() {
+async fn gateway_update_download_rejects_manifest_without_verified_asset() {
     let (manifest_url, shutdown) = spawn_update_manifest(json!({
         "dcc-mcp-server": {
             "version": "0.19.0",
@@ -766,12 +767,12 @@ async fn gateway_update_download_reports_missing_url_as_structured_payload() {
     let (status, body) = response_json(response).await;
     let _ = shutdown.send(());
 
-    assert_eq!(status, StatusCode::NOT_FOUND);
-    assert_eq!(body["status"], "download_url_not_configured");
-    assert_eq!(body["error"], "download_url_not_configured");
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+    assert_eq!(body["status"], "manifest_error");
+    assert_eq!(body["error"], "invalid_update_manifest");
     assert_eq!(body["binary_name"], "dcc-mcp-server");
-    assert_eq!(body["latest_version"], "0.19.0");
     assert_eq!(body["update_available"], false);
+    assert!(body["message"].as_str().unwrap().contains("download URL"));
 }
 
 #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/update_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/update_impl.rs
@@ -36,6 +36,19 @@ fn not_found(binary: &str) -> (StatusCode, Json<Value>) {
     )
 }
 
+fn invalid_manifest(binary: &str, message: impl Into<String>) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::BAD_GATEWAY,
+        Json(json!({
+            "status": "manifest_error",
+            "error": "invalid_update_manifest",
+            "message": message.into(),
+            "binary_name": binary,
+            "update_available": false,
+        })),
+    )
+}
+
 // ── Query params ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -103,12 +116,22 @@ pub(crate) async fn handle_v1_update_check(
     };
 
     let update_available = is_newer_version(&entry.version, &current_version);
+    let verified_asset = if update_available {
+        match entry.require_asset(&binary_name) {
+            Ok(asset) => Some(asset),
+            Err(error) => return invalid_manifest(&binary_name, error.to_string()).into_response(),
+        }
+    } else {
+        None
+    };
 
     let resp = json!({
         "update_available": update_available,
         "latest_version": entry.version,
-        "download_url": entry.url,
-        "sha256": entry.sha256,
+        "download_url": verified_asset.as_ref().map(|asset| asset.url),
+        "sha256": verified_asset
+            .as_ref()
+            .map(|asset| asset.sha256.as_str()),
         "release_notes": entry.release_notes,
         "current_version": current_version,
     });
@@ -149,27 +172,17 @@ pub(crate) async fn handle_v1_update_download(
         None => return not_found(&binary_name).into_response(),
     };
 
-    let download_url = match &entry.url {
-        Some(url) => url.clone(),
-        None => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({
-                    "status": "download_url_not_configured",
-                    "error": "download_url_not_configured",
-                    "message": format!("No download URL is configured for binary '{binary_name}'."),
-                    "binary_name": binary_name,
-                    "latest_version": entry.version,
-                    "update_available": false,
-                })),
-            )
-                .into_response();
-        }
+    let asset = match entry.require_asset(&binary_name) {
+        Ok(asset) => asset,
+        Err(error) => return invalid_manifest(&binary_name, error.to_string()).into_response(),
     };
 
     (
         StatusCode::OK,
-        Json(json!({ "download_url": download_url })),
+        Json(json!({
+            "download_url": asset.url,
+            "sha256": asset.sha256.as_str(),
+        })),
     )
         .into_response()
 }

--- a/crates/dcc-mcp-gateway/src/gateway/rest_openapi.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/rest_openapi.rs
@@ -757,13 +757,20 @@ fn gateway_schemas() -> Vec<(&'static str, Value)> {
                     "binary_name": {"type": "string", "description": "Present on CLI-normalized payloads or binary-specific errors."},
                     "latest_version": {"type": "string", "description": "Present when the binary exists in the update manifest."},
                     "download_url": {"type": ["string", "null"], "format": "uri"},
-                    "sha256": {"type": ["string", "null"]},
+                    "sha256": {"type": ["string", "null"], "pattern": "^[0-9a-fA-F]{64}$"},
                     "release_notes": {"type": ["string", "null"]},
                     "status": {"type": "string", "description": "Present on structured error responses."},
                     "error": {"type": "string"},
                     "message": {"type": "string"},
                     "hint": {"type": "string"}
                 },
+                "allOf": [{
+                    "if": {
+                        "properties": {"update_available": {"const": true}},
+                        "required": ["update_available"]
+                    },
+                    "then": {"required": ["download_url", "sha256"]}
+                }],
                 "additionalProperties": true,
             }),
         ),
@@ -773,6 +780,7 @@ fn gateway_schemas() -> Vec<(&'static str, Value)> {
                 "type": "object",
                 "properties": {
                     "download_url": {"type": "string", "format": "uri"},
+                    "sha256": {"type": "string", "pattern": "^[0-9a-fA-F]{64}$"},
                     "status": {"type": "string"},
                     "error": {"type": "string"},
                     "message": {"type": "string"},
@@ -780,6 +788,10 @@ fn gateway_schemas() -> Vec<(&'static str, Value)> {
                     "latest_version": {"type": "string"},
                     "update_available": {"type": "boolean"}
                 },
+                "oneOf": [
+                    {"required": ["download_url", "sha256"]},
+                    {"required": ["error"]}
+                ],
                 "additionalProperties": true,
             }),
         ),
@@ -1478,3 +1490,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "rest_openapi_contract_tests.rs"]
+mod contract_tests;

--- a/crates/dcc-mcp-gateway/src/gateway/rest_openapi_contract_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/rest_openapi_contract_tests.rs
@@ -1,0 +1,22 @@
+use super::build_gateway_openapi_document;
+
+#[test]
+fn gateway_openapi_requires_verified_update_downloads() {
+    let doc = build_gateway_openapi_document("1.2.3");
+    let check = &doc["components"]["schemas"]["GatewayUpdateCheckResponse"];
+    let download = &doc["components"]["schemas"]["GatewayUpdateDownloadResponse"];
+
+    assert_eq!(
+        check["properties"]["sha256"]["pattern"],
+        "^[0-9a-fA-F]{64}$"
+    );
+    assert_eq!(
+        download["properties"]["sha256"]["pattern"],
+        "^[0-9a-fA-F]{64}$"
+    );
+    assert_eq!(
+        doc["paths"]["/v1/update/download/{binary_name}"]["get"]["responses"]["200"]["content"]["application/json"]
+            ["schema"]["$ref"],
+        "#/components/schemas/GatewayUpdateDownloadResponse"
+    );
+}

--- a/crates/dcc-mcp-gateway/src/gateway/update_manifest.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/update_manifest.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use reqwest::header::ACCEPT;
 use serde::Deserialize;
+use thiserror::Error;
 
 /// A single entry in the update manifest (binary_name -> entry).
 #[derive(Debug, Clone, Deserialize)]
@@ -12,6 +13,37 @@ pub(crate) struct ManifestEntry {
     pub(crate) url: Option<String>,
     pub(crate) sha256: Option<String>,
     pub(crate) release_notes: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct VerifiedManifestAsset<'a> {
+    pub(crate) url: &'a str,
+    pub(crate) sha256: dcc_mcp_updater::Sha256Digest,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ManifestAssetError {
+    #[error("Update manifest entry for {binary_name} is missing a download URL")]
+    MissingUrl { binary_name: String },
+    #[error(transparent)]
+    Integrity(#[from] dcc_mcp_updater::UpdateError),
+}
+
+impl ManifestEntry {
+    pub(crate) fn require_asset(
+        &self,
+        binary_name: &str,
+    ) -> Result<VerifiedManifestAsset<'_>, ManifestAssetError> {
+        let url = self
+            .url
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| ManifestAssetError::MissingUrl {
+                binary_name: binary_name.to_owned(),
+            })?;
+        let sha256 = dcc_mcp_updater::Sha256Digest::require(binary_name, self.sha256.as_deref())?;
+        Ok(VerifiedManifestAsset { url, sha256 })
+    }
 }
 
 /// Top-level update manifest fetched from `update_manifest_url`.

--- a/crates/dcc-mcp-server/src/update.rs
+++ b/crates/dcc-mcp-server/src/update.rs
@@ -33,9 +33,13 @@ async fn stage_server_update(gateway_url: &str) -> anyhow::Result<()> {
         print_up_to_date(&info)?;
         return Ok(());
     }
-    let downloaded = updater.download_update(&info).await?;
-    dcc_mcp_updater::Updater::stage_update(&downloaded, updater.binary_name())?;
-    print_staged(&info, &[downloaded])?;
+    let downloaded = updater.download_verified_update(&info).await?;
+    dcc_mcp_updater::Updater::stage_verified_update(
+        downloaded.path(),
+        updater.binary_name(),
+        downloaded.sha256(),
+    )?;
+    print_staged(&info, &[downloaded.path().to_path_buf()])?;
     Ok(())
 }
 
@@ -74,6 +78,13 @@ pub(crate) fn apply_staged_update() -> anyhow::Result<bool> {
             Ok(true)
         }
         Ok(false) => Ok(false),
+        Err(
+            dcc_mcp_updater::UpdateError::LegacyUnsignedStage
+            | dcc_mcp_updater::UpdateError::RejectedStagedUpdate { .. },
+        ) => {
+            tracing::warn!("refused and quarantined an untrusted staged server update");
+            Ok(false)
+        }
         Err(error) => Err(error.into()),
     }
 }

--- a/crates/dcc-mcp-updater/src/lib.rs
+++ b/crates/dcc-mcp-updater/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! 1. `check` — query the gateway for the latest version
 //! 2. `download` — fetch the new binary to a temp staging directory
-//! 3. `stage` — write a "pending update" marker so the next launch applies it
-//! 4. On next launch, `apply_staged` — atomically swap the old binary
+//! 3. `stage` — bind a verified component manifest to the exact installation
+//! 4. On next launch, `apply_staged` — re-verify and atomically swap the binary
 //!
 //! Each step is independent so callers (CLI or server) can decide the UX.
 
@@ -22,13 +22,19 @@ use thiserror::Error;
 
 mod update_set;
 
+const MAX_UPDATE_BYTES: u64 = 256 * 1024 * 1024;
+
 pub use update_set::{
-    UpdateSetSource, UpdateTarget, apply_staged_update_set, install_verified_sibling,
-    stage_update_set,
+    UpdateSetSource, UpdateTarget, apply_staged_binary_update, apply_staged_update_set,
+    clear_staged_binary_update, install_verified_sibling, stage_update_set,
+    stage_verified_binary_update,
 };
 
 #[doc(hidden)]
-pub use update_set::{apply_staged_update_set_for, stage_update_set_for};
+pub use update_set::{
+    apply_staged_binary_update_for, apply_staged_update_set_for, clear_staged_binary_update_for,
+    stage_update_set_for, stage_verified_binary_update_for,
+};
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -39,9 +45,9 @@ pub struct UpdateCheckResponse {
     pub update_available: bool,
     /// The latest version string available.
     pub latest_version: String,
-    /// URL to download the new binary archive.
+    /// URL to download the new binary; required when an update is available.
     pub download_url: Option<String>,
-    /// SHA-256 hex digest of the downloadable archive (optional).
+    /// SHA-256 hex digest; required when an update is available.
     pub sha256: Option<String>,
     /// Human-readable release notes / changelog excerpt.
     pub release_notes: Option<String>,
@@ -56,6 +62,59 @@ pub struct UpdateInfo {
     pub download_url: Option<String>,
     pub sha256: Option<String>,
     pub release_notes: Option<String>,
+}
+
+/// A validated, canonical lowercase SHA-256 digest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sha256Digest(String);
+
+impl Sha256Digest {
+    /// Require and validate a manifest digest for one binary.
+    pub fn require(binary_name: &str, value: Option<&str>) -> Result<Self, UpdateError> {
+        let value = value.ok_or_else(|| UpdateError::MissingChecksum {
+            binary_name: binary_name.to_owned(),
+        })?;
+        if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(UpdateError::InvalidChecksum {
+                binary_name: binary_name.to_owned(),
+            });
+        }
+        Ok(Self(value.to_ascii_lowercase()))
+    }
+
+    /// Borrow the canonical lowercase digest.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the digest and return its canonical lowercase string.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+/// One downloaded update asset bound to its validated manifest digest.
+#[derive(Debug)]
+pub struct VerifiedUpdateAsset {
+    path: PathBuf,
+    sha256: Sha256Digest,
+}
+
+impl VerifiedUpdateAsset {
+    /// Borrow the atomically persisted local asset path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Borrow the manifest digest verified for this asset.
+    pub fn sha256(&self) -> &Sha256Digest {
+        &self.sha256
+    }
+
+    /// Consume the verified asset handle and return its local path.
+    pub fn into_path(self) -> PathBuf {
+        self.path
+    }
 }
 
 #[derive(Debug, Error)]
@@ -78,6 +137,30 @@ pub enum UpdateError {
 
     #[error("Checksum mismatch: expected {expected}, got {actual}")]
     ChecksumMismatch { expected: String, actual: String },
+
+    #[error("Update manifest entry for {binary_name} is missing a required SHA-256 digest")]
+    MissingChecksum { binary_name: String },
+
+    #[error("Update manifest entry for {binary_name} contains an invalid SHA-256 digest")]
+    InvalidChecksum { binary_name: String },
+
+    #[error("Update manifest entry for {binary_name} is missing a download URL")]
+    MissingDownloadUrl { binary_name: String },
+
+    #[error("Update binary name must be a portable filename")]
+    InvalidBinaryName,
+
+    #[error("Refused a legacy unsigned staged update; run update apply again")]
+    LegacyUnsignedStage,
+
+    #[error("Refused and quarantined an invalid staged update: {reason}")]
+    RejectedStagedUpdate { reason: String },
+
+    #[error("Update download exceeds the {max_bytes}-byte safety limit")]
+    DownloadTooLarge { max_bytes: u64 },
+
+    #[error("Update download is empty")]
+    EmptyDownload,
 
     #[error("Cannot determine current executable path")]
     NoExePath,
@@ -165,18 +248,38 @@ impl Updater {
     /// request to the gateway.
     pub async fn check_update(&self) -> Result<UpdateInfo, UpdateError> {
         let payload = self.check_update_json().await?;
+        self.update_info_from_payload(payload)
+    }
+
+    fn update_info_from_payload(
+        &self,
+        payload: GatewayUpdateJson,
+    ) -> Result<UpdateInfo, UpdateError> {
         if !payload.success || payload.body.get("error").is_some() {
             return Err(gateway_error(payload.status, &payload.body));
         }
 
         let resp: UpdateCheckResponse = serde_json::from_value(payload.body)?;
 
+        let (download_url, sha256) = if resp.update_available {
+            let download_url = resp
+                .download_url
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| UpdateError::MissingDownloadUrl {
+                    binary_name: self.binary_name.clone(),
+                })?;
+            let sha256 = Sha256Digest::require(&self.binary_name, resp.sha256.as_deref())?;
+            (Some(download_url), Some(sha256.into_string()))
+        } else {
+            (None, None)
+        };
+
         Ok(UpdateInfo {
             update_available: resp.update_available,
             current_version: self.current_version.clone(),
             latest_version: resp.latest_version,
-            download_url: resp.download_url,
-            sha256: resp.sha256,
+            download_url,
+            sha256,
             release_notes: resp.release_notes,
         })
     }
@@ -207,21 +310,39 @@ impl Updater {
                 .or_insert_with(|| Value::String(self.binary_name.clone()));
         }
 
-        Ok(GatewayUpdateJson {
+        let payload = GatewayUpdateJson {
             status: status.as_u16(),
             success: status.is_success(),
             body,
-        })
+        };
+        if payload.success && payload.body.get("error").is_none() {
+            // CLI `update check` preserves successful gateway JSON, but it
+            // must enforce the same integrity contract as `update apply`.
+            self.update_info_from_payload(payload.clone())?;
+        }
+        Ok(payload)
     }
 
-    /// Download the update archive to a temporary staging directory.
+    /// Download the update binary to a temporary staging directory.
     ///
     /// Returns the path to the downloaded file.
     pub async fn download_update(&self, info: &UpdateInfo) -> Result<PathBuf, UpdateError> {
+        Ok(self.download_verified_update(info).await?.into_path())
+    }
+
+    /// Download an update and bind the local asset to its manifest digest.
+    pub async fn download_verified_update(
+        &self,
+        info: &UpdateInfo,
+    ) -> Result<VerifiedUpdateAsset, UpdateError> {
+        let expected_sha = Sha256Digest::require(&self.binary_name, info.sha256.as_deref())?;
         let download_url = info
             .download_url
             .as_deref()
-            .ok_or_else(|| UpdateError::Stage("no download_url in update info".into()))?;
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| UpdateError::MissingDownloadUrl {
+                binary_name: self.binary_name.clone(),
+            })?;
 
         let staging_dir = staging_dir(&self.binary_name)?;
         std::fs::create_dir_all(&staging_dir)?;
@@ -232,42 +353,76 @@ impl Updater {
         let dest_path = staging_dir.join(format!("{}.download", self.binary_name));
 
         let response = self.client.get(download_url).send().await?;
-        let response = response.error_for_status()?;
-        let bytes = response.bytes().await?;
-
-        // Verify SHA-256 if provided
-        if let Some(expected_sha) = &info.sha256 {
-            let actual_sha = sha256_bytes(&bytes);
-            if !actual_sha.eq_ignore_ascii_case(expected_sha) {
-                return Err(UpdateError::ChecksumMismatch {
-                    expected: expected_sha.clone(),
-                    actual: actual_sha,
-                });
-            }
+        let mut response = response.error_for_status()?;
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_UPDATE_BYTES)
+        {
+            return Err(UpdateError::DownloadTooLarge {
+                max_bytes: MAX_UPDATE_BYTES,
+            });
         }
 
-        tokio::fs::write(&dest_path, &bytes).await?;
-        Ok(dest_path)
+        use std::io::Write as _;
+        let mut temp = tempfile::NamedTempFile::new_in(&staging_dir)?;
+        let mut hasher = Sha256::new();
+        let mut total = 0_u64;
+        while let Some(chunk) = response.chunk().await? {
+            total = total.saturating_add(chunk.len() as u64);
+            if total > MAX_UPDATE_BYTES {
+                return Err(UpdateError::DownloadTooLarge {
+                    max_bytes: MAX_UPDATE_BYTES,
+                });
+            }
+            hasher.update(&chunk);
+            temp.write_all(&chunk)?;
+        }
+        if total == 0 {
+            return Err(UpdateError::EmptyDownload);
+        }
+        temp.as_file().sync_all()?;
+
+        let actual_sha = hex::encode(hasher.finalize().as_slice());
+        if actual_sha != expected_sha.as_str() {
+            return Err(UpdateError::ChecksumMismatch {
+                expected: expected_sha.into_string(),
+                actual: actual_sha,
+            });
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mut permissions = temp.as_file().metadata()?.permissions();
+            permissions.set_mode(0o755);
+            temp.as_file().set_permissions(permissions)?;
+        }
+        temp.persist(&dest_path)
+            .map_err(|error| UpdateError::Io(error.error))?;
+        Ok(VerifiedUpdateAsset {
+            path: dest_path,
+            sha256: expected_sha,
+        })
     }
 
     /// Stage a downloaded update for replacement on the next launch.
     ///
-    /// Writes a pending-update marker and the new binary to the staging
-    /// directory. On the next launch, the launcher should call
-    /// [`apply_staged_update`].
+    /// Compatibility entry point for trusted local files. Network update paths
+    /// should use [`Updater::stage_verified_update`] with the manifest digest.
+    /// On the next launch, the launcher should call [`apply_staged_update`].
     pub fn stage_update(downloaded: &Path, binary_name: &str) -> Result<(), UpdateError> {
-        let dir = staging_dir(binary_name)?;
-        std::fs::create_dir_all(&dir)?;
+        let actual_sha256 = sha256_file(downloaded)?;
+        let expected_sha256 = Sha256Digest::require(binary_name, Some(&actual_sha256))?;
+        Self::stage_verified_update(downloaded, binary_name, &expected_sha256)
+    }
 
-        let staged_bin = dir.join("pending.bin");
-        std::fs::copy(downloaded, &staged_bin)?;
-
-        // Write a marker so the next launch knows to apply the update
-        let marker_path = dir.join("pending.marker");
-        std::fs::write(&marker_path, "pending")?;
-
-        tracing::info!("Update staged at {}", staged_bin.display());
-        Ok(())
+    /// Stage a manifest-verified update for replacement on the next launch.
+    pub fn stage_verified_update(
+        downloaded: &Path,
+        binary_name: &str,
+        expected_sha256: &Sha256Digest,
+    ) -> Result<(), UpdateError> {
+        stage_verified_binary_update(binary_name, downloaded, expected_sha256.as_str())
     }
 
     /// Apply a previously staged update by swapping the current binary.
@@ -275,48 +430,15 @@ impl Updater {
     /// To be called at startup BEFORE the main application logic runs.
     /// Returns `true` if an update was applied, `false` if no update was staged.
     pub fn apply_staged_update(binary_name: &str) -> Result<bool, UpdateError> {
-        let dir = staging_dir(binary_name)?;
-        let marker_path = dir.join("pending.marker");
-        let staged_bin = dir.join("pending.bin");
-
-        if !marker_path.exists() || !staged_bin.exists() {
-            return Ok(false);
+        if quarantine_legacy_staged_update(binary_name)? {
+            return Err(UpdateError::LegacyUnsignedStage);
         }
-
-        let current_exe = std::env::current_exe().map_err(|_| UpdateError::NoExePath)?;
-
-        tracing::info!(
-            "Applying staged update: {} → {}",
-            staged_bin.display(),
-            current_exe.display()
-        );
-
-        // On Windows we can't replace a running exe, so we rename the current
-        // binary aside and copy the new one in place.
-        #[cfg(target_os = "windows")]
-        {
-            let backup = current_exe.with_extension("exe.bak");
-            let _ = std::fs::remove_file(&backup);
-            std::fs::rename(&current_exe, &backup)?;
-            std::fs::copy(&staged_bin, &current_exe)?;
-        }
-
-        #[cfg(not(target_os = "windows"))]
-        {
-            // On Unix, rename(2) atomically replaces the target even if running
-            // (the inode stays open in the running process; new exec gets the new inode).
-            std::fs::rename(&staged_bin, &current_exe)?;
-        }
-
-        // Clean up markers
-        let _ = std::fs::remove_file(&marker_path);
-
-        tracing::info!("Staged update applied successfully");
-        Ok(true)
+        apply_staged_binary_update(binary_name)
     }
 
     /// Remove any staged update artifacts (rollback).
     pub fn clear_staged_update(binary_name: &str) -> Result<(), UpdateError> {
+        clear_staged_binary_update(binary_name)?;
         let dir = staging_dir(binary_name)?;
         for entry in ["pending.bin", "pending.marker"] {
             let p = dir.join(entry);
@@ -349,10 +471,60 @@ fn gateway_error(status: u16, body: &Value) -> UpdateError {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn staging_dir(binary_name: &str) -> Result<PathBuf, UpdateError> {
+    validate_binary_name(binary_name)?;
     // Use a platform-appropriate data dir for staging updates
     // Falls back to a temp dir if we can't determine the data dir
     let base = dirs_data_dir().unwrap_or_else(|| std::env::temp_dir().join("dcc-mcp"));
     Ok(base.join("update").join(binary_name))
+}
+
+fn quarantine_legacy_staged_update(binary_name: &str) -> Result<bool, UpdateError> {
+    let dir = staging_dir(binary_name)?;
+    let marker = dir.join("pending.marker");
+    let binary = dir.join("pending.bin");
+    if !marker.exists() && !binary.exists() {
+        return Ok(false);
+    }
+
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| UpdateError::Stage(error.to_string()))?
+        .as_nanos();
+    let quarantine = dir.join(format!("legacy-unsigned-{}-{nonce}", std::process::id()));
+    let result = (|| -> Result<(), std::io::Error> {
+        std::fs::create_dir_all(&quarantine)?;
+        if marker.exists() {
+            std::fs::rename(&marker, quarantine.join("pending.marker"))?;
+        }
+        if binary.exists() {
+            std::fs::rename(&binary, quarantine.join("pending.bin"))?;
+        }
+        Ok(())
+    })();
+    if let Err(error) = result {
+        tracing::warn!(%error, "failed to quarantine legacy unsigned staged update");
+    } else {
+        tracing::warn!(path = %quarantine.display(), "quarantined legacy unsigned staged update");
+    }
+    Ok(true)
+}
+
+fn validate_binary_name(binary_name: &str) -> Result<(), UpdateError> {
+    let portable = binary_name
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    if binary_name.is_empty()
+        || !portable
+        || binary_name.ends_with('.')
+        || matches!(binary_name, "." | "..")
+        || Path::new(binary_name)
+            .file_name()
+            .and_then(|value| value.to_str())
+            != Some(binary_name)
+    {
+        return Err(UpdateError::InvalidBinaryName);
+    }
+    Ok(())
 }
 
 /// Return the lowercase SHA-256 digest for a local file.
@@ -422,6 +594,55 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
+    async fn spawn_json_response(
+        body: Value,
+    ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0_u8; 1024];
+            let _ = stream.read(&mut buf).await.unwrap();
+            let body = body.to_string();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        (addr, server)
+    }
+
+    async fn spawn_binary_response(
+        body: &'static [u8],
+        content_length: u64,
+    ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0_u8; 1024];
+            let _ = stream.read(&mut buf).await.unwrap();
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/octet-stream\r\ncontent-length: {content_length}\r\n\r\n"
+            );
+            stream.write_all(headers.as_bytes()).await.unwrap();
+            stream.write_all(body).await.unwrap();
+        });
+        (addr, server)
+    }
+
+    fn unique_binary_name(label: &str) -> String {
+        format!(
+            "dcc-mcp-test-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        )
+    }
+
     #[test]
     fn version_comparison() {
         assert!(is_newer_version("0.18.16", "0.18.15"));
@@ -440,6 +661,14 @@ mod tests {
         assert!(dir.to_string_lossy().contains("update"));
     }
 
+    #[test]
+    fn staging_dir_rejects_untrusted_binary_names() {
+        for binary_name in ["", ".", "..", "../escape", "nested/name", "C:\\escape"] {
+            let error = staging_dir(binary_name).unwrap_err();
+            assert!(matches!(error, UpdateError::InvalidBinaryName));
+        }
+    }
+
     #[tokio::test]
     async fn download_update_rejects_http_error_status() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -456,21 +685,14 @@ mod tests {
                 .unwrap();
         });
 
-        let binary_name = format!(
-            "dcc-mcp-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        );
+        let binary_name = unique_binary_name("http-error");
         let updater = Updater::new("http://127.0.0.1", &binary_name, "0.1.0");
         let info = UpdateInfo {
             update_available: true,
             current_version: "0.1.0".into(),
             latest_version: "0.2.0".into(),
             download_url: Some(format!("http://{addr}/missing")),
-            sha256: None,
+            sha256: Some("a".repeat(64)),
             release_notes: None,
         };
 
@@ -482,6 +704,182 @@ mod tests {
                 .join(format!("{binary_name}.download"))
                 .exists()
         );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn download_update_rejects_missing_sha256_before_network() {
+        let updater = Updater::new("http://127.0.0.1", "dcc-mcp-cli", "0.1.0");
+        let info = UpdateInfo {
+            update_available: true,
+            current_version: "0.1.0".into(),
+            latest_version: "0.2.0".into(),
+            download_url: Some("http://127.0.0.1:9/unreachable".into()),
+            sha256: None,
+            release_notes: None,
+        };
+
+        let error = updater.download_update(&info).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            UpdateError::MissingChecksum { binary_name } if binary_name == "dcc-mcp-cli"
+        ));
+    }
+
+    #[tokio::test]
+    async fn download_update_streams_and_persists_verified_executable() {
+        let body = b"verified-binary";
+        let (addr, server) = spawn_binary_response(body, body.len() as u64).await;
+        let binary_name = unique_binary_name("verified");
+        let updater = Updater::new("http://127.0.0.1", &binary_name, "0.1.0");
+        let info = UpdateInfo {
+            update_available: true,
+            current_version: "0.1.0".into(),
+            latest_version: "0.2.0".into(),
+            download_url: Some(format!("http://{addr}/binary")),
+            sha256: Some(sha256_bytes(body)),
+            release_notes: None,
+        };
+
+        let asset = updater.download_verified_update(&info).await.unwrap();
+
+        assert_eq!(std::fs::read(asset.path()).unwrap(), body);
+        assert_eq!(asset.sha256().as_str(), sha256_bytes(body));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_ne!(
+                std::fs::metadata(asset.path())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o111,
+                0
+            );
+        }
+        server.await.unwrap();
+        std::fs::remove_dir_all(staging_dir(&binary_name).unwrap()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn download_update_rejects_empty_and_oversized_assets() {
+        for (label, content_length, expected) in [
+            ("empty", 0, "empty"),
+            ("oversized", MAX_UPDATE_BYTES + 1, "safety limit"),
+        ] {
+            let (addr, server) = spawn_binary_response(b"", content_length).await;
+            let binary_name = unique_binary_name(label);
+            let updater = Updater::new("http://127.0.0.1", &binary_name, "0.1.0");
+            let info = UpdateInfo {
+                update_available: true,
+                current_version: "0.1.0".into(),
+                latest_version: "0.2.0".into(),
+                download_url: Some(format!("http://{addr}/binary")),
+                sha256: Some(sha256_bytes(b"")),
+                release_notes: None,
+            };
+
+            let error = updater.download_verified_update(&info).await.unwrap_err();
+
+            assert!(error.to_string().contains(expected), "{label}: {error}");
+            server.await.unwrap();
+            let dir = staging_dir(&binary_name).unwrap();
+            if dir.exists() {
+                std::fs::remove_dir_all(dir).unwrap();
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn check_update_rejects_manifest_without_sha256() {
+        let (addr, server) = spawn_json_response(serde_json::json!({
+            "update_available": true,
+            "latest_version": "0.2.0",
+            "download_url": "https://example.invalid/dcc-mcp-cli",
+            "release_notes": null,
+        }))
+        .await;
+
+        let updater = Updater::new(&format!("http://{addr}"), "dcc-mcp-cli", "0.1.0");
+        let error = updater.check_update().await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            UpdateError::MissingChecksum { binary_name } if binary_name == "dcc-mcp-cli"
+        ));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn check_update_rejects_available_manifest_without_download_url() {
+        let (addr, server) = spawn_json_response(serde_json::json!({
+            "update_available": true,
+            "latest_version": "0.2.0",
+            "download_url": null,
+            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        }))
+        .await;
+        let updater = Updater::new(&format!("http://{addr}"), "dcc-mcp-cli", "0.1.0");
+
+        let error = updater.check_update().await.unwrap_err();
+
+        assert!(matches!(error, UpdateError::MissingDownloadUrl { .. }));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn check_update_rejects_invalid_sha256() {
+        let (addr, server) = spawn_json_response(serde_json::json!({
+            "update_available": true,
+            "latest_version": "0.2.0",
+            "download_url": "https://example.invalid/dcc-mcp-cli",
+            "sha256": "abc123",
+            "release_notes": null,
+        }))
+        .await;
+
+        let updater = Updater::new(&format!("http://{addr}"), "dcc-mcp-cli", "0.1.0");
+        let error = updater.check_update().await.unwrap_err();
+
+        assert!(error.to_string().contains("invalid SHA-256"));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn raw_check_update_rejects_invalid_success_payloads() {
+        let (addr, server) = spawn_json_response(serde_json::json!({
+            "update_available": true,
+            "latest_version": "0.2.0",
+            "download_url": "https://example.invalid/dcc-mcp-cli",
+            "sha256": null,
+        }))
+        .await;
+        let updater = Updater::new(&format!("http://{addr}"), "dcc-mcp-cli", "0.1.0");
+
+        let error = updater.check_update_json().await.unwrap_err();
+
+        assert!(matches!(error, UpdateError::MissingChecksum { .. }));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn check_update_accepts_up_to_date_response_without_download_asset() {
+        let (addr, server) = spawn_json_response(serde_json::json!({
+            "update_available": false,
+            "latest_version": "0.1.0",
+            "download_url": "not-needed",
+            "sha256": "not-needed",
+            "release_notes": null,
+        }))
+        .await;
+
+        let updater = Updater::new(&format!("http://{addr}"), "dcc-mcp-cli", "0.1.0");
+        let info = updater.check_update().await.unwrap();
+
+        assert!(!info.update_available);
+        assert!(info.download_url.is_none());
+        assert!(info.sha256.is_none());
         server.await.unwrap();
     }
 }

--- a/crates/dcc-mcp-updater/src/update_set.rs
+++ b/crates/dcc-mcp-updater/src/update_set.rs
@@ -14,6 +14,7 @@ use super::{UpdateError, sha256_bytes, sha256_file, staging_dir};
 const PENDING_SET_DIR: &str = "pending-set";
 const PREVIOUS_SET_DIR: &str = "pending-set.previous";
 const COMMITTED_SET_PREFIX: &str = "pending-set.committed-";
+const REJECTED_SET_PREFIX: &str = "pending-set.rejected-";
 const MANIFEST_FILE: &str = "manifest.json";
 const JOURNAL_FILE: &str = "journal.json";
 const APPLIED_GENERATION_FILE: &str = "applied-generation.json";
@@ -111,6 +112,42 @@ struct JournalEntry {
     had_original: bool,
     original_sha256: Option<String>,
     expected_sha256: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UpdateSetPolicy {
+    Any,
+    CurrentExecutableOnly,
+}
+
+/// Stage one verified binary update bound to the current executable.
+pub fn stage_verified_binary_update(
+    binary_name: &str,
+    downloaded: &Path,
+    expected_sha256: &str,
+) -> Result<(), UpdateError> {
+    let current_exe = std::env::current_exe().map_err(|_| UpdateError::NoExePath)?;
+    stage_verified_binary_update_for(binary_name, &current_exe, downloaded, expected_sha256)
+}
+
+/// Stage one verified binary update for an explicit executable path.
+#[doc(hidden)]
+pub fn stage_verified_binary_update_for(
+    binary_name: &str,
+    current_exe: &Path,
+    downloaded: &Path,
+    expected_sha256: &str,
+) -> Result<(), UpdateError> {
+    let target = UpdateTarget::CurrentExecutable;
+    stage_update_set_for(
+        binary_name,
+        current_exe,
+        &[UpdateSetSource {
+            downloaded,
+            target: &target,
+            expected_sha256,
+        }],
+    )
 }
 
 /// Stage a complete update set and bind it to this executable installation.
@@ -273,6 +310,74 @@ pub fn apply_staged_update_set(binary_name: &str) -> Result<bool, UpdateError> {
     apply_staged_update_set_for(binary_name, &current_exe)
 }
 
+/// Apply one staged binary update bound to the current executable.
+pub fn apply_staged_binary_update(binary_name: &str) -> Result<bool, UpdateError> {
+    let current_exe = std::env::current_exe().map_err(|_| UpdateError::NoExePath)?;
+    apply_staged_binary_update_for(binary_name, &current_exe)
+}
+
+/// Apply one staged binary update for an explicit executable path.
+#[doc(hidden)]
+pub fn apply_staged_binary_update_for(
+    binary_name: &str,
+    current_exe: &Path,
+) -> Result<bool, UpdateError> {
+    apply_staged_update_set_for_build_with_policy(
+        binary_name,
+        current_exe,
+        env!("CARGO_PKG_VERSION"),
+        UPDATE_LOCK_TIMEOUT,
+        UpdateSetPolicy::CurrentExecutableOnly,
+    )
+}
+
+/// Clear one staged binary update bound to the current executable.
+pub fn clear_staged_binary_update(binary_name: &str) -> Result<(), UpdateError> {
+    let current_exe = std::env::current_exe().map_err(|_| UpdateError::NoExePath)?;
+    clear_staged_binary_update_for(binary_name, &current_exe)
+}
+
+/// Clear one staged binary update for an explicit executable path.
+#[doc(hidden)]
+pub fn clear_staged_binary_update_for(
+    binary_name: &str,
+    current_exe: &Path,
+) -> Result<(), UpdateError> {
+    let current_exe = canonical_existing(current_exe)?;
+    let root = installation_staging_dir(binary_name, &current_exe)?;
+    let _lock = acquire_installation_lock(&root, &current_exe, UPDATE_LOCK_TIMEOUT)?;
+    recover_stage_swap(&root)?;
+    cleanup_committed_sets(&root)?;
+
+    let pending = root.join(PENDING_SET_DIR);
+    if !pending.exists() {
+        return Ok(());
+    }
+    if !pending.is_dir() {
+        return Err(UpdateError::Stage(format!(
+            "pending binary update is not a directory: {}",
+            pending.display()
+        )));
+    }
+    let manifest: UpdateSetManifest = read_json(&pending.join(MANIFEST_FILE))?;
+    validate_single_binary_manifest(&manifest, &current_exe)?;
+
+    let journal_path = pending.join(JOURNAL_FILE);
+    if journal_path.is_file() {
+        let journal: UpdateJournal = read_json(&journal_path)?;
+        if journal.state == JournalState::Committed {
+            persist_applied_generation(&root, &manifest)?;
+            finish_committed(&pending, &journal)?;
+            return Ok(());
+        }
+        rollback(&journal)?;
+        std::fs::remove_file(&journal_path)?;
+        cleanup_committed_entries(&journal)?;
+    }
+    std::fs::remove_dir_all(pending)?;
+    Ok(())
+}
+
 /// Apply a complete staged update set to an explicit executable path.
 #[doc(hidden)]
 pub fn apply_staged_update_set_for(
@@ -301,6 +406,22 @@ fn apply_staged_update_set_for_build_with_timeout(
     current_build_version: &str,
     lock_timeout: Duration,
 ) -> Result<bool, UpdateError> {
+    apply_staged_update_set_for_build_with_policy(
+        binary_name,
+        current_exe,
+        current_build_version,
+        lock_timeout,
+        UpdateSetPolicy::Any,
+    )
+}
+
+fn apply_staged_update_set_for_build_with_policy(
+    binary_name: &str,
+    current_exe: &Path,
+    current_build_version: &str,
+    lock_timeout: Duration,
+    policy: UpdateSetPolicy,
+) -> Result<bool, UpdateError> {
     let current_exe = canonical_existing(current_exe)?;
     let root = installation_staging_dir(binary_name, &current_exe)?;
     let _lock = acquire_installation_lock(&root, &current_exe, lock_timeout)?;
@@ -311,13 +432,24 @@ fn apply_staged_update_set_for_build_with_timeout(
     if !pending.is_dir() {
         return applied_generation_requires_reexec(&root, &current_exe, current_build_version);
     }
-    let manifest: UpdateSetManifest = read_json(&pending.join(MANIFEST_FILE))?;
-    if manifest.format_version != 2 {
-        return Err(UpdateError::Stage(
-            "unsupported staged update-set format".into(),
-        ));
+    let manifest: UpdateSetManifest = match read_json(&pending.join(MANIFEST_FILE)) {
+        Ok(manifest) => manifest,
+        Err(error)
+            if policy == UpdateSetPolicy::CurrentExecutableOnly
+                && is_rejectable_manifest_read_error(&error) =>
+        {
+            return reject_pending_set(&root, &pending, error);
+        }
+        Err(error) => return Err(error),
+    };
+    if let Err(error) = validate_manifest_shape(&manifest) {
+        return reject_or_return(policy, &root, &pending, error);
     }
-    if !paths_equal(&current_exe, &manifest.bound_executable) {
+    if policy == UpdateSetPolicy::CurrentExecutableOnly {
+        if let Err(error) = validate_single_binary_manifest(&manifest, &current_exe) {
+            return reject_pending_set(&root, &pending, error);
+        }
+    } else if !paths_equal(&current_exe, &manifest.bound_executable) {
         return Err(UpdateError::Stage(format!(
             "staged update belongs to a different executable: {}",
             manifest.bound_executable.display()
@@ -348,10 +480,15 @@ fn apply_staged_update_set_for_build_with_timeout(
 
     let actual_source_sha = sha256_file(&current_exe)?;
     if !actual_source_sha.eq_ignore_ascii_case(&manifest.source_server_sha256) {
-        return Err(UpdateError::Stage(format!(
-            "staged update source changed: expected {}, got {actual_source_sha}",
-            manifest.source_server_sha256
-        )));
+        return reject_or_return(
+            policy,
+            &root,
+            &pending,
+            UpdateError::Stage(format!(
+                "staged update source changed: expected {}, got {actual_source_sha}",
+                manifest.source_server_sha256
+            )),
+        );
     }
 
     let install_dir = current_exe
@@ -360,30 +497,41 @@ fn apply_staged_update_set_for_build_with_timeout(
     let mut entries = Vec::with_capacity(manifest.components.len());
     let mut seen_targets = HashSet::new();
     for component in &manifest.components {
-        validate_target(&component.target)?;
-        validate_expected_sha(&component.sha256)?;
         let source = pending.join(&component.staged_file);
         if !source.is_file() {
-            return Err(UpdateError::Stage(format!(
-                "staged update component is missing: {}",
-                source.display()
-            )));
+            return reject_or_return(
+                policy,
+                &root,
+                &pending,
+                UpdateError::Stage(format!(
+                    "staged update component is missing: {}",
+                    source.display()
+                )),
+            );
         }
         let actual = sha256_file(&source)?;
         if !actual.eq_ignore_ascii_case(&component.sha256) {
-            return Err(UpdateError::ChecksumMismatch {
-                expected: component.sha256.clone(),
-                actual,
-            });
+            return reject_or_return(
+                policy,
+                &root,
+                &pending,
+                UpdateError::ChecksumMismatch {
+                    expected: component.sha256.clone(),
+                    actual,
+                },
+            );
         }
         let target = match &component.target {
             UpdateTarget::CurrentExecutable => current_exe.clone(),
             UpdateTarget::Sibling { file_name } => install_dir.join(file_name),
         };
         if !seen_targets.insert(path_key(&target)) {
-            return Err(UpdateError::Stage(
-                "staged update contains duplicate resolved targets".into(),
-            ));
+            return reject_or_return(
+                policy,
+                &root,
+                &pending,
+                UpdateError::Stage("staged update contains duplicate resolved targets".into()),
+            );
         }
         let file_name = target
             .file_name()
@@ -967,6 +1115,94 @@ fn unique_nonce() -> Result<String, UpdateError> {
             .map_err(|error| UpdateError::Stage(error.to_string()))?
             .as_nanos()
     ))
+}
+
+fn validate_single_binary_manifest(
+    manifest: &UpdateSetManifest,
+    current_exe: &Path,
+) -> Result<(), UpdateError> {
+    if manifest.format_version != 2 {
+        return Err(UpdateError::Stage(
+            "unsupported staged update-set format".into(),
+        ));
+    }
+    if !paths_equal(current_exe, &manifest.bound_executable) {
+        return Err(UpdateError::Stage(format!(
+            "staged update belongs to a different executable: {}",
+            manifest.bound_executable.display()
+        )));
+    }
+    if manifest.components.len() != 1
+        || !matches!(
+            manifest.components[0].target,
+            UpdateTarget::CurrentExecutable
+        )
+    {
+        return Err(UpdateError::Stage(
+            "single binary update contains foreign or sibling components".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_manifest_shape(manifest: &UpdateSetManifest) -> Result<(), UpdateError> {
+    if manifest.format_version != 2 {
+        return Err(UpdateError::Stage(
+            "unsupported staged update-set format".into(),
+        ));
+    }
+    validate_expected_sha(&manifest.source_server_sha256)?;
+    if manifest.components.is_empty() {
+        return Err(UpdateError::Stage(
+            "staged update set must contain at least one component".into(),
+        ));
+    }
+    for (index, component) in manifest.components.iter().enumerate() {
+        let expected_file = format!("component-{index}.bin");
+        if component.staged_file != expected_file {
+            return Err(UpdateError::Stage(format!(
+                "invalid staged component path: {:?}",
+                component.staged_file
+            )));
+        }
+        validate_target(&component.target)?;
+        validate_expected_sha(&component.sha256)?;
+    }
+    Ok(())
+}
+
+fn is_rejectable_manifest_read_error(error: &UpdateError) -> bool {
+    matches!(error, UpdateError::Json(_))
+        || matches!(error, UpdateError::Io(error) if error.kind() == std::io::ErrorKind::NotFound)
+}
+
+fn reject_or_return<T>(
+    policy: UpdateSetPolicy,
+    root: &Path,
+    pending: &Path,
+    error: UpdateError,
+) -> Result<T, UpdateError> {
+    if policy == UpdateSetPolicy::CurrentExecutableOnly {
+        reject_pending_set(root, pending, error)
+    } else {
+        Err(error)
+    }
+}
+
+fn reject_pending_set<T>(
+    root: &Path,
+    pending: &Path,
+    error: UpdateError,
+) -> Result<T, UpdateError> {
+    let reason = error.to_string();
+    let rejected = root.join(format!("{REJECTED_SET_PREFIX}{}", unique_nonce()?));
+    std::fs::rename(pending, &rejected).map_err(|quarantine_error| {
+        UpdateError::Stage(format!(
+            "invalid staged update ({reason}); quarantine failed: {quarantine_error}"
+        ))
+    })?;
+    tracing::warn!(path = %rejected.display(), %reason, "quarantined invalid staged update");
+    Err(UpdateError::RejectedStagedUpdate { reason })
 }
 
 fn validate_target(target: &UpdateTarget) -> Result<(), UpdateError> {

--- a/crates/dcc-mcp-updater/src/update_set/tests.rs
+++ b/crates/dcc-mcp-updater/src/update_set/tests.rs
@@ -66,6 +66,94 @@ fn stage_set_rejects_missing_and_hash_mismatch_without_marker() {
 }
 
 #[test]
+fn single_binary_update_rejects_tampered_staged_bytes() {
+    let temp = tempfile::tempdir().unwrap();
+    let current = write_fixture(temp.path(), "dcc-mcp-cli.exe", b"old-cli");
+    let downloaded = write_fixture(temp.path(), "cli.download", b"new-cli");
+    let expected_sha256 = sha256_file(&downloaded).unwrap();
+    let binary_name = unique_name("tampered-single");
+
+    stage_verified_binary_update_for(&binary_name, &current, &downloaded, &expected_sha256)
+        .unwrap();
+    let staged = installation_root(&binary_name, &current)
+        .join(PENDING_SET_DIR)
+        .join("component-0.bin");
+    std::fs::write(staged, b"tampered-cli").unwrap();
+
+    let error = apply_staged_binary_update_for(&binary_name, &current).unwrap_err();
+
+    assert!(matches!(error, UpdateError::RejectedStagedUpdate { .. }));
+    assert_eq!(std::fs::read(&current).unwrap(), b"old-cli");
+    assert!(
+        !installation_root(&binary_name, &current)
+            .join(PENDING_SET_DIR)
+            .exists()
+    );
+    assert!(!apply_staged_binary_update_for(&binary_name, &current).unwrap());
+}
+
+#[test]
+fn single_binary_update_rejects_staged_sibling_components() {
+    let temp = tempfile::tempdir().unwrap();
+    let current = write_fixture(temp.path(), "dcc-mcp-server.exe", b"old-server");
+    let sibling = write_fixture(temp.path(), "dcc-mcp-host.exe", b"old-host");
+    let server_download = write_fixture(temp.path(), "server.download", b"new-server");
+    let host_download = write_fixture(temp.path(), "host.download", b"new-host");
+    let server_sha = sha256_file(&server_download).unwrap();
+    let host_sha = sha256_file(&host_download).unwrap();
+    let current_target = UpdateTarget::CurrentExecutable;
+    let sibling_target = UpdateTarget::Sibling {
+        file_name: "dcc-mcp-host.exe".into(),
+    };
+    let binary_name = unique_name("foreign-set");
+    stage_update_set_for(
+        &binary_name,
+        &current,
+        &[
+            UpdateSetSource {
+                downloaded: &server_download,
+                target: &current_target,
+                expected_sha256: &server_sha,
+            },
+            UpdateSetSource {
+                downloaded: &host_download,
+                target: &sibling_target,
+                expected_sha256: &host_sha,
+            },
+        ],
+    )
+    .unwrap();
+
+    let error = apply_staged_binary_update_for(&binary_name, &current).unwrap_err();
+
+    assert!(matches!(error, UpdateError::RejectedStagedUpdate { .. }));
+    assert!(error.to_string().contains("single binary"));
+    assert_eq!(std::fs::read(&current).unwrap(), b"old-server");
+    assert_eq!(std::fs::read(sibling).unwrap(), b"old-host");
+    assert!(
+        !installation_root(&binary_name, &current)
+            .join(PENDING_SET_DIR)
+            .exists()
+    );
+}
+
+#[test]
+fn clearing_a_staged_binary_update_preserves_the_current_executable() {
+    let temp = tempfile::tempdir().unwrap();
+    let current = write_fixture(temp.path(), "dcc-mcp-cli.exe", b"old-cli");
+    let downloaded = write_fixture(temp.path(), "cli.download", b"new-cli");
+    let expected_sha256 = sha256_file(&downloaded).unwrap();
+    let binary_name = unique_name("clear-single");
+    stage_verified_binary_update_for(&binary_name, &current, &downloaded, &expected_sha256)
+        .unwrap();
+
+    clear_staged_binary_update_for(&binary_name, &current).unwrap();
+
+    assert!(!apply_staged_binary_update_for(&binary_name, &current).unwrap());
+    assert_eq!(std::fs::read(current).unwrap(), b"old-cli");
+}
+
+#[test]
 fn sibling_target_rejects_windows_ads_and_ambiguous_names() {
     for file_name in [
         "host.exe:stream",

--- a/docs/adr/023-installation-bound-binary-updates.md
+++ b/docs/adr/023-installation-bound-binary-updates.md
@@ -1,0 +1,64 @@
+# Installation-Bound Binary Updates
+
+Status: Accepted
+
+## Context
+
+The gateway update transport allowed a missing SHA-256, while CLI and server
+production paths staged `pending.bin` behind a literal `pending.marker` and did
+not re-verify it before replacement. Gateway Admin could also stage selected
+binaries without proving which executable installation owned the request.
+
+The updater already contained a versioned update-set manifest, installation
+binding, locking, journal recovery, rollback, and stage/apply hash checks. The
+production single-binary path had diverged from those primitives.
+
+## Decision
+
+- Transport DTOs retain optional URL and SHA-256 fields so up-to-date and old
+  gateway responses remain readable. An `update_available=true` response must
+  cross a domain gate requiring a URL and exactly 64 hexadecimal SHA-256 bytes.
+- Downloads are streamed into a bounded same-directory temporary file, hashed
+  before atomic persistence, and represented as a verified asset carrying the
+  validated manifest digest.
+- CLI and server stage one `CurrentExecutable` component through update-set
+  format v2. The manifest is bound to the canonical executable path and source
+  hash. Single-binary apply rejects sibling or multi-component sets.
+- Apply re-verifies the manifest, source executable, and staged component before
+  creating a transaction journal or touching the target executable. Invalid
+  pre-transaction sets are quarantined; the current binary remains usable.
+- Legacy `pending.bin` / `pending.marker` state is unsigned and is never
+  migrated into the verified format. It is quarantined with a stable warning.
+- A successful CLI replacement re-executes the CLI with its original arguments.
+  A successful server replacement follows the existing restart path.
+- Gateway Admin is check-only for every binary. Staging must run inside the
+  exact target installation that can establish executable ownership.
+
+## Consequences
+
+- Available updates fail closed on missing, malformed, mismatched, or tampered
+  digests while up-to-date responses may omit download fields.
+- Existing public optional DTO fields and updater entry-point signatures remain
+  source-compatible. New verified types make the trusted boundary explicit.
+- The first hop from an older release still executes its older updater. Users
+  requiring a verified bootstrap must install the first fixed release through
+  an externally SHA-256-verified asset.
+- SHA-256 proves consistency with the fetched manifest, not publisher identity.
+  Detached signed manifests remain a separate required authenticity layer.
+
+## Alternatives considered
+
+### Make transport SHA fields non-optional
+
+Rejected because an up-to-date response has no download asset and downstream
+Rust callers may construct the public transport structs directly.
+
+### Keep the legacy marker and add a digest sidecar
+
+Rejected because it would create a second transaction format beside the
+existing crash-recoverable update-set implementation.
+
+### Let Gateway Admin stage local binaries
+
+Rejected because a gateway binary name does not prove the target executable
+path, especially across multiple installations and remote DCC instances.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ Decision / Consequences / Alternatives considered.
 | 020 | [Consume application control through standalone dcc-cua](./020-external-cua-runtime.md) | Accepted |
 | 021 | [Use content-addressed revisions for cross-DCC asset sync](./021-content-addressed-asset-sync.md) | Accepted |
 | 022 | [Canonical Tool Result Envelope](./022-canonical-tool-result-envelope.md) | Accepted |
+| 023 | [Installation-Bound Binary Updates](./023-installation-bound-binary-updates.md) | Accepted |
 
 > Numbering is strictly sequential and never reused. ADR 001 is reserved for
 > the first historical record; filling it in is tracked separately from any

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -355,11 +355,17 @@ source was removed) are silently skipped.
 manifest configured with `DCC_MCP_UPDATE_MANIFEST_URL` (or
 `GatewayConfig.update_manifest_url`). `update check` is safe for both humans
 and agents because it only reads `/v1/update/check`; the CLI auto-ensures the
-local gateway before the request. `update apply` stages only the CLI binary.
-The Admin Instances panel checks server availability but does not stage an
-update because the gateway cannot prove a selected local or remote instance's
-installation root. Run `dcc-mcp-server update apply` in the exact server
-environment. On every platform that command validates and stages only the
+local gateway before the request. An available entry is valid only when its URL
+and 64-hex SHA-256 are present. `update apply` streams and verifies that exact
+asset, stages one installation-bound CLI component, and re-verifies it before
+replacement on the next launch. The CLI then restarts with the original
+arguments. Legacy `pending.bin` / `pending.marker` state is unsigned and is
+quarantined rather than applied.
+
+The Admin Instances panel is check-only for every binary because the gateway
+cannot prove a selected local or remote instance's installation root. Run
+`dcc-mcp-server update apply` in the exact server environment. It uses the same
+mandatory digest and apply-time verification contract and stages only the
 server binary. The standalone `dcc-cua` CLI is released independently and is
 reconciled through `components ensure`; it is not part of the gateway update
 manifest.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -69,7 +69,9 @@ dcc-mcp-cli update check
 dcc-mcp-cli update apply
 ```
 
-`update apply` stages the latest CLI for the next launch. It does not replace a
+`update apply` requires the release-manifest SHA-256, verifies the downloaded
+CLI, and stages it for the next launch. Replacement re-verifies the staged
+bytes and restarts the CLI with the same arguments. It does not replace a
 running `dcc-mcp-server`; update that server in its own environment.
 
 The CLI is also available as a standalone ZIP archive

--- a/docs/guide/production-deployment.md
+++ b/docs/guide/production-deployment.md
@@ -63,13 +63,22 @@ standalone `cua-driver` asset.
 ### Server self-update transaction
 
 Run `dcc-mcp-server update apply` from the exact target installation. On every
-platform it verifies and stages only the server binary. The next server launch
-applies that installation-bound update with rollback/journal recovery and then
-starts the new server image. `dcc-cua` has its own release lifecycle.
+platform an available manifest entry must contain a URL and valid SHA-256. The
+server verifies the downloaded asset, stages only one installation-bound server
+binary, and re-verifies it before replacement. The next launch applies it with
+rollback/journal recovery and starts the new server image. Invalid v2 staging
+and legacy unsigned markers are quarantined while the existing server remains
+available. `dcc-cua` has its own release lifecycle.
 
 The Admin Instances panel is check-only. A gateway cannot prove the selected
-local or remote instance's executable directory, so it never stages a
-`dcc-mcp-server` update by binary name alone.
+local or remote instance's executable directory, so it never stages any binary
+update by name alone.
+
+The first upgrade from an older release still runs that older release's update
+code. High-assurance deployments should install the first digest-enforcing
+release through an externally SHA-256-verified release asset. Digest validation
+proves consistency with the manifest, not publisher authenticity; detached
+manifest signatures are a separate trust layer.
 
 ### Install Location
 

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -264,10 +264,15 @@ adapter 启动时被发现。要让运行中的 adapter 立即看到准确包名
 manifest 通过 `DCC_MCP_UPDATE_MANIFEST_URL`（或
 `GatewayConfig.update_manifest_url`）配置。`update check` 只读取
 `/v1/update/check`，适合人和 agent 使用；CLI 会在请求前默认确保本机 gateway
-存在。`update apply` 只暂存 CLI binary。Admin 实例页只检查 server 是否有更新；
-gateway 无法证明本机或远端实例的实际安装目录，因此不会代替实例暂存 server。
-请在目标 server 环境运行 `dcc-mcp-server update apply`。所有平台都只校验和暂存
-server 自身；独立的 `dcc-cua` CLI 单独更新。
+存在。有更新时，manifest 必须同时提供 URL 和 64 位十六进制 SHA-256。
+`update apply` 流式下载并校验该资产，只暂存一个与当前安装绑定的 CLI component；
+下次启动替换前会再次校验，替换后用原参数重启 CLI。旧的 `pending.bin` /
+`pending.marker` 没有摘要，只会被隔离，绝不会应用。
+
+Admin 实例页对所有 binary 都只做检查；gateway 无法证明本机或远端实例的实际
+安装目录，因此不会代替目标环境暂存更新。请在目标 server 环境运行
+`dcc-mcp-server update apply`。它使用相同的强制摘要与应用前复验契约，并且只
+暂存 server 自身；独立的 `dcc-cua` CLI 单独更新。
 
 `lint` 复用生产 `dcc-mcp-skills` validator，因此本地检查与运行时加载会因同一类
 结构问题失败。CI 也通过 `just lint-skills` 显式传入仓库 skill roots，跑同一条

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -66,8 +66,9 @@ dcc-mcp-cli update check
 dcc-mcp-cli update apply
 ```
 
-`update apply` 会暂存最新版 CLI，并在下一次启动时生效；它不会替换正在运行的
-`dcc-mcp-server`，server 需要在自己的运行环境中单独更新。
+`update apply` 会强制读取 release manifest 的 SHA-256、校验下载的 CLI，并为
+下一次启动暂存。替换前会再次校验 staged bytes，之后用相同参数重启 CLI。它不会
+替换正在运行的 `dcc-mcp-server`，server 需要在自己的运行环境中单独更新。
 
 CLI 也提供了独立 ZIP 包（`dcc-mcp-cli-<version>-<platform>.zip`），
 可从每个 [GitHub Release](https://github.com/dcc-mcp/dcc-mcp-core/releases) 下载。

--- a/docs/zh/guide/production-deployment.md
+++ b/docs/zh/guide/production-deployment.md
@@ -57,8 +57,14 @@ GitHub Release 会附带可直接解压部署的
 `dcc-mcp/dcc-cua` 项目单独发布为 `dcc-cua`；Core 运行时校验其
 machine manifest，但不再打包或更新它。manifest 必须声明
 `runtime.separate_driver_required=false`，因此部署不会再添加独立的 `cua-driver`
-资产。`dcc-mcp-server update apply` 在所有平台
-都只校验并暂存 server binary，CUA 保持独立发布生命周期。
+资产。请从目标安装环境运行 `dcc-mcp-server update apply`。有更新时 manifest
+必须提供 URL 和有效 SHA-256；server 会校验下载资产，只暂存一个与当前安装绑定
+的 server binary，并在替换前再次校验。损坏的 v2 staging 与旧 unsigned marker
+会被隔离，现有 server 继续运行。CUA 保持独立发布生命周期。
+
+从旧版本第一次升级到强制摘要版本时，执行的仍是旧 updater。高保证部署应通过
+外部 SHA-256 已验证的 release 资产安装首个修复版本。摘要只能证明资产与 manifest
+一致，不等同于发布者签名；detached manifest signature 属于后续独立信任层。
 
 ### 安装路径
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3602,7 +3602,8 @@ dcc-mcp-cli call <tool-slug> --json '{"radius":2.0}'
 If the CLI is missing, obtain user consent before using the official release
 installers in `README.md`. Keep it current with `dcc-mcp-cli update check`,
 then `dcc-mcp-cli update apply`. The apply step stages the next CLI launch and
-does not replace a running server.
+requires a valid manifest SHA-256, re-verifies installation-bound staged bytes,
+quarantines legacy unsigned staging, and does not replace a running server.
 
 ### 2. Skill-Based Tools (preferred over raw API calls)
 - Use skill tools (e.g. `maya_geometry__create_sphere`) — they have validated schemas, error handling, and `next-tools` guidance

--- a/llms.txt
+++ b/llms.txt
@@ -59,7 +59,8 @@ Start a new agent turn after installation.
 If `dcc-mcp-cli` is missing, obtain user consent before using the official
 release installers in `README.md`. Keep it current with
 `dcc-mcp-cli update check`, then `dcc-mcp-cli update apply`; apply stages the
-next CLI launch and does not replace a running server.
+next CLI launch, requires and re-verifies the manifest SHA-256, quarantines
+legacy unsigned staging, and does not replace a running server.
 
 **New to this project?** Read [`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md) FIRST.
 

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -61,8 +61,10 @@ Use the `dcc-mcp` skill and `dcc-mcp-cli` for discovery, validation, and live
 DCC control whenever the agent can run shell commands. If the CLI is missing,
 follow the consent-gated official installation instructions in `dcc-mcp`.
 Before long-lived validation, run `dcc-mcp-cli update check`; use
-`dcc-mcp-cli update apply` to stage the latest CLI for the next launch. This
-does not replace a running server binary.
+`dcc-mcp-cli update apply` to verify and stage the latest CLI for the next
+launch. Apply-time verification is installation-bound and legacy unsigned
+staging is quarantined. This does not replace a running server binary; update
+the server from its exact target environment. Gateway Admin is check-only.
 
 ## Runtime Vocabulary
 

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -463,7 +463,7 @@ Load `dcc-mcp-skills-creator` and request `review_skill_improvement` with bounde
 
 ## Updates and Marketplace Maintenance
 
-Use the gateway release manifest for binary checks. `update apply` stages the CLI for its next launch; a running server must be updated in its own environment. The Admin Instances panel remains check-only because the gateway cannot prove an instance's installation root. See the CLI cheatsheet for platform manifests, server updates, and the verified `dcc-cua` sibling contract.
+Use the gateway release manifest for binary checks. An available binary must have a valid SHA-256; `update apply` verifies it during download, binds one component to the exact CLI installation, and re-verifies it before replacement and restart. Legacy unsigned staging is quarantined. A running server must be updated in its own environment. The Admin Instances panel is check-only for every binary because the gateway cannot prove an installation root. See the CLI cheatsheet for platform manifests, server updates, and the verified `dcc-cua` sibling contract.
 
 ```bash
 dcc-mcp-cli update check

--- a/skills/dcc-mcp/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-mcp/references/CLI_CHEATSHEET.md
@@ -35,8 +35,12 @@ dcc-mcp-cli components status dcc-cua
 dcc-mcp-cli components ensure dcc-cua --yes
 ```
 
-`update apply` downloads and stages the latest CLI for the next launch. It does
-not update a running `dcc-mcp-server`; update that server in its own environment.
+`update apply` requires the available entry's 64-hex SHA-256, verifies the
+streamed download, and stages one component bound to the exact CLI installation.
+The next launch re-verifies the bytes before replacement and restarts with the
+original arguments. Legacy unsigned staging is quarantined. It does not update
+a running `dcc-mcp-server`; update that server in its own environment. Gateway
+Admin remains check-only for every binary.
 The official CLI installer also reconciles the independently released
 `dcc-cua` sibling. `components status` is read-only; `components ensure`
 requires explicit `--yes`, a mandatory archive SHA-256, and an exact official

--- a/tests/test_update_manifest.py
+++ b/tests/test_update_manifest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 import subprocess
@@ -41,4 +42,5 @@ def test_platform_manifests_publish_only_core_binaries(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     manifest = json.loads((tmp_path / "dist" / "dcc-mcp-update-manifest-windows-x86_64.json").read_text())
     assert set(manifest) == {"dcc-mcp-server", "dcc-mcp-cli"}
-    assert all(len(asset["sha256"]) == 64 for asset in manifest.values())
+    assert manifest["dcc-mcp-server"]["sha256"] == hashlib.sha256(b"server").hexdigest()
+    assert manifest["dcc-mcp-cli"]["sha256"] == hashlib.sha256(b"cli").hexdigest()


### PR DESCRIPTION
## Summary
- require a valid SHA-256 and bounded verified download for every available binary update
- bind staging to the exact installation, reverify before apply, quarantine legacy or invalid state, and restart into the installed binary
- make Gateway Admin update checks fail closed and keep apply operations target-local
- document the updater trust boundary in ADR 023 and operator guidance

## Validation
- `vx cargo nextest run --workspace` (3522 passed)
- `vx cargo test --workspace --doc`
- `vx cargo clippy --workspace -- -D warnings`
- `vx cargo hakari verify`
- `vx cargo fmt --all -- --check`
- `vx ruff check python/dcc_mcp_core/ tests/ examples/ scripts/`
- `vx ruff format --check python/dcc_mcp_core/ tests/ examples/ scripts/`
- Admin UI and docs production builds
- 31 bundled skill packages linted with no warnings

Advances #2186. The remaining Git, pip, and signature enforcement work will follow in separate atomic PRs.