### PR TITLE
fix(marketplace): require immutable install sources

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -194,10 +194,10 @@ pub struct CatalogInstall {
     /// Source URL or local path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-    /// Git ref, tag, branch, or revision where applicable.
+    /// Full 40-character Git commit object ID for `git` installs.
     #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
     pub ref_: Option<String>,
-    /// Optional content hash for archive installs.
+    /// Required SHA-256 content hash for `zip` installs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
     /// Repository-relative roots that contain the skills this package is allowed to install.
@@ -573,6 +573,22 @@ const MARKETPLACE_V2_SCHEMA_JSON: &str = r##"{
             "entry_point": { "type": "string" },
             "instructions_url": { "type": "string" }
           },
+          "allOf": [
+            {
+              "if": { "properties": { "type": { "const": "git" } } },
+              "then": {
+                "required": ["url", "ref"],
+                "properties": { "ref": { "pattern": "^[0-9a-fA-F]{40}$" } }
+              }
+            },
+            {
+              "if": { "properties": { "type": { "const": "zip" } } },
+              "then": {
+                "required": ["url", "sha256"],
+                "properties": { "sha256": { "pattern": "^(sha256:)?[0-9a-fA-F]{64}$" } }
+              }
+            }
+          ],
           "additionalProperties": false
         }
       },
@@ -1054,7 +1070,7 @@ entries:
                 install_type: "zip".into(),
                 url: Some("https://example.com/skill.zip".into()),
                 ref_: Some("v0.1.0".into()),
-                sha256: Some("abc123".into()),
+                sha256: Some("a".repeat(64)),
                 skill_roots: None,
                 pip_package: None,
                 pip_extras: None,
@@ -1065,6 +1081,50 @@ entries:
             icon: None,
             showcase: None,
         };
+        assert!(validate_entry(&entry).is_ok());
+    }
+
+    #[test]
+    fn test_validate_entry_requires_immutable_git_commit() {
+        let mut entry = make_entry("git-skill", "A Git-installed skill");
+        entry.install = Some(CatalogInstall {
+            install_type: "git".into(),
+            url: Some("https://github.com/dcc-mcp/example".into()),
+            ref_: Some("main".into()),
+            sha256: None,
+            skill_roots: None,
+            pip_package: None,
+            pip_extras: None,
+            python_path: None,
+            entry_point: None,
+            instructions_url: None,
+        });
+
+        assert!(validate_entry(&entry).is_err());
+        entry.install.as_mut().unwrap().ref_ = Some("a".repeat(40));
+        assert!(validate_entry(&entry).is_ok());
+    }
+
+    #[test]
+    fn test_validate_entry_requires_well_formed_zip_sha256() {
+        let mut entry = make_entry("zip-skill", "A ZIP-installed skill");
+        entry.install = Some(CatalogInstall {
+            install_type: "zip".into(),
+            url: Some("https://example.com/skill.zip".into()),
+            ref_: None,
+            sha256: None,
+            skill_roots: None,
+            pip_package: None,
+            pip_extras: None,
+            python_path: None,
+            entry_point: None,
+            instructions_url: None,
+        });
+
+        assert!(validate_entry(&entry).is_err());
+        entry.install.as_mut().unwrap().sha256 = Some("abc123".into());
+        assert!(validate_entry(&entry).is_err());
+        entry.install.as_mut().unwrap().sha256 = Some(format!("sha256:{}", "A".repeat(64)));
         assert!(validate_entry(&entry).is_ok());
     }
 

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -441,6 +441,7 @@ fn execute_git_clone(
     ref_: Option<&str>,
     dest: &Path,
 ) -> Result<Option<StepRollback>, InstallError> {
+    let commit = required_git_commit(ref_)?;
     if dest.exists() {
         return Err(InstallError::StepFailed {
             step: "git-clone".into(),
@@ -453,26 +454,74 @@ fn execute_git_clone(
         std::fs::create_dir_all(parent)?;
     }
 
-    let mut cmd = Command::new("git");
-    cmd.arg("clone").arg("--depth").arg("1");
-    if let Some(r) = ref_.filter(|v| !v.trim().is_empty()) {
-        cmd.arg("--branch").arg(r);
-    }
-    cmd.arg(url).arg(dest);
+    run_git(
+        dest,
+        "init",
+        &["init", "--quiet", dest.to_string_lossy().as_ref()],
+    )?;
+    run_git(dest, "remote-add", &["remote", "add", "origin", url])?;
+    run_git(dest, "fetch", &["fetch", "--depth", "1", "origin", &commit])?;
+    run_git(
+        dest,
+        "checkout",
+        &["checkout", "--detach", "--quiet", "FETCH_HEAD"],
+    )?;
 
-    let status = cmd.status().map_err(|e| InstallError::StepFailed {
-        step: "git-clone".into(),
-        message: format!("failed to launch git: {e}"),
-    })?;
-
-    if !status.success() {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dest)
+        .output()
+        .map_err(|error| InstallError::StepFailed {
+            step: "git-verify".into(),
+            message: format!("failed to launch git: {error}"),
+        })?;
+    if !output.status.success() {
         return Err(InstallError::StepFailed {
-            step: "git-clone".into(),
-            message: format!("git clone exited with {status}"),
+            step: "git-verify".into(),
+            message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    let actual = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .to_ascii_lowercase();
+    if actual != commit {
+        return Err(InstallError::StepFailed {
+            step: "git-verify".into(),
+            message: format!("commit mismatch: expected {commit}, got {actual}"),
         });
     }
 
     Ok(Some(StepRollback::RemovePath(dest.to_path_buf())))
+}
+
+fn required_git_commit(ref_: Option<&str>) -> Result<String, InstallError> {
+    let reference = ref_.unwrap_or_default().trim();
+    if reference.len() != 40 || !reference.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(InstallError::StepFailed {
+            step: "git-integrity".into(),
+            message: "a full 40-character commit object ID is required".into(),
+        });
+    }
+    Ok(reference.to_ascii_lowercase())
+}
+
+fn run_git(dest: &Path, step: &str, args: &[&str]) -> Result<(), InstallError> {
+    let mut command = Command::new("git");
+    command.args(args);
+    if step != "init" {
+        command.current_dir(dest);
+    }
+    let output = command.output().map_err(|error| InstallError::StepFailed {
+        step: format!("git-{step}"),
+        message: format!("failed to launch git: {error}"),
+    })?;
+    if !output.status.success() {
+        return Err(InstallError::StepFailed {
+            step: format!("git-{step}"),
+            message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    Ok(())
 }
 
 fn execute_zip_extract(
@@ -480,6 +529,7 @@ fn execute_zip_extract(
     sha256: Option<&str>,
     dest: &Path,
 ) -> Result<Option<StepRollback>, InstallError> {
+    let expected = required_archive_sha256(sha256)?;
     if dest.exists() {
         return Err(InstallError::StepFailed {
             step: "zip-extract".into(),
@@ -498,20 +548,17 @@ fn execute_zip_extract(
         message: format!("failed to read response from {url}: {e}"),
     })?;
 
-    // Verify SHA-256 if requested
-    if let Some(expected) = sha256 {
-        use sha2::Digest;
-        let actual = sha2::Sha256::digest(&bytes);
-        let actual_hex = actual
-            .iter()
-            .map(|b| format!("{b:02x}"))
-            .collect::<String>();
-        if !actual_hex.eq_ignore_ascii_case(expected) {
-            return Err(InstallError::StepFailed {
-                step: "zip-checksum".into(),
-                message: format!("SHA-256 mismatch: expected {expected}, got {actual_hex}"),
-            });
-        }
+    use sha2::Digest;
+    let actual = sha2::Sha256::digest(&bytes);
+    let actual_hex = actual
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    if !actual_hex.eq_ignore_ascii_case(&expected) {
+        return Err(InstallError::StepFailed {
+            step: "zip-checksum".into(),
+            message: format!("SHA-256 mismatch: expected {expected}, got {actual_hex}"),
+        });
     }
 
     // Ensure parent directory exists
@@ -534,6 +581,18 @@ fn execute_zip_extract(
         })?;
 
     Ok(Some(StepRollback::RemovePath(dest.to_path_buf())))
+}
+
+fn required_archive_sha256(sha256: Option<&str>) -> Result<String, InstallError> {
+    let value = sha256.unwrap_or_default().trim();
+    let checksum = value.strip_prefix("sha256:").unwrap_or(value);
+    if checksum.len() != 64 || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(InstallError::StepFailed {
+            step: "zip-integrity".into(),
+            message: "exactly 64 hexadecimal SHA-256 digits are required".into(),
+        });
+    }
+    Ok(checksum.to_ascii_lowercase())
 }
 
 fn execute_path_copy(source: &Path, dest: &Path) -> Result<Option<StepRollback>, InstallError> {
@@ -908,6 +967,35 @@ mod tests {
         let dest = PathBuf::from("/__nonexistent__/test-repo");
         let result = execute_git_clone("https://__nonexistent__.invalid/repo.git", None, &dest);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn git_and_zip_integrity_fail_before_network_or_filesystem_io() {
+        let root = tempfile::tempdir().unwrap();
+        let git_dest = root.path().join("git-install");
+        let git_error = execute_git_clone(
+            "https://__nonexistent__.invalid/repo.git",
+            Some("main"),
+            &git_dest,
+        )
+        .unwrap_err();
+        assert!(git_error.to_string().contains("40-character commit"));
+        assert!(!git_dest.exists());
+
+        let zip_dest = root.path().join("zip-install");
+        let zip_error = execute_zip_extract(
+            "https://__nonexistent__.invalid/archive.zip",
+            None,
+            &zip_dest,
+        )
+        .unwrap_err();
+        assert!(zip_error.to_string().contains("64 hexadecimal"));
+        assert!(!zip_dest.exists());
+
+        assert_eq!(
+            required_archive_sha256(Some(&format!("sha256:{}", "A".repeat(64)))).unwrap(),
+            "a".repeat(64)
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -94,21 +94,21 @@ pub enum InstallStepAction {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         python: Option<String>,
     },
-    /// Clone a git repository.
+    /// Check out a git repository at an immutable commit.
     GitClone {
         /// Git remote URL.
         url: String,
-        /// Git ref, tag, or branch to check out.
+        /// Full 40-character commit object ID to check out.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         ref_: Option<String>,
         /// Target directory for the clone.
         dest: PathBuf,
     },
-    /// Download and extract a ZIP archive.
+    /// Download, verify, and extract a ZIP archive.
     ZipExtract {
         /// Archive download URL.
         url: String,
-        /// Optional SHA-256 hash for integrity verification.
+        /// Required SHA-256 hash for integrity verification.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         sha256: Option<String>,
         /// Target extract directory.
@@ -142,6 +142,10 @@ pub enum InstallPlanError {
     UnsupportedDcc(String),
     #[error("no install metadata found in catalog entry for '{0}'")]
     MissingInstallMetadata(String),
+    #[error("git install requires a full 40-character commit object ID")]
+    UnpinnedGitReference,
+    #[error("zip install requires exactly 64 hexadecimal SHA-256 digits")]
+    InvalidArchiveChecksum,
 }
 
 // ── defaults ─────────────────────────────────────────────────────────────────────
@@ -161,6 +165,26 @@ fn dirs_data_dir() -> PathBuf {
 
 pub struct InstallPlanner;
 
+fn validate_install_integrity(install: &CatalogInstall) -> Result<(), InstallPlanError> {
+    match install.install_type.as_str() {
+        "git" => {
+            let reference = install.ref_.as_deref().unwrap_or_default().trim();
+            if reference.len() != 40 || !reference.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                return Err(InstallPlanError::UnpinnedGitReference);
+            }
+        }
+        "zip" => {
+            let value = install.sha256.as_deref().unwrap_or_default().trim();
+            let checksum = value.strip_prefix("sha256:").unwrap_or(value);
+            if checksum.len() != 64 || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                return Err(InstallPlanError::InvalidArchiveChecksum);
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 impl InstallPlanner {
     /// Generate an install plan from catalog entries and user request.
     ///
@@ -179,6 +203,10 @@ impl InstallPlanner {
         let dcc_type = request.dcc_type.clone();
         let version = request.version.clone();
         let dcc_path = request.dcc_path.clone();
+
+        if let Some(install) = &adapter.install {
+            validate_install_integrity(install)?;
+        }
 
         let steps = match &adapter.install {
             Some(install) => Self::build_executable_steps(
@@ -876,7 +904,7 @@ mod tests {
         let install = CatalogInstall {
             install_type: "git".into(),
             url: Some("https://github.com/dcc-mcp/dcc-mcp-maya-mgear".into()),
-            ref_: Some("main".into()),
+            ref_: Some("a".repeat(40)),
             sha256: None,
             skill_roots: None,
             pip_package: None,
@@ -908,6 +936,62 @@ mod tests {
             plan.steps[0].action,
             Some(InstallStepAction::GitClone { .. })
         ));
+    }
+
+    #[test]
+    fn planner_rejects_mutable_git_and_unverified_zip_installs() {
+        let mut install = CatalogInstall {
+            install_type: "git".into(),
+            url: Some("https://github.com/dcc-mcp/example".into()),
+            ref_: Some("main".into()),
+            sha256: None,
+            skill_roots: None,
+            pip_package: None,
+            pip_extras: None,
+            python_path: None,
+            entry_point: None,
+            instructions_url: None,
+        };
+        let request = || InstallRequest {
+            dcc_type: "maya".into(),
+            version: None,
+            catalog_path: None,
+            python: None,
+            dcc_path: None,
+        };
+
+        let error = InstallPlanner::plan(
+            &[catalog_entry(
+                "git-adapter",
+                &["maya"],
+                Some(install.clone()),
+            )],
+            request(),
+        )
+        .unwrap_err();
+        assert_eq!(error, InstallPlanError::UnpinnedGitReference);
+
+        install.install_type = "zip".into();
+        install.ref_ = None;
+        let error = InstallPlanner::plan(
+            &[catalog_entry(
+                "zip-adapter",
+                &["maya"],
+                Some(install.clone()),
+            )],
+            request(),
+        )
+        .unwrap_err();
+        assert_eq!(error, InstallPlanError::InvalidArchiveChecksum);
+
+        install.sha256 = Some(format!("sha256:{}", "a".repeat(64)));
+        assert!(
+            InstallPlanner::plan(
+                &[catalog_entry("zip-adapter", &["maya"], Some(install))],
+                request(),
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -1024,6 +1024,7 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                 }
                 MarketplaceAction::AddRepo {
                     repo_ref,
+                    commit,
                     dcc,
                     list,
                     force,
@@ -1031,7 +1032,13 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                     if list {
                         to_json(service.list_repo_skills(&repo_ref)?)?
                     } else {
-                        to_json(service.add_repo(&repo_ref, dcc.as_deref(), force)?)?
+                        let commit = commit.expect("clap requires --commit unless --list is set");
+                        to_json(service.add_repo_at_commit(
+                            &repo_ref,
+                            &commit,
+                            dcc.as_deref(),
+                            force,
+                        )?)?
                     }
                 }
                 MarketplaceAction::Pack(args) => marketplace_cmd::run_pack(args)?,

--- a/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
@@ -148,6 +148,46 @@ fn marketplace_search_contract_accepts_positional_query_and_dcc_type_alias() {
 }
 
 #[test]
+fn marketplace_add_repo_requires_commit_for_install_but_not_list() {
+    assert!(
+        Args::try_parse_from(["dcc-mcp-cli", "marketplace", "add-repo", "dcc-mcp/example",])
+            .is_err()
+    );
+
+    let args = Args::try_parse_from([
+        "dcc-mcp-cli",
+        "marketplace",
+        "add-repo",
+        "dcc-mcp/example",
+        "--commit",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ])
+    .expect("parse pinned direct repo install");
+    let Command::Marketplace {
+        action: MarketplaceAction::AddRepo { commit, list, .. },
+    } = args.command
+    else {
+        panic!("expected marketplace add-repo command");
+    };
+    assert_eq!(
+        commit.as_deref(),
+        Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    );
+    assert!(!list);
+
+    assert!(
+        Args::try_parse_from([
+            "dcc-mcp-cli",
+            "marketplace",
+            "add-repo",
+            "dcc-mcp/example",
+            "--list",
+        ])
+        .is_ok()
+    );
+}
+
+#[test]
 fn stats_contract_parses_composable_runtime_filters() {
     let args = Args::try_parse_from([
         "dcc-mcp-cli",

--- a/crates/dcc-mcp-cli/src/presentation/marketplace_cmd.rs
+++ b/crates/dcc-mcp-cli/src/presentation/marketplace_cmd.rs
@@ -76,6 +76,9 @@ pub(crate) enum MarketplaceAction {
     },
     AddRepo {
         repo_ref: String,
+        /// Full 40-character commit object ID. Required for installation.
+        #[arg(long, required_unless_present = "list")]
+        commit: Option<String>,
         #[arg(long)]
         dcc: Option<String>,
         #[arg(long)]
@@ -109,14 +112,14 @@ pub(crate) struct MarketplacePublishArgs {
     /// Install source type.
     #[arg(long = "install-type", default_value = "zip")]
     pub(crate) install_type: String,
-    /// Git ref/tag for git installs.
-    #[arg(long = "install-ref")]
+    /// Full 40-character commit object ID for git installs.
+    #[arg(long = "install-ref", required_if_eq("install_type", "git"))]
     pub(crate) install_ref: Option<String>,
     /// Skill directories to install from the source. Repeat for multi-skill packages.
     #[arg(long = "skill-root")]
     pub(crate) skill_roots: Vec<String>,
     /// Archive SHA-256, optionally prefixed with sha256:.
-    #[arg(long)]
+    #[arg(long, required_if_eq("install_type", "zip"))]
     pub(crate) sha256: Option<String>,
     /// Override package name when PATH has no root SKILL.md.
     #[arg(long)]

--- a/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_marketplace_e2e.rs
@@ -28,7 +28,7 @@ fn marketplace_add_list_search_and_inspect_local_source() {
     "install": {
       "type": "git",
       "url": "https://github.com/dcc-mcp/dcc-asset-hunyuan-download",
-      "ref": "v0.1.0"
+      "ref": "0123456789abcdef0123456789abcdef01234567"
     }
   }, {
     "name": "dcc-asset-polyhaven",
@@ -39,7 +39,7 @@ fn marketplace_add_list_search_and_inspect_local_source() {
     "install": {
       "type": "git",
       "url": "https://github.com/dcc-mcp/dcc-asset-polyhaven",
-      "ref": "v0.1.0"
+      "ref": "fedcba9876543210fedcba9876543210fedcba98"
     }
   }]
 }
@@ -95,7 +95,10 @@ fn marketplace_add_list_search_and_inspect_local_source() {
         &envs,
     );
     assert_eq!(inspect["count"], 1);
-    assert_eq!(inspect["matches"][0]["entry"]["install"]["ref"], "v0.1.0");
+    assert_eq!(
+        inspect["matches"][0]["entry"]["install"]["ref"],
+        "0123456789abcdef0123456789abcdef01234567"
+    );
 }
 
 #[test]
@@ -785,6 +788,7 @@ fn marketplace_install_git_package_promotes_single_nested_skill_dir() {
     std::fs::write(skill_dir.join("marker.txt"), "nested").unwrap();
     run_git(&repo, &["add", "."]);
     run_git(&repo, &["commit", "-m", "nested skill"]);
+    let commit = git_head(&repo);
 
     let catalog_path = tmp.path().join("marketplace.json");
     let source = catalog_path.to_string_lossy().to_string();
@@ -813,7 +817,8 @@ fn marketplace_install_git_package_promotes_single_nested_skill_dir() {
             "version": "0.1.0",
             "install": {
                 "type": "git",
-                "url": repo.to_string_lossy()
+                "url": repo.to_string_lossy(),
+                "ref": commit
             }
         }]
     });
@@ -1117,7 +1122,7 @@ fn marketplace_install_zip_rejects_sha256_mismatch_without_replacing_existing_pa
             "install": {
                 "type": "zip",
                 "url": zip_path.to_string_lossy(),
-                "sha256": "sha256:0000"
+                "sha256": format!("sha256:{}", "0".repeat(64))
             }
         }]
     });
@@ -1329,8 +1334,8 @@ fn marketplace_update_git_package_uses_latest_catalog_ref() {
     run_git(&repo, &["init"]);
     run_git(&repo, &["config", "user.name", "dcc-mcp-test"]);
     run_git(&repo, &["config", "user.email", "dcc-mcp-test@example.com"]);
-    commit_git_skill_version(&repo, "v0.1.0", "v1");
-    commit_git_skill_version(&repo, "v0.2.0", "v2");
+    let commit_v1 = commit_git_skill_version(&repo, "v0.1.0", "v1");
+    let commit_v2 = commit_git_skill_version(&repo, "v0.2.0", "v2");
 
     let catalog_path = tmp.path().join("marketplace.json");
     let source = catalog_path.to_string_lossy().to_string();
@@ -1361,7 +1366,7 @@ fn marketplace_update_git_package_uses_latest_catalog_ref() {
             "install": {
                 "type": "git",
                 "url": repo.to_string_lossy(),
-                "ref": "v0.1.0"
+                "ref": commit_v1
             }
         }]
     });
@@ -1400,7 +1405,7 @@ fn marketplace_update_git_package_uses_latest_catalog_ref() {
             "install": {
                 "type": "git",
                 "url": repo.to_string_lossy(),
-                "ref": "v0.2.0"
+                "ref": commit_v2.clone()
             }
         }]
     });
@@ -1416,7 +1421,7 @@ fn marketplace_update_git_package_uses_latest_catalog_ref() {
     );
     assert_eq!(outdated["count"], 1);
     assert_eq!(outdated["packages"][0]["latest_version"], "0.2.0");
-    assert_eq!(outdated["packages"][0]["install_ref"], "v0.2.0");
+    assert_eq!(outdated["packages"][0]["install_ref"], commit_v2);
 
     let updated = run_json_with_env(
         &["marketplace", "update", "git-skill", "--dcc", "maya"],
@@ -1430,7 +1435,7 @@ fn marketplace_update_git_package_uses_latest_catalog_ref() {
 
     let listed = run_json_with_env(&["marketplace", "list-installed", "--dcc", "maya"], &envs);
     assert_eq!(listed["packages"][0]["version"], "0.2.0");
-    assert_eq!(listed["packages"][0]["install_ref"], "v0.2.0");
+    assert_eq!(listed["packages"][0]["install_ref"], commit_v2);
 }
 
 #[test]

--- a/crates/dcc-mcp-cli/tests/support/mod.rs
+++ b/crates/dcc-mcp-cli/tests/support/mod.rs
@@ -1154,7 +1154,21 @@ pub(crate) fn run_git(repo: &std::path::Path, args: &[&str]) {
     );
 }
 
-pub(crate) fn commit_git_skill_version(repo: &std::path::Path, version: &str, marker: &str) {
+pub(crate) fn git_head(repo: &std::path::Path) -> String {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+pub(crate) fn commit_git_skill_version(
+    repo: &std::path::Path,
+    version: &str,
+    marker: &str,
+) -> String {
     std::fs::write(
         repo.join("SKILL.md"),
         format!("---\nname: git-skill\ndescription: Git skill {version}\n---\n"),
@@ -1164,6 +1178,7 @@ pub(crate) fn commit_git_skill_version(repo: &std::path::Path, version: &str, ma
     run_git(repo, &["add", "."]);
     run_git(repo, &["commit", "-m", version]);
     run_git(repo, &["tag", version]);
+    git_head(repo)
 }
 
 pub(crate) fn write_zip(entries: &[(&str, &str)], dest: &std::path::Path) -> Vec<u8> {

--- a/crates/dcc-mcp-marketplace/src/add_repo.rs
+++ b/crates/dcc-mcp-marketplace/src/add_repo.rs
@@ -1,7 +1,8 @@
 //! Direct GitHub repo installation — SKILL.md discovery, no marketplace.json needed.
 //!
 //! This module implements `dcc-mcp-cli marketplace add-repo <owner/repo>`:
-//! - Clone a GitHub repo via `git clone --depth 1`
+//! - Preview the current repository contents without installing
+//! - Install only an explicitly pinned 40-character commit
 //! - Discover SKILL.md files to infer name/dcc/description
 //! - Support `@subpath` syntax (vercel skills parity)
 //! - `--list` to enumerate available skills without installing
@@ -9,10 +10,13 @@
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use dcc_mcp_catalog::CatalogInstall;
+
 use crate::error::MarketplaceError;
 use crate::git_command;
 use crate::path_component;
 use crate::plugin::load_agent_plugin;
+use crate::service::service_internals::{install_from_git_command, required_git_commit};
 use crate::types::{RepoInstallResult, RepoSkillInfo, RepoSkillList};
 
 /// Parse a repo reference into a clone URL and optional subpath.
@@ -261,7 +265,7 @@ pub fn list_repo_skills(repo_ref: &str) -> Result<RepoSkillList, MarketplaceErro
     })
 }
 
-/// Install a Skill or Agent Plugin directly from a GitHub repo into the marketplace.
+/// Legacy direct-install entry point retained to fail closed for existing callers.
 ///
 /// `repo_ref`: owner/repo, full URL, or @subpath variant.
 /// `dcc`: explicit DCC override (required when SKILL.md doesn't declare one).
@@ -273,13 +277,40 @@ pub fn install_from_repo(
     force: bool,
     root: &Path,
 ) -> Result<RepoInstallResult, MarketplaceError> {
+    let _ = (repo_ref, dcc, force, root);
+    Err(MarketplaceError::UnpinnedGitReference {
+        reference: String::new(),
+    })
+}
+
+/// Install from a direct repository at an immutable commit.
+pub fn install_from_repo_at_commit(
+    repo_ref: &str,
+    commit: &str,
+    dcc: Option<&str>,
+    force: bool,
+    root: &Path,
+) -> Result<RepoInstallResult, MarketplaceError> {
     let (url, subpath) = parse_repo_ref(repo_ref)?;
+    let install = CatalogInstall {
+        install_type: "git".into(),
+        url: Some(url.clone()),
+        ref_: Some(commit.into()),
+        sha256: None,
+        skill_roots: None,
+        pip_package: None,
+        pip_extras: None,
+        python_path: None,
+        entry_point: None,
+        instructions_url: None,
+    };
+    required_git_commit(&install)?;
 
     // Temp staging for clone
     let staging = StagingDir::new()?;
     let clone_dir = staging.path.clone();
 
-    clone_repo(&url, &clone_dir)?;
+    install_from_git_command(&install, &clone_dir)?;
 
     let search_root = match &subpath {
         Some(sub) => {
@@ -502,6 +533,14 @@ mod tests {
         let (url, subpath) = parse_repo_ref("dcc-mcp/dcc-mcp-maya").unwrap();
         assert_eq!(url, "https://github.com/dcc-mcp/dcc-mcp-maya.git");
         assert!(subpath.is_none());
+    }
+
+    #[test]
+    fn legacy_direct_install_api_fails_closed_without_commit() {
+        let root = tempfile::tempdir().unwrap();
+        let error =
+            install_from_repo("dcc-mcp/example", Some("maya"), false, root.path()).unwrap_err();
+        assert!(error.to_string().contains("40-character commit"));
     }
 
     #[test]

--- a/crates/dcc-mcp-marketplace/src/error.rs
+++ b/crates/dcc-mcp-marketplace/src/error.rs
@@ -71,6 +71,14 @@ pub enum MarketplaceError {
     #[error("marketplace install command failed: {0}")]
     CommandFailed(String),
 
+    #[error(
+        "marketplace git install requires a full 40-character commit object ID, got '{reference}'"
+    )]
+    UnpinnedGitReference { reference: String },
+
+    #[error("marketplace git checkout mismatch: expected commit {expected}, got {actual}")]
+    GitCommitMismatch { expected: String, actual: String },
+
     #[error("installed package does not contain SKILL.md at '{0}'")]
     MissingSkill(String),
 
@@ -80,6 +88,12 @@ pub enum MarketplaceError {
         expected: String,
         actual: String,
     },
+
+    #[error("marketplace archive '{url}' requires SHA-256 before it can be read or downloaded")]
+    MissingArchiveChecksum { url: String },
+
+    #[error("marketplace archive has invalid SHA-256 '{value}'; expected 64 hexadecimal digits")]
+    InvalidArchiveChecksum { value: String },
 
     #[error("marketplace archive error for '{0}': {1}")]
     Archive(String, String),

--- a/crates/dcc-mcp-marketplace/src/lib.rs
+++ b/crates/dcc-mcp-marketplace/src/lib.rs
@@ -39,7 +39,9 @@ fn hide_command_window(command: &mut std::process::Command) {
 fn hide_command_window(_: &mut std::process::Command) {}
 
 // Re-export the public API for convenience.
-pub use add_repo::{install_from_repo, list_repo_skills, parse_repo_ref};
+pub use add_repo::{
+    install_from_repo, install_from_repo_at_commit, list_repo_skills, parse_repo_ref,
+};
 pub use error::MarketplaceError;
 pub use package::{
     MarketplacePackOptions, MarketplacePackResult, MarketplacePublishOptions,

--- a/crates/dcc-mcp-marketplace/src/service.rs
+++ b/crates/dcc-mcp-marketplace/src/service.rs
@@ -23,7 +23,7 @@ use crate::types::{
 };
 
 #[path = "service_internals.rs"]
-mod service_internals;
+pub(crate) mod service_internals;
 use service_internals::*;
 pub(crate) use service_internals::{
     copy_dir_recursive, promote_single_nested_skill_directory, remove_path, write_atomic,
@@ -280,6 +280,7 @@ impl MarketplaceService {
             .install
             .clone()
             .ok_or_else(|| MarketplaceError::MissingInstall(hit.entry.name.clone()))?;
+        validate_install_integrity(&install)?;
         let package_name = path_component("package name", &hit.entry.name)?;
         let dcc_root = self.dcc_dir(&dcc);
         let dest = dcc_root.join(&package_name);
@@ -425,6 +426,7 @@ impl MarketplaceService {
             .install
             .clone()
             .ok_or_else(|| MarketplaceError::MissingInstall(hit.entry.name.clone()))?;
+        validate_install_integrity(&install)?;
         let package = hit.entry.package.as_ref().ok_or_else(|| {
             MarketplaceError::CommandFailed(
                 "generic target package requires package metadata".into(),
@@ -852,7 +854,7 @@ impl MarketplaceService {
         crate::add_repo::list_repo_skills(repo_ref)
     }
 
-    /// Install a Skill or Agent Plugin directly from GitHub (no catalog needed).
+    /// Legacy direct-install entry point retained to fail closed without a commit.
     pub fn add_repo(
         &self,
         repo_ref: &str,
@@ -860,6 +862,17 @@ impl MarketplaceService {
         force: bool,
     ) -> Result<RepoInstallResult, MarketplaceError> {
         crate::add_repo::install_from_repo(repo_ref, dcc, force, &self.root)
+    }
+
+    /// Install a Skill or Agent Plugin from an immutable repository commit.
+    pub fn add_repo_at_commit(
+        &self,
+        repo_ref: &str,
+        commit: &str,
+        dcc: Option<&str>,
+        force: bool,
+    ) -> Result<RepoInstallResult, MarketplaceError> {
+        crate::add_repo::install_from_repo_at_commit(repo_ref, commit, dcc, force, &self.root)
     }
 
     // ── internal helpers ─────────────────────────────────────────────────────
@@ -992,8 +1005,9 @@ impl MarketplaceService {
         install: &CatalogInstall,
         dest: &Path,
     ) -> Result<(), MarketplaceError> {
+        let expected_sha256 = required_archive_sha256(install)?;
         let (url, bytes) = self.load_archive(install).await?;
-        verify_archive_sha256(&bytes, install.sha256.as_deref(), &url)?;
+        verify_archive_sha256(&bytes, &expected_sha256, &url)?;
         extract_zip_archive(&bytes, dest)?;
         flatten_single_skill_directory(dest)?;
         Ok(())
@@ -1004,21 +1018,6 @@ impl MarketplaceService {
         install: &CatalogInstall,
         dest: &Path,
     ) -> Result<(), MarketplaceError> {
-        if let Some(url) = github_archive_url(install) {
-            let archive_install = CatalogInstall {
-                install_type: "zip".into(),
-                url: Some(url),
-                ref_: None,
-                sha256: None,
-                skill_roots: None,
-                pip_package: None,
-                pip_extras: None,
-                python_path: None,
-                entry_point: None,
-                instructions_url: None,
-            };
-            return self.install_from_zip(&archive_install, dest).await;
-        }
         install_from_git_command(install, dest)
     }
 
@@ -1080,7 +1079,7 @@ impl MarketplaceService {
     async fn update_git_package(
         &self,
         pkg: &OutdatedMarketplacePackage,
-        dest: &Path,
+        _dest: &Path,
     ) -> Result<MarketplaceUpdateResult, MarketplaceError> {
         let latest_entry = self
             .find_latest_entry_for_package(
@@ -1110,57 +1109,25 @@ impl MarketplaceService {
             ensure_entry_installable(entry)?;
         }
 
-        let git_dir = dest.join(".git");
-        let install_url_changed = pkg.install_url.as_deref().is_some_and(|url| {
-            git_remote_url(dest)
-                .ok()
-                .is_some_and(|remote_url| remote_url.trim() != url)
-        });
-
-        if git_dir.is_dir() && !install_url_changed {
-            if let Some(ref_) = pkg.install_ref.as_deref() {
-                git_fetch_and_checkout(dest, ref_)?;
-            } else {
-                git_pull(dest)?;
-            }
-        } else {
-            let result = self
-                .install(
-                    pkg.name.clone(),
-                    Some(pkg.dcc.clone()),
-                    vec![pkg.source_url.clone()],
-                    true,
-                    false,
-                )
-                .await?;
-            return Ok(MarketplaceUpdateResult {
-                updated: true,
-                name: pkg.name.clone(),
-                dcc: pkg.dcc.clone(),
-                previous_version: pkg.installed_version.clone(),
-                new_version: result.version,
-                previous_commit: pkg.installed_commit.clone(),
-                new_commit: result.resolved_commit,
-                path: result.path,
-                install_type: result.install_type,
-                source_name: pkg.source_name.clone(),
-                source_url: pkg.source_url.clone(),
-                reload_required: true,
-            });
-        }
-
-        let new_version = latest_entry.and_then(|entry| entry.version);
-
+        let result = self
+            .install(
+                pkg.name.clone(),
+                Some(pkg.dcc.clone()),
+                vec![pkg.source_url.clone()],
+                true,
+                false,
+            )
+            .await?;
         Ok(MarketplaceUpdateResult {
             updated: true,
             name: pkg.name.clone(),
             dcc: pkg.dcc.clone(),
             previous_version: pkg.installed_version.clone(),
-            new_version,
+            new_version: result.version,
             previous_commit: pkg.installed_commit.clone(),
-            new_commit: pkg.latest_commit.clone().or_else(|| git_head_commit(dest)),
-            path: dest.display().to_string(),
-            install_type: pkg.install_type.clone(),
+            new_commit: result.resolved_commit,
+            path: result.path,
+            install_type: result.install_type,
             source_name: pkg.source_name.clone(),
             source_url: pkg.source_url.clone(),
             reload_required: true,
@@ -1361,45 +1328,6 @@ mod tests {
         let list = svc.list_installed(None).unwrap();
         assert_eq!(list.count, 1);
         assert_eq!(list.packages[0].name, "test-skill");
-    }
-
-    #[test]
-    fn github_archive_url_converts_https_git_url() {
-        let install = CatalogInstall {
-            install_type: "git".into(),
-            url: Some("https://github.com/dcc-mcp/dcc-mcp-maya-mgear.git".into()),
-            ref_: Some("main".into()),
-            sha256: None,
-            skill_roots: None,
-            pip_package: None,
-            pip_extras: None,
-            python_path: None,
-            entry_point: None,
-            instructions_url: None,
-        };
-
-        assert_eq!(
-            github_archive_url(&install).as_deref(),
-            Some("https://codeload.github.com/dcc-mcp/dcc-mcp-maya-mgear/zip/main")
-        );
-    }
-
-    #[test]
-    fn github_archive_url_leaves_ssh_git_for_git_command() {
-        let install = CatalogInstall {
-            install_type: "git".into(),
-            url: Some("git@github.com:dcc-mcp/private-pack.git".into()),
-            ref_: Some("main".into()),
-            sha256: None,
-            skill_roots: None,
-            pip_package: None,
-            pip_extras: None,
-            python_path: None,
-            entry_point: None,
-            instructions_url: None,
-        };
-
-        assert_eq!(github_archive_url(&install), None);
     }
 
     #[test]

--- a/crates/dcc-mcp-marketplace/src/service_internals.rs
+++ b/crates/dcc-mcp-marketplace/src/service_internals.rs
@@ -227,27 +227,71 @@ pub fn install_from_git_command(
     install: &CatalogInstall,
     dest: &Path,
 ) -> Result<(), MarketplaceError> {
+    let commit = required_git_commit(install)?;
     let url = install
         .url
         .as_deref()
         .ok_or_else(|| MarketplaceError::MissingInstall("git.url".into()))?;
-    let mut command = git_command();
-    command.arg("clone").arg("--depth").arg("1");
-    if let Some(ref_) = install.ref_.as_deref().filter(|v| !v.trim().is_empty()) {
-        command.arg("--branch").arg(ref_);
-    }
-    command.arg(url).arg(dest);
-    let output = command
+    let output = git_command()
+        .args(["init", "--quiet"])
+        .arg(dest)
         .output()
-        .map_err(|err| MarketplaceError::CommandFailed(format!("git clone: {err}")))?;
+        .map_err(|err| MarketplaceError::CommandFailed(format!("git init: {err}")))?;
+    ensure_git_success("init", output)?;
+
+    let output = git_command()
+        .args(["remote", "add", "origin", url])
+        .current_dir(dest)
+        .output()
+        .map_err(|err| MarketplaceError::CommandFailed(format!("git remote add: {err}")))?;
+    ensure_git_success("remote add", output)?;
+
+    let output = git_command()
+        .args(["fetch", "--depth", "1", "origin", &commit])
+        .current_dir(dest)
+        .output()
+        .map_err(|err| MarketplaceError::CommandFailed(format!("git fetch: {err}")))?;
+    ensure_git_success("fetch pinned commit", output)?;
+
+    let output = git_command()
+        .args(["checkout", "--detach", "--quiet", "FETCH_HEAD"])
+        .current_dir(dest)
+        .output()
+        .map_err(|err| MarketplaceError::CommandFailed(format!("git checkout: {err}")))?;
+    ensure_git_success("checkout pinned commit", output)?;
+
+    let actual = git_head_commit(dest).unwrap_or_else(|| "<unresolved>".into());
+    if actual != commit {
+        return Err(MarketplaceError::GitCommitMismatch {
+            expected: commit,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+fn ensure_git_success(
+    operation: &str,
+    output: std::process::Output,
+) -> Result<(), MarketplaceError> {
     if output.status.success() {
         return Ok(());
     }
     Err(MarketplaceError::CommandFailed(format!(
-        "git clone exited with {}: {}",
+        "git {operation} exited with {}: {}",
         output.status,
         String::from_utf8_lossy(&output.stderr)
     )))
+}
+
+pub fn required_git_commit(install: &CatalogInstall) -> Result<String, MarketplaceError> {
+    let reference = install.ref_.as_deref().unwrap_or_default().trim();
+    if !is_full_git_oid(reference) {
+        return Err(MarketplaceError::UnpinnedGitReference {
+            reference: reference.to_string(),
+        });
+    }
+    Ok(reference.to_ascii_lowercase())
 }
 
 pub fn immutable_git_commit(install: &CatalogInstall) -> Option<String> {
@@ -300,32 +344,6 @@ pub fn git_head_commit(repo_path: &Path) -> Option<String> {
     is_full_git_oid(&revision).then_some(revision)
 }
 
-pub fn github_archive_url(install: &CatalogInstall) -> Option<String> {
-    let url = install.url.as_deref()?.trim().trim_end_matches('/');
-    let path = url
-        .strip_prefix("https://github.com/")
-        .or_else(|| url.strip_prefix("http://github.com/"))?;
-    let mut parts = path.split('/');
-    let owner = parts.next()?.trim();
-    let repo = parts.next()?.trim().trim_end_matches(".git");
-    if owner.is_empty() || repo.is_empty() {
-        return None;
-    }
-    let ref_ = install
-        .ref_
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("HEAD");
-    // Fetch the archive directly from GitHub's archive host. The public
-    // github.com endpoint redirects here; avoiding that extra request prevents
-    // long downloads from being cut off when the redirect connection is
-    // closed before the response body completes.
-    Some(format!(
-        "https://codeload.github.com/{owner}/{repo}/zip/{ref_}"
-    ))
-}
-
 pub fn install_from_path(install: &CatalogInstall, dest: &Path) -> Result<(), MarketplaceError> {
     let url = install
         .url
@@ -341,82 +359,42 @@ pub fn install_from_path(install: &CatalogInstall, dest: &Path) -> Result<(), Ma
     copy_dir_recursive(&src, dest)
 }
 
-pub fn git_fetch_and_checkout(repo_path: &Path, ref_: &str) -> Result<(), MarketplaceError> {
-    let output = git_command()
-        .args(["fetch", "origin", "--tags"])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|err| MarketplaceError::CommandFailed(format!("git fetch: {err}")))?;
-    if !output.status.success() {
-        return Err(MarketplaceError::CommandFailed(format!(
-            "git fetch failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        )));
-    }
-    let output = git_command()
-        .args(["checkout", ref_])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|err| MarketplaceError::CommandFailed(format!("git checkout: {err}")))?;
-    if !output.status.success() {
-        return Err(MarketplaceError::CommandFailed(format!(
-            "git checkout failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        )));
-    }
-    Ok(())
-}
-
-pub fn git_pull(repo_path: &Path) -> Result<(), MarketplaceError> {
-    let output = git_command()
-        .args(["pull", "--ff-only"])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|err| MarketplaceError::CommandFailed(format!("git pull: {err}")))?;
-    if !output.status.success() {
-        return Err(MarketplaceError::CommandFailed(format!(
-            "git pull failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        )));
-    }
-    Ok(())
-}
-
-pub fn git_remote_url(repo_path: &Path) -> Result<String, MarketplaceError> {
-    let output = git_command()
-        .args(["remote", "get-url", "origin"])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|err| MarketplaceError::CommandFailed(format!("git remote get-url: {err}")))?;
-    if !output.status.success() {
-        return Err(MarketplaceError::CommandFailed(format!(
-            "git remote get-url failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        )));
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
-}
-
 // ── zip / sha256 ─────────────────────────────────────────────────────────────
+
+pub fn required_archive_sha256(install: &CatalogInstall) -> Result<String, MarketplaceError> {
+    let url = install.url.as_deref().unwrap_or("<missing-url>");
+    let Some(value) = install.sha256.as_deref() else {
+        return Err(MarketplaceError::MissingArchiveChecksum { url: url.into() });
+    };
+    let normalized = normalize_sha256(value);
+    if normalized.len() != 64 || !normalized.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(MarketplaceError::InvalidArchiveChecksum {
+            value: value.to_string(),
+        });
+    }
+    Ok(normalized)
+}
+
+pub fn validate_install_integrity(install: &CatalogInstall) -> Result<(), MarketplaceError> {
+    match install.install_type.as_str() {
+        "git" => required_git_commit(install).map(|_| ()),
+        "zip" => required_archive_sha256(install).map(|_| ()),
+        _ => Ok(()),
+    }
+}
 
 pub fn verify_archive_sha256(
     bytes: &[u8],
-    expected: Option<&str>,
+    expected: &str,
     url: &str,
 ) -> Result<(), MarketplaceError> {
-    let Some(expected) = expected
-        .map(normalize_sha256)
-        .filter(|value| !value.is_empty())
-    else {
-        return Ok(());
-    };
     let actual = sha256_hex(bytes);
-    if actual.eq_ignore_ascii_case(&expected) {
+    if actual.eq_ignore_ascii_case(expected) {
         return Ok(());
     }
     Err(MarketplaceError::HashMismatch {
         url: url.to_string(),
-        expected,
+        expected: expected.to_string(),
         actual,
     })
 }
@@ -429,7 +407,7 @@ fn normalize_sha256(value: &str) -> String {
         .to_ascii_lowercase()
 }
 
-fn sha256_hex(bytes: &[u8]) -> String {
+pub(super) fn sha256_hex(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
     let mut out = String::with_capacity(digest.len() * 2);
     for byte in digest {

--- a/crates/dcc-mcp-marketplace/src/service_tests.rs
+++ b/crates/dcc-mcp-marketplace/src/service_tests.rs
@@ -258,6 +258,128 @@ fn immutable_git_commit_only_accepts_full_object_ids() {
 }
 
 #[test]
+fn git_install_rejects_mutable_ref_before_starting_git() {
+    let temp = tempfile::tempdir().unwrap();
+    let destination = temp.path().join("checkout");
+    let install = CatalogInstall {
+        install_type: "git".into(),
+        url: Some("https://example.invalid/skill".into()),
+        ref_: Some("main".into()),
+        sha256: None,
+        skill_roots: None,
+        pip_package: None,
+        pip_extras: None,
+        python_path: None,
+        entry_point: None,
+        instructions_url: None,
+    };
+
+    let error = install_from_git_command(&install, &destination).unwrap_err();
+    assert!(error.to_string().contains("40-character commit"));
+    assert!(!destination.exists());
+}
+
+#[test]
+fn git_install_checks_out_the_declared_commit_detached() {
+    fn run_git(repo: &Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    let source = tempfile::tempdir().unwrap();
+    run_git(source.path(), &["init", "--quiet"]);
+    run_git(source.path(), &["config", "user.name", "Marketplace Test"]);
+    run_git(
+        source.path(),
+        &["config", "user.email", "marketplace@example.invalid"],
+    );
+    std::fs::write(source.path().join("SKILL.md"), "first\n").unwrap();
+    run_git(source.path(), &["add", "SKILL.md"]);
+    run_git(source.path(), &["commit", "--quiet", "-m", "first"]);
+    let pinned = run_git(source.path(), &["rev-parse", "HEAD"]);
+    std::fs::write(source.path().join("SKILL.md"), "second\n").unwrap();
+    run_git(source.path(), &["commit", "--quiet", "-am", "second"]);
+
+    let target_root = tempfile::tempdir().unwrap();
+    let destination = target_root.path().join("checkout");
+    let install = CatalogInstall {
+        install_type: "git".into(),
+        url: Some(source.path().display().to_string()),
+        ref_: Some(pinned.clone()),
+        sha256: None,
+        skill_roots: None,
+        pip_package: None,
+        pip_extras: None,
+        python_path: None,
+        entry_point: None,
+        instructions_url: None,
+    };
+
+    install_from_git_command(&install, &destination).unwrap();
+    assert_eq!(
+        git_head_commit(&destination).as_deref(),
+        Some(pinned.as_str())
+    );
+    assert_eq!(
+        std::fs::read_to_string(destination.join("SKILL.md"))
+            .unwrap()
+            .trim(),
+        "first"
+    );
+    assert_eq!(run_git(&destination, &["branch", "--show-current"]), "");
+}
+
+#[tokio::test]
+async fn zip_install_rejects_missing_or_invalid_sha_before_reading_archive() {
+    let temp = tempfile::tempdir().unwrap();
+    let service = MarketplaceService::new(temp.path().to_path_buf());
+    let mut install = CatalogInstall {
+        install_type: "zip".into(),
+        url: Some(temp.path().join("missing.zip").display().to_string()),
+        ref_: None,
+        sha256: None,
+        skill_roots: None,
+        pip_package: None,
+        pip_extras: None,
+        python_path: None,
+        entry_point: None,
+        instructions_url: None,
+    };
+
+    let error = service
+        .install_from_zip(&install, &temp.path().join("missing-hash"))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("requires SHA-256"));
+
+    install.sha256 = Some("abc123".into());
+    let error = service
+        .install_from_zip(&install, &temp.path().join("invalid-hash"))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("invalid SHA-256"));
+}
+
+#[test]
+fn archive_verification_accepts_only_the_declared_bytes() {
+    let bytes = b"verified marketplace package";
+    let expected = service_internals::sha256_hex(bytes);
+    verify_archive_sha256(bytes, &expected, "package.zip").unwrap();
+
+    let error = verify_archive_sha256(b"tampered", &expected, "package.zip").unwrap_err();
+    assert!(matches!(error, MarketplaceError::HashMismatch { .. }));
+}
+
+#[test]
 fn core_version_gate_rejects_too_new_or_invalid_requirements() {
     let mut entry = CatalogEntry {
         name: "test-skill".into(),

--- a/docs/adr/024-immutable-marketplace-install-sources.md
+++ b/docs/adr/024-immutable-marketplace-install-sources.md
@@ -1,0 +1,60 @@
+# Immutable Marketplace Install Sources
+
+Status: Accepted
+
+## Context
+
+Marketplace Git entries accepted branches, tags, short object IDs, or a missing
+ref. GitHub URLs were optimized into codeload ZIP downloads while discarding
+the catalog checksum. ZIP verification also treated a missing checksum as
+success. Direct `marketplace add-repo` installs cloned the current branch HEAD.
+
+Those paths allowed catalog metadata to select mutable or unverified content.
+An update could therefore install different bytes without changing the entry.
+
+## Decision
+
+- Every catalog Git install requires a full 40-character commit object ID.
+  Runtime enforcement remains active even when a caller skips schema
+  validation.
+- Git installs initialize a staging repository, fetch the declared commit,
+  check out `FETCH_HEAD` detached, and verify that `HEAD` equals the normalized
+  object ID before package files are promoted.
+- GitHub catalog entries use the same Git path. They are not converted into an
+  archive whose bytes lack an independently declared digest.
+- Git updates reinstall the next catalog-pinned commit through staging instead
+  of pulling or checking out a mutable ref in place.
+- Every ZIP install requires exactly 64 hexadecimal SHA-256 digits before a
+  local file is read or a network request starts. Received bytes are verified
+  before extraction.
+- Direct repository installation requires `--commit`. The read-only `--list`
+  preview may inspect the current repository head but cannot install it.
+
+## Consequences
+
+- Existing catalog entries using branches, tags, short object IDs, or ZIPs
+  without SHA-256 must be migrated before installation.
+- Official Git entries already use full commit IDs and remain installable.
+- Existing direct-install Rust entry points remain callable but fail closed;
+  callers migrate to the explicit `*_at_commit` API.
+- Commit IDs and archive hashes provide integrity and immutability, not
+  publisher identity. Signed marketplace manifests remain a separate required
+  authenticity layer.
+
+## Alternatives considered
+
+### Trust HTTPS and release tags
+
+Rejected because both the selected ref and its resolved content can change
+without a catalog diff.
+
+### Keep the GitHub codeload optimization
+
+Rejected because a Git commit identifies repository objects, not the generated
+archive bytes. Retaining codeload would require a separate archive digest for
+every Git entry and duplicate ZIP semantics.
+
+### Resolve mutable refs once and persist the result
+
+Rejected because the first install would still trust content not declared by
+the reviewed catalog, and repeated installations would not be reproducible.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ Decision / Consequences / Alternatives considered.
 | 021 | [Use content-addressed revisions for cross-DCC asset sync](./021-content-addressed-asset-sync.md) | Accepted |
 | 022 | [Canonical Tool Result Envelope](./022-canonical-tool-result-envelope.md) | Accepted |
 | 023 | [Installation-Bound Binary Updates](./023-installation-bound-binary-updates.md) | Accepted |
+| 024 | [Immutable Marketplace Install Sources](./024-immutable-marketplace-install-sources.md) | Accepted |
 
 > Numbering is strictly sequential and never reused. ADR 001 is reserved for
 > the first historical record; filling it in is tracked separately from any

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -232,7 +232,8 @@ their worker-owned status tool.
 | `marketplace list-installed [--dcc <dcc>]` | local installed-state file | List locally installed marketplace packages and their versions/paths. |
 | `marketplace uninstall <name> [--dcc <dcc>] [--reload]` | local installed-state file + filesystem | Remove an installed marketplace package; infer the DCC from installed state when unambiguous, and optionally reload the adapter. |
 | `marketplace outdated [NAME...] [--dcc <dcc>]` | marketplace catalog + local installed state | Compare installed versions against latest catalog entries and list packages with newer versions available. |
-| `marketplace update [<name>] [--all] [--dcc <dcc>]` | marketplace catalog + git/filesystem + local installed state | Upgrade installed packages to the latest catalog version. For `git` installs, fetches the new ref in place; for other types, re-installs from the catalog. Use `--all` to update every outdated package. |
+| `marketplace update [<name>] [--all] [--dcc <dcc>]` | marketplace catalog + git/filesystem + local installed state | Upgrade installed packages to the latest catalog version. Git updates reinstall the next full commit OID through verified staging; ZIP updates require and verify SHA-256. Use `--all` to update every outdated package. |
+| `marketplace add-repo <repo> --commit <40-hex-oid> [--dcc <dcc>]` | direct Git fetch + local filesystem | Install directly from an immutable repository commit. `--list` is read-only and may omit `--commit`; installation may not. |
 | `marketplace pack <path> [--out <path>]` | local filesystem + zip | Build a release zip for a marketplace package and print its SHA-256 digest. |
 | `marketplace publish <path> --catalog <file> --install-url <url>` | local marketplace catalog file | Build or update a `marketplace.json` entry from `SKILL.md` metadata and CLI overrides. |
 | `update check [--binary <name>] [--current-version <version>]` | `GET /v1/update/check` | Check the gateway update manifest. Defaults to the CLI binary/version; pass `--binary dcc-mcp-server` plus a server version when checking an instance shown in Admin. |
@@ -334,8 +335,9 @@ Additional sources are persisted under
 `~/.dcc-mcp/marketplace/<dcc>/<name>/`, with
 `DCC_MCP_MARKETPLACE_INSTALL_ROOT` overriding the root. The current installer
 supports `install.type: git`, `install.type: path`, and `install.type: zip`.
-Archive installs verify `install.sha256` when present and reject entries that
-escape the install root. DCC adapters include
+Git installs require and verify a full 40-character commit object ID. Archive
+installs require `install.sha256` before I/O, verify the received bytes, and
+reject entries that escape the install root. DCC adapters include
 `~/.dcc-mcp/marketplace/<dcc>` in their skill search paths, so installed skills
 are discovered on adapter startup. To expose an exact package to running
 adapters immediately, use
@@ -345,11 +347,10 @@ adapters immediately, use
 the adapter has not auto-loaded that skill yet.
 
 `update` compares each installed package version against the latest catalog
-entry. For `git`-type installs, if a `.git` directory already exists the
-command runs `git fetch && git checkout <ref>` in place; otherwise it
-re-clones. The local installed-state file is updated with the new version
-metadata. Installed packages with no matching catalog entry (e.g. the
-source was removed) are silently skipped.
+entry. Git packages are reinstalled through staging at the next catalog-pinned
+commit rather than mutated in place. The local installed-state file is updated
+with the new version metadata. Installed packages with no matching catalog
+entry (e.g. the source was removed) are silently skipped.
 
 `dcc-mcp-cli update` is for binary updates exposed by the gateway update
 manifest configured with `DCC_MCP_UPDATE_MANIFEST_URL` (or

--- a/docs/guide/marketplace.md
+++ b/docs/guide/marketplace.md
@@ -81,7 +81,7 @@ Set `DCC_MCP_MARKETPLACE_NO_DEFAULT_SOURCES=1` to disable the built-in source.
 | `marketplace uninstall <name> [--dcc <dcc>] [--reload]`| Remove an installed package and optionally refresh the adapter |
 | `marketplace outdated [name] --dcc <dcc>` | Check for newer versions                       |
 | `marketplace update [name] --all`         | Upgrade installed packages                     |
-| `marketplace add-repo <repo> [--dcc]`     | Install directly from a GitHub repo            |
+| `marketplace add-repo <repo> --commit <oid> [--dcc]` | Install an immutable Git commit directly |
 | `marketplace pack <path> --out dist/`     | Build a zip package and SHA-256 digest         |
 | `marketplace publish <path> --catalog <file>` | Upsert a catalog entry for a package       |
 
@@ -139,29 +139,32 @@ backward-compatible input alias and should not be used for new entries.
 
 ### Git (`install.type: git`)
 
-Clones the repository on install, then uses `git fetch && git checkout <ref>`
-on subsequent updates. Best for actively developed skill packages.
+Requires a full 40-character commit object ID, fetches that exact object, checks
+it out detached, and verifies `HEAD` before installation. Branches, tags, short
+object IDs, and missing refs fail before Git starts. Updates reinstall the next
+catalog-pinned commit through the same staging boundary.
 
 ```yaml
 - name: dcc-mcp-maya-skills
   install:
     type: git
     url: "https://github.com/example/dcc-mcp-maya-skills.git"
-    ref: "v1.2.0"
+    ref: "0123456789abcdef0123456789abcdef01234567"
 ```
 
 ### Zip (`install.type: zip`)
 
-Downloads a ZIP archive (from URL or local path) and extracts it. Supports
-`sha256` verification. The archive root must contain exactly one top-level
-directory, which is flattened automatically.
+Requires exactly 64 hexadecimal SHA-256 digits before reading a local archive
+or starting a download, verifies the received bytes, and only then extracts.
+The archive root must contain exactly one top-level directory, which is
+flattened automatically.
 
 ```yaml
 - name: dcc-asset-hunyuan-download
   install:
     type: zip
     url: "https://example.com/packages/hunyuan-v2.zip"
-    sha256: "a1b2c3d4e5f6..."
+    sha256: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 ```
 
 ### Path (`install.type: path`)
@@ -205,7 +208,7 @@ dcc-mcp-cli marketplace publish . \
 ```
 
 This is the recommended path for stable packages. Development packages can
-still use `install.type: git` entries.
+still use `install.type: git`, but must publish the exact commit being tested.
 
 Minimal GitHub Actions shape for package repositories:
 
@@ -241,25 +244,25 @@ installs either the complete plugin or the matching Skill.
 
 ```bash
 # Install from GitHub shorthand (owner/repo → https://github.com/owner/repo.git)
-dcc-mcp-cli marketplace add-repo dcc-mcp/dcc-mcp-maya --dcc maya
+dcc-mcp-cli marketplace add-repo dcc-mcp/dcc-mcp-maya --commit <40-hex-commit> --dcc maya
 
 # Install from full URL
-dcc-mcp-cli marketplace add-repo https://github.com/dcc-mcp/dcc-mcp-maya --dcc maya
+dcc-mcp-cli marketplace add-repo https://github.com/dcc-mcp/dcc-mcp-maya --commit <40-hex-commit> --dcc maya
 
 # List available skills in a repo without installing
 dcc-mcp-cli marketplace add-repo dcc-mcp/dcc-mcp-maya --list
 
 # Install a subpath within a repo (e.g., owner/repo@subdir)
-dcc-mcp-cli marketplace add-repo my-org/skill-repo@maya-skills --dcc maya
+dcc-mcp-cli marketplace add-repo my-org/skill-repo@maya-skills --commit <40-hex-commit> --dcc maya
 
 # Force replace an existing installation
-dcc-mcp-cli marketplace add-repo dcc-mcp/dcc-mcp-maya --dcc maya --force
+dcc-mcp-cli marketplace add-repo dcc-mcp/dcc-mcp-maya --commit <40-hex-commit> --dcc maya --force
 ```
 
 ### How It Works
 
-1. **Clone**: runs `git clone --depth 1` of the target repo to a temporary
-   staging directory.
+1. **Fetch**: initializes a temporary repository, fetches only the required
+   commit, checks it out detached, and verifies `HEAD` before discovery.
 2. **Discover**: validates root `plugin.json` and its immediate `skills/*`
    components when present; otherwise scans for `SKILL.md` files.
 3. **Parse**: reads plugin metadata plus each Skill's `name`, `description`, and
@@ -292,7 +295,7 @@ The `dcc` field (under `metadata.dcc-mcp.dcc`) is optional but recommended; use
 |-------------------------|------------------------------|---------------------------------|
 | Requires catalog entry  | Yes                          | No                              |
 | Source resolution       | Via sources.json / --source  | Direct GitHub clone             |
-| Version tracking        | Catalog version + git ref    | HEAD of cloned branch           |
+| Version tracking        | Catalog version + commit OID | Explicit `--commit` OID         |
 | Update mechanism        | Catalog-driven update check  | Re-clone (future)               |
 | SKILL.md discovery      | Via catalog entry metadata   | Filesystem scan                 |
 
@@ -332,8 +335,10 @@ so installed skills appear on adapter startup or `reload_skill_paths`.
 
 - **Path traversal protection**: `marketplace_path_component()` rejects empty
   components, `.`, `..`, leading dots, and non-ASCII alphanumeric characters.
-- **SHA256 verification**: Zip installs verify `install.sha256` when present
-  and reject mismatches without modifying existing packages.
+- **Immutable Git installs**: catalog Git sources and direct repository
+  installs require a full commit object ID and verify the detached checkout.
+- **Mandatory SHA-256**: Zip installs require a valid digest before I/O and
+  reject missing, malformed, or mismatched values without modifying packages.
 - **Archive escape detection**: Zip extraction rejects entries that escape the
   install root directory.
 - **Plugin containment**: Agent Plugin manifests and fixed Skill components
@@ -370,8 +375,8 @@ falling back to the local `dcc-mcp-catalog.yml` when offline. Set
   install:
     type: git                        # git | zip | path
     url: "https://github.com/..."
-    ref: "v1.2.0"                    # tag/branch/commit (git type)
-    sha256: "a1b2c3..."              # content hash (zip type)
+    ref: "0123456789abcdef0123456789abcdef01234567" # full commit OID (git)
+    sha256: "sha256:<64-hex-digest>" # mandatory content hash (zip)
   package:
     format: agent-plugin              # agent-plugin | skill-bundle
     skills: [maya-rig, rig-review]    # displayed package components
@@ -429,7 +434,7 @@ future phase.
 | Uninstall | `marketplace uninstall <name> [--dcc <dcc>] [--reload]` | Uninstall button in Installed tab |
 | List installed | `marketplace list-installed --dcc <dcc>` | Installed tab |
 | Add source | `marketplace add <source>` | Source management in panel |
-| Direct GitHub install | `marketplace add-repo <repo> --dcc <dcc>` | Admin API (planned) |
+| Direct GitHub install | `marketplace add-repo <repo> --commit <oid> --dcc <dcc>` | Admin API (planned) |
 | Update | `marketplace update [name] --all` | Admin API (`POST /admin/api/marketplace/update`) |
 | Live adapter refresh | Bundled with install `--reload`; standalone after update/uninstall | Automatic when the backend reports `reload_required` |
 

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -482,8 +482,9 @@ dcc-mcp-cli marketplace install <profile_package_name> --target game:the-bazaar
 `--query "maya rigging"` remains supported for scripts. Search and inspect are
 read-only; install/update require consent. Inspect is optional when the exact
 package ID is already known, and `--dcc` is optional for single-DCC packages.
-After updates or installs without `--reload`, run `reload-skills`; then use
-`load-skill` only if the adapter did not auto-load it.
+Catalog Git installs require a full commit object ID and ZIP installs require a
+valid SHA-256 before I/O. Direct `marketplace add-repo` installation requires `--commit <40-hex-oid>`; only its read-only `--list` mode may omit it.
+After updates or installs without `--reload`, run `reload-skills`; then use `load-skill` only if the adapter did not auto-load it.
 
 Use `install` for adapter plans, never for marketplace Skills:
 
@@ -495,6 +496,5 @@ package installation as live registration. If no standard DCC is found, ask for 
 the returned policy prompt and hand off to the named deployment owner.
 
 The CLI is the **default agent-facing control plane**. The Python fallback uses
-the same gateway REST endpoints only when the CLI is unavailable after a
-verified install attempt fails. The gateway still serves MCP for IDE clients in
-parallel; choosing this skill does not replace or disable the IDE MCP path.
+the same gateway REST endpoints only when the CLI is unavailable after a verified install attempt fails.
+The gateway still serves MCP for IDE clients in parallel; choosing this skill does not replace or disable the IDE MCP path.

--- a/skills/dcc-mcp/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-mcp/references/CLI_CHEATSHEET.md
@@ -160,6 +160,7 @@ paths, or full tool payloads.
 | `dcc-mcp-cli marketplace install <package_name> --target game:the-bazaar` | Install a typed CUA Profile for a generic application target; no DCC reload is requested |
 | `dcc-mcp-cli reload-skills --dcc-type maya` | Ask running Maya adapters to re-scan installed skill paths |
 | `dcc-mcp-cli marketplace update <package_name> --dcc maya` | Update an installed skill package from the catalog |
+| `dcc-mcp-cli marketplace add-repo <repo> --commit <40-hex-oid> --dcc maya` | Install a direct repository source only at the reviewed immutable commit; `--list` may omit the commit |
 | `dcc-mcp-cli marketplace uninstall <package_name> --reload` | Remove an installed skill package; infer its DCC when it is installed for one DCC and refresh the adapter |
 
 After adapter package install, follow the plan's `next_steps`: read the

--- a/skills/marketplace-publish-extension/SKILL.md
+++ b/skills/marketplace-publish-extension/SKILL.md
@@ -91,8 +91,9 @@ push the change.
 ## Official catalog requirements
 
 - Pass `--min-core-version`; v1 entries require an explicit compatibility floor.
-- Git sources in the official catalog must use a complete 40-character commit
-  SHA in `--install-ref`, never a mutable branch name.
+- Git sources must use a complete 40-character commit object ID in
+  `--install-ref`; every catalog and runtime rejects branches, tags, short
+  object IDs, and missing refs.
 - Host-neutral Skills declare `dcc: any`. They match every concrete adapter,
   but installation must still pass a concrete `--dcc`; `any` is never an
   installation directory or a standalone DCC runtime.
@@ -103,8 +104,9 @@ push the change.
   Skill at an immediate `skills/<name>/SKILL.md` path. Publishing records
   `package.format: agent-plugin`; legacy multi-root packages use
   `skill-bundle`.
-- Zip sources require a 64-character SHA-256 digest. When the archive URL
-  changes, provide the new digest rather than reusing old metadata.
+- Zip sources require a 64-character SHA-256 digest before any archive read or
+  download. When the archive URL changes, provide the new digest rather than
+  reusing old metadata.
 - The publisher preserves v1 curation fields such as `requires` and `policy`
   when updating an existing entry, but new official entries must provide the
   complete marketplace metadata required by the catalog schema.

--- a/skills/marketplace-publish-extension/scripts/publish.py
+++ b/skills/marketplace-publish-extension/scripts/publish.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import re
 import subprocess
 import sys
 from typing import Any
@@ -182,6 +183,7 @@ def _build_catalog_entry(
     install_url: str,
     install_type: str,
     install_ref: str | None,
+    sha256: str | None,
     version: str | None,
     maintainer: str | None,
     icon: str | None,
@@ -190,6 +192,10 @@ def _build_catalog_entry(
     extension_url: str | None,
 ) -> dict[str, Any]:
     """Build a CatalogEntry dict from SKILL.md metadata and CLI inputs."""
+    if install_type == "git" and not re.fullmatch(r"[0-9a-fA-F]{40}", install_ref or ""):
+        raise ValueError("git installs require a full 40-character commit object ID")
+    if install_type == "zip" and not re.fullmatch(r"(?:sha256:)?[0-9a-fA-F]{64}", sha256 or ""):
+        raise ValueError("zip installs require exactly 64 hexadecimal SHA-256 digits")
     dcc_mcp_meta = skill_md.get("metadata", {}).get("dcc-mcp", {})
 
     # Name from SKILL.md frontmatter
@@ -237,6 +243,8 @@ def _build_catalog_entry(
 
     if install_ref:
         entry["install"]["ref"] = install_ref
+    if sha256:
+        entry["install"]["sha256"] = sha256
 
     if entry_version:
         entry["version"] = entry_version
@@ -462,7 +470,16 @@ def main() -> None:
     )
     parser.add_argument("--install_url", required=True, help="Install source URL for the CatalogEntry")
     parser.add_argument("--install_type", default="git", choices=["git", "path", "zip"], help="Install source type")
-    parser.add_argument("--install_ref", default=None, help="Git ref, branch, or tag for git-type installs")
+    parser.add_argument(
+        "--install_ref",
+        default=None,
+        help="Full 40-character commit object ID for git-type installs",
+    )
+    parser.add_argument(
+        "--sha256",
+        default=None,
+        help="Required 64-hex SHA-256 for zip-type installs",
+    )
     parser.add_argument("--version", default=None, help="Semantic version (overrides SKILL.md metadata if set)")
     parser.add_argument("--maintainer", default=None, help="Extension maintainer name")
     parser.add_argument("--icon", default=None, help="Icon path or URL for the CatalogEntry")
@@ -506,6 +523,7 @@ def main() -> None:
             install_url=args.install_url,
             install_type=args.install_type,
             install_ref=args.install_ref,
+            sha256=args.sha256,
             version=args.version,
             maintainer=args.maintainer,
             icon=args.icon,

--- a/skills/marketplace-publish-extension/tools.yaml
+++ b/skills/marketplace-publish-extension/tools.yaml
@@ -42,9 +42,15 @@ tools:
         install_ref:
           type: string
           description: >-
-            Git revision for git-type installs. Official catalogs require a
-            complete immutable 40-character commit SHA; custom catalogs may
-            use a studio-managed release tag.
+            Git revision for git-type installs. Every catalog requires a
+            complete immutable 40-character commit object ID; branch and tag
+            names are rejected at validation and installation boundaries.
+        sha256:
+          type: string
+          pattern: "^(sha256:)?[0-9a-fA-F]{64}$"
+          description: >-
+            Required archive digest for zip-type installs. The publisher and
+            installer reject missing or malformed values before archive I/O.
         skill_roots:
           type: array
           description: >-
@@ -95,6 +101,24 @@ tools:
             When true and the marketplace_source resolves to a local git
             repository, stage the updated marketplace.json, commit it with a
             standardised message, and push to origin.
+      allOf:
+        - if:
+            properties:
+              install_type:
+                const: git
+          then:
+            required:
+              - install_ref
+            properties:
+              install_ref:
+                pattern: "^[0-9a-fA-F]{40}$"
+        - if:
+            properties:
+              install_type:
+                const: zip
+          then:
+            required:
+              - sha256
       additionalProperties: false
     output_schema:
       type: object

--- a/tests/test_marketplace_publish_integrity.py
+++ b/tests/test_marketplace_publish_integrity.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "skills" / "marketplace-publish-extension" / "scripts" / "publish.py"
+_SPEC = importlib.util.spec_from_file_location("marketplace_publish_integrity", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_PUBLISH = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_PUBLISH)
+
+
+def _build_entry(**overrides):
+    options = {
+        "skill_md": {"name": "test-skill", "description": "Test skill"},
+        "install_url": "https://github.com/dcc-mcp/example.git",
+        "install_type": "git",
+        "install_ref": "a" * 40,
+        "sha256": None,
+        "version": None,
+        "maintainer": None,
+        "icon": None,
+        "tags": [],
+        "min_core_version": None,
+        "extension_url": None,
+    }
+    options.update(overrides)
+    return _PUBLISH._build_catalog_entry(**options)
+
+
+def test_git_publish_requires_full_commit_object_id():
+    with pytest.raises(ValueError, match="40-character commit"):
+        _build_entry(install_ref="main")
+
+    entry = _build_entry(install_ref="A" * 40)
+    assert entry["install"]["ref"] == "A" * 40
+
+
+def test_zip_publish_requires_and_preserves_sha256():
+    with pytest.raises(ValueError, match="64 hexadecimal SHA-256"):
+        _build_entry(
+            install_type="zip",
+            install_ref=None,
+            sha256=None,
+            install_url="https://example.invalid/package.zip",
+        )
+
+    digest = "sha256:" + "b" * 64
+    entry = _build_entry(
+        install_type="zip",
+        install_ref=None,
+        sha256=digest,
+        install_url="https://example.invalid/package.zip",
+    )
+    assert entry["install"]["sha256"] == digest


### PR DESCRIPTION
## Summary
- require full commit OIDs for catalog, direct, and adapter Git installs
- require SHA-256 before ZIP I/O and verify bytes before extraction
- reinstall Git updates through verified staging and update publishing contracts

## Validation
- `vx just preflight` (3530 tests)
- `vx cargo test -p dcc-mcp-cli --test cli_marketplace_e2e` (26 tests)
- VitePress build, Python Ruff/pytest, bundled Skill lint

Advances #2186