### PR TITLE
perf: avoid catalog clones before search pruning

### DIFF
--- a/crates/dcc-mcp-skills/benches/scoring_bench.rs
+++ b/crates/dcc-mcp-skills/benches/scoring_bench.rs
@@ -6,11 +6,14 @@
 //! (cached tokens) to quantify the allocation/CPU saving.
 
 use criterion::{Criterion, criterion_group, criterion_main};
+use dcc_mcp_actions::ToolRegistry;
 use dcc_mcp_models::{SkillMetadata, SkillScope, ToolDeclaration};
+use dcc_mcp_skills::SkillCatalog;
 use dcc_mcp_skills::catalog::inverted_index::InvertedIndex;
 use dcc_mcp_skills::catalog::scoring::{FieldTokens, score_skills, score_skills_with_tokens};
 use rand::RngExt;
 use std::hint::black_box;
+use std::sync::Arc;
 
 // ── Synthetic skill generation ──────────────────────────────────────────
 
@@ -203,5 +206,24 @@ fn bench_score_skills(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_score_skills);
+fn bench_catalog_search(c: &mut Criterion) {
+    for n in [1_000usize, 10_000] {
+        let (metas, _, _, _) = synthetic_catalogue(n);
+        let catalog = SkillCatalog::new(Arc::new(ToolRegistry::new()));
+        for metadata in metas {
+            catalog.add_skill(metadata);
+        }
+
+        // Build the lazy index outside the measured loop. The benchmark then
+        // captures candidate selection + scoring without catalog-wide clones.
+        black_box(catalog.search_skills(Some("polygon bevel"), &[], None, None, Some(25)));
+        c.bench_function(&format!("catalog_search/{n}_skills"), |b| {
+            b.iter(|| {
+                black_box(catalog.search_skills(Some("polygon bevel"), &[], None, None, Some(25)));
+            })
+        });
+    }
+}
+
+criterion_group!(benches, bench_score_skills, bench_catalog_search);
 criterion_main!(benches);

--- a/crates/dcc-mcp-skills/src/catalog/catalog.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog.rs
@@ -37,130 +37,127 @@ impl SkillCatalog {
             .filter(|d| !d.is_empty())
             .map(|d| d.to_ascii_lowercase());
 
-        // ── 1. Pre-filter by tags/dcc (AND semantics) ──
-        let mut prefiltered: Vec<SkillEntry> = match &dcc_key {
-            Some(key) => {
-                let shard = self.dcc_shards.get(key);
-                let Some(shard) = shard else {
-                    return Vec::new();
-                };
-                self.entries
-                    .iter()
-                    .filter(|entry| {
-                        // Fast shard membership check before inspecting metadata.
-                        if !shard.contains(entry.key()) {
-                            return false;
-                        }
-                        let meta = &entry.value().metadata;
-
-                        if !tags.is_empty() {
-                            for tag in tags {
-                                if !meta.tags.iter().any(|t| t.eq_ignore_ascii_case(tag)) {
-                                    return false;
-                                }
-                            }
-                        }
-
-                        // dcc filter already satisfied by shard membership.
-                        true
-                    })
-                    .map(|entry| entry.value().clone())
-                    .collect()
-            }
-            None => {
-                // No dcc filter: scan all entries (existing path).
-                self.entries
-                    .iter()
-                    .filter(|entry| {
-                        let meta = &entry.value().metadata;
-
-                        if !tags.is_empty() {
-                            for tag in tags {
-                                if !meta.tags.iter().any(|t| t.eq_ignore_ascii_case(tag)) {
-                                    return false;
-                                }
-                            }
-                        }
-
-                        true
-                    })
-                    .map(|entry| entry.value().clone())
-                    .collect()
-            }
-        };
-
-        // ── 2. No query → deterministic order, no ranking ──
         let q_trim = query.map(str::trim).unwrap_or("");
-        let ranked: Vec<SkillSummary> = if q_trim.is_empty() {
-            prefiltered.sort_by(|a, b| {
-                b.scope
-                    .cmp(&a.scope)
-                    .then_with(|| a.metadata.name.cmp(&b.metadata.name))
-            });
-            prefiltered
-                .iter()
-                .map(helpers::skill_entry_to_summary)
-                .collect()
-        } else {
-            // ── 3. BM25-lite scoring (with layer-based rank penalty, #1398) ──
-            //
-            // When the caller filters by a known layer name through `tags`,
-            // they have explicitly asked to browse that layer — bypass the
-            // penalty so the raw BM25 order is honoured inside the filtered
-            // slice. Otherwise apply the penalty so infrastructure / example
-            // skills behave as the documented "fallback" tier.
-            let layer_filter_explicit = tags.iter().any(|t| {
-                let l = t.to_ascii_lowercase();
-                matches!(
-                    l.as_str(),
-                    scoring::LAYER_DOMAIN
-                        | scoring::LAYER_THIN_HARNESS
-                        | scoring::LAYER_INFRASTRUCTURE
-                        | scoring::LAYER_EXAMPLE
-                )
-            });
-
-            // ── 3a. Inverted-index candidate pruning (PIP-2469) ──
-            //
-            // Build or rebuild the inverted index if stale. When the index
-            // is available, extract only the subset of prefiltered entries
-            // that intersect the query's posting lists — BM25 scoring then
-            // only visits those candidates instead of the full prefiltered
-            // set. If the index is not available (first call or after a
-            // mutation that hasn't been rebuilt yet), fall back to the
-            // existing linear scan.
-            let (candidate_entries, _candidate_indices): (Vec<&SkillEntry>, Vec<usize>) =
-                self.prune_with_index(q_trim, &prefiltered);
-            let candidate_count = candidate_entries.len();
-            let total_count = prefiltered.len();
-            if candidate_count < total_count {
-                tracing::debug!(
-                    "search_skills inverted index pruned {total_count} → {candidate_count} entries"
-                );
-            }
-
-            let metas: Vec<&SkillMetadata> =
-                candidate_entries.iter().map(|e| &e.metadata).collect();
-            let scopes: Vec<SkillScope> = candidate_entries.iter().map(|e| e.scope).collect();
-            let path_sources: Vec<scoring::SkillPathSource> =
-                candidate_entries.iter().map(|e| e.path_source).collect();
-            let fields: Vec<&scoring::FieldTokens> =
-                candidate_entries.iter().map(|e| &e.field_tokens).collect();
-            let doc_lens: Vec<usize> = candidate_entries.iter().map(|e| e.doc_len).collect();
-            let scored = scoring::score_skills_with_tokens(
-                q_trim,
-                &metas,
-                &scopes,
-                layer_filter_explicit,
-                Some(&path_sources),
-                &fields,
-                &doc_lens,
-            );
-            scored
-                .into_iter()
-                .map(|s| helpers::skill_entry_to_summary(candidate_entries[s.index]))
-                .collect()
+        let shard = match &dcc_key {
+            Some(key) => match self.dcc_shards.get(key) {
+                Some(shard) => Some(shard),
+                None => return Vec::new(),
+            },
+            None => None,
         };
+
+        let matches_filters = |name: &str, meta: &SkillMetadata| {
+            if shard.as_ref().is_some_and(|names| !names.contains(name)) {
+                return false;
+            }
+            !tags.iter().any(|tag| {
+                !meta
+                    .tags
+                    .iter()
+                    .any(|value| value.eq_ignore_ascii_case(tag))
+            })
+        };
+
+        // ── 1. No query → project summaries directly, then sort ──
+        if q_trim.is_empty() {
+            let mut summaries: Vec<_> = self
+                .entries
+                .iter()
+                .filter(|entry| matches_filters(entry.key(), &entry.value().metadata))
+                .filter(|entry| scope.is_none_or(|value| value == entry.value().scope))
+                .map(|entry| {
+                    (
+                        entry.value().scope,
+                        helpers::skill_entry_to_summary(entry.value()),
+                    )
+                })
+                .collect();
+            summaries.sort_by(|(scope_a, summary_a), (scope_b, summary_b)| {
+                scope_b
+                    .cmp(scope_a)
+                    .then_with(|| summary_a.name.cmp(&summary_b.name))
+            });
+            return summaries
+                .into_iter()
+                .map(|(_, summary)| summary)
+                .take(limit.unwrap_or(usize::MAX))
+                .collect();
+        }
+
+        let indexed_candidates = self.candidate_names_with_index(q_trim);
+
+        // ── 2. Pre-filter by tags/dcc and indexed candidate name ──
+        let mut total_prefiltered = 0usize;
+        let mut prefiltered = Vec::new();
+        for entry in self.entries.iter() {
+            let meta = &entry.value().metadata;
+            if !matches_filters(entry.key(), meta) {
+                continue;
+            }
+            total_prefiltered += 1;
+            if indexed_candidates
+                .as_ref()
+                .is_some_and(|names| !names.contains(&meta.name))
+            {
+                continue;
+            }
+            // Retain the DashMap guard instead of deep-cloning SkillEntry.
+            prefiltered.push(entry);
+        }
+
+        // ── 3. BM25-lite scoring (with layer-based rank penalty, #1398) ──
+        //
+        // When the caller filters by a known layer name through `tags`,
+        // they have explicitly asked to browse that layer — bypass the
+        // penalty so the raw BM25 order is honoured inside the filtered
+        // slice. Otherwise apply the penalty so infrastructure / example
+        // skills behave as the documented "fallback" tier.
+        let layer_filter_explicit = tags.iter().any(|t| {
+            let l = t.to_ascii_lowercase();
+            matches!(
+                l.as_str(),
+                scoring::LAYER_DOMAIN
+                    | scoring::LAYER_THIN_HARNESS
+                    | scoring::LAYER_INFRASTRUCTURE
+                    | scoring::LAYER_EXAMPLE
+            )
+        });
+
+        // ── 3a. Inverted-index candidate pruning (PIP-2469) ──
+        //
+        // The index returns stable candidate names before this scan, so
+        // BM25 only visits matching guards. Tokenless queries retain the
+        // linear path for correctness.
+        let candidate_count = prefiltered.len();
+        let total_count = total_prefiltered;
+        if candidate_count < total_count {
+            tracing::debug!(
+                "search_skills inverted index pruned {total_count} → {candidate_count} entries"
+            );
+        }
+
+        let metas: Vec<&SkillMetadata> = prefiltered.iter().map(|e| &e.value().metadata).collect();
+        let scopes: Vec<SkillScope> = prefiltered.iter().map(|e| e.value().scope).collect();
+        let path_sources: Vec<scoring::SkillPathSource> =
+            prefiltered.iter().map(|e| e.value().path_source).collect();
+        let fields: Vec<&scoring::FieldTokens> = prefiltered
+            .iter()
+            .map(|e| &e.value().field_tokens)
+            .collect();
+        let doc_lens: Vec<usize> = prefiltered.iter().map(|e| e.value().doc_len).collect();
+        let scored = scoring::score_skills_with_tokens(
+            q_trim,
+            &metas,
+            &scopes,
+            layer_filter_explicit,
+            Some(&path_sources),
+            &fields,
+            &doc_lens,
+        );
+        let ranked: Vec<SkillSummary> = scored
+            .into_iter()
+            .map(|s| helpers::skill_entry_to_summary(prefiltered[s.index].value()))
+            .collect();
 
         // ── 4. Scope filter (post-ranking) ──
         let filtered: Vec<SkillSummary> = match scope {

--- a/crates/dcc-mcp-skills/src/catalog/catalog_index.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_index.rs
@@ -8,21 +8,17 @@
 //! The index is built from the **full catalog** (`self.entries`), not from the
 //! per-query `prefiltered` slice. This gives every skill a stable `doc_idx`
 //! that is independent of the current `tags`/`dcc` filter. During pruning,
-//! index hits are intersected with the current prefiltered set via a
-//! `name → prefiltered_position` lookup so the correct entries are returned
-//! regardless of which filter is active.
+//! index hits are returned as stable skill names and intersected while the
+//! caller applies its current `tags`/`dcc` filters.
 
-use super::scoring::FieldTokens;
 use super::*;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 impl SkillCatalog {
-    /// Use the inverted index to prune `prefiltered` to only entries that
-    /// contain at least one query token.
+    /// Return the stable names of catalog entries matching any query token.
     ///
-    /// Returns `(candidate_entries, original_indices)` where
-    /// `original_indices[i]` is the position of `candidate_entries[i]` in
-    /// the original `prefiltered` slice.
+    /// `None` means the query cannot use the index and callers must retain the
+    /// linear path. `Some(empty)` is a valid indexed result with no matches.
     ///
     /// # Index lifecycle
     ///
@@ -33,27 +29,23 @@ impl SkillCatalog {
     /// - **Invalidated** only by catalog mutation, **not** by filter changes.
     ///   This is correct because the index maps stable catalog-level doc_idx,
     ///   and pruning maps those back through the current prefiltered set.
-    pub(super) fn prune_with_index<'a>(
-        &self,
-        query: &str,
-        prefiltered: &'a [SkillEntry],
-    ) -> (Vec<&'a SkillEntry>, Vec<usize>) {
+    pub(super) fn candidate_names_with_index(&self, query: &str) -> Option<HashSet<String>> {
         let tokens = super::scoring::tokenize(query);
-        if tokens.is_empty() || prefiltered.is_empty() {
-            return (
-                prefiltered.iter().collect(),
-                (0..prefiltered.len()).collect(),
-            );
+        if tokens.is_empty() {
+            return None;
         }
 
         // Build or rebuild the index from the full catalog if stale.
         {
             let mut guard = self.inverted_index.write();
             if guard.is_stale() {
-                let entries: Vec<_> = self.entries.iter().map(|e| e.value().clone()).collect();
-                let names_and_fields: Vec<(&str, &FieldTokens)> = entries
+                // Keep DashMap read guards alive while the index borrows names
+                // and token fields. This avoids a deep SkillEntry clone for
+                // every catalog row on each rebuild.
+                let entries: Vec<_> = self.entries.iter().collect();
+                let names_and_fields: Vec<_> = entries
                     .iter()
-                    .map(|e| (e.metadata.name.as_str(), &e.field_tokens))
+                    .map(|e| (e.value().metadata.name.as_str(), &e.value().field_tokens))
                     .collect();
                 let idx = InvertedIndex::build(&names_and_fields);
                 guard.set(idx);
@@ -64,52 +56,18 @@ impl SkillCatalog {
         let guard = self.inverted_index.read();
         let idx = match &guard.index {
             Some(i) => i,
-            None => {
-                return (
-                    prefiltered.iter().collect(),
-                    (0..prefiltered.len()).collect(),
-                );
-            }
+            None => return None,
         };
 
-        // Build a lookup: catalog-level doc_idx → prefiltered position.
-        //
-        // The index stores doc_idx relative to the full ordered snapshot of
-        // `self.entries` at build time. The current prefiltered slice may be
-        // a subset (tags/dcc filter) or a different ordering — we map back
-        // through skill name, which is the stable identity.
-        let mut name_to_prefiltered_pos: HashMap<&str, usize> =
-            HashMap::with_capacity(prefiltered.len());
-        for (i, entry) in prefiltered.iter().enumerate() {
-            name_to_prefiltered_pos.insert(&entry.metadata.name, i);
-        }
-
-        // Collect candidate prefiltered positions that match any query token.
-        let mut candidate_set: HashSet<usize> = HashSet::new();
+        let mut candidates = HashSet::new();
         for token in &tokens {
             if let Some(postings) = idx.get(token) {
                 for posting in postings {
-                    if let Some(&pos) = name_to_prefiltered_pos.get(posting.name.as_str()) {
-                        candidate_set.insert(pos);
-                    }
+                    candidates.insert(posting.name);
                 }
             }
         }
 
-        if candidate_set.is_empty() {
-            return (Vec::new(), Vec::new());
-        }
-
-        // Preserve the original ordering of prefiltered entries.
-        let mut candidates: Vec<&SkillEntry> = Vec::with_capacity(candidate_set.len());
-        let mut indices: Vec<usize> = Vec::with_capacity(candidate_set.len());
-        for (i, entry) in prefiltered.iter().enumerate() {
-            if candidate_set.contains(&i) {
-                candidates.push(entry);
-                indices.push(i);
-            }
-        }
-
-        (candidates, indices)
+        Some(candidates)
     }
 }

--- a/crates/dcc-mcp-skills/src/catalog/inverted_index.rs
+++ b/crates/dcc-mcp-skills/src/catalog/inverted_index.rs
@@ -15,7 +15,8 @@
 //!   `register`, `remove`, `add_skill`, `remove_skill`, `rediscover`,
 //!   `load_skill_object` (via `refresh_tokens`), and `load_skill_metadata`
 //!   (via `refresh_tokens`).
-//! - **Re-built** on the next search after invalidation.
+//! - **Re-built** synchronously on the next indexed search after invalidation,
+//!   borrowing catalog entries instead of deep-cloning them.
 //! - The `stale` flag is cheap (`AtomicBool`); invalidation never blocks on
 //!   the index lock.
 //!
@@ -31,12 +32,9 @@
 //!
 //! # Fallback path
 //!
-//! When the index is stale (e.g. because it hasn't been rebuilt yet after a
-//! mutation), `search_skills` falls back to the existing linear scan. The
-//! stale flag is checked at the top of the query path; if set, the index is
-//! not used and the linear path is taken. The flag is only cleared after a
-//! successful rebuild. This guarantees correctness at all times — stale
-//! index = slower, but never wrong results.
+//! Tokenless queries use the linear scan. A stale index is rebuilt before it
+//! participates in candidate selection and the flag is cleared only after a
+//! successful rebuild.
 
 use super::scoring::FieldTokens;
 use dashmap::DashMap;


### PR DESCRIPTION
Part of #2190.\n\n- asks the inverted index for stable candidate names before catalog filtering\n- retains only candidate DashMap guards instead of deep-cloning every SkillEntry\n- rebuilds the lazy index from borrowed entries and projects empty-query summaries directly\n- adds end-to-end 1k/10k catalog search benchmarks\n\nValidation:\n- dcc-mcp-skills: 361 tests and 5 doctests passed\n- strict clippy and Cargo fmt\n- benchmark smoke: ~0.82 ms at 1k and ~18.8 ms at 10k skills\n\nIncremental index mutation will follow separately before #2190 closes. Skill guidance is unchanged because the public search contract is unchanged.