### PR TITLE
refactor: centralize workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
  "pyo3",
  "pyo3-stub-gen",
  "pyo3-stub-gen-derive",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,10 @@ dcc-mcp-models = { path = "crates/dcc-mcp-models" }
 dcc-mcp-actions = { path = "crates/dcc-mcp-actions" }
 dcc-mcp-skills = { path = "crates/dcc-mcp-skills" }
 dcc-mcp-protocols = { path = "crates/dcc-mcp-protocols" }
+dcc-mcp-jsonrpc = { path = "crates/dcc-mcp-jsonrpc" }
+dcc-mcp-wire = { path = "crates/dcc-mcp-wire" }
+dcc-mcp-job = { path = "crates/dcc-mcp-job" }
+dcc-mcp-skill-rest = { path = "crates/dcc-mcp-skill-rest" }
 dcc-mcp-logging = { path = "crates/dcc-mcp-logging" }
 dcc-mcp-pybridge = { path = "crates/dcc-mcp-pybridge" }
 dcc-mcp-pybridge-derive = { path = "crates/dcc-mcp-pybridge-derive" }
@@ -80,6 +84,7 @@ dcc-mcp-shm = { path = "crates/dcc-mcp-shm" }
 dcc-mcp-capture = { path = "crates/dcc-mcp-capture" }
 dcc-mcp-usd = { path = "crates/dcc-mcp-usd" }
 dcc-mcp-http = { path = "crates/dcc-mcp-http" }
+dcc-mcp-http-types = { path = "crates/dcc-mcp-http-types" }
 dcc-mcp-http-server = { path = "crates/dcc-mcp-http-server" }
 dcc-mcp-http-py = { path = "crates/dcc-mcp-http-py" }
 dcc-mcp-cli = { path = "crates/dcc-mcp-cli" }
@@ -97,11 +102,13 @@ dcc-mcp-marketplace = { path = "crates/dcc-mcp-marketplace" }
 dcc-mcp-catalog = { path = "crates/dcc-mcp-catalog" }
 dcc-mcp-db = { path = "crates/dcc-mcp-db" }
 dcc-mcp-gateway = { path = "crates/dcc-mcp-gateway" }
+dcc-mcp-gateway-core = { path = "crates/dcc-mcp-gateway-core" }
 dcc-mcp-updater = { path = "crates/dcc-mcp-updater" }
 dcc-mcp-attestation = { path = "crates/dcc-mcp-attestation" }
 dcc-mcp-gateway-ensure = { path = "crates/dcc-mcp-gateway-ensure" }
 dcc-mcp-gateway-search = { path = "crates/dcc-mcp-gateway-search" }
 dcc-mcp-semantic = { path = "crates/dcc-mcp-semantic" }
+dcc-mcp-test-utils = { path = "crates/dcc-mcp-test-utils" }
 
 # Shared dependencies (single version across workspace)
 pyo3 = { version = "0.28", features = ["multiple-pymethods"] }
@@ -140,6 +147,14 @@ base64 = "0.22"
 # only when the `job-persist-sqlite` feature is enabled on `dcc-mcp-http`;
 # otherwise zero SQLite code compiles into the wheel.
 rusqlite = { version = "0.39", features = ["bundled"] }
+axum = "0.8"
+tower = "0.5"
+tower-http = "0.6"
+tempfile = "3"
+sha2 = "0.11"
+rand = "0.10"
+http = "1.0"
+futures = "0.3"
 
 # Safe zero-copy (de)serialisation for shared-memory headers.
 bytemuck = { version = "1.22", features = ["derive", "extern_crate_alloc", "min_const_generics"] }
@@ -181,7 +196,6 @@ keywords = ["dcc", "mcp", "maya", "blender", "houdini", "pyo3"]
 [lib]
 name = "_core"
 crate-type = ["cdylib", "rlib"]
-required-features = ["python-bindings"]
 
 [dependencies]
 # Internal crates

--- a/crates/dcc-mcp-artefact/Cargo.toml
+++ b/crates/dcc-mcp-artefact/Cargo.toml
@@ -22,13 +22,12 @@ tracing = { workspace = true }
 parking_lot = { workspace = true }
 uuid = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
-sha2 = "0.11"
+sha2.workspace = true
 hex = "0.4"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
-tempfile = "3"
-
+tempfile.workspace = true
 [features]
 default = []
 python-bindings = ["dep:pyo3"]

--- a/crates/dcc-mcp-attestation/Cargo.toml
+++ b/crates/dcc-mcp-attestation/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 description = "GitHub OIDC and Sigstore artifact-attestation verification for DCC-MCP"
 
 [dependencies]
-sha2 = "0.11"
+sha2.workspace = true
 sigstore-verify = { version = "0.11", default-features = false }
 thiserror.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/dcc-mcp-capture/Cargo.toml
+++ b/crates/dcc-mcp-capture/Cargo.toml
@@ -54,8 +54,7 @@ libc.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
-tempfile = "3"
-
+tempfile.workspace = true
 [features]
 default = []
 python-bindings = ["pyo3"]

--- a/crates/dcc-mcp-catalog/Cargo.toml
+++ b/crates/dcc-mcp-catalog/Cargo.toml
@@ -18,4 +18,4 @@ uuid = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true

--- a/crates/dcc-mcp-cli/Cargo.toml
+++ b/crates/dcc-mcp-cli/Cargo.toml
@@ -18,6 +18,7 @@ base64.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 dcc-mcp-catalog.workspace = true
 dcc-mcp-gateway-ensure.workspace = true
+# Keep the path override: Cargo cannot override inherited workspace default features.
 dcc-mcp-sidecar = { path = "../dcc-mcp-sidecar", default-features = false, features = ["gateway-daemon", "admin"] }
 dcc-mcp-transport.workspace = true
 dcc-mcp-updater.workspace = true
@@ -30,9 +31,9 @@ reqwest.workspace = true
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-sha2 = "0.11"
+sha2.workspace = true
 tar = "0.4"
-tempfile = "3"
+tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 toon-format.workspace = true
@@ -40,7 +41,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
-axum = { version = "0.8", features = ["http1", "tokio"] }
+axum = { workspace = true, features = ["http1", "tokio"] }
 dcc-mcp-actions.workspace = true
 dcc-mcp-http.workspace = true
 hex = "0.4"

--- a/crates/dcc-mcp-db/Cargo.toml
+++ b/crates/dcc-mcp-db/Cargo.toml
@@ -23,4 +23,4 @@ rusqlite = { workspace = true, optional = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true

--- a/crates/dcc-mcp-gateway-core/Cargo.toml
+++ b/crates/dcc-mcp-gateway-core/Cargo.toml
@@ -24,7 +24,7 @@ dcc-mcp-gateway-search = { workspace = true }
 # `naming` domain depends on the tool-name validator and emits one-shot
 # warnings through `tracing`. Both are pure / facade-only deps so the
 # inward dependency direction is preserved.
-dcc-mcp-naming = { path = "../dcc-mcp-naming" }
+dcc-mcp-naming = { workspace = true }
 tracing = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/crates/dcc-mcp-gateway-ensure/Cargo.toml
+++ b/crates/dcc-mcp-gateway-ensure/Cargo.toml
@@ -19,5 +19,5 @@ tracing.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
-tempfile = "3"
-dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }
+tempfile.workspace = true
+dcc-mcp-test-utils = { workspace = true }

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -11,21 +11,23 @@ build = "build.rs"
 
 [dependencies]
 # Internal
-dcc-mcp-attestation = { path = "../dcc-mcp-attestation" }
+dcc-mcp-attestation = { workspace = true }
+# Keep path overrides where this crate intentionally disables dependency defaults;
+# Cargo does not allow an inherited workspace dependency to override that setting.
 dcc-mcp-db = { path = "../dcc-mcp-db", default-features = false }
-dcc-mcp-models = { path = "../dcc-mcp-models" }
-dcc-mcp-actions = { path = "../dcc-mcp-actions" }
-dcc-mcp-gateway-core = { path = "../dcc-mcp-gateway-core" }
-dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
-dcc-mcp-naming = { path = "../dcc-mcp-naming" }
-dcc-mcp-transport = { path = "../dcc-mcp-transport" }
-dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
-dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
+dcc-mcp-models = { workspace = true }
+dcc-mcp-actions = { workspace = true }
+dcc-mcp-gateway-core = { workspace = true }
+dcc-mcp-jsonrpc = { workspace = true }
+dcc-mcp-naming = { workspace = true }
+dcc-mcp-transport = { workspace = true }
+dcc-mcp-telemetry = { workspace = true, optional = true }
+dcc-mcp-skill-rest = { workspace = true }
 dcc-mcp-skills = { path = "../dcc-mcp-skills", default-features = false }
-dcc-mcp-catalog = { path = "../dcc-mcp-catalog" }
-dcc-mcp-marketplace = { path = "../dcc-mcp-marketplace" }
-dcc-mcp-updater = { path = "../dcc-mcp-updater" }
-dcc-mcp-workflow = { path = "../dcc-mcp-workflow" }
+dcc-mcp-catalog = { workspace = true }
+dcc-mcp-marketplace = { workspace = true }
+dcc-mcp-updater = { workspace = true }
+dcc-mcp-workflow = { workspace = true }
 opentelemetry = { version = "0.32", features = ["trace"], optional = true }
 prometheus = { version = "0.14", default-features = false, optional = true }
 
@@ -48,12 +50,12 @@ chrono = { version = "0.4", features = ["serde"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 
 # HTTP server
-axum = { version = "0.8", features = ["http1", "tokio", "ws"] }
-tower = { version = "0.5", features = ["util"] }
-tower-http = { version = "0.6", features = ["cors", "trace", "limit"] }
+axum = { workspace = true, features = ["http1", "tokio", "ws"] }
+tower = { workspace = true, features = ["util"] }
+tower-http = { workspace = true, features = ["cors", "trace", "limit"] }
 sysinfo = { workspace = true }
-http = "1.0"
-futures = "0.3"
+http.workspace = true
+futures.workspace = true
 futures-util = { workspace = true }
 slab = "0.4"
 tokio-stream = { version = "0.1", features = ["sync", "tokio-util"] }
@@ -79,12 +81,12 @@ prometheus = ["telemetry", "dcc-mcp-telemetry/prometheus", "dep:prometheus"]
 mdns = ["dcc-mcp-transport/mdns"]
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 criterion = { version = "0.8", features = ["html_reports"] }
-tower = { version = "0.5", features = ["util"] }
+tower = { workspace = true, features = ["util"] }
 proptest = "1.5"
-dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }
+dcc-mcp-test-utils = { workspace = true }
 
 [[bench]]
 name = "search_bench"

--- a/crates/dcc-mcp-host/Cargo.toml
+++ b/crates/dcc-mcp-host/Cargo.toml
@@ -14,8 +14,8 @@ parking_lot = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 serde_json = { workspace = true }
-dcc-mcp-wire = { path = "../dcc-mcp-wire" }
-dcc-mcp-pybridge = { path = "../dcc-mcp-pybridge", optional = true }
+dcc-mcp-wire = { workspace = true }
+dcc-mcp-pybridge = { workspace = true, optional = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 pyo3 = { workspace = true, optional = true }

--- a/crates/dcc-mcp-http-py/Cargo.toml
+++ b/crates/dcc-mcp-http-py/Cargo.toml
@@ -17,16 +17,16 @@ doctest = false
 workspace = true
 
 [dependencies]
-dcc-mcp-http = { path = "../dcc-mcp-http" }
-dcc-mcp-http-types = { path = "../dcc-mcp-http-types" }
-dcc-mcp-actions = { path = "../dcc-mcp-actions" }
-dcc-mcp-artefact = { path = "../dcc-mcp-artefact" }
-dcc-mcp-host = { path = "../dcc-mcp-host" }
-dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
-dcc-mcp-models = { path = "../dcc-mcp-models" }
-dcc-mcp-pybridge = { path = "../dcc-mcp-pybridge" }
-dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
-dcc-mcp-skills = { path = "../dcc-mcp-skills" }
+dcc-mcp-http = { workspace = true }
+dcc-mcp-http-types = { workspace = true }
+dcc-mcp-actions = { workspace = true }
+dcc-mcp-artefact = { workspace = true }
+dcc-mcp-host = { workspace = true }
+dcc-mcp-jsonrpc = { workspace = true }
+dcc-mcp-models = { workspace = true }
+dcc-mcp-pybridge = { workspace = true }
+dcc-mcp-skill-rest = { workspace = true }
+dcc-mcp-skills = { workspace = true }
 parking_lot = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 pyo3-stub-gen = { workspace = true, optional = true }

--- a/crates/dcc-mcp-http-server/Cargo.toml
+++ b/crates/dcc-mcp-http-server/Cargo.toml
@@ -16,21 +16,21 @@ workspace = true
 
 [dependencies]
 # Internal crates
-dcc-mcp-http-types = { path = "../dcc-mcp-http-types" }
-dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
-dcc-mcp-job = { path = "../dcc-mcp-job" }
-dcc-mcp-naming = { path = "../dcc-mcp-naming" }
-dcc-mcp-actions = { path = "../dcc-mcp-actions" }
-dcc-mcp-skills = { path = "../dcc-mcp-skills" }
-dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
-dcc-mcp-host = { path = "../dcc-mcp-host" }
+dcc-mcp-http-types = { workspace = true }
+dcc-mcp-jsonrpc = { workspace = true }
+dcc-mcp-job = { workspace = true }
+dcc-mcp-naming = { workspace = true }
+dcc-mcp-actions = { workspace = true }
+dcc-mcp-skills = { workspace = true }
+dcc-mcp-skill-rest = { workspace = true }
+dcc-mcp-host = { workspace = true }
 # Only the pure naming domain is needed here — the gateway runtime
 # itself is a peer crate, not an inward dependency (issue #1368).
-dcc-mcp-gateway-core = { path = "../dcc-mcp-gateway-core" }
-dcc-mcp-models = { path = "../dcc-mcp-models" }
-dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
-dcc-mcp-workflow = { path = "../dcc-mcp-workflow" }
-dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
+dcc-mcp-gateway-core = { workspace = true }
+dcc-mcp-models = { workspace = true }
+dcc-mcp-protocols = { workspace = true }
+dcc-mcp-workflow = { workspace = true }
+dcc-mcp-telemetry = { workspace = true, optional = true }
 
 # Workspace shared
 serde = { workspace = true }
@@ -50,7 +50,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 rmcp = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 
 [features]

--- a/crates/dcc-mcp-http-types/Cargo.toml
+++ b/crates/dcc-mcp-http-types/Cargo.toml
@@ -19,9 +19,9 @@ workspace = true
 # HttpError bubbles into (issue #488). dcc-mcp-models is itself a
 # pure-types crate, so depending on it here keeps the dependency
 # direction inward.
-dcc-mcp-models = { path = "../dcc-mcp-models" }
-dcc-mcp-gateway-core = { path = "../dcc-mcp-gateway-core" }
-dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
+dcc-mcp-models = { workspace = true }
+dcc-mcp-gateway-core = { workspace = true }
+dcc-mcp-jsonrpc = { workspace = true }
 
 # Workspace shared
 serde = { workspace = true }

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -10,14 +10,14 @@ description = "MCP Streamable HTTP server for DCC applications (axum-based, thre
 
 [dependencies]
 # Internal crates
-dcc-mcp-http-types = { path = "../dcc-mcp-http-types" }
-dcc-mcp-http-server = { path = "../dcc-mcp-http-server" }
-dcc-mcp-actions = { path = "../dcc-mcp-actions" }
-dcc-mcp-naming = { path = "../dcc-mcp-naming" }
-dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
-dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
-dcc-mcp-job = { path = "../dcc-mcp-job" }
-dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
+dcc-mcp-http-types = { workspace = true }
+dcc-mcp-http-server = { workspace = true }
+dcc-mcp-actions = { workspace = true }
+dcc-mcp-naming = { workspace = true }
+dcc-mcp-protocols = { workspace = true }
+dcc-mcp-jsonrpc = { workspace = true }
+dcc-mcp-job = { workspace = true }
+dcc-mcp-skill-rest = { workspace = true }
 # Optional via the `auto-gateway` feature (default-on). Embedders that
 # only need the per-DCC MCP HTTP server (no first-wins election, no
 # admin UI, no aggregation) can opt out with `default-features = false`
@@ -26,17 +26,17 @@ dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
 # here — they are forwarded through the `admin` / `admin-persist-sqlite`
 # feature gates below so the default wheel path pulls in neither the Vite
 # admin bundle nor the Prometheus exporter (issue #2182).
-dcc-mcp-gateway = { path = "../dcc-mcp-gateway", optional = true }
-dcc-mcp-models = { path = "../dcc-mcp-models" }
-dcc-mcp-skills = { path = "../dcc-mcp-skills" }
-dcc-mcp-pybridge = { path = "../dcc-mcp-pybridge", optional = true }
-dcc-mcp-transport = { path = "../dcc-mcp-transport" }
-dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
-dcc-mcp-capture = { path = "../dcc-mcp-capture" }
-dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
-dcc-mcp-workflow = { path = "../dcc-mcp-workflow" }
-dcc-mcp-artefact = { path = "../dcc-mcp-artefact" }
-dcc-mcp-host = { path = "../dcc-mcp-host" }
+dcc-mcp-gateway = { workspace = true, optional = true }
+dcc-mcp-models = { workspace = true }
+dcc-mcp-skills = { workspace = true }
+dcc-mcp-pybridge = { workspace = true, optional = true }
+dcc-mcp-transport = { workspace = true }
+dcc-mcp-sandbox = { workspace = true }
+dcc-mcp-capture = { workspace = true }
+dcc-mcp-telemetry = { workspace = true, optional = true }
+dcc-mcp-workflow = { workspace = true }
+dcc-mcp-artefact = { workspace = true }
+dcc-mcp-host = { workspace = true }
 
 # Workspace shared
 serde = { workspace = true }
@@ -57,11 +57,11 @@ tokio-util = { version = "0.7", features = ["rt"] }
 # HTTP server
 # MCP Streamable HTTP uses HTTP/1.1 SSE; http2 is not required and pulls in
 # the heavy `h2` crate — keep it disabled for faster builds.
-axum = { version = "0.8", features = ["http1", "tokio"] }
-tower = { version = "0.5", features = ["util"] }
-tower-http = { version = "0.6", features = ["cors", "trace", "limit"] }
-http = "1.0"
-futures = "0.3"
+axum = { workspace = true, features = ["http1", "tokio"] }
+tower = { workspace = true, features = ["util"] }
+tower-http = { workspace = true, features = ["cors", "trace", "limit"] }
+http.workspace = true
+futures.workspace = true
 tokio-stream = { version = "0.1", features = ["sync", "tokio-util"] }
 pin-project-lite = "0.2"
 
@@ -89,8 +89,8 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 axum-test = "20"
 rstest = "0.26"
-tempfile = "3"
-dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
+tempfile.workspace = true
+dcc-mcp-sandbox = { workspace = true }
 # Enable `auto-initialize` only during testing so the in-crate Rust
 # tests that exercise PyO3 surface (e.g. `python::resources_handle`
 # issue #730) can spin up an embedded Python interpreter automatically.

--- a/crates/dcc-mcp-jsonrpc/Cargo.toml
+++ b/crates/dcc-mcp-jsonrpc/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 description = "JSON-RPC 2.0 + MCP 2025-03-26 Streamable HTTP wire types (no transport, no axum)"
 
 [dependencies]
-dcc-mcp-wire = { path = "../dcc-mcp-wire" }
-dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
+dcc-mcp-wire = { workspace = true }
+dcc-mcp-protocols = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/dcc-mcp-marketplace/Cargo.toml
+++ b/crates/dcc-mcp-marketplace/Cargo.toml
@@ -16,12 +16,12 @@ serde.workspace = true
 serde_yaml_ng.workspace = true
 serde_json.workspace = true
 semver.workspace = true
-sha2 = "0.11"
+sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
-tempfile = "3"
-dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }
+tempfile.workspace = true
+dcc-mcp-test-utils = { workspace = true }

--- a/crates/dcc-mcp-process/Cargo.toml
+++ b/crates/dcc-mcp-process/Cargo.toml
@@ -21,7 +21,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 pyo3-stub-gen-derive = { workspace = true, optional = true }
 
 ipckit.workspace = true
-dcc-mcp-models = { path = "../dcc-mcp-models" }
+dcc-mcp-models = { workspace = true }
 
 # Cross-platform system/process information
 sysinfo = { workspace = true }

--- a/crates/dcc-mcp-scheduler/Cargo.toml
+++ b/crates/dcc-mcp-scheduler/Cargo.toml
@@ -34,20 +34,20 @@ chrono-tz = "0.10"
 
 # HMAC-SHA256 webhook validation
 hmac = "0.13"
-sha2 = "0.11"
+sha2.workspace = true
 subtle = "2.6"
 hex = "0.4"
 
 # Axum router for webhook endpoints
-axum = { version = "0.8", features = ["http1", "tokio"] }
+axum = { workspace = true, features = ["http1", "tokio"] }
 bytes = "1"
 
 # Seedable PRNG for jitter testing
-rand = "0.10"
+rand.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 
 [features]

--- a/crates/dcc-mcp-server/Cargo.toml
+++ b/crates/dcc-mcp-server/Cargo.toml
@@ -16,19 +16,18 @@ path = "src/main.rs"
 # `dcc-mcp-http` default features include `auto-gateway` which pulls in
 # the full gateway runtime. We forward that explicitly through our own
 # `gateway-auto` feature so this binary can also build slim variants
-# (issue #1359). Use a direct path dep here because the workspace
-# inheritance form (`workspace = true`) cannot override the inherited
-# `default-features` setting.
+# (issue #1359). Keep direct path deps for HTTP and sidecar because Cargo's
+# workspace inheritance cannot override the inherited `default-features` setting.
 dcc-mcp-http = { path = "../dcc-mcp-http", default-features = false }
 dcc-mcp-actions.workspace = true
 dcc-mcp-skills.workspace = true
 dcc-mcp-protocols.workspace = true
 dcc-mcp-logging.workspace = true
 dcc-mcp-transport.workspace = true
-dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
+dcc-mcp-telemetry = { workspace = true, optional = true }
 dcc-mcp-catalog.workspace = true
 dcc-mcp-capture.workspace = true
-dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
+dcc-mcp-jsonrpc = { workspace = true }
 dcc-mcp-updater.workspace = true
 dcc-mcp-sidecar = { path = "../dcc-mcp-sidecar", default-features = false, optional = true }
 serde.workspace = true
@@ -45,8 +44,8 @@ futures-util.workspace = true
 reqwest.workspace = true
 rusqlite.workspace = true
 # MCP Streamable HTTP uses HTTP/1.1 SSE only; http2 feature removed to avoid h2 crate.
-axum = { version = "0.8", features = ["http1", "tokio"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+axum = { workspace = true, features = ["http1", "tokio"] }
+tower-http = { workspace = true, features = ["cors", "trace"] }
 clap = { version = "4", features = ["derive", "env"] }
 sysinfo.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
@@ -104,11 +103,6 @@ admin = [
     "dcc-mcp-sidecar?/admin",
 ]
 
-# Placeholder for embedding the relay tunnel agent in-process. Wired
-# up by issue #1363; currently a no-op feature gate so downstream
-# build configs can already declare it.
-tunnel-agent = []
-
 # Optional LAN-local mDNS/DNS-SD advertisement and gateway browsing.
 mdns = [
     "dcc-mcp-http/mdns",
@@ -135,6 +129,6 @@ tracy = ["dcc-mcp-logging/tracy"]
 sentry = ["dep:sentry"]
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
-dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }
+dcc-mcp-test-utils = { workspace = true }

--- a/crates/dcc-mcp-sidecar/Cargo.toml
+++ b/crates/dcc-mcp-sidecar/Cargo.toml
@@ -14,7 +14,7 @@ dcc-mcp-gateway-ensure.workspace = true
 dcc-mcp-host-rpc.workspace = true
 dcc-mcp-transport.workspace = true
 anyhow.workspace = true
-axum = { version = "0.8", features = ["http1", "tokio"] }
+axum = { workspace = true, features = ["http1", "tokio"] }
 clap = { version = "4", features = ["derive", "env"] }
 reqwest.workspace = true
 serde.workspace = true
@@ -48,9 +48,9 @@ mdns = [
 prometheus = ["dcc-mcp-gateway?/prometheus"]
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
-dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }
+dcc-mcp-test-utils = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/dcc-mcp-skill-rest/Cargo.toml
+++ b/crates/dcc-mcp-skill-rest/Cargo.toml
@@ -10,9 +10,9 @@ description = "Per-DCC RESTful skill API surface (issues #658, #660) — extract
 
 [dependencies]
 # Internal
-dcc-mcp-actions = { path = "../dcc-mcp-actions" }
-dcc-mcp-models = { path = "../dcc-mcp-models" }
-dcc-mcp-skills = { path = "../dcc-mcp-skills" }
+dcc-mcp-actions = { workspace = true }
+dcc-mcp-models = { workspace = true }
+dcc-mcp-skills = { workspace = true }
 
 # Workspace shared
 serde = { workspace = true }
@@ -23,10 +23,10 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # HTTP server
-axum = { version = "0.8", features = ["http1", "tokio"] }
+axum = { workspace = true, features = ["http1", "tokio"] }
 
 # Async + SSE streaming (#818 phase 1b)
-futures = "0.3"
+futures.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["rt"] }
@@ -40,4 +40,4 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 axum-test = "20"
-dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }
+dcc-mcp-test-utils = { workspace = true }

--- a/crates/dcc-mcp-skills/Cargo.toml
+++ b/crates/dcc-mcp-skills/Cargo.toml
@@ -31,11 +31,11 @@ thiserror = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 criterion = { workspace = true }
-rand = "0.8"
+rand.workspace = true
 dcc-mcp-models = { workspace = true, features = ["testing"] }
-dcc-mcp-test-utils = { path = "../dcc-mcp-test-utils" }
+dcc-mcp-test-utils = { workspace = true }
 
 [[bench]]
 name = "scoring_bench"

--- a/crates/dcc-mcp-skills/benches/scoring_bench.rs
+++ b/crates/dcc-mcp-skills/benches/scoring_bench.rs
@@ -9,14 +9,15 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use dcc_mcp_models::{SkillMetadata, SkillScope, ToolDeclaration};
 use dcc_mcp_skills::catalog::inverted_index::InvertedIndex;
 use dcc_mcp_skills::catalog::scoring::{FieldTokens, score_skills, score_skills_with_tokens};
+use rand::RngExt;
 use std::hint::black_box;
 
 // ── Synthetic skill generation ──────────────────────────────────────────
 
 fn synthetic_skill(i: usize, rng: &mut impl rand::Rng) -> SkillMetadata {
-    let dcc = ["maya", "blender", "max", "houdini", "unreal"][rng.gen_range(0..5)];
+    let dcc = ["maya", "blender", "max", "houdini", "unreal"][rng.random_range(0..5)];
     let mut name = format!("{dcc}-skill-{i:05}");
-    if rng.gen_bool(0.2) {
+    if rng.random_bool(0.2) {
         name.push_str("-advanced");
     }
 
@@ -32,9 +33,9 @@ fn synthetic_skill(i: usize, rng: &mut impl rand::Rng) -> SkillMetadata {
         "fx",
         "layout",
     ];
-    let tag_count = rng.gen_range(1..=3);
+    let tag_count = rng.random_range(1..=3);
     let mut tags: Vec<String> = (0..tag_count)
-        .map(|_| tags_pool[rng.gen_range(0..tags_pool.len())].to_string())
+        .map(|_| tags_pool[rng.random_range(0..tags_pool.len())].to_string())
         .collect();
     tags.sort();
     tags.dedup();
@@ -71,40 +72,40 @@ fn synthetic_skill(i: usize, rng: &mut impl rand::Rng) -> SkillMetadata {
         "simulate",
         "bake",
     ];
-    let desc_len = rng.gen_range(3..=12);
+    let desc_len = rng.random_range(3..=12);
     let description: String = (0..desc_len)
-        .map(|_| desc_words[rng.gen_range(0..desc_words.len())])
+        .map(|_| desc_words[rng.random_range(0..desc_words.len())])
         .collect::<Vec<_>>()
         .join(" ");
 
-    let hint = if rng.gen_bool(0.5) {
-        let hint_len = rng.gen_range(1..=5);
+    let hint = if rng.random_bool(0.5) {
+        let hint_len = rng.random_range(1..=5);
         (0..hint_len)
-            .map(|_| desc_words[rng.gen_range(0..desc_words.len())])
+            .map(|_| desc_words[rng.random_range(0..desc_words.len())])
             .collect::<Vec<_>>()
             .join(" ")
     } else {
         String::new()
     };
 
-    let tool_count = rng.gen_range(1..=4);
+    let tool_count = rng.random_range(1..=4);
     let tools: Vec<ToolDeclaration> = (0..tool_count)
         .map(|t| ToolDeclaration {
             name: format!("{name}-tool-{t}"),
-            description: (0..rng.gen_range(2..=6))
-                .map(|_| desc_words[rng.gen_range(0..desc_words.len())])
+            description: (0..rng.random_range(2..=6))
+                .map(|_| desc_words[rng.random_range(0..desc_words.len())])
                 .collect::<Vec<_>>()
                 .join(" "),
             ..Default::default()
         })
         .collect();
 
-    let alias_count = rng.gen_range(0..=2);
+    let alias_count = rng.random_range(0..=2);
     let search_aliases: Vec<String> = (0..alias_count)
-        .map(|_| format!("alias-{}-{}", name, rng.gen_range(0..999)))
+        .map(|_| format!("alias-{}-{}", name, rng.random_range(0..999)))
         .collect();
 
-    let layer = match rng.gen_range(0u8..100) {
+    let layer = match rng.random_range(0u8..100) {
         0..=59 => None,
         60..=79 => Some("domain".to_string()),
         80..=89 => Some("infrastructure".to_string()),

--- a/crates/dcc-mcp-transport/Cargo.toml
+++ b/crates/dcc-mcp-transport/Cargo.toml
@@ -33,7 +33,7 @@ fs4 = "1.1.0"
 [dev-dependencies]
 criterion = { workspace = true }
 rstest = "0.26"
-tempfile = "3.14"
+tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 # Deterministic network fault injection (issue #251 AC#3).
 # Scoped to tcp-only simulation — the IPC-backed paths are covered by

--- a/crates/dcc-mcp-tunnel-relay/Cargo.toml
+++ b/crates/dcc-mcp-tunnel-relay/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { workspace = true }
 uuid = { workspace = true }
 # /tunnels admin endpoint + WebSocket frontend transport. http1-only mirrors
 # `dcc-mcp-http`'s feature set so the relay does not pull in `h2`.
-axum = { version = "0.8", features = ["http1", "tokio", "ws"] }
+axum = { workspace = true, features = ["http1", "tokio", "ws"] }
 tokio-tungstenite = { workspace = true }
 futures-util = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/dcc-mcp-updater/Cargo.toml
+++ b/crates/dcc-mcp-updater/Cargo.toml
@@ -17,6 +17,6 @@ tokio.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 fs4 = "1.1.0"
-sha2 = "0.11"
-tempfile = "3"
+sha2.workspace = true
+tempfile.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/dcc-mcp-wire/Cargo.toml
+++ b/crates/dcc-mcp-wire/Cargo.toml
@@ -20,7 +20,7 @@ stub-gen = ["python-bindings", "dep:pyo3-stub-gen", "dep:pyo3-stub-gen-derive"]
 
 [dependencies]
 # Internal — pure protocol types only; avoids circular imports.
-dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
+dcc-mcp-protocols = { workspace = true }
 
 # Workspace shared
 serde = { workspace = true }

--- a/crates/dcc-mcp-workflow/Cargo.toml
+++ b/crates/dcc-mcp-workflow/Cargo.toml
@@ -36,10 +36,9 @@ base64 = { workspace = true }
 # Optional: SQLite persistence (writer + interrupted-on-restart recovery).
 rusqlite = { version = "0.39", optional = true, features = ["bundled"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
-sha2 = "0.11.0"
-
+sha2.workspace = true
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 tokio = { workspace = true, features = ["sync", "time", "rt", "rt-multi-thread", "macros", "test-util"] }
 dcc-mcp-models = { workspace = true, features = ["testing"] }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ module-name = "dcc_mcp_core._core"
 # Feature list MUST stay in sync with `WHEEL_FEATURES` in the root justfile.
 # The justfile is the single source of truth for CI; this list only matters
 # for downstream `pip install .` / sdist rebuilds that bypass our CI.
-features = ["python-bindings", "ext-module", "abi3-py38", "workflow", "scheduler", "prometheus", "job-persist-sqlite"]
+features = ["python-bindings", "ext-module", "abi3-py38", "workflow", "scheduler", "prometheus", "job-persist-sqlite", "admin"]
 bindings = "pyo3"
 [tool.mypy]
 python_version = "3.7"

--- a/scripts/ci/check_python_support.py
+++ b/scripts/ci/check_python_support.py
@@ -533,6 +533,46 @@ def collect_expected_fragment_errors(root: Path, contract: Mapping[str, Any]) ->
     return errors
 
 
+def collect_wheel_feature_projection_errors(root: Path) -> list[str]:
+    """Require pyproject's default maturin features to match the Justfile wheel set."""
+    justfile = (root / "justfile").read_text(encoding="utf-8")
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    opt_match = re.search(r'^OPT_FEATURES\s*:=\s*"([^"]*)"', justfile, re.MULTILINE)
+    wheel_match = re.search(
+        r'^WHEEL_FEATURES\s*:=\s*"([^"]*)"\s*\+\s*OPT_FEATURES',
+        justfile,
+        re.MULTILINE,
+    )
+    maturin_match = re.search(
+        r"(?ms)^\[tool\.maturin\]\s*(.*?)(?=^\[|\Z)",
+        pyproject,
+    )
+    if not opt_match or not wheel_match or not maturin_match:
+        return ["Justfile/pyproject.toml: cannot resolve canonical wheel feature projections"]
+    pyproject_match = re.search(
+        r"(?ms)^features\s*=\s*\[(.*?)\]",
+        maturin_match.group(1),
+    )
+    if not pyproject_match:
+        return ["pyproject.toml: [tool.maturin] is missing features"]
+
+    expected = {
+        feature.strip()
+        for value in (wheel_match.group(1), opt_match.group(1))
+        for feature in value.split(",")
+        if feature.strip()
+    }
+    actual = set(re.findall(r'"([^"]+)"', pyproject_match.group(1)))
+    if actual == expected:
+        return []
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    return [
+        "pyproject.toml: [tool.maturin].features drifted from Justfile "
+        f"WHEEL_FEATURES (missing={missing}, extra={extra})"
+    ]
+
+
 def collect_projection_errors(root: Path, contract: Mapping[str, Any]) -> list[str]:
     """Collect all contract drift errors without failing at the first one."""
     errors = collect_expected_fragment_errors(root, contract)
@@ -544,6 +584,7 @@ def collect_projection_errors(root: Path, contract: Mapping[str, Any]) -> list[s
     errors.extend(collect_wheel_action_errors(root))
     errors.extend(collect_backfill_tooling_errors(root))
     errors.extend(collect_semantic_release_errors(root))
+    errors.extend(collect_wheel_feature_projection_errors(root))
 
     release_jobs = {
         "linux-x86_64": "linux-py37",

--- a/tests/test_python_support_contract.py
+++ b/tests/test_python_support_contract.py
@@ -15,6 +15,7 @@ from scripts.ci.check_python_support import collect_full_matrix_errors
 from scripts.ci.check_python_support import collect_projection_errors
 from scripts.ci.check_python_support import collect_semantic_release_errors
 from scripts.ci.check_python_support import collect_wheel_action_errors
+from scripts.ci.check_python_support import collect_wheel_feature_projection_errors
 from scripts.ci.check_python_support import expected_fragments
 from scripts.ci.python_support_contract import ContractError
 from scripts.ci.python_support_contract import load_contract
@@ -23,6 +24,17 @@ from scripts.ci.python_support_contract import python37_test_requirements
 from scripts.ci.python_support_contract import validate_contract
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pyproject_maturin_features_match_canonical_wheel_features(tmp_path: Path) -> None:
+    (tmp_path / "justfile").write_text((_REPO_ROOT / "justfile").read_text(encoding="utf-8"), encoding="utf-8")
+    pyproject = (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+    assert collect_wheel_feature_projection_errors(tmp_path) == []
+
+    (tmp_path / "pyproject.toml").write_text(pyproject.replace(', "admin"]', "]", 1), encoding="utf-8")
+    errors = collect_wheel_feature_projection_errors(tmp_path)
+    assert any("missing=['admin']" in error for error in errors)
 
 
 def test_contract_is_internally_valid_and_matches_repository() -> None:

--- a/tests/test_workspace_dependency_hygiene.py
+++ b/tests/test_workspace_dependency_hygiene.py
@@ -1,0 +1,77 @@
+"""Regression tests for workspace dependency ownership."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+_ROOT = Path(__file__).resolve().parents[1]
+_INTERNAL_NAME = re.compile(r'^name\s*=\s*"(dcc-mcp-[^"]+)"', re.MULTILINE)
+_DEPENDENCY_LINE = re.compile(r"^(dcc-mcp-[a-z0-9-]+)\s*=\s*\{([^\n]+)\}", re.MULTILINE)
+_SHARED_THIRD_PARTY = {
+    "axum",
+    "futures",
+    "http",
+    "rand",
+    "sha2",
+    "tempfile",
+    "tower",
+    "tower-http",
+}
+_DEFAULT_FEATURE_EXCEPTIONS = {
+    ("dcc-mcp-cli", "dcc-mcp-sidecar"),
+    ("dcc-mcp-gateway", "dcc-mcp-db"),
+    ("dcc-mcp-gateway", "dcc-mcp-skills"),
+    ("dcc-mcp-server", "dcc-mcp-http"),
+    ("dcc-mcp-server", "dcc-mcp-sidecar"),
+}
+
+
+def _workspace_dependency_names() -> set[str]:
+    root_manifest = (_ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    section = root_manifest.split("[workspace.dependencies]", 1)[1].split("[workspace.lints", 1)[0]
+    return {match.group(1) for match in re.finditer(r"^(dcc-mcp-[a-z0-9-]+)\s*=", section, re.MULTILINE)}
+
+
+def test_every_internal_crate_has_a_workspace_dependency() -> None:
+    workspace_dependencies = _workspace_dependency_names()
+    crate_names = set()
+    for manifest in (_ROOT / "crates").glob("dcc-mcp-*/Cargo.toml"):
+        match = _INTERNAL_NAME.search(manifest.read_text(encoding="utf-8"))
+        assert match is not None, manifest
+        crate_names.add(match.group(1))
+    assert crate_names - workspace_dependencies == set()
+
+
+def test_internal_paths_are_only_used_to_disable_workspace_defaults() -> None:
+    exceptions = set()
+    for manifest in (_ROOT / "crates").glob("dcc-mcp-*/Cargo.toml"):
+        crate_name = _INTERNAL_NAME.search(manifest.read_text(encoding="utf-8")).group(1)
+        text = manifest.read_text(encoding="utf-8")
+        for match in _DEPENDENCY_LINE.finditer(text):
+            dependency, declaration = match.groups()
+            if 'path = "../dcc-mcp-' not in declaration:
+                continue
+            assert "default-features = false" in declaration
+            exceptions.add((crate_name, dependency))
+    assert exceptions == _DEFAULT_FEATURE_EXCEPTIONS
+
+
+def test_shared_third_party_dependencies_are_inherited() -> None:
+    direct = []
+    for manifest in (_ROOT / "crates").glob("dcc-mcp-*/Cargo.toml"):
+        text = manifest.read_text(encoding="utf-8")
+        for name in _SHARED_THIRD_PARTY:
+            match = re.search(rf"^{re.escape(name)}\s*=\s*(.+)$", text, re.MULTILINE)
+            if match and "workspace = true" not in match.group(1):
+                direct.append(f"{manifest.parent.name}:{name}")
+    assert direct == []
+
+
+def test_removed_manifest_noops_do_not_return() -> None:
+    root_manifest = (_ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    lib_section = root_manifest.split("[lib]", 1)[1].split("[dependencies]", 1)[0]
+    assert "required-features" not in lib_section
+
+    server_manifest = (_ROOT / "crates/dcc-mcp-server/Cargo.toml").read_text(encoding="utf-8")
+    assert not re.search(r"^tunnel-agent\s*=", server_manifest, re.MULTILINE)


### PR DESCRIPTION
Closes #2195.\n\n- registers every internal crate in workspace dependencies and inherits ordinary internal paths\n- centralizes axum/tower/tempfile/sha2/rand/http/futures versions and migrates the benchmark to rand 0.10\n- removes the ignored library key and empty server feature\n- enforces workspace dependency hygiene and Justfile/pyproject wheel-feature parity in tests\n\nFive direct paths remain intentionally where Cargo workspace inheritance cannot override default-features. Existing stub-gen forwards remain because they now have real annotated consumers.\n\nValidation:\n- cargo check --workspace --all-targets\n- strict clippy for changed benchmark/scheduler targets\n- scheduler + skills Rust suites (385 passed, 6 doctests)\n- workspace dependency and Python support contract tests (23 passed)\n- Hakari verify, Cargo fmt, Ruff