### PR TITLE
perf: update skill search index incrementally

### DIFF
--- a/crates/dcc-mcp-skills/benches/scoring_bench.rs
+++ b/crates/dcc-mcp-skills/benches/scoring_bench.rs
@@ -203,6 +203,12 @@ fn bench_score_skills(c: &mut Criterion) {
                 black_box(total);
             })
         });
+
+        c.bench_function(&format!("inverted_index_upsert/{group_label}"), |b| {
+            b.iter(|| {
+                idx.upsert("benchmark-updated-skill", &fields[0]);
+            })
+        });
     }
 }
 

--- a/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
@@ -296,6 +296,7 @@ impl SkillCatalog {
         };
 
         let mut new_count = 0;
+        let mut new_names = Vec::new();
         for (skill, path_source) in result.skills {
             let name = skill.name.clone();
             let dcc = skill.dcc.clone();
@@ -312,12 +313,13 @@ impl SkillCatalog {
                     ),
                 );
                 self.shard_insert(&name, &dcc);
+                new_names.push(name);
                 new_count += 1;
             }
         }
         self.refresh_dependency_states();
-        if new_count > 0 {
-            self.inverted_index.write().invalidate();
+        for name in new_names {
+            self.sync_search_index(&name);
         }
 
         if !result.skipped.is_empty() {
@@ -356,6 +358,7 @@ impl SkillCatalog {
         let mut added = 0usize;
         let mut updated = 0usize;
         let mut loaded_to_reload = Vec::new();
+        let mut index_updates = Vec::new();
 
         for (skill, path_source) in result.skills {
             let name = skill.name.clone();
@@ -377,6 +380,7 @@ impl SkillCatalog {
                         loaded_to_reload.push(name.clone());
                     }
                     updated += 1;
+                    index_updates.push(name.clone());
                 }
                 // Update shard if dcc changed.
                 self.shard_move(&name, &old_dcc, &dcc);
@@ -392,6 +396,7 @@ impl SkillCatalog {
                     ),
                 );
                 self.shard_insert(&name, &dcc);
+                index_updates.push(name.clone());
                 added += 1;
             }
         }
@@ -419,8 +424,8 @@ impl SkillCatalog {
             }
         }
 
-        if added + updated + removed > 0 {
-            self.inverted_index.write().invalidate();
+        for name in index_updates {
+            self.sync_search_index(&name);
         }
 
         if !result.skipped.is_empty() {
@@ -470,7 +475,7 @@ impl SkillCatalog {
             self.shard_insert(&name, &dcc);
         }
         self.refresh_dependency_states();
-        self.inverted_index.write().invalidate();
+        self.sync_search_index(&name);
     }
 
     /// Discover skills from paths grouped by [`SkillScope`].
@@ -480,6 +485,7 @@ impl SkillCatalog {
         dcc_name: Option<&str>,
     ) -> usize {
         let mut total_new = 0;
+        let mut new_names = Vec::new();
         for (scope, paths) in scoped_paths {
             let result =
                 match crate::loader::scan_and_load_lenient(Some(paths.as_slice()), dcc_name) {
@@ -518,13 +524,14 @@ impl SkillCatalog {
                         ),
                     );
                     self.shard_insert(&name, &dcc);
+                    new_names.push(name);
                     total_new += 1;
                 }
             }
         }
         self.refresh_dependency_states();
-        if total_new > 0 {
-            self.inverted_index.write().invalidate();
+        for name in new_names {
+            self.sync_search_index(&name);
         }
         tracing::info!(
             "SkillCatalog::discover_scoped: {} new skill(s) across {} scope(s)",

--- a/crates/dcc-mcp-skills/src/catalog/catalog_index.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_index.rs
@@ -15,6 +15,15 @@ use super::*;
 use std::collections::HashSet;
 
 impl SkillCatalog {
+    pub(super) fn sync_search_index(&self, name: &str) {
+        let mut index = self.inverted_index.write();
+        if let Some(entry) = self.entries.get(name) {
+            index.upsert(name, &entry.field_tokens);
+        } else {
+            index.remove(name);
+        }
+    }
+
     /// Return the stable names of catalog entries matching any query token.
     ///
     /// `None` means the query cannot use the index and callers must retain the

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -229,7 +229,7 @@ impl SkillCatalog {
             ),
         );
         self.refresh_dependency_states();
-        self.inverted_index.write().invalidate();
+        self.sync_search_index(&skill_name);
         self.load_skill(&skill_name)
     }
 
@@ -651,7 +651,7 @@ impl SkillCatalog {
             entry.state = SkillState::Loaded;
             entry.registered_tools = registered.clone();
         }
-        self.inverted_index.write().invalidate();
+        self.sync_search_index(skill_name);
         self.loaded.insert(skill_name.to_string());
         self.notify_after_load_hook(skill_name, metadata, &registered);
 
@@ -765,7 +765,7 @@ impl SkillCatalog {
         let removed = self.entries.remove(skill_name).is_some();
         if removed {
             self.refresh_dependency_states();
-            self.inverted_index.write().invalidate();
+            self.sync_search_index(skill_name);
         }
         removed
     }
@@ -783,7 +783,7 @@ impl SkillCatalog {
         self.entries.clear();
         self.skipped.clear();
         self.dcc_shards.clear();
-        self.inverted_index.write().invalidate();
+        *self.inverted_index.write() = Default::default();
     }
 
     /// Replay a persisted set of loaded skills + active groups (#1405).

--- a/crates/dcc-mcp-skills/src/catalog/inverted_index.rs
+++ b/crates/dcc-mcp-skills/src/catalog/inverted_index.rs
@@ -11,14 +11,10 @@
 //!
 //! - **Built lazily** on the first `search_skills` call that carries a query.
 //!   The build walks every `SkillEntry` in the catalog and is O(total tokens).
-//! - **Invalidated** on every mutation that changes a skill's searchable text:
-//!   `register`, `remove`, `add_skill`, `remove_skill`, `rediscover`,
-//!   `load_skill_object` (via `refresh_tokens`), and `load_skill_metadata`
-//!   (via `refresh_tokens`).
-//! - **Re-built** synchronously on the next indexed search after invalidation,
-//!   borrowing catalog entries instead of deep-cloning them.
-//! - The `stale` flag is cheap (`AtomicBool`); invalidation never blocks on
-//!   the index lock.
+//! - **Updated incrementally** after the first build when a mutation adds,
+//!   removes, or changes one skill's searchable fields.
+//! - **Reset** only when the entire catalog is cleared; the next indexed
+//!   search rebuilds from borrowed catalog entries.
 //!
 //! # Data structure
 //!
@@ -38,8 +34,11 @@
 
 use super::scoring::FieldTokens;
 use dashmap::DashMap;
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+type DocumentTokens = (usize, HashMap<String, usize>);
 
 /// A single posting: skill name + term frequency in that document.
 ///
@@ -63,6 +62,8 @@ pub struct InvertedIndex {
     /// Maps a token string to its posting list. The posting list is sorted
     /// by `doc_idx` for deterministic iteration.
     index: Arc<DashMap<String, Vec<Posting>>>,
+    documents: Arc<DashMap<String, DocumentTokens>>,
+    next_doc_idx: Arc<AtomicUsize>,
 }
 
 impl InvertedIndex {
@@ -73,32 +74,51 @@ impl InvertedIndex {
     /// Complexity: O(total tokens across all fields). The posting lists are
     /// built by scanning every token in every field for every document.
     pub fn build(names_and_fields: &[(&str, &FieldTokens)]) -> Self {
-        let index = Arc::new(DashMap::<String, Vec<Posting>>::new());
+        let index = Self {
+            index: Arc::new(DashMap::new()),
+            documents: Arc::new(DashMap::new()),
+            next_doc_idx: Arc::new(AtomicUsize::new(0)),
+        };
+        for (name, fields) in names_and_fields {
+            index.upsert(name, fields);
+        }
+        index
+    }
 
-        // Accumulate per-document token → tf maps first, then merge into
-        // the global index. This avoids locking the DashMap shard on every
-        // single token insertion.
-        let per_doc: Vec<_> = names_and_fields
-            .iter()
-            .map(|(name, ft)| (name.to_string(), doc_token_tfs(ft)))
-            .collect();
+    /// Add or replace one searchable document without rebuilding the catalog.
+    pub fn upsert(&self, name: &str, fields: &FieldTokens) {
+        self.remove(name);
+        let doc_idx = self.next_doc_idx.fetch_add(1, Ordering::Relaxed);
+        let token_tfs = doc_token_tfs(fields);
+        for (token, tf) in &token_tfs {
+            let mut postings = self.index.entry(token.clone()).or_default();
+            postings.push(Posting {
+                name: name.to_string(),
+                doc_idx,
+                tf: *tf,
+            });
+            postings.sort_by_key(|posting| posting.doc_idx);
+        }
+        self.documents
+            .insert(name.to_string(), (doc_idx, token_tfs));
+    }
 
-        for (doc_idx, (name, doc_tf)) in per_doc.iter().enumerate() {
-            for (token, tf) in doc_tf.iter() {
-                index.entry(token.clone()).or_default().push(Posting {
-                    name: name.clone(),
-                    doc_idx,
-                    tf: *tf,
-                });
+    /// Remove one searchable document and all of its postings.
+    pub fn remove(&self, name: &str) {
+        let Some((_, (_, token_tfs))) = self.documents.remove(name) else {
+            return;
+        };
+        for token in token_tfs.keys() {
+            let remove_token = if let Some(mut postings) = self.index.get_mut(token) {
+                postings.retain(|posting| posting.name != name);
+                postings.is_empty()
+            } else {
+                false
+            };
+            if remove_token {
+                self.index.remove(token);
             }
         }
-
-        // Sort each posting list by doc_idx for deterministic iteration.
-        for mut entry in index.iter_mut() {
-            entry.value_mut().sort_by_key(|p| p.doc_idx);
-        }
-
-        InvertedIndex { index }
     }
 
     /// Return the posting list for `token`, if present.
@@ -142,11 +162,6 @@ impl Default for IndexGuard {
 }
 
 impl IndexGuard {
-    /// Mark the index as stale so the next query rebuilds it.
-    pub fn invalidate(&self) {
-        self.stale.store(true, Ordering::Release);
-    }
-
     /// Check whether the index is stale.
     pub fn is_stale(&self) -> bool {
         self.stale.load(Ordering::Acquire)
@@ -156,6 +171,22 @@ impl IndexGuard {
     pub fn set(&mut self, index: InvertedIndex) {
         self.index = Some(Arc::new(index));
         self.stale.store(false, Ordering::Release);
+    }
+
+    pub fn upsert(&mut self, name: &str, fields: &FieldTokens) {
+        if !self.is_stale()
+            && let Some(index) = &self.index
+        {
+            index.upsert(name, fields);
+        }
+    }
+
+    pub fn remove(&mut self, name: &str) {
+        if !self.is_stale()
+            && let Some(index) = &self.index
+        {
+            index.remove(name);
+        }
     }
 }
 
@@ -252,15 +283,11 @@ mod tests {
     }
 
     #[test]
-    fn test_index_guard_set_and_invalidate() {
+    fn test_index_guard_set() {
         let mut guard = IndexGuard::default();
         let idx = InvertedIndex::build(&[]);
         guard.set(idx);
         assert!(!guard.is_stale());
         assert!(guard.index.is_some());
-
-        guard.invalidate();
-        assert!(guard.is_stale());
-        // index ref still alive but stale flag says "don't use".
     }
 }

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -152,9 +152,9 @@ pub struct SkillCatalog {
     pub(super) after_scoped_group_change_hook: RwLock<Option<Arc<AfterScopedGroupChangeFn>>>,
     /// Tool groups currently active (`"<skill>:<group>"` keys).
     pub(super) active_groups: DashSet<String>,
-    /// Inverted index for fast `search_skills` scoring. Built lazily on
-    /// the first query, invalidated on any mutation. Wrapped in `RwLock`
-    /// so builds (writer) and reads (readers) can coexist.
+    /// Inverted index for fast `search_skills` scoring. Built lazily on the
+    /// first query, then updated per changed entry. Wrapped in `RwLock` so
+    /// builds/mutations (writer) and queries (readers) can coexist.
     pub(super) inverted_index: RwLock<IndexGuard>,
     /// Per-`dcc_type` shards mapping lowercase dcc name → set of skill
     /// names. Populated on every mutation; `search_skills` with a
@@ -215,7 +215,7 @@ impl Registry<SkillEntry> for SkillCatalog {
         self.entries.insert(key.clone(), entry);
         self.shard_insert(&key, &dcc);
         self.refresh_dependency_states();
-        self.inverted_index.write().invalidate();
+        self.sync_search_index(&key);
     }
 
     fn get(&self, key: &str) -> Option<SkillEntry> {
@@ -235,7 +235,7 @@ impl Registry<SkillEntry> for SkillCatalog {
         let removed = self.entries.remove(key).is_some();
         if removed {
             self.refresh_dependency_states();
-            self.inverted_index.write().invalidate();
+            self.sync_search_index(key);
         }
         removed
     }

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_search_skills.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_search_skills.rs
@@ -162,9 +162,7 @@ fn test_search_skills_with_inverted_index_same_results() {
 }
 
 #[test]
-fn test_search_skills_index_invalidation_on_add() {
-    // Adding a new skill must invalidate the index; subsequent search
-    // must include the new skill.
+fn test_search_skills_index_updates_incrementally_on_add() {
     let catalog = make_test_catalog();
 
     // Populate and query once to build index.
@@ -175,9 +173,9 @@ fn test_search_skills_index_invalidation_on_add() {
     let mut new_skill = make_test_skill("maya-bevel", "maya", &[]);
     new_skill.description = "bevel polygon edges".to_string();
     catalog.add_skill(new_skill);
+    assert!(!catalog.inverted_index.read().is_stale());
 
-    // Search again — the index was invalidated and rebuilt; new skill
-    // must appear.
+    // Search again without a full rebuild; the new skill must appear.
     let results = catalog.search_skills(Some("bevel"), &[], None, None, None);
     assert!(
         results.iter().any(|s| s.name == "maya-bevel"),
@@ -186,9 +184,7 @@ fn test_search_skills_index_invalidation_on_add() {
 }
 
 #[test]
-fn test_search_skills_index_invalidation_on_remove() {
-    // Removing a skill must invalidate the index; subsequent search
-    // must not include the removed skill.
+fn test_search_skills_index_updates_incrementally_on_remove() {
     let catalog = make_test_catalog();
 
     catalog.add_skill(make_test_skill("maya-modeling", "maya", &[]));
@@ -199,6 +195,7 @@ fn test_search_skills_index_invalidation_on_remove() {
 
     // Remove a skill.
     assert!(catalog.remove_skill("maya-bevel"));
+    assert!(!catalog.inverted_index.read().is_stale());
 
     // Search again — removed skill must not appear.
     let results = catalog.search_skills(Some("maya"), &[], None, None, None);


### PR DESCRIPTION
Closes #2190.\n\n- tracks per-document token maps and incrementally upserts/removes postings after the lazy first build\n- wires register, discovery, rediscovery, load, update, removal, and clear lifecycles to the index\n- keeps a full rebuild only for initial construction or whole-catalog reset\n- adds mutation-state assertions and an incremental upsert benchmark\n\nValidation:\n- dcc-mcp-skills: 361 tests and 5 doctests passed\n- strict clippy, Cargo fmt, benchmark compile\n- 10k upsert: ~114 us versus ~122 ms full rebuild baseline\n\nThe proposed SkillEntry schema field is intentionally omitted: no persistence call site serializes SkillEntry. The actual on-disk PersistedCatalogState already carries schema_version.