### PR TITLE
refactor: share main-thread queue statistics

### DIFF
--- a/crates/dcc-mcp-host/src/lib.rs
+++ b/crates/dcc-mcp-host/src/lib.rs
@@ -467,27 +467,37 @@ pub struct QueueStats {
 /// 256 samples so the percentile compute stays O(n log n) over a
 /// small n; operators who need higher-resolution histograms scrape
 /// Prometheus instead.
-struct WaitTimeRing {
+#[derive(Debug)]
+pub struct WaitTimeSamples {
     samples: VecDeque<u64>,
 }
 
-impl WaitTimeRing {
+impl Default for WaitTimeSamples {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WaitTimeSamples {
     const CAPACITY: usize = 256;
 
-    fn new() -> Self {
+    /// Create an empty bounded sample ring.
+    pub fn new() -> Self {
         Self {
             samples: VecDeque::with_capacity(Self::CAPACITY),
         }
     }
 
-    fn observe(&mut self, wait_ms: u64) {
+    /// Record one enqueue-to-dequeue wait duration in milliseconds.
+    pub fn observe(&mut self, wait_ms: u64) {
         if self.samples.len() == Self::CAPACITY {
             self.samples.pop_front();
         }
         self.samples.push_back(wait_ms);
     }
 
-    fn percentiles(&self) -> (Option<u64>, Option<u64>, Option<u64>) {
+    /// Return p50, p95, and p99 over the retained samples.
+    pub fn percentiles(&self) -> (Option<u64>, Option<u64>, Option<u64>) {
         if self.samples.is_empty() {
             return (None, None, None);
         }
@@ -548,7 +558,7 @@ struct Shared {
     submit_times: Mutex<VecDeque<Instant>>,
     /// Bounded ring of recent completed-job wait-times for percentile
     /// surfacing.
-    wait_samples: Mutex<WaitTimeRing>,
+    wait_samples: Mutex<WaitTimeSamples>,
 }
 
 impl Shared {
@@ -568,7 +578,7 @@ impl Shared {
             total_dequeued: AtomicU64::new(0),
             total_rejected: AtomicU64::new(0),
             submit_times: Mutex::new(VecDeque::new()),
-            wait_samples: Mutex::new(WaitTimeRing::new()),
+            wait_samples: Mutex::new(WaitTimeSamples::new()),
         })
     }
 

--- a/crates/dcc-mcp-http-server/src/executor.rs
+++ b/crates/dcc-mcp-http-server/src/executor.rs
@@ -27,7 +27,11 @@ use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
+use dcc_mcp_host::{QueueStats, WaitTimeSamples};
 use dcc_mcp_http_types::error::HttpError;
+
+/// Backward-compatible name for the shared dispatcher queue snapshot.
+pub type ExecutorQueueStats = QueueStats;
 
 /// Shared observability state for a [`DccExecutorHandle`] and its
 /// backing channel (issue #715).
@@ -51,7 +55,7 @@ pub(crate) struct ExecutorStats {
     /// to surface `oldest_submit_age`.
     pub submit_times: parking_lot::Mutex<VecDeque<Instant>>,
     /// Wait-time samples for completed jobs (bounded ring of 256).
-    pub wait_samples: parking_lot::Mutex<VecDeque<u64>>,
+    pub wait_samples: parking_lot::Mutex<WaitTimeSamples>,
 }
 
 impl ExecutorStats {
@@ -63,7 +67,7 @@ impl ExecutorStats {
             total_dequeued: AtomicU64::new(0),
             total_rejected: AtomicU64::new(0),
             submit_times: parking_lot::Mutex::new(VecDeque::new()),
-            wait_samples: parking_lot::Mutex::new(VecDeque::with_capacity(256)),
+            wait_samples: parking_lot::Mutex::new(WaitTimeSamples::new()),
         })
     }
 
@@ -76,11 +80,7 @@ impl ExecutorStats {
         let submitted_at = self.submit_times.lock().pop_front();
         if let Some(submitted) = submitted_at {
             let wait_ms = now.saturating_duration_since(submitted).as_millis() as u64;
-            let mut ring = self.wait_samples.lock();
-            if ring.len() == 256 {
-                ring.pop_front();
-            }
-            ring.push_back(wait_ms);
+            self.wait_samples.lock().observe(wait_ms);
         }
         self.total_dequeued.fetch_add(1, Ordering::Release);
     }
@@ -102,38 +102,8 @@ impl ExecutorStats {
     }
 
     pub(crate) fn percentiles(&self) -> (Option<u64>, Option<u64>, Option<u64>) {
-        let ring = self.wait_samples.lock();
-        if ring.is_empty() {
-            return (None, None, None);
-        }
-        let mut sorted: Vec<u64> = ring.iter().copied().collect();
-        drop(ring);
-        sorted.sort_unstable();
-        let pick = |q: f64| -> u64 {
-            let n = sorted.len();
-            let idx = ((q * n as f64).ceil() as usize)
-                .saturating_sub(1)
-                .min(n - 1);
-            sorted[idx]
-        };
-        (Some(pick(0.50)), Some(pick(0.95)), Some(pick(0.99)))
+        self.wait_samples.lock().percentiles()
     }
-}
-
-/// Public observability snapshot for the DCC main-thread executor
-/// queue (issue #715). Field names are the stable wire shape
-/// consumed by `diagnostics__process_status.queue.executor_*`.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct ExecutorQueueStats {
-    pub pending: usize,
-    pub capacity: usize,
-    pub total_enqueued: u64,
-    pub total_dequeued: u64,
-    pub total_rejected: u64,
-    pub oldest_wait_ms: Option<u64>,
-    pub wait_p50_ms: Option<u64>,
-    pub wait_p95_ms: Option<u64>,
-    pub wait_p99_ms: Option<u64>,
 }
 
 /// A boxed async-compatible task that runs on the DCC main thread.
@@ -199,7 +169,7 @@ impl DccExecutorHandle {
         let (p50, p95, p99) = self.stats.percentiles();
         ExecutorQueueStats {
             pending: self.stats.pending(),
-            capacity: self.stats.capacity,
+            capacity: Some(self.stats.capacity),
             total_enqueued: self.stats.total_enqueued.load(Ordering::Acquire),
             total_dequeued: self.stats.total_dequeued.load(Ordering::Acquire),
             total_rejected: self.stats.total_rejected.load(Ordering::Acquire),

--- a/crates/dcc-mcp-http-server/src/executor/tests.rs
+++ b/crates/dcc-mcp-http-server/src/executor/tests.rs
@@ -244,7 +244,7 @@ async fn execute_returns_queue_overloaded_on_saturation() {
     }
     let stats = handle.queue_stats();
     assert!(stats.total_rejected >= 1, "reject counter bumped");
-    assert_eq!(stats.capacity, 2, "capacity reported in snapshot");
+    assert_eq!(stats.capacity, Some(2), "capacity reported in snapshot");
 }
 
 /// Issue #715: the queue-stats snapshot tracks enqueued/dequeued


### PR DESCRIPTION
Closes #2185.\n\n- shares QueueStats and the bounded wait-time percentile sampler between host and HTTP queues\n- keeps ExecutorQueueStats as a compatibility alias to the canonical host snapshot\n- removes the second percentile implementation while preserving diagnostics counters\n\nValidation:\n- dcc-mcp-host: 13 tests passed\n- dcc-mcp-http-server: 67 tests passed\n- doctests, strict clippy, Cargo fmt\n\nDccExecutorHandle remains the HTTP-specific backpressure/cancellation facade over DccDispatcher; merging those types would leak HTTP policy into the portable host contract. HostRpcClient remains a cross-process transport boundary, not a duplicate in-process queue.