### PR TITLE
feat(cli): pin pip adapter artifacts

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -24,6 +24,8 @@ use uuid::Uuid;
 
 mod error;
 pub use error::{CatalogError, CatalogValidationError};
+mod validation;
+pub use validation::{validate_catalog_entries, validate_entry};
 
 // ── types ─────────────────────────────────────────────────────────────────────
 
@@ -197,7 +199,7 @@ pub struct CatalogInstall {
     /// Full 40-character Git commit object ID for `git` installs.
     #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
     pub ref_: Option<String>,
-    /// Required SHA-256 content hash for `zip` installs.
+    /// Required SHA-256 content hash for `zip` and `pip` artifact installs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
     /// Repository-relative roots that contain the skills this package is allowed to install.
@@ -443,217 +445,6 @@ pub fn search(entries: &[CatalogEntry], query: &str) -> Vec<CatalogEntry> {
 /// Look up a single entry by exact name.
 pub fn describe(entries: &[CatalogEntry], name: &str) -> Option<CatalogEntry> {
     entries.iter().find(|e| e.name == name).cloned()
-}
-
-// ── schema validation ─────────────────────────────────────────────────────────
-
-/// JSON Schema (Draft 2020-12) for marketplace-v2 catalog entries.
-///
-/// Each entry must declare at least `name` and `description`; all other
-/// fields are optional.  `additionalProperties: false` on both the top-level
-/// document and each entry catches typos early.
-const MARKETPLACE_V2_SCHEMA_JSON: &str = r##"{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://dcc-mcp.github.io/schemas/marketplace-v2.schema.json",
-  "title": "DCC-MCP Marketplace Catalog",
-  "description": "Schema for marketplace.json catalog entries",
-  "type": "object",
-  "required": ["entries"],
-  "properties": {
-    "version": { "type": "string" },
-    "entries": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/entry" }
-    }
-  },
-  "additionalProperties": false,
-  "$defs": {
-    "entry": {
-      "type": "object",
-      "required": ["name", "description"],
-      "properties": {
-        "name":        { "type": "string", "minLength": 1 },
-        "description": { "type": "string", "minLength": 1 },
-        "dcc":         { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
-        "targets": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "required": ["kind", "id"],
-            "properties": {
-              "kind": { "type": "string", "enum": ["dcc", "application", "game", "web"] },
-              "id": { "type": "string", "minLength": 1 }
-            },
-            "additionalProperties": false
-          },
-          "uniqueItems": true
-        },
-        "url":         { "type": "string" },
-        "tags":        { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
-        "version":          { "type": "string" },
-        "min_core_version": { "type": "string" },
-        "maintainer":       { "type": "string" },
-        "category":         { "type": "string" },
-        "policy": {
-          "type": "object",
-          "required": ["installation"],
-          "properties": {
-            "installation": { "type": "string" }
-          },
-          "additionalProperties": false
-        },
-        "requires": {
-          "type": "object",
-          "properties": {
-            "env": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
-            "bins": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
-            "python": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
-            "skills": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
-          },
-          "additionalProperties": false
-        },
-        "icon":        { "type": "string" },
-        "showcase": {
-          "type": "string",
-          "pattern": "^(https?://[^\\s]+|[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)*\\.(png|jpg|jpeg|webp|avif|gif))$"
-        },
-        "package": {
-          "type": "object",
-          "required": ["format"],
-          "properties": {
-            "format": { "type": "string", "enum": ["skill", "agent-plugin", "skill-bundle", "cua-profile", "composite"] },
-            "skills": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 },
-              "uniqueItems": true
-            },
-            "components": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": ["kind", "id", "root"],
-                "properties": {
-                  "kind": { "type": "string", "enum": ["skill", "cua-profile"] },
-                  "id": { "type": "string", "minLength": 1 },
-                  "root": { "type": "string", "minLength": 1 }
-                },
-                "additionalProperties": false
-              }
-            }
-          },
-          "allOf": [
-            {
-              "if": { "properties": { "format": { "enum": ["skill", "agent-plugin", "skill-bundle"] } } },
-              "then": { "required": ["skills"], "properties": { "skills": { "minItems": 1 } } }
-            },
-            {
-              "if": { "properties": { "format": { "const": "skill-bundle" } } },
-              "then": { "properties": { "skills": { "minItems": 2 } } }
-            },
-            {
-              "if": { "properties": { "format": { "const": "cua-profile" } } },
-              "then": { "required": ["components"], "properties": { "components": { "minItems": 1, "maxItems": 1 } } }
-            }
-          ],
-          "additionalProperties": false
-        },
-        "install": {
-          "type": "object",
-          "required": ["type"],
-          "properties": {
-            "type":        { "type": "string", "enum": ["git", "zip", "path", "pip"] },
-            "url":         { "type": "string" },
-            "ref":         { "type": "string" },
-            "sha256":      { "type": "string" },
-            "skillRoots":  { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
-            "pip_package": { "type": "string" },
-            "pip_extras":  { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
-            "python_path": { "type": "string" },
-            "entry_point": { "type": "string" },
-            "instructions_url": { "type": "string" }
-          },
-          "allOf": [
-            {
-              "if": { "properties": { "type": { "const": "git" } } },
-              "then": {
-                "required": ["url", "ref"],
-                "properties": { "ref": { "pattern": "^[0-9a-fA-F]{40}$" } }
-              }
-            },
-            {
-              "if": { "properties": { "type": { "const": "zip" } } },
-              "then": {
-                "required": ["url", "sha256"],
-                "properties": { "sha256": { "pattern": "^(sha256:)?[0-9a-fA-F]{64}$" } }
-              }
-            }
-          ],
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    }
-  }
-}"##;
-
-/// Validate a single [`CatalogEntry`] against the marketplace-v2 JSON Schema.
-///
-/// Returns `Ok(())` if the entry is valid, or a
-/// [`CatalogValidationError::ValidationFailed`] with a human-readable message
-/// describing what failed.
-pub fn validate_entry(entry: &CatalogEntry) -> Result<(), CatalogValidationError> {
-    let value = serde_json::to_value(entry).map_err(|e| {
-        CatalogValidationError::SchemaError(format!(
-            "failed to serialize entry '{}' for validation: {e}",
-            entry.name
-        ))
-    })?;
-
-    let schema = entry_schema()?;
-    let validation = schema.validate(&value);
-    if let Err(err) = validation {
-        return Err(CatalogValidationError::ValidationFailed {
-            name: entry.name.clone(),
-            message: format!("  - {}: {}", err.instance_path, err),
-        });
-    }
-    Ok(())
-}
-
-/// Validate a slice of [`CatalogEntry`] against the marketplace-v2 JSON Schema.
-///
-/// Returns `Ok(())` if all entries pass, or
-/// [`CatalogValidationError::MultipleFailures`] aggregating each failed entry.
-pub fn validate_catalog_entries(entries: &[CatalogEntry]) -> Result<(), CatalogValidationError> {
-    let mut failures = Vec::new();
-    for entry in entries {
-        if let Err(err) = validate_entry(entry) {
-            failures.push(err);
-        }
-    }
-    if failures.is_empty() {
-        Ok(())
-    } else {
-        let count = failures.len();
-        Err(CatalogValidationError::MultipleFailures { count, failures })
-    }
-}
-
-/// Compile the entry sub-schema once from `$defs/entry`.
-fn entry_schema() -> Result<jsonschema::Validator, CatalogValidationError> {
-    let schema_value: serde_json::Value = serde_json::from_str(MARKETPLACE_V2_SCHEMA_JSON)
-        .map_err(|e| {
-            CatalogValidationError::SchemaError(format!("invalid embedded schema: {e}"))
-        })?;
-    let entry_schema_value = schema_value
-        .pointer("/$defs/entry")
-        .cloned()
-        .ok_or_else(|| {
-            CatalogValidationError::SchemaError("missing $defs/entry in schema".into())
-        })?;
-    jsonschema::validator_for(&entry_schema_value)
-        .map_err(|e| CatalogValidationError::SchemaError(format!("failed to compile schema: {e}")))
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
@@ -1146,9 +937,9 @@ entries:
             requires: None,
             install: Some(CatalogInstall {
                 install_type: "pip".into(),
-                url: None,
+                url: Some("https://files.pythonhosted.org/packages/example/dcc_mcp_maya-0.3.0-py3-none-any.whl".into()),
                 ref_: None,
-                sha256: None,
+                sha256: Some("a".repeat(64)),
                 skill_roots: None,
                 pip_package: Some("dcc-mcp-maya".into()),
                 pip_extras: Some(vec!["maya".into()]),
@@ -1211,8 +1002,8 @@ entries:
     }
 
     #[test]
-    fn test_validate_entry_with_minimal_pip_install_passes() {
-        let entry = CatalogEntry {
+    fn test_validate_entry_requires_pinned_pip_artifact() {
+        let mut entry = CatalogEntry {
             name: "minimal-pip".into(),
             description: "A minimal pip-installed adapter".into(),
             dcc: vec![],
@@ -1241,7 +1032,20 @@ entries:
             icon: None,
             showcase: None,
         };
+        assert!(validate_entry(&entry).is_err());
+        let install = entry.install.as_mut().unwrap();
+        install.url = Some(
+            "https://files.pythonhosted.org/packages/example/dcc_mcp_core-0.20.8-py3-none-any.whl"
+                .into(),
+        );
+        install.sha256 = Some("a".repeat(64));
+        entry.version = Some("0.20.8".into());
         assert!(validate_entry(&entry).is_ok());
+        entry.version = Some("0.20.9".into());
+        assert!(validate_entry(&entry).is_err());
+        entry.version = Some("0.20.8".into());
+        entry.install.as_mut().unwrap().pip_package = Some("bad package".into());
+        assert!(validate_entry(&entry).is_err());
     }
 
     #[test]
@@ -1393,8 +1197,28 @@ entries:
     }
 
     #[test]
-    fn bundled_sidecar_adapters_expose_installable_entry_points() {
+    fn bundled_pip_adapters_bind_published_wheels_and_entry_points() {
         let entries = load_from_str(include_str!("../../../dcc-mcp-catalog.yml")).unwrap();
+        validate_catalog_entries(&entries).unwrap();
+
+        let pip_entries = entries
+            .iter()
+            .filter(|entry| {
+                entry
+                    .install
+                    .as_ref()
+                    .is_some_and(|install| install.install_type == "pip")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(pip_entries.len(), 31);
+        assert!(pip_entries.iter().all(|entry| {
+            let install = entry.install.as_ref().unwrap();
+            install
+                .url
+                .as_deref()
+                .is_some_and(|url| url.ends_with(".whl"))
+                && install.sha256.as_deref().is_some_and(|sha| sha.len() == 64)
+        }));
 
         for (name, dcc, entry_point) in [
             (
@@ -1416,13 +1240,6 @@ entries:
             ("dcc-mcp-shogun", "shogun", "dcc_mcp_shogun:ShogunMcpServer"),
             ("dcc-mcp-krita", "krita", "dcc_mcp_krita.server:main"),
             ("dcc-mcp-gimp", "gimp", "dcc_mcp_gimp.server:main"),
-            ("dcc-mcp-tiled", "tiled", "dcc_mcp_tiled.server:main"),
-            (
-                "dcc-mcp-material-maker",
-                "material-maker",
-                "dcc_mcp_material_maker.server:main",
-            ),
-            ("dcc-mcp-wwise", "wwise", "dcc_mcp_wwise.server:main"),
         ] {
             let entry = entries
                 .iter()
@@ -1436,6 +1253,17 @@ entries:
                 .unwrap_or_else(|| panic!("{name} is missing install metadata"));
             assert_eq!(install.pip_package.as_deref(), Some(name));
             assert_eq!(install.entry_point.as_deref(), Some(entry_point));
+        }
+
+        for name in ["dcc-mcp-tiled", "dcc-mcp-material-maker", "dcc-mcp-wwise"] {
+            let entry = entries
+                .iter()
+                .find(|entry| entry.name == name)
+                .unwrap_or_else(|| panic!("bundled catalog is missing {name}"));
+            assert!(
+                entry.install.is_none(),
+                "{name} must not advertise automatic installation before an artifact is published"
+            );
         }
     }
 }

--- a/crates/dcc-mcp-catalog/src/validation.rs
+++ b/crates/dcc-mcp-catalog/src/validation.rs
@@ -1,0 +1,265 @@
+use super::{CatalogEntry, CatalogInstall};
+use crate::CatalogValidationError;
+
+// ── schema validation ─────────────────────────────────────────────────────────
+
+/// JSON Schema (Draft 2020-12) for marketplace-v2 catalog entries.
+///
+/// Each entry must declare at least `name` and `description`; all other
+/// fields are optional.  `additionalProperties: false` on both the top-level
+/// document and each entry catches typos early.
+const MARKETPLACE_V2_SCHEMA_JSON: &str = r##"{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dcc-mcp.github.io/schemas/marketplace-v2.schema.json",
+  "title": "DCC-MCP Marketplace Catalog",
+  "description": "Schema for marketplace.json catalog entries",
+  "type": "object",
+  "required": ["entries"],
+  "properties": {
+    "version": { "type": "string" },
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/entry" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "required": ["name", "description"],
+      "properties": {
+        "name":        { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "dcc":         { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "targets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["kind", "id"],
+            "properties": {
+              "kind": { "type": "string", "enum": ["dcc", "application", "game", "web"] },
+              "id": { "type": "string", "minLength": 1 }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
+        },
+        "url":         { "type": "string" },
+        "tags":        { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "version":          { "type": "string" },
+        "min_core_version": { "type": "string" },
+        "maintainer":       { "type": "string" },
+        "category":         { "type": "string" },
+        "policy": {
+          "type": "object",
+          "required": ["installation"],
+          "properties": {
+            "installation": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "requires": {
+          "type": "object",
+          "properties": {
+            "env": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+            "bins": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+            "python": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+            "skills": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+          },
+          "additionalProperties": false
+        },
+        "icon":        { "type": "string" },
+        "showcase": {
+          "type": "string",
+          "pattern": "^(https?://[^\\s]+|[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)*\\.(png|jpg|jpeg|webp|avif|gif))$"
+        },
+        "package": {
+          "type": "object",
+          "required": ["format"],
+          "properties": {
+            "format": { "type": "string", "enum": ["skill", "agent-plugin", "skill-bundle", "cua-profile", "composite"] },
+            "skills": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "uniqueItems": true
+            },
+            "components": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["kind", "id", "root"],
+                "properties": {
+                  "kind": { "type": "string", "enum": ["skill", "cua-profile"] },
+                  "id": { "type": "string", "minLength": 1 },
+                  "root": { "type": "string", "minLength": 1 }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "allOf": [
+            {
+              "if": { "properties": { "format": { "enum": ["skill", "agent-plugin", "skill-bundle"] } } },
+              "then": { "required": ["skills"], "properties": { "skills": { "minItems": 1 } } }
+            },
+            {
+              "if": { "properties": { "format": { "const": "skill-bundle" } } },
+              "then": { "properties": { "skills": { "minItems": 2 } } }
+            },
+            {
+              "if": { "properties": { "format": { "const": "cua-profile" } } },
+              "then": { "required": ["components"], "properties": { "components": { "minItems": 1, "maxItems": 1 } } }
+            }
+          ],
+          "additionalProperties": false
+        },
+        "install": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type":        { "type": "string", "enum": ["git", "zip", "path", "pip"] },
+            "url":         { "type": "string" },
+            "ref":         { "type": "string" },
+            "sha256":      { "type": "string" },
+            "skillRoots":  { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+            "pip_package": { "type": "string", "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$" },
+            "pip_extras":  { "type": "array", "items": { "type": "string", "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$" }, "uniqueItems": true },
+            "python_path": { "type": "string" },
+            "entry_point": { "type": "string" },
+            "instructions_url": { "type": "string" }
+          },
+          "allOf": [
+            {
+              "if": { "properties": { "type": { "const": "git" } } },
+              "then": {
+                "required": ["url", "ref"],
+                "properties": { "ref": { "pattern": "^[0-9a-fA-F]{40}$" } }
+              }
+            },
+            {
+              "if": { "properties": { "type": { "const": "zip" } } },
+              "then": {
+                "required": ["url", "sha256"],
+                "properties": { "sha256": { "pattern": "^(sha256:)?[0-9a-fA-F]{64}$" } }
+              }
+            },
+            {
+              "if": { "properties": { "type": { "const": "pip" } } },
+              "then": {
+                "required": ["url", "sha256", "pip_package"],
+                "properties": {
+                  "url": { "pattern": "^https://" },
+                  "sha256": { "pattern": "^(sha256:)?[0-9a-fA-F]{64}$" },
+                  "pip_package": { "minLength": 1 }
+                }
+              }
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}"##;
+
+/// Validate a single [`CatalogEntry`] against the marketplace-v2 JSON Schema.
+///
+/// Returns `Ok(())` if the entry is valid, or a
+/// [`CatalogValidationError::ValidationFailed`] with a human-readable message
+/// describing what failed.
+pub fn validate_entry(entry: &CatalogEntry) -> Result<(), CatalogValidationError> {
+    let value = serde_json::to_value(entry).map_err(|e| {
+        CatalogValidationError::SchemaError(format!(
+            "failed to serialize entry '{}' for validation: {e}",
+            entry.name
+        ))
+    })?;
+
+    let schema = entry_schema()?;
+    let validation = schema.validate(&value);
+    if let Err(err) = validation {
+        return Err(CatalogValidationError::ValidationFailed {
+            name: entry.name.clone(),
+            message: format!("  - {}: {}", err.instance_path, err),
+        });
+    }
+    if let Some(install) = entry
+        .install
+        .as_ref()
+        .filter(|install| install.install_type == "pip")
+    {
+        validate_pip_artifact_binding(entry, install)?;
+    }
+    Ok(())
+}
+
+fn validate_pip_artifact_binding(
+    entry: &CatalogEntry,
+    install: &CatalogInstall,
+) -> Result<(), CatalogValidationError> {
+    let package = install.pip_package.as_deref().unwrap_or_default().trim();
+    let version = entry.version.as_deref().unwrap_or_default().trim();
+    let artifact_url = install.url.as_deref().unwrap_or_default().trim();
+    let filename = artifact_url.rsplit('/').next().unwrap_or_default();
+    let normalized_package = package
+        .chars()
+        .map(|character| match character {
+            '-' | '.' => '_',
+            other => other.to_ascii_lowercase(),
+        })
+        .collect::<String>();
+    let expected_prefix = format!("{normalized_package}-{version}-");
+    let valid = !version.is_empty()
+        && !artifact_url.contains('#')
+        && !artifact_url.contains('?')
+        && filename
+            .to_ascii_lowercase()
+            .starts_with(&expected_prefix.to_ascii_lowercase())
+        && filename.ends_with("-py3-none-any.whl");
+    if valid {
+        return Ok(());
+    }
+    Err(CatalogValidationError::ValidationFailed {
+        name: entry.name.clone(),
+        message: format!(
+            "  - /install/url: pip artifact must be an immutable py3-none-any wheel for {package}=={version}"
+        ),
+    })
+}
+
+/// Validate a slice of [`CatalogEntry`] against the marketplace-v2 JSON Schema.
+///
+/// Returns `Ok(())` if all entries pass, or
+/// [`CatalogValidationError::MultipleFailures`] aggregating each failed entry.
+pub fn validate_catalog_entries(entries: &[CatalogEntry]) -> Result<(), CatalogValidationError> {
+    let mut failures = Vec::new();
+    for entry in entries {
+        if let Err(err) = validate_entry(entry) {
+            failures.push(err);
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        let count = failures.len();
+        Err(CatalogValidationError::MultipleFailures { count, failures })
+    }
+}
+
+/// Compile the entry sub-schema once from `$defs/entry`.
+fn entry_schema() -> Result<jsonschema::Validator, CatalogValidationError> {
+    let schema_value: serde_json::Value = serde_json::from_str(MARKETPLACE_V2_SCHEMA_JSON)
+        .map_err(|e| {
+            CatalogValidationError::SchemaError(format!("invalid embedded schema: {e}"))
+        })?;
+    let entry_schema_value = schema_value
+        .pointer("/$defs/entry")
+        .cloned()
+        .ok_or_else(|| {
+            CatalogValidationError::SchemaError("missing $defs/entry in schema".into())
+        })?;
+    jsonschema::validator_for(&entry_schema_value)
+        .map_err(|e| CatalogValidationError::SchemaError(format!("failed to compile schema: {e}")))
+}

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -336,11 +336,15 @@ fn execute_action(action: &InstallStepAction) -> Result<Option<StepRollback>, In
             version,
             extras,
             python,
+            artifact_url,
+            sha256,
         } => execute_pip_install(
             package,
             version.as_deref(),
             extras.as_deref(),
             python.as_deref(),
+            artifact_url.as_deref(),
+            sha256.as_deref(),
         ),
         InstallStepAction::GitClone { url, ref_, dest } => {
             execute_git_clone(url, ref_.as_deref(), dest)
@@ -366,10 +370,13 @@ fn execute_pip_install(
     version: Option<&str>,
     extras: Option<&[String]>,
     python: Option<&str>,
+    artifact_url: Option<&str>,
+    sha256: Option<&str>,
 ) -> Result<Option<StepRollback>, InstallError> {
     let python_cmd = python.unwrap_or("python");
+    let package_spec = verified_pip_artifact_spec(package, version, extras, artifact_url, sha256)?;
     let mut cmd = Command::new(python_cmd);
-    cmd.args(pip_install_args(package, version, extras));
+    cmd.args(pip_install_args(&package_spec));
 
     let status = cmd.status().map_err(|e| InstallError::StepFailed {
         step: format!("pip-install-{package}"),
@@ -390,30 +397,92 @@ fn execute_pip_install(
     }))
 }
 
-fn pip_package_spec(package: &str, version: Option<&str>, extras: Option<&[String]>) -> String {
+fn verified_pip_artifact_spec(
+    package: &str,
+    version: Option<&str>,
+    extras: Option<&[String]>,
+    artifact_url: Option<&str>,
+    sha256: Option<&str>,
+) -> Result<String, InstallError> {
+    let version = version.unwrap_or_default().trim();
+    let artifact_url = artifact_url.unwrap_or_default().trim();
+    let value = sha256.unwrap_or_default().trim();
+    let checksum = value.strip_prefix("sha256:").unwrap_or(value);
+    let valid_package = !package.is_empty()
+        && package
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_alphanumeric)
+        && package
+            .as_bytes()
+            .last()
+            .is_some_and(u8::is_ascii_alphanumeric)
+        && package
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    let valid_extras = extras.is_none_or(|values| {
+        values.iter().all(|value| {
+            !value.is_empty()
+                && value
+                    .as_bytes()
+                    .first()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                && value
+                    .as_bytes()
+                    .last()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        })
+    });
+    let normalized_package = package
+        .chars()
+        .map(|character| match character {
+            '-' | '.' => '_',
+            other => other.to_ascii_lowercase(),
+        })
+        .collect::<String>();
+    let filename = artifact_url.rsplit('/').next().unwrap_or_default();
+    let expected_prefix = format!("{normalized_package}-{version}-");
+    let valid_artifact = artifact_url.starts_with("https://")
+        && !artifact_url.contains('#')
+        && !artifact_url.contains('?')
+        && filename
+            .to_ascii_lowercase()
+            .starts_with(&expected_prefix.to_ascii_lowercase())
+        && filename.ends_with("-py3-none-any.whl");
+    if !valid_package
+        || !valid_extras
+        || version.is_empty()
+        || !valid_artifact
+        || checksum.len() != 64
+        || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err(InstallError::StepFailed {
+            step: "pip-integrity".into(),
+            message: "catalog-pinned wheel URL, version, and SHA-256 are required".into(),
+        });
+    }
+
     let package_with_extras = if extras.is_some_and(|values| !values.is_empty()) {
         format!("{}[{}]", package, extras.unwrap().join(","))
     } else {
         package.to_string()
     };
-    if let Some(version) = version.filter(|value| !value.trim().is_empty()) {
-        format!("{package_with_extras}=={version}")
-    } else {
-        package_with_extras
-    }
+    Ok(format!(
+        "{package_with_extras} @ {artifact_url}#sha256={}",
+        checksum.to_ascii_lowercase()
+    ))
 }
 
-fn pip_install_args(
-    package: &str,
-    version: Option<&str>,
-    extras: Option<&[String]>,
-) -> Vec<String> {
+fn pip_install_args(package_spec: &str) -> Vec<String> {
     vec![
         "-m".into(),
         "pip".into(),
         "install".into(),
         "--upgrade".into(),
-        pip_package_spec(package, version, extras),
+        package_spec.into(),
     ]
 }
 
@@ -659,8 +728,11 @@ fn execute_verify(plan: &InstallPlan) -> Result<Option<StepRollback>, InstallErr
             | InstallStepAction::ZipExtract { dest, .. }
             | InstallStepAction::PathCopy { dest, .. } => verify_installed_path(dest)?,
             InstallStepAction::PipInstall {
-                package, python, ..
-            } => verify_pip_package(package, python.as_deref())?,
+                package,
+                version,
+                python,
+                ..
+            } => verify_pip_package(package, version.as_deref(), python.as_deref())?,
             InstallStepAction::RegisterDcc { .. } | InstallStepAction::Verify => {}
         }
     }
@@ -683,20 +755,40 @@ fn verify_installed_path(path: &Path) -> Result<(), InstallError> {
     Ok(())
 }
 
-fn verify_pip_package(package: &str, python: Option<&str>) -> Result<(), InstallError> {
+fn verify_pip_package(
+    package: &str,
+    expected_version: Option<&str>,
+    python: Option<&str>,
+) -> Result<(), InstallError> {
     let python_cmd = python.unwrap_or("python");
-    let status = Command::new(python_cmd)
+    let output = Command::new(python_cmd)
         .args(pip_show_args(package))
-        .status()
+        .output()
         .map_err(|e| InstallError::StepFailed {
             step: "verify".into(),
             message: format!("failed to launch {python_cmd}: {e}"),
         })?;
-    if !status.success() {
+    if !output.status.success() {
         return Err(InstallError::StepFailed {
             step: "verify".into(),
             message: format!("{python_cmd} could not verify installed pip package '{package}'"),
         });
+    }
+    if let Some(expected) = expected_version {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let actual = stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("Version:"))
+            .map(str::trim)
+            .unwrap_or_default();
+        if actual != expected {
+            return Err(InstallError::StepFailed {
+                step: "verify".into(),
+                message: format!(
+                    "installed {package} version mismatch: expected {expected}, got {actual}"
+                ),
+            });
+        }
     }
     Ok(())
 }
@@ -950,9 +1042,13 @@ mod tests {
     fn pip_install_missing_python_reports_error() {
         let result = execute_pip_install(
             "nonexistent-package",
-            None,
+            Some("1.0.0"),
             None,
             Some("/__nonexistent__/python"),
+            Some(
+                "https://files.pythonhosted.org/packages/example/nonexistent_package-1.0.0-py3-none-any.whl",
+            ),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
         );
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -1021,27 +1117,39 @@ mod tests {
     }
 
     #[test]
-    fn pip_install_uses_python_module_invocation() {
+    fn pip_install_uses_verified_direct_artifact_reference() {
+        let spec = verified_pip_artifact_spec(
+            "dcc-mcp-maya",
+            Some("0.9.22"),
+            Some(&["maya".to_string()]),
+            Some(
+                "https://files.pythonhosted.org/packages/example/dcc_mcp_maya-0.9.22-py3-none-any.whl",
+            ),
+            Some("A".repeat(64).as_str()),
+        )
+        .unwrap();
         assert_eq!(
-            pip_install_args("dcc-mcp-maya", None, Some(&["maya".to_string()])),
+            pip_install_args(&spec),
             vec![
                 "-m".to_string(),
                 "pip".to_string(),
                 "install".to_string(),
                 "--upgrade".to_string(),
-                "dcc-mcp-maya[maya]".to_string(),
+                format!(
+                    "dcc-mcp-maya[maya] @ https://files.pythonhosted.org/packages/example/dcc_mcp_maya-0.9.22-py3-none-any.whl#sha256={}",
+                    "a".repeat(64)
+                ),
             ]
         );
-        assert_eq!(
-            pip_install_args("dcc-mcp-unity", Some("0.11.2"), None),
-            vec![
-                "-m".to_string(),
-                "pip".to_string(),
-                "install".to_string(),
-                "--upgrade".to_string(),
-                "dcc-mcp-unity==0.11.2".to_string(),
-            ]
+
+        let error = verified_pip_artifact_spec(
+            "dcc-mcp-unity",
+            Some("0.11.2"),
+            None,
+            Some("https://pypi.org/project/dcc-mcp-unity"),
+            None,
         );
+        assert!(error.unwrap_err().to_string().contains("pip-integrity"));
         assert_eq!(
             pip_uninstall_args("dcc-mcp-maya"),
             vec![

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -93,6 +93,12 @@ pub enum InstallStepAction {
         /// Optional Python/mayapy interpreter path override.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         python: Option<String>,
+        /// Immutable wheel artifact URL declared by the catalog.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        artifact_url: Option<String>,
+        /// Required SHA-256 for the declared wheel artifact.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sha256: Option<String>,
     },
     /// Check out a git repository at an immutable commit.
     GitClone {
@@ -146,6 +152,10 @@ pub enum InstallPlanError {
     UnpinnedGitReference,
     #[error("zip install requires exactly 64 hexadecimal SHA-256 digits")]
     InvalidArchiveChecksum,
+    #[error("pip install requires a package, version, universal wheel URL, and SHA-256")]
+    InvalidPipArtifact,
+    #[error("requested pip version '{requested}' differs from catalog version '{catalog}'")]
+    PipVersionMismatch { requested: String, catalog: String },
 }
 
 // ── defaults ─────────────────────────────────────────────────────────────────────
@@ -165,7 +175,11 @@ fn dirs_data_dir() -> PathBuf {
 
 pub struct InstallPlanner;
 
-fn validate_install_integrity(install: &CatalogInstall) -> Result<(), InstallPlanError> {
+fn validate_install_integrity(
+    entry: &CatalogEntry,
+    install: &CatalogInstall,
+    requested_version: Option<&str>,
+) -> Result<(), InstallPlanError> {
     match install.install_type.as_str() {
         "git" => {
             let reference = install.ref_.as_deref().unwrap_or_default().trim();
@@ -178,6 +192,74 @@ fn validate_install_integrity(install: &CatalogInstall) -> Result<(), InstallPla
             let checksum = value.strip_prefix("sha256:").unwrap_or(value);
             if checksum.len() != 64 || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit()) {
                 return Err(InstallPlanError::InvalidArchiveChecksum);
+            }
+        }
+        "pip" => {
+            let package = install.pip_package.as_deref().unwrap_or_default().trim();
+            let catalog_version = entry.version.as_deref().unwrap_or_default().trim();
+            let artifact_url = install.url.as_deref().unwrap_or_default().trim();
+            let value = install.sha256.as_deref().unwrap_or_default().trim();
+            let checksum = value.strip_prefix("sha256:").unwrap_or(value);
+            let normalized_package = package
+                .chars()
+                .map(|character| match character {
+                    '-' | '.' => '_',
+                    other => other.to_ascii_lowercase(),
+                })
+                .collect::<String>();
+            let filename = artifact_url.rsplit('/').next().unwrap_or_default();
+            let expected_prefix = format!("{normalized_package}-{catalog_version}-");
+            let valid_package = !package.is_empty()
+                && package
+                    .as_bytes()
+                    .first()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                && package
+                    .as_bytes()
+                    .last()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                && package
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+            let valid_extras = install.pip_extras.as_ref().is_none_or(|values| {
+                values.iter().all(|value| {
+                    !value.is_empty()
+                        && value
+                            .as_bytes()
+                            .first()
+                            .is_some_and(u8::is_ascii_alphanumeric)
+                        && value
+                            .as_bytes()
+                            .last()
+                            .is_some_and(u8::is_ascii_alphanumeric)
+                        && value.bytes().all(|byte| {
+                            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')
+                        })
+                })
+            });
+            let valid_artifact = artifact_url.starts_with("https://")
+                && !artifact_url.contains('#')
+                && !artifact_url.contains('?')
+                && filename
+                    .to_ascii_lowercase()
+                    .starts_with(&expected_prefix.to_ascii_lowercase())
+                && filename.ends_with("-py3-none-any.whl");
+            if !valid_package
+                || !valid_extras
+                || catalog_version.is_empty()
+                || !valid_artifact
+                || checksum.len() != 64
+                || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit())
+            {
+                return Err(InstallPlanError::InvalidPipArtifact);
+            }
+            if let Some(requested) = requested_version
+                && requested.trim() != catalog_version
+            {
+                return Err(InstallPlanError::PipVersionMismatch {
+                    requested: requested.into(),
+                    catalog: catalog_version.into(),
+                });
             }
         }
         _ => {}
@@ -201,11 +283,11 @@ impl InstallPlanner {
             .ok_or_else(|| InstallPlanError::UnsupportedDcc(request.dcc_type.clone()))?;
 
         let dcc_type = request.dcc_type.clone();
-        let version = request.version.clone();
+        let version = request.version.clone().or_else(|| adapter.version.clone());
         let dcc_path = request.dcc_path.clone();
 
         if let Some(install) = &adapter.install {
-            validate_install_integrity(install)?;
+            validate_install_integrity(&adapter, install, request.version.as_deref())?;
         }
 
         let steps = match &adapter.install {
@@ -256,6 +338,8 @@ impl InstallPlanner {
                     version,
                     extras: install.pip_extras.clone(),
                     python,
+                    artifact_url: install.url.clone(),
+                    sha256: install.sha256.clone(),
                 }
             }
             "git" => InstallStepAction::GitClone {
@@ -604,7 +688,7 @@ mod tests {
             targets: vec![],
             url: Some("https://example.invalid/adapter".into()),
             tags: vec!["official".into()],
-            version: None,
+            version: Some("0.3.0".into()),
             min_core_version: None,
             install,
             package: None,
@@ -693,9 +777,12 @@ mod tests {
     fn planner_generates_executable_steps_for_pip_install() {
         let install = CatalogInstall {
             install_type: "pip".into(),
-            url: Some("https://pypi.org/project/dcc-mcp-maya".into()),
+            url: Some(
+                "https://files.pythonhosted.org/packages/example/dcc_mcp_maya-0.3.0-py3-none-any.whl"
+                    .into(),
+            ),
             ref_: None,
-            sha256: None,
+            sha256: Some("a".repeat(64)),
             skill_roots: None,
             pip_package: Some("dcc-mcp-maya".into()),
             pip_extras: Some(vec!["maya".into()]),
@@ -727,12 +814,19 @@ mod tests {
             version,
             extras,
             python,
+            artifact_url,
+            sha256,
         }) = &plan.steps[0].action
         {
             assert_eq!(package, "dcc-mcp-maya");
-            assert_eq!(version, &None);
+            assert_eq!(version.as_deref(), Some("0.3.0"));
             assert_eq!(extras.as_deref(), Some(&["maya".into()][..]));
             assert_eq!(python.as_deref(), Some("/usr/bin/mayapy"));
+            assert!(artifact_url.as_deref().unwrap().ends_with(".whl"));
+            assert_eq!(
+                sha256.as_deref(),
+                Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            );
         } else {
             panic!("expected PipInstall action");
         }
@@ -869,9 +963,12 @@ mod tests {
     fn planner_prefers_catalog_install_instructions_url() {
         let install = CatalogInstall {
             install_type: "pip".into(),
-            url: None,
+            url: Some(
+                "https://files.pythonhosted.org/packages/example/dcc_mcp_maya-0.3.0-py3-none-any.whl"
+                    .into(),
+            ),
             ref_: None,
-            sha256: None,
+            sha256: Some("a".repeat(64)),
             skill_roots: None,
             pip_package: Some("dcc-mcp-maya".into()),
             pip_extras: None,
@@ -995,6 +1092,71 @@ mod tests {
     }
 
     #[test]
+    fn planner_rejects_unpinned_pip_artifacts_and_version_overrides() {
+        let mut install = CatalogInstall {
+            install_type: "pip".into(),
+            url: None,
+            ref_: None,
+            sha256: None,
+            skill_roots: None,
+            pip_package: Some("dcc-mcp-maya".into()),
+            pip_extras: None,
+            python_path: None,
+            entry_point: None,
+            instructions_url: None,
+        };
+        let entry = |install| catalog_entry("dcc-mcp-maya", &["maya"], Some(install));
+        let request = |version: Option<&str>| InstallRequest {
+            dcc_type: "maya".into(),
+            version: version.map(str::to_string),
+            catalog_path: None,
+            python: None,
+            dcc_path: None,
+        };
+
+        let error = InstallPlanner::plan(&[entry(install.clone())], request(None)).unwrap_err();
+        assert_eq!(error, InstallPlanError::InvalidPipArtifact);
+
+        install.url = Some(
+            "https://files.pythonhosted.org/packages/example/dcc_mcp_maya-0.3.0-py3-none-any.whl"
+                .into(),
+        );
+        install.sha256 = Some("a".repeat(64));
+        assert!(InstallPlanner::plan(&[entry(install.clone())], request(None)).is_ok());
+
+        let error = InstallPlanner::plan(&[entry(install)], request(Some("0.2.0"))).unwrap_err();
+        assert_eq!(
+            error,
+            InstallPlanError::PipVersionMismatch {
+                requested: "0.2.0".into(),
+                catalog: "0.3.0".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_pip_plan_deserializes_without_integrity_but_cannot_hide_it() {
+        let action: InstallStepAction = serde_json::from_value(serde_json::json!({
+            "type": "PipInstall",
+            "package": "dcc-mcp-maya",
+            "version": "0.9.22"
+        }))
+        .unwrap();
+
+        match action {
+            InstallStepAction::PipInstall {
+                artifact_url,
+                sha256,
+                ..
+            } => {
+                assert!(artifact_url.is_none());
+                assert!(sha256.is_none());
+            }
+            other => panic!("expected PipInstall action, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn planner_missing_install_metadata_uses_info_steps() {
         let entries = vec![catalog_entry("dcc-mcp-blender", &["blender"], None)];
         let plan = InstallPlanner::plan(
@@ -1017,9 +1179,12 @@ mod tests {
     fn planner_prefers_requested_python_for_pip_install() {
         let install = CatalogInstall {
             install_type: "pip".into(),
-            url: None,
+            url: Some(
+                "https://files.pythonhosted.org/packages/example/dcc_mcp_maya-0.3.0-py3-none-any.whl"
+                    .into(),
+            ),
             ref_: None,
-            sha256: None,
+            sha256: Some("a".repeat(64)),
             skill_roots: None,
             pip_package: Some("dcc-mcp-maya".into()),
             pip_extras: None,
@@ -1052,9 +1217,12 @@ mod tests {
     fn planner_prefers_adapter_entry_over_skill_pack() {
         let install = CatalogInstall {
             install_type: "pip".into(),
-            url: None,
+            url: Some(
+                "https://files.pythonhosted.org/packages/example/dcc_mcp_photoshop-0.3.0-py3-none-any.whl"
+                    .into(),
+            ),
             ref_: None,
-            sha256: None,
+            sha256: Some("a".repeat(64)),
             skill_roots: None,
             pip_package: Some("dcc-mcp-photoshop".into()),
             pip_extras: None,

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -296,6 +296,7 @@ enum Command {
     Install {
         #[arg(long)]
         dcc_type: String,
+        /// Exact adapter package version; must match the catalog-pinned artifact.
         #[arg(long)]
         version: Option<String>,
         #[arg(long, env = "DCC_MCP_CATALOG_PATH")]

--- a/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
@@ -83,7 +83,7 @@ fn install_uses_bundled_adapter_metadata_and_python_override() {
             "--dcc-type",
             "maya",
             "--version",
-            "0.11.2",
+            "0.9.22",
             "--python",
             "C:/Autodesk/Maya2026/bin/mayapy.exe",
         ],
@@ -97,7 +97,17 @@ fn install_uses_bundled_adapter_metadata_and_python_override() {
     assert_eq!(plan["steps"][0]["name"], "install-pip");
     assert_eq!(plan["steps"][0]["action"]["type"], "PipInstall");
     assert_eq!(plan["steps"][0]["action"]["package"], "dcc-mcp-maya");
-    assert_eq!(plan["steps"][0]["action"]["version"], "0.11.2");
+    assert_eq!(plan["steps"][0]["action"]["version"], "0.9.22");
+    assert_eq!(
+        plan["steps"][0]["action"]["sha256"],
+        "b288c2bf95014f827d3833ef5af4f7c36b2ff8a465ac647f9feb2163bc44397b"
+    );
+    assert!(
+        plan["steps"][0]["action"]["artifact_url"]
+            .as_str()
+            .unwrap()
+            .ends_with("dcc_mcp_maya-0.9.22-py3-none-any.whl")
+    );
     assert_eq!(
         plan["steps"][0]["action"]["python"],
         "C:/Autodesk/Maya2026/bin/mayapy.exe"
@@ -205,6 +215,48 @@ fn bundled_catalog_reports_current_unity_adapter_version() {
 
     assert_eq!(plan["adapter"]["name"], "dcc-mcp-unity");
     assert_eq!(plan["adapter"]["version"], "0.11.2");
+}
+
+#[test]
+fn install_rejects_pip_version_without_a_catalog_pinned_artifact() {
+    let output = cli_command()
+        .args([
+            "install",
+            "--dcc-type",
+            "maya",
+            "--version",
+            "0.9.21",
+            "--output",
+            "json",
+        ])
+        .env_remove("DCC_MCP_CATALOG_PATH")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("differs from catalog version '0.9.22'")
+    );
+}
+
+#[test]
+fn unpublished_adapters_do_not_advertise_automatic_install_steps() {
+    for dcc_type in ["tiled", "material-maker", "wwise"] {
+        let plan = run_json_with_env_removed(
+            &["install", "--dcc-type", dcc_type],
+            &[],
+            &["DCC_MCP_CATALOG_PATH", "DCC_MCP_INSTALL_PYTHON"],
+        );
+        assert!(plan["adapter"]["install"].is_null(), "{dcc_type}");
+        assert!(
+            plan["steps"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|step| step["action"].is_null()),
+            "{dcc_type}"
+        );
+    }
 }
 
 #[test]

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -49,6 +49,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-maya"
+      url: "https://files.pythonhosted.org/packages/98/cb/204ff09455e119520635592e039c1fa16b12824a54cc34850d12894356e7/dcc_mcp_maya-0.9.22-py3-none-any.whl"
+      sha256: "b288c2bf95014f827d3833ef5af4f7c36b2ff8a465ac647f9feb2163bc44397b"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-maya/main/install.md"
 
   - name: "dcc-mcp-blender"
@@ -62,6 +64,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-blender"
+      url: "https://files.pythonhosted.org/packages/8c/56/3a075f0389408e64268b193447f56cd68be7a4cedb2ac759c49ba4497b27/dcc_mcp_blender-0.1.43-py3-none-any.whl"
+      sha256: "0f2c4a0957dd41f72b711d164e36b0da039f6f13311b0eb0fecb73059bd7c0bf"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-blender/main/install.md"
 
   - name: "dcc-mcp-houdini"
@@ -75,6 +79,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-houdini"
+      url: "https://files.pythonhosted.org/packages/af/9e/7e37c169d3f52ccad8ad441521dc1dbff5e8eabd984d21c6e2f65a2f49d4/dcc_mcp_houdini-0.31.5-py3-none-any.whl"
+      sha256: "af8b68d2d7c6002a575e93de073404f2bebc04f415833d6d1a60363b607d5c15"
       entry_point: "dcc_mcp_houdini.cli:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-houdini/main/install.md"
 
@@ -89,6 +95,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-3dsmax"
+      url: "https://files.pythonhosted.org/packages/f0/23/db420ca34459f378e2a9fa294ceb525b49c1242dec817ca53f39f13343fd/dcc_mcp_3dsmax-0.1.40-py3-none-any.whl"
+      sha256: "c5b117c232f35d47cbb9e4801cd57de5d1e84e15bf40391f99529edb4b7c8ccd"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-3dsmax/main/install.md"
 
   - name: "dcc-mcp-photoshop"
@@ -102,6 +110,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-photoshop"
+      url: "https://files.pythonhosted.org/packages/e0/77/23de5e60335b229708ae75f399a6591503065c624dfdc0dad5ea0b0105da/dcc_mcp_photoshop-0.1.37-py3-none-any.whl"
+      sha256: "210d7b47a590ad4a9d39d942b2df9997418427edf326e9fe6169482e6e569aff"
       entry_point: "dcc_mcp_photoshop.cli:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-photoshop/main/docs/distribution.md"
 
@@ -116,6 +126,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-nuke"
+      url: "https://files.pythonhosted.org/packages/2f/33/84bbba6cff8bd69d6e33eb2a62fbef678c3d2e18b37e134a809e7cf305df/dcc_mcp_nuke-0.13.1-py3-none-any.whl"
+      sha256: "c00aef395d6b6c50724acb093ece25063cc2c50d64348059b334e562fc9a67bf"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-nuke/main/README.md"
 
   - name: "dcc-mcp-unreal"
@@ -123,12 +135,14 @@ entries:
     dcc: ["unreal"]
     url: "https://github.com/dcc-mcp/dcc-mcp-unreal"
     tags: ["adapter", "unreal", "official", "pip", "game-engine"]
-    version: "0.2.0"
+    version: "0.3.0"
     min_core_version: "0.19.45"
     maintainer: "dcc-mcp"
     install:
       type: pip
       pip_package: "dcc-mcp-unreal"
+      url: "https://files.pythonhosted.org/packages/0b/e2/e70e3f6d0433ac7155b34668453b131efed2e5fea060ff7f1997494196e6/dcc_mcp_unreal-0.3.0-py3-none-any.whl"
+      sha256: "4df543a902bcd771bc0733c1ba894fd802a64e1e897adb65c29800dcf5cb2ccf"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unreal/main/README.md"
 
   - name: "dcc-mcp-zbrush"
@@ -142,6 +156,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-zbrush"
+      url: "https://files.pythonhosted.org/packages/dc/01/62d1465a4904147cd6eaaaef580c5c5d97b2506a10457d391e3528fe6534/dcc_mcp_zbrush-0.2.18-py3-none-any.whl"
+      sha256: "5740703345a9b8c54c7fd6dcfd9fab52b524d943f48e90d4493ffa2a8d86804b"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-zbrush/main/README.md"
 
   - name: "dcc-mcp-premiere"
@@ -155,6 +171,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-premiere"
+      url: "https://files.pythonhosted.org/packages/5c/e1/f7602fec72ded139a7a10bde8783cd5690b14f4377278e0ead284f2137e2/dcc_mcp_premiere-0.5.0-py3-none-any.whl"
+      sha256: "e35061610b0aba182b2eec29f2dc111cffb9d92194f9321f43805213456c3252"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-premiere/main/README.md"
 
   - name: "dcc-mcp-aftereffects"
@@ -168,6 +186,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-aftereffects"
+      url: "https://files.pythonhosted.org/packages/af/63/4d000ba740d427d27984f40edaacaf8e06ddf16ef888f2d96674813828cb/dcc_mcp_aftereffects-0.6.0-py3-none-any.whl"
+      sha256: "b48e27139027790117a3d5fa8da7d3d92920ab94b68007b56800840a2e30e702"
       entry_point: "dcc_mcp_aftereffects.cli:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-aftereffects/main/README.md"
 
@@ -182,6 +202,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-illustrator"
+      url: "https://files.pythonhosted.org/packages/c5/ef/ca6090fadcfb57402f82e99cfebf3b0b16dde59421dd482bebb970d909dc/dcc_mcp_illustrator-0.2.0-py3-none-any.whl"
+      sha256: "506266fe09aa38a66a08bb28f6bad8aadaacdf868336f59c85f8aad912b6f630"
       entry_point: "dcc_mcp_illustrator.cli:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-illustrator/main/README.md"
 
@@ -196,6 +218,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-gimp"
+      url: "https://files.pythonhosted.org/packages/d4/a4/ac98c7af64baedbb60c9c06cb4ccb8e698e158477ea0f0ddefc7d6d3ed78/dcc_mcp_gimp-0.3.0-py3-none-any.whl"
+      sha256: "e03544e7a2ed04b658c9e1fd14c58209f0c1f1ae5159d06e267a6f280c497186"
       entry_point: "dcc_mcp_gimp.server:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-gimp/main/README.md"
 
@@ -210,6 +234,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-krita"
+      url: "https://files.pythonhosted.org/packages/35/8f/b8c0dadfebf4601663bbb4dbef2fe438f764d19d45dc3b8581d3f798c7ed/dcc_mcp_krita-0.3.0-py3-none-any.whl"
+      sha256: "8d9f14012a07a9cec6c16fb4f796c2356bf08a968444d04c3b2688bd0ae5a5e4"
       entry_point: "dcc_mcp_krita.server:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-krita/main/README.md"
 
@@ -224,6 +250,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-katana"
+      url: "https://files.pythonhosted.org/packages/b2/fc/5b75058d0ae2a2873f5cdb358f6a450332c06d6fe8190db25c77bd295539/dcc_mcp_katana-0.4.0-py3-none-any.whl"
+      sha256: "0fe54a32a600616be78d62d22a88f0ca9e88674722f0fdc0c80ded485fc7f876"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-katana/main/README.md"
 
   - name: "dcc-mcp-mobu"
@@ -237,6 +265,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-mobu"
+      url: "https://files.pythonhosted.org/packages/b5/99/63df289d8b6319f6267b5b8d2ac5c9c09e2fc6291cf174822f518e26dc94/dcc_mcp_mobu-0.3.0-py3-none-any.whl"
+      sha256: "7c27cf99a3d0bdcd314a7a57954bc06d039b013c0bd70401b4d38831353ff6c5"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-mobu/main/README.md"
 
   - name: "dcc-mcp-renderdoc"
@@ -250,6 +280,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-renderdoc"
+      url: "https://files.pythonhosted.org/packages/db/ef/0966f1657f016669be5b57bdc5657f140a3863aac459979e1f2a15b1f0be/dcc_mcp_renderdoc-0.3.0-py3-none-any.whl"
+      sha256: "f8d0290c825c6e167acade9d1fbdaafc2c5e42edc06eaca6506acde251d4aa17"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-renderdoc/main/README.md"
 
   - name: "dcc-mcp-substance3d-designer"
@@ -263,6 +295,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-substance3d-designer"
+      url: "https://files.pythonhosted.org/packages/c2/3c/e7cacb084b2087380a7785edf83c05f3a05d77779eeb99899a47c9546df6/dcc_mcp_substance3d_designer-0.3.0-py3-none-any.whl"
+      sha256: "65e16406a0ba4a15dfdde9dd082a2092685c204c678681da5e228dc68fe9b29c"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-substance3d-designer/main/README.md"
 
   - name: "dcc-mcp-substance3d-painter"
@@ -276,6 +310,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-substance3d-painter"
+      url: "https://files.pythonhosted.org/packages/80/3f/e642c17c5515752bc66bbba088d9f20f4162a7fd532fd1b87cc39de437f1/dcc_mcp_substance3d_painter-0.1.3-py3-none-any.whl"
+      sha256: "cdaf37c4de958eeb3855ee52d3466558d9c4605db988f26c4111affba954a57b"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-substance3d-painter/main/README.md"
 
   - name: "dcc-mcp-godot"
@@ -289,6 +325,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-godot"
+      url: "https://files.pythonhosted.org/packages/57/c8/f81a9d014d24747a2219fd8ceec002decdab304df3fb8303ff74700294cb/dcc_mcp_godot-0.4.0-py3-none-any.whl"
+      sha256: "4d260738e0b2823b802c01a3571d0d660c19d9f390a5505991e6c2aed41c1186"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-godot/main/README.md"
 
   - name: "dcc-mcp-unity"
@@ -302,6 +340,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-unity"
+      url: "https://files.pythonhosted.org/packages/d5/d7/a4ef262fae42a8ae7ba95057b85a2128d7a1ec54a320b777adf768550889/dcc_mcp_unity-0.11.2-py3-none-any.whl"
+      sha256: "aab6097038ec0153bfd9bd3a111ce9435a1d57aecfc8bc76030e7bf73643eedd"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unity/main/install.md"
 
   - name: "dcc-mcp-marmoset"
@@ -315,6 +355,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-marmoset"
+      url: "https://files.pythonhosted.org/packages/26/b8/cac4c22c973f46129bae4d74397ae11fe460a50ecd599ec2d48df5741a72/dcc_mcp_marmoset-0.1.1-py3-none-any.whl"
+      sha256: "3c368e8889b1af87b412b625635e222fe5fc01cc21841dba28656b056acab9df"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-marmoset/main/install.md"
 
   - name: "dcc-mcp-openscad"
@@ -328,6 +370,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-openscad"
+      url: "https://files.pythonhosted.org/packages/73/dc/d32e4116781858eea2f3d802f3a2d07f986de01bcbe8e7474dfbb2173e30/dcc_mcp_openscad-0.1.2-py3-none-any.whl"
+      sha256: "c1345969b62f4f6fd457c0caf5a20a3776afa8a26365e096054334758036927b"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-openscad/main/README.md"
 
   - name: "dcc-mcp-freecad"
@@ -341,6 +385,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-freecad"
+      url: "https://files.pythonhosted.org/packages/7e/9f/5ae064ce1aca90fded4240e27f19b6fd0116d4f7eda0c2e5c2d55d286155/dcc_mcp_freecad-0.1.2-py3-none-any.whl"
+      sha256: "b039012cd6be9ce52ed0bd64b1a9f00a87add9115b61474d17b8a93a51e2f978"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-freecad/main/README.md"
 
   - name: "dcc-mcp-cinema4d"
@@ -354,6 +400,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-cinema4d"
+      url: "https://files.pythonhosted.org/packages/d4/27/ddcdf195531048af08ab2c3aa6d456b20d712277c518bc405121ba94ab7d/dcc_mcp_cinema4d-0.1.3-py3-none-any.whl"
+      sha256: "6038f3584f7f5c3cd8d3d051bb9308c6c9381ca021c1f04951cca29c334374f9"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-cinema4d/main/README.md"
 
   - name: "dcc-mcp-comfyui"
@@ -367,6 +415,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-comfyui"
+      url: "https://files.pythonhosted.org/packages/7c/e9/68babf57175e35985a543d437e668b92f5328c4c616cc86ce74d317be7de/dcc_mcp_comfyui-0.1.1-py3-none-any.whl"
+      sha256: "69ac8fb98d88217abd22c6281835bd282caf00bb63a5aa26887f369370f7d756"
       entry_point: "dcc_mcp_comfyui.cli:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-comfyui/main/README.md"
 
@@ -381,6 +431,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-mari"
+      url: "https://files.pythonhosted.org/packages/76/81/f1bf615945acd175ff579d0084f35df249fd027d96870fa321647b724bf8/dcc_mcp_mari-0.2.1-py3-none-any.whl"
+      sha256: "de160ebe7ee7910238bf05e76a96ab8d35c0945885c1651b2c5809aeb61555a7"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-mari/main/README.md"
 
   - name: "dcc-mcp-sketchup"
@@ -394,6 +446,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-sketchup"
+      url: "https://files.pythonhosted.org/packages/34/53/a3035083471a1b5692754b1c0a027a5cd951bc2640980baaac132e0e0262/dcc_mcp_sketchup-0.1.0-py3-none-any.whl"
+      sha256: "22a2fc8a502109be756e1c8f5eb673499f1c92e401e08b411019293f607aa375"
       entry_point: "dcc_mcp_sketchup.server:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-sketchup/main/README.md"
 
@@ -408,6 +462,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-touchdesigner"
+      url: "https://files.pythonhosted.org/packages/a3/bd/2b67130f5a889824659dc87398ed61e0140bc7a9cc55110a984b6a0256de/dcc_mcp_touchdesigner-0.1.1-py3-none-any.whl"
+      sha256: "99ce677d8bdb674116849220ff92751c15b9f3ba410aff8b3371ff96ef13f4dc"
       entry_point: "dcc_mcp_touchdesigner:TouchDesignerMcpServer"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-touchdesigner/main/install.md"
 
@@ -422,10 +478,13 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-shogun"
+      url: "https://files.pythonhosted.org/packages/41/ca/3eba76e8696d3f478f1b2f776abd52640403ea20ac4057b689e57fdde82d/dcc_mcp_shogun-0.8.1-py3-none-any.whl"
+      sha256: "975a2d967a5c9b09cc285b7dd5bd1b8db16cdf3043d75cbae3b7d30d90529b5d"
       entry_point: "dcc_mcp_shogun:ShogunMcpServer"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-shogun/main/README.md"
 
   - name: "dcc-mcp-tiled"
+    # Automatic install is omitted until a wheel is published.
     description: "Tiled adapter for typed workspace-bounded map authoring, validation, and conversion"
     dcc: ["tiled"]
     url: "https://github.com/dcc-mcp/dcc-mcp-tiled"
@@ -433,13 +492,9 @@ entries:
     version: "0.3.0"
     min_core_version: "0.19.38"
     maintainer: "dcc-mcp"
-    install:
-      type: pip
-      pip_package: "dcc-mcp-tiled"
-      entry_point: "dcc_mcp_tiled.server:main"
-      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-tiled/main/README.md"
 
   - name: "dcc-mcp-material-maker"
+    # Automatic install is omitted until a wheel is published.
     description: "Material Maker adapter for typed bounded .ptex inspection, validation, and native export"
     dcc: ["material-maker"]
     url: "https://github.com/dcc-mcp/dcc-mcp-material-maker"
@@ -447,13 +502,9 @@ entries:
     version: "0.3.1"
     min_core_version: "0.19.38"
     maintainer: "dcc-mcp"
-    install:
-      type: pip
-      pip_package: "dcc-mcp-material-maker"
-      entry_point: "dcc_mcp_material_maker.server:main"
-      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-material-maker/main/README.md"
 
   - name: "dcc-mcp-wwise"
+    # Automatic install is omitted until a wheel is published.
     description: "Audiokinetic Wwise Authoring adapter with typed WAAPI project, audio, SoundBank, and profiler workflows"
     dcc: ["wwise"]
     url: "https://github.com/dcc-mcp/dcc-mcp-wwise"
@@ -461,11 +512,6 @@ entries:
     version: "0.1.2"
     min_core_version: "0.19.86"
     maintainer: "dcc-mcp"
-    install:
-      type: pip
-      pip_package: "dcc-mcp-wwise"
-      entry_point: "dcc_mcp_wwise.server:main"
-      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-wwise/main/install.md"
 
   - name: "dcc-mcp-fpt"
     description: "Autodesk Flow Production Tracking adapter for DCC-MCP"
@@ -478,6 +524,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-fpt"
+      url: "https://files.pythonhosted.org/packages/a3/89/8a127a24ab0b4b0992a19cc5b59332a455d74ac97fa79804c5ec513e5658/dcc_mcp_fpt-0.1.8-py3-none-any.whl"
+      sha256: "197952ea4133217a9e68913798c0b0ed470fc1be3ad2854121c20261f737387b"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-fpt/main/README.md"
 
   - name: "dcc-mcp-openusd"
@@ -491,6 +539,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-openusd"
+      url: "https://files.pythonhosted.org/packages/fd/f6/36fced0c6c3799545c40852194178038fead5fb6e971121f855785e1d7c8/dcc_mcp_openusd-0.8.1-py3-none-any.whl"
+      sha256: "82902d82b12c6d037afe69e040cf33339461de51c85d7e3b4cab8a57313ae4c6"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-openusd/main/README.md"
 
   - name: "autodesk-product-help"

--- a/docs/adr/025-pinned-pip-adapter-artifacts.md
+++ b/docs/adr/025-pinned-pip-adapter-artifacts.md
@@ -1,0 +1,68 @@
+# Pinned Pip Adapter Artifacts
+
+Status: Accepted
+
+## Context
+
+Catalog-backed adapter installation passed a package name and optional caller
+version to `pip install --upgrade`. The catalog version was descriptive: when a
+caller omitted `--version`, pip selected the latest release available at
+execution time. A later upload or catalog drift could therefore change the
+installed adapter without changing the reviewed catalog.
+
+The bundled catalog also advertised pip installation for three adapter projects
+that had no published PyPI project, and referenced an unpublished Unreal
+version. Those entries could produce plans that were impossible to execute.
+
+## Decision
+
+- An executable `install.type: pip` entry requires an exact catalog `version`,
+  an HTTPS `py3-none-any` wheel URL whose filename binds the normalized package
+  name and version, and the wheel's SHA-256.
+- Catalog validation checks that binding. The install planner repeats it before
+  producing an executable action, and the executor repeats it for deserialized
+  or externally supplied plans.
+- Pip receives a PEP 508 direct reference with a `#sha256=` fragment. The
+  adapter package name is retained separately for rollback and `pip show`.
+- `--version` may only repeat the catalog version. Installing another version
+  requires a reviewed catalog entry with its own artifact URL and digest.
+- Post-install verification requires `pip show` to report the catalog version.
+- Catalog entries without a published wheel remain discoverable but omit
+  automatic install metadata. Unreal moves to its published 0.3.0 wheel.
+- The public Rust `PipInstall` plan variant adds optional `artifact_url` and
+  `sha256` fields so old serialized plans still decode, then fail closed at
+  execution. Rust source that constructs the variant must add those fields;
+  this change belongs in the next pre-1 minor release.
+
+The migration downloaded every declared wheel, verified its SHA-256, and
+checked its `METADATA` name/version plus `py3-none-any` wheel tag.
+
+## Consequences
+
+- A package release changes the catalog URL and digest in the same reviewed
+  update; pip no longer resolves the adapter package by mutable name.
+- Removed or replaced wheel files fail closed instead of selecting another
+  release.
+- This decision authenticates the selected adapter wheel only to the extent
+  that the reviewed catalog is trusted. It does not sign the catalog.
+- Transitive dependencies still follow normal pip index resolution. Fully
+  reproducible dependency graphs require per-runtime lock manifests with every
+  dependency hash; a single cross-DCC lock cannot represent all supported
+  Python and platform combinations.
+
+## Alternatives considered
+
+### Pin only `package==version`
+
+Rejected because the installer would still trust whatever bytes the package
+index serves for that release and the catalog would not bind an artifact.
+
+### Use `pip --require-hashes` immediately
+
+Deferred because that mode requires hashes for the complete transitive graph.
+The graph differs across host Python versions and operating systems, so it
+needs a typed artifact matrix rather than one global requirements file.
+
+### Keep unpublished packages marked installable
+
+Rejected because an executable plan that can never resolve is a false contract.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,7 @@ Decision / Consequences / Alternatives considered.
 | 022 | [Canonical Tool Result Envelope](./022-canonical-tool-result-envelope.md) | Accepted |
 | 023 | [Installation-Bound Binary Updates](./023-installation-bound-binary-updates.md) | Accepted |
 | 024 | [Immutable Marketplace Install Sources](./024-immutable-marketplace-install-sources.md) | Accepted |
+| 025 | [Pinned Pip Adapter Artifacts](./025-pinned-pip-adapter-artifacts.md) | Accepted |
 
 > Numbering is strictly sequential and never reused. ADR 001 is reserved for
 > the first historical record; filling it in is tracked separately from any

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -37,7 +37,7 @@ submit a PR updating this matrix before the release PR merges.
 | Houdini | [dcc-mcp-houdini](https://github.com/dcc-mcp/dcc-mcp-houdini) | 0.31.5 | >=0.19.45,<1.0.0 | 20.5+ | Event-loop callback | 2026-08 |
 | FPT / ShotGrid | [dcc-mcp-fpt](https://github.com/dcc-mcp/dcc-mcp-fpt) | 0.1.8 | >=0.19.45,<1.0.0 | — | REST bridge | 2026-06 |
 | Nuke | [dcc-mcp-nuke](https://github.com/dcc-mcp/dcc-mcp-nuke) | 0.13.1 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
-| Unreal | [dcc-mcp-unreal](https://github.com/dcc-mcp/dcc-mcp-unreal) | 0.2.0 | >=0.19.45,<1.0.0 | — | Unreal Python bridge | — |
+| Unreal | [dcc-mcp-unreal](https://github.com/dcc-mcp/dcc-mcp-unreal) | 0.3.0 | >=0.19.45,<1.0.0 | — | Unreal Python bridge | — |
 | ZBrush | [dcc-mcp-zbrush](https://github.com/dcc-mcp/dcc-mcp-zbrush) | 0.2.18 | >=0.19.45,<1.0.0 | — | Socket bridge + sidecar | — |
 | Photoshop | [dcc-mcp-photoshop](https://github.com/dcc-mcp/dcc-mcp-photoshop) | 0.1.37 | >=0.19.45,<1.0.0 | Photoshop UXP | WebSocket bridge | 2026-06 |
 | Premiere Pro | [dcc-mcp-premiere](https://github.com/dcc-mcp/dcc-mcp-premiere) | 0.5.0 | >=0.19.45,<1.0.0 | 25.6+ | UXP WebSocket bridge | — |
@@ -59,6 +59,10 @@ submit a PR updating this matrix before the release PR merges.
 | Unity | [dcc-mcp-unity](https://github.com/dcc-mcp/dcc-mcp-unity) | 0.11.2 | >=0.19.45,<1.0.0 | 2018.4.36f1+ | EditorApplication.update + WebSocket bridge | — |
 | OpenUSD | [dcc-mcp-openusd](https://github.com/dcc-mcp/dcc-mcp-openusd) | 0.8.1 | >=0.19.45,<1.0.0 | — | Headless USD stage adapter | 2026-07 |
 | Custom Studio Tool | _(your repo here)_ | _your version_ | _your pin_ | _your min_ | _your pattern_ | _date_ |
+
+Tiled, Material Maker, and Wwise remain discoverable source projects, but the
+bundled catalog omits automatic install metadata until each project publishes a
+wheel that can be pinned by URL and SHA-256.
 
 ## Column Reference
 

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -168,9 +168,9 @@ dcc-mcp-cli call unity.abc12345.run_tests --require-gateway --wait --wait-timeou
 dcc-mcp-cli call maya_scene__get_session_info --dcc-type maya --instance-id abc12345 --json '{}'
 dcc-mcp-cli wait-ready --dcc-type maya --instance-id abc12345 --require skill_catalog,host_execution_bridge
 dcc-mcp-cli stop-instance --dcc-type maya --instance-id abc12345 --expected-owner release-smoke-test
-dcc-mcp-cli install --dcc-type maya --version 2026
-dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe"
-dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe" --execute
+dcc-mcp-cli install --dcc-type maya
+dcc-mcp-cli install --dcc-type maya --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe"
+dcc-mcp-cli install --dcc-type maya --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe" --execute
 dcc-mcp-cli marketplace add dcc-mcp/marketplace
 dcc-mcp-cli marketplace search --query "maya rigging" --limit 20
 dcc-mcp-cli marketplace inspect dcc-asset-hunyuan-download
@@ -223,7 +223,7 @@ their worker-owned status tool.
 | `wait-ready [--dcc-type <dcc>] [--instance-id <id>] [--require <bits>]` | local registry + per-instance `/v1/readyz`, or remote gateway inventory + `/v1/readyz` | Wait for smoke-test readiness bits such as `skill_catalog` or `host_execution_bridge`. |
 | `reload-skills [--dcc-type <dcc>] [--instance-id <id>]` | local MCP `tools/call dcc_admin__reload_skills`, or remote `POST /v1/dcc/{dcc}/instances/{id}/call` | Ask running adapters to re-scan skill search paths after marketplace installs or path changes. |
 | `stop-instance --dcc-type <dcc> --instance-id <id>` | local `safe_stop_url` or remote `POST /v1/dcc/{dcc}/instances/{id}/stop` | Forward a guarded safe-stop request to instances that advertise `safe_stop_url`. |
-| `install --dcc-type <dcc> [--version <v>] [--python <path>] [--dcc-path <path>] [--execute]` | catalog-backed local plan / executor | Resolve the matching adapter and emit an auditable install plan; if the host is non-standard, supply its executable/application path with `--dcc-path`. With `--execute`, the path is verified before completion. |
+| `install --dcc-type <dcc> [--version <catalog-version>] [--python <path>] [--dcc-path <path>] [--execute]` | catalog-backed local plan / executor | Resolve the matching adapter and emit an auditable install plan. Pip adapters use the catalog-pinned wheel URL and SHA-256; `--version` may only repeat that artifact version. If the host is non-standard, supply its path with `--dcc-path`. |
 | `marketplace add <source>` | local source registry | Register a marketplace source (`dcc-mcp/marketplace`, a GitHub `owner/repo`, raw JSON URL, or local catalog file). |
 | `marketplace list` | local source registry | List the built-in, configured, and environment-provided marketplace sources. |
 | `marketplace search [-q\|--query <q>] [--dcc <dcc>] [--source <source>]` | marketplace catalog JSON/YAML | Fuzzy-rank Skill packages across configured or explicit sources using the shared search engine; the query flag works with released builds, while current builds also accept positional words as an alternative. Deduplicate by package name before applying `--limit`; `--dcc-type` is an alias for `--dcc`. |
@@ -310,10 +310,11 @@ plus the manual host-plugin start step. Pass `--python` (or
 `DCC_MCP_INSTALL_PYTHON`) when a pip-based adapter must be installed into a DCC
 interpreter such as `mayapy`, `hython`, or Blender's bundled Python. Pass
 `--execute` to prompt for consent and run executable package-install steps.
-Execution rolls back completed steps when a later step fails, uses
-`<python> -m pip` for pip installs, verifies pip installs with `pip show`, and
-verifies git/zip/path installs by checking that their target path exists and is
-not an empty directory. A DCC is considered online only after its host plugin or
+Execution rolls back completed steps when a later step fails. Pip installs use
+an HTTPS wheel bound to the catalog package/version and SHA-256, pass pip a
+direct reference with `#sha256=`, and verify the installed version with
+`pip show`. Git/ZIP/path installs verify that their target exists and is not an
+empty directory. A DCC is considered online only after its host plugin or
 sidecar starts, remains alive, and appears in `dcc-mcp-cli list`; the CLI does
 not fake gateway registration during install.
 

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -143,9 +143,9 @@ dcc-mcp-cli call maya.abc12345.create_sphere --require-gateway --agent-session-i
 dcc-mcp-cli call maya_scene__get_session_info --dcc-type maya --instance-id abc12345 --json '{}'
 dcc-mcp-cli wait-ready --dcc-type maya --instance-id abc12345 --require skill_catalog,host_execution_bridge
 dcc-mcp-cli stop-instance --dcc-type maya --instance-id abc12345 --expected-owner release-smoke-test
-dcc-mcp-cli install --dcc-type maya --version 2026
-dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe"
-dcc-mcp-cli install --dcc-type maya --version 2026 --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe" --execute
+dcc-mcp-cli install --dcc-type maya
+dcc-mcp-cli install --dcc-type maya --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe"
+dcc-mcp-cli install --dcc-type maya --python "C:/Program Files/Autodesk/Maya2026/bin/mayapy.exe" --execute
 dcc-mcp-cli marketplace add dcc-mcp/marketplace
 dcc-mcp-cli marketplace search --query hunyuan --dcc maya
 dcc-mcp-cli marketplace inspect dcc-asset-hunyuan-download
@@ -190,7 +190,7 @@ dcc-mcp-cli lint path/to/skills
 | `wait-ready [--dcc-type <dcc>] [--instance-id <id>] [--require <bits>]` | 本地 registry + per-instance `/v1/readyz`，或远程 gateway inventory + `/v1/readyz` | 等待 release smoke test 所需 readiness bit，例如 `skill_catalog` 或 `host_execution_bridge`。 |
 | `reload-skills [--dcc-type <dcc>] [--instance-id <id>]` | 本地 MCP `tools/call dcc_admin__reload_skills`，或远程 `POST /v1/dcc/{dcc}/instances/{id}/call` | marketplace 安装或 skill path 变更后，让正在运行的 adapter 重新扫描 skill 搜索路径。 |
 | `stop-instance --dcc-type <dcc> --instance-id <id>` | 本地 `safe_stop_url` 或远程 `POST /v1/dcc/{dcc}/instances/{id}/stop` | 对声明了 `safe_stop_url` 的实例发起带保护条件的 safe-stop 请求。 |
-| `install --dcc-type <dcc> [--version <v>] [--python <path>] [--execute]` | catalog-backed local plan / executor | 解析匹配的 adapter 并输出可审计安装计划；加 `--execute` 后会在确认后执行 package 安装步骤、失败回滚并做 package/path 验证。Live DCC 检查保留在返回的 `next_steps` 中。 |
+| `install --dcc-type <dcc> [--version <catalog-version>] [--python <path>] [--execute]` | catalog-backed local plan / executor | 解析匹配的 adapter 并输出可审计安装计划；加 `--execute` 后会在确认后执行 package 安装步骤、失败回滚并做 package/path 验证。Live DCC 检查保留在返回的 `next_steps` 中。 |
 | `marketplace install <name> [--dcc <dcc>] [--reload]` | marketplace catalog + local installed state；可选控制运行中的 DCC | 安装本地 marketplace skill 包；`--reload` 会让匹配的运行中 adapter 重新扫描 skill path，并把刷新结果写入安装 JSON。 |
 | `marketplace search/update/...` | marketplace catalog + local installed state | 搜索、卸载和更新本地 marketplace skill 包。 |
 | `marketplace pack <path> [--out <path>]` | local filesystem + zip | 生成 marketplace 发布 ZIP 并输出 SHA-256 摘要。 |
@@ -242,6 +242,9 @@ Blender 自带 Python。传 `--execute` 后才会请求确认并执行
 pip 安装使用 `<python> -m pip`，并用 `pip show` 验证；git/zip/path 安装会检查目标路径
 确实存在，且目标目录不是空目录。DCC 只有在 host plugin / sidecar 启动、保持存活、
 并出现在 `dcc-mcp-cli list` 中后才算在线；CLI install 不会伪造 gateway 注册。
+
+Pip execution requires the catalog-pinned universal wheel URL, exact version,
+and SHA-256. `--version` may only repeat that reviewed artifact version.
 
 如果工作室有专门的 Pipeline 部署流程，可以设置
 `DCC_MCP_INSTALL_DISABLED=1` 禁用自动执行安装。plan 仍会返回 adapter metadata 和

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -82,7 +82,9 @@ the server from its exact target environment. Gateway Admin is check-only.
 1. Classify the ownership boundary before creating files:
    - Public DCC adapter: run `dcc-mcp-cli dcc-types`; improve an existing
      adapter instead of creating a duplicate. Add a genuinely new public
-     adapter to `dcc-mcp-catalog.yml` and the compatibility matrix.
+     adapter to `dcc-mcp-catalog.yml` and the compatibility matrix. A pip
+     install entry requires the released universal wheel's exact HTTPS URL,
+     catalog version, and SHA-256; omit install metadata until it is published.
    - Private non-DCC service: work in the supplied local or intranet project,
      keep its stable custom service id private, and do not require a GitHub
      repository, public catalog entry, issue, or release. Use a studio-owned

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -489,10 +489,10 @@ After updates or installs without `--reload`, run `reload-skills`; then use `loa
 Use `install` for adapter plans, never for marketplace Skills:
 
 ```bash
-dcc-mcp-cli install --dcc-type maya --version 2026
+dcc-mcp-cli install --dcc-type maya
 ```
 Ask before `--execute`, follow the returned `next_steps`, and do not treat
-package installation as live registration. If no standard DCC is found, ask for an absolute path and pass `--dcc-path`. If auto-install is disabled, show
+package installation as live registration. Pip plans must preserve the catalog-pinned artifact; see the CLI cheatsheet. If no standard DCC is found, ask for an absolute path and pass `--dcc-path`. If auto-install is disabled, show
 the returned policy prompt and hand off to the named deployment owner.
 
 The CLI is the **default agent-facing control plane**. The Python fallback uses

--- a/skills/dcc-mcp/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-mcp/references/CLI_CHEATSHEET.md
@@ -151,8 +151,8 @@ paths, or full tool payloads.
 
 | Command | Purpose |
 |---------|---------|
-| `dcc-mcp-cli install --dcc-type maya --version 2026` | Build an auditable adapter install plan with machine-readable `next_steps`, without changing local state |
-| `dcc-mcp-cli install --dcc-type maya --version 2026 --python "<mayapy>" --execute` | Execute package install after consent; rolls back on failure and verifies pip/path outputs |
+| `dcc-mcp-cli install --dcc-type maya` | Build an auditable adapter install plan with a catalog-pinned wheel URL, version, SHA-256, and machine-readable `next_steps` |
+| `dcc-mcp-cli install --dcc-type maya --python "<mayapy>" --execute` | Execute the verified wheel after consent; roll back on failure and verify the installed package version |
 | `dcc-mcp-cli install --dcc-type maya --dcc-path "<maya-executable>"` | Supply a non-standard DCC executable/application path when the host is not found automatically |
 | `dcc-mcp-cli marketplace search --query "maya rigging" --limit 20` | Find installable Skill packages with released and current CLI builds |
 | `dcc-mcp-cli marketplace inspect <package_name>` | Inspect the selected skill package metadata before installing |


### PR DESCRIPTION
## Summary
- bind pip adapter plans to exact universal wheel URLs and SHA-256
- install through hashed PEP 508 references and verify the installed version
- migrate 31 published wheels; keep three unpublished adapters discovery-only

## Compatibility
`PipInstall` adds optional wire-compatible integrity fields; Rust constructors must supply them in the next minor release.

## Validation
- workspace check, Clippy, format, 3534 nextest tests, and doctests
- catalog, install E2E, docs, markdown, and Skill lint
- downloaded and verified all 31 wheel digests and METADATA bindings

Advances #2186