### PR TITLE
refactor: centralize JSON-RPC envelopes

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handlers/marketplace_ws.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/marketplace_ws.rs
@@ -33,6 +33,8 @@ use axum::{
     http::{StatusCode, header},
     response::IntoResponse,
 };
+use dcc_mcp_jsonrpc::error_codes::{INTERNAL_ERROR, INVALID_REQUEST};
+use dcc_mcp_jsonrpc::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
 use futures_util::{SinkExt, StreamExt};
 use serde_json::Value;
 use tokio::sync::{RwLock, broadcast, mpsc};
@@ -281,7 +283,7 @@ async fn serve_socket(socket: WebSocket, state: MarketplaceWsState) {
                 }
                 Message::Binary(_) => {
                     // We only accept text frames
-                    let err = serde_json::to_string(&JsonRpcError::new(
+                    let err = serde_json::to_string(&JsonRpcResponse::error_with_data(
                         None,
                         INVALID_REQUEST,
                         "Binary frames not supported".to_string(),
@@ -311,13 +313,13 @@ async fn handle_message(state: &MarketplaceWsState, text: &str) -> Option<String
         Ok(req) => req,
         Err(e) => {
             warn!("Failed to parse JSON-RPC request: {e}");
-            let err = JsonRpcError::parse_error();
+            let err = JsonRpcResponse::parse_error();
             return Some(serde_json::to_string(&err).unwrap_or_default());
         }
     };
 
     if request.jsonrpc != "2.0" {
-        let err = JsonRpcError::invalid_request();
+        let err = JsonRpcResponse::invalid_request();
         return Some(serde_json::to_string(&err).unwrap_or_default());
     }
 
@@ -349,7 +351,7 @@ async fn handle_message(state: &MarketplaceWsState, text: &str) -> Option<String
                 None
             } else {
                 Some(
-                    serde_json::to_string(&JsonRpcSuccess::new(
+                    serde_json::to_string(&JsonRpcResponse::success(
                         request.id,
                         Value::String("pong".into()),
                     ))
@@ -361,7 +363,7 @@ async fn handle_message(state: &MarketplaceWsState, text: &str) -> Option<String
             if is_notification {
                 None
             } else {
-                let err = JsonRpcError::method_not_found(request.id.clone(), &request.method);
+                let err = JsonRpcResponse::method_not_found(request.id.clone(), &request.method);
                 Some(serde_json::to_string(&err).unwrap_or_default())
             }
         }
@@ -375,7 +377,7 @@ async fn handle_hello(id: Option<Value>) -> String {
         "protocol": "dcc-mcp-marketplace.v1",
         "version": env!("CARGO_PKG_VERSION"),
     });
-    serde_json::to_string(&JsonRpcSuccess::new(id, result)).unwrap_or_default()
+    serde_json::to_string(&JsonRpcResponse::success(id, result)).unwrap_or_default()
 }
 
 async fn handle_catalog_list(state: &MarketplaceWsState, id: Option<Value>) -> String {
@@ -408,7 +410,7 @@ async fn handle_catalog_list(state: &MarketplaceWsState, id: Option<Value>) -> S
                     })
                 })
                 .collect();
-            serde_json::to_string(&JsonRpcSuccess::new(
+            serde_json::to_string(&JsonRpcResponse::success(
                 id,
                 serde_json::json!({ "entries": entries }),
             ))
@@ -416,7 +418,8 @@ async fn handle_catalog_list(state: &MarketplaceWsState, id: Option<Value>) -> S
         }
         Err(err) => {
             let (code, msg) = marketplace_error_to_rpc(&err);
-            serde_json::to_string(&JsonRpcError::new(id, code, msg, None)).unwrap_or_default()
+            serde_json::to_string(&JsonRpcResponse::error_with_data(id, code, msg, None))
+                .unwrap_or_default()
         }
     }
 }
@@ -440,7 +443,7 @@ async fn handle_installed_list(state: &MarketplaceWsState, id: Option<Value>) ->
                     })
                 })
                 .collect();
-            serde_json::to_string(&JsonRpcSuccess::new(
+            serde_json::to_string(&JsonRpcResponse::success(
                 id,
                 serde_json::json!({ "packages": packages }),
             ))
@@ -448,7 +451,8 @@ async fn handle_installed_list(state: &MarketplaceWsState, id: Option<Value>) ->
         }
         Err(err) => {
             let (code, msg) = marketplace_error_to_rpc(&err);
-            serde_json::to_string(&JsonRpcError::new(id, code, msg, None)).unwrap_or_default()
+            serde_json::to_string(&JsonRpcResponse::error_with_data(id, code, msg, None))
+                .unwrap_or_default()
         }
     }
 }
@@ -464,11 +468,11 @@ async fn handle_install(
     {
         Ok(Some(p)) => p,
         Ok(None) => {
-            return serde_json::to_string(&JsonRpcError::invalid_params(id, "params required"))
+            return serde_json::to_string(&JsonRpcResponse::invalid_params(id, "params required"))
                 .unwrap_or_default();
         }
         Err(e) => {
-            return serde_json::to_string(&JsonRpcError::invalid_params(
+            return serde_json::to_string(&JsonRpcResponse::invalid_params(
                 id,
                 &format!("invalid install params: {e}"),
             ))
@@ -600,7 +604,7 @@ async fn handle_install(
                 "path": result.path,
                 "reload_required": result.reload_required,
             });
-            serde_json::to_string(&JsonRpcSuccess::new(id, response)).unwrap_or_default()
+            serde_json::to_string(&JsonRpcResponse::success(id, response)).unwrap_or_default()
         }
         Err(err) => {
             // Emit operation.failed
@@ -619,7 +623,8 @@ async fn handle_install(
             );
 
             let (code, msg) = marketplace_error_to_rpc(&err);
-            serde_json::to_string(&JsonRpcError::new(id, code, msg, None)).unwrap_or_default()
+            serde_json::to_string(&JsonRpcResponse::error_with_data(id, code, msg, None))
+                .unwrap_or_default()
         }
     }
 }
@@ -635,11 +640,11 @@ async fn handle_uninstall(
     {
         Ok(Some(p)) => p,
         Ok(None) => {
-            return serde_json::to_string(&JsonRpcError::invalid_params(id, "params required"))
+            return serde_json::to_string(&JsonRpcResponse::invalid_params(id, "params required"))
                 .unwrap_or_default();
         }
         Err(e) => {
-            return serde_json::to_string(&JsonRpcError::invalid_params(
+            return serde_json::to_string(&JsonRpcResponse::invalid_params(
                 id,
                 &format!("invalid uninstall params: {e}"),
             ))
@@ -743,7 +748,7 @@ async fn handle_uninstall(
                 "path": result.path,
                 "reload_required": result.reload_required,
             });
-            serde_json::to_string(&JsonRpcSuccess::new(id, response)).unwrap_or_default()
+            serde_json::to_string(&JsonRpcResponse::success(id, response)).unwrap_or_default()
         }
         Err(err) => {
             let _ = state.events_tx.send(
@@ -761,7 +766,8 @@ async fn handle_uninstall(
             );
 
             let (code, msg) = marketplace_error_to_rpc(&err);
-            serde_json::to_string(&JsonRpcError::new(id, code, msg, None)).unwrap_or_default()
+            serde_json::to_string(&JsonRpcResponse::error_with_data(id, code, msg, None))
+                .unwrap_or_default()
         }
     }
 }
@@ -780,7 +786,7 @@ async fn handle_sources_list(state: &MarketplaceWsState, id: Option<Value>) -> S
                     })
                 })
                 .collect();
-            serde_json::to_string(&JsonRpcSuccess::new(
+            serde_json::to_string(&JsonRpcResponse::success(
                 id,
                 serde_json::json!({ "sources": items }),
             ))
@@ -788,7 +794,8 @@ async fn handle_sources_list(state: &MarketplaceWsState, id: Option<Value>) -> S
         }
         Err(err) => {
             let (code, msg) = marketplace_error_to_rpc(&err);
-            serde_json::to_string(&JsonRpcError::new(id, code, msg, None)).unwrap_or_default()
+            serde_json::to_string(&JsonRpcResponse::error_with_data(id, code, msg, None))
+                .unwrap_or_default()
         }
     }
 }
@@ -804,11 +811,11 @@ async fn handle_sources_add(
     {
         Ok(Some(p)) => p,
         Ok(None) => {
-            return serde_json::to_string(&JsonRpcError::invalid_params(id, "params required"))
+            return serde_json::to_string(&JsonRpcResponse::invalid_params(id, "params required"))
                 .unwrap_or_default();
         }
         Err(e) => {
-            return serde_json::to_string(&JsonRpcError::invalid_params(
+            return serde_json::to_string(&JsonRpcResponse::invalid_params(
                 id,
                 &format!("invalid params: {e}"),
             ))
@@ -829,7 +836,7 @@ async fn handle_sources_add(
                     })
                 })
                 .collect();
-            serde_json::to_string(&JsonRpcSuccess::new(
+            serde_json::to_string(&JsonRpcResponse::success(
                 id,
                 serde_json::json!({ "sources": items }),
             ))
@@ -837,7 +844,8 @@ async fn handle_sources_add(
         }
         Err(err) => {
             let (code, msg) = marketplace_error_to_rpc(&err);
-            serde_json::to_string(&JsonRpcError::new(id, code, msg, None)).unwrap_or_default()
+            serde_json::to_string(&JsonRpcResponse::error_with_data(id, code, msg, None))
+                .unwrap_or_default()
         }
     }
 }
@@ -850,7 +858,7 @@ async fn handle_sources_remove(
     // MarketplaceService doesn't have a remove_source method — reserved for future.
     // Use INTERNAL_ERROR with data.reason=not_implemented to avoid confusing
     // clients with METHOD_NOT_FOUND.
-    serde_json::to_string(&JsonRpcError::new(
+    serde_json::to_string(&JsonRpcResponse::error_with_data(
         id,
         INTERNAL_ERROR,
         "sources.remove not yet implemented".to_string(),
@@ -870,7 +878,7 @@ async fn handle_subscribe(
     {
         Ok(Some(p)) => p,
         _ => {
-            let err = JsonRpcError::invalid_params(id.clone(), "topics array required");
+            let err = JsonRpcResponse::invalid_params(id.clone(), "topics array required");
             return Some(serde_json::to_string(&err).unwrap_or_default());
         }
     };
@@ -886,8 +894,11 @@ async fn handle_subscribe(
         None
     } else {
         Some(
-            serde_json::to_string(&JsonRpcSuccess::new(id, Value::String("subscribed".into())))
-                .unwrap_or_default(),
+            serde_json::to_string(&JsonRpcResponse::success(
+                id,
+                Value::String("subscribed".into()),
+            ))
+            .unwrap_or_default(),
         )
     }
 }
@@ -1018,7 +1029,7 @@ mod tests {
             "protocol": "dcc-mcp-marketplace.v1",
             "version": env!("CARGO_PKG_VERSION"),
         });
-        let resp = JsonRpcSuccess::new(Some(Value::Number(1.into())), result);
+        let resp = JsonRpcResponse::success(Some(Value::Number(1.into())), result);
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("\"protocol\":\"dcc-mcp-marketplace.v1\""));
         assert!(json.contains("\"id\":1"));
@@ -1027,7 +1038,7 @@ mod tests {
     /// Verify handle_sources_remove uses INTERNAL_ERROR not METHOD_NOT_FOUND.
     #[test]
     fn test_sources_remove_uses_internal_error() {
-        let json = serde_json::to_string(&JsonRpcError::new(
+        let json = serde_json::to_string(&JsonRpcResponse::error_with_data(
             Some(Value::Number(1.into())),
             INTERNAL_ERROR,
             "sources.remove not yet implemented".to_string(),
@@ -1054,7 +1065,7 @@ mod tests {
     fn test_subscribe_invalid_params_returns_error_directly() {
         // Simulate what handle_subscribe would return for invalid params
         let err =
-            JsonRpcError::invalid_params(Some(Value::Number(1.into())), "topics array required");
+            JsonRpcResponse::invalid_params(Some(Value::Number(1.into())), "topics array required");
         let json = serde_json::to_string(&err).unwrap();
         assert!(json.contains("\"code\":-32602"));
         assert!(json.contains("topics array required"));
@@ -1117,7 +1128,7 @@ mod tests {
     /// Verify subscribe response (not notification) returns "subscribed".
     #[test]
     fn test_subscribe_success_response() {
-        let resp = JsonRpcSuccess::new(
+        let resp = JsonRpcResponse::success(
             Some(Value::Number(1.into())),
             Value::String("subscribed".into()),
         );

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/marketplace_ws_protocol.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/marketplace_ws_protocol.rs
@@ -5,67 +5,19 @@
 
 #![allow(dead_code)]
 
+use dcc_mcp_jsonrpc::error_codes::INTERNAL_ERROR;
 use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+use dcc_mcp_jsonrpc::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
+#[cfg(test)]
 use serde_json::Value;
-
-// ── JSON-RPC 2.0 envelopes ────────────────────────────────────────────────
-
-/// JSON-RPC 2.0 request.
-#[derive(Debug, Clone, Deserialize)]
-pub struct JsonRpcRequest {
-    pub jsonrpc: String,
-    #[serde(default)]
-    pub id: Option<Value>,
-    pub method: String,
-    #[serde(default)]
-    pub params: Option<Value>,
-}
-
-/// JSON-RPC 2.0 success response.
-#[derive(Debug, Clone, Serialize)]
-pub struct JsonRpcSuccess {
-    pub jsonrpc: &'static str,
-    pub id: Option<Value>,
-    pub result: Value,
-}
-
-/// JSON-RPC 2.0 error response.
-#[derive(Debug, Clone, Serialize)]
-pub struct JsonRpcError {
-    pub jsonrpc: &'static str,
-    pub id: Option<Value>,
-    pub error: JsonRpcErrorBody,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct JsonRpcErrorBody {
-    pub code: i32,
-    pub message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<Value>,
-}
-
-/// JSON-RPC 2.0 notification (no id field).
-#[derive(Debug, Clone, Serialize)]
-pub struct JsonRpcNotification {
-    pub jsonrpc: &'static str,
-    pub method: String,
-    pub params: Value,
-}
-
-// ── Standard JSON-RPC 2.0 error codes ─────────────────────────────────────
-
-pub const PARSE_ERROR: i32 = -32700;
-pub const INVALID_REQUEST: i32 = -32600;
-pub const METHOD_NOT_FOUND: i32 = -32601;
-pub const INVALID_PARAMS: i32 = -32602;
-pub const INTERNAL_ERROR: i32 = -32603;
 
 // ── Application error codes ───────────────────────────────────────────────
 
 /// Domain error codes for marketplace operations (PIP-1096 M2).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(i32)]
+#[repr(i64)]
 pub enum MarketplaceErrorCode {
     PackageNotFound = -32000,
     DccMismatch = -32001,
@@ -87,14 +39,14 @@ impl MarketplaceErrorCode {
         }
     }
 
-    pub fn code(self) -> i32 {
-        self as i32
+    pub fn code(self) -> i64 {
+        self as i64
     }
 }
 
 /// Map a `dcc_mcp_marketplace::MarketplaceError` to the appropriate JSON-RPC
 /// application error code.
-pub fn marketplace_error_to_rpc(err: &dcc_mcp_marketplace::MarketplaceError) -> (i32, String) {
+pub fn marketplace_error_to_rpc(err: &dcc_mcp_marketplace::MarketplaceError) -> (i64, String) {
     use dcc_mcp_marketplace::MarketplaceError;
     let code = match err {
         MarketplaceError::NotFound(_) => MarketplaceErrorCode::PackageNotFound,
@@ -184,77 +136,6 @@ pub struct RemoveSourceParams {
     pub name: String,
 }
 
-// ── Builder helpers ───────────────────────────────────────────────────────
-
-impl JsonRpcSuccess {
-    pub fn new(id: Option<Value>, result: Value) -> Self {
-        Self {
-            jsonrpc: "2.0",
-            id,
-            result,
-        }
-    }
-}
-
-impl JsonRpcError {
-    pub fn new(id: Option<Value>, code: i32, message: String, data: Option<Value>) -> Self {
-        Self {
-            jsonrpc: "2.0",
-            id,
-            error: JsonRpcErrorBody {
-                code,
-                message,
-                data,
-            },
-        }
-    }
-
-    pub fn method_not_found(id: Option<Value>, method: &str) -> Self {
-        Self::new(
-            id,
-            METHOD_NOT_FOUND,
-            format!("Method not found: {method}"),
-            None,
-        )
-    }
-
-    pub fn invalid_params(id: Option<Value>, detail: &str) -> Self {
-        Self::new(
-            id,
-            INVALID_PARAMS,
-            format!("Invalid params: {detail}"),
-            None,
-        )
-    }
-
-    pub fn internal(id: Option<Value>, detail: &str) -> Self {
-        Self::new(
-            id,
-            INTERNAL_ERROR,
-            format!("Internal error: {detail}"),
-            None,
-        )
-    }
-
-    pub fn parse_error() -> Self {
-        Self::new(None, PARSE_ERROR, "Parse error".to_string(), None)
-    }
-
-    pub fn invalid_request() -> Self {
-        Self::new(None, INVALID_REQUEST, "Invalid Request".to_string(), None)
-    }
-}
-
-impl JsonRpcNotification {
-    pub fn new(method: &str, params: Value) -> Self {
-        Self {
-            jsonrpc: "2.0",
-            method: method.to_string(),
-            params,
-        }
-    }
-}
-
 // ── Unit tests ────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -280,7 +161,10 @@ mod tests {
 
     #[test]
     fn serialize_success_response() {
-        let resp = JsonRpcSuccess::new(Some(Value::Number(1.into())), Value::String("ok".into()));
+        let resp = JsonRpcResponse::success(
+            Some(serde_json::Value::Number(1.into())),
+            serde_json::Value::String("ok".into()),
+        );
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains(r#""jsonrpc":"2.0""#));
         assert!(json.contains(r#""id":1"#));
@@ -289,7 +173,10 @@ mod tests {
 
     #[test]
     fn serialize_error_response() {
-        let resp = JsonRpcError::method_not_found(Some(Value::Number(1.into())), "bad.method");
+        let resp = JsonRpcResponse::method_not_found(
+            Some(serde_json::Value::Number(1.into())),
+            "bad.method",
+        );
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains(r#""code":-32601"#));
         assert!(json.contains("Method not found"));
@@ -346,7 +233,8 @@ mod tests {
 
     #[test]
     fn serialize_notification() {
-        let notif = JsonRpcNotification::new("marketplace.installed.changed", Value::Null);
+        let notif =
+            JsonRpcNotification::new("marketplace.installed.changed", serde_json::Value::Null);
         let json = serde_json::to_string(&notif).unwrap();
         assert!(json.contains(r#""method":"marketplace.installed.changed""#));
         // Notification must not have an id field.

--- a/crates/dcc-mcp-jsonrpc/Cargo.toml
+++ b/crates/dcc-mcp-jsonrpc/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "JSON-RPC 2.0 + MCP 2025-03-26 Streamable HTTP wire types (no transport, no axum)"
+description = "Transport-neutral JSON-RPC 2.0 envelopes and MCP wire types (no transport, no axum)"
 
 [dependencies]
 dcc-mcp-wire = { workspace = true }

--- a/crates/dcc-mcp-jsonrpc/src/jsonrpc.rs
+++ b/crates/dcc-mcp-jsonrpc/src/jsonrpc.rs
@@ -140,7 +140,37 @@ impl JsonRpcResponse {
         )
     }
 
+    /// Build the standard JSON-RPC parse-error response.
+    pub fn parse_error() -> Self {
+        Self::error(None, error_codes::PARSE_ERROR, "Parse error")
+    }
+
+    /// Build the standard JSON-RPC invalid-request response.
+    pub fn invalid_request() -> Self {
+        Self::error(None, error_codes::INVALID_REQUEST, "Invalid Request")
+    }
+
+    /// Build an invalid-params response with a human-readable detail.
+    pub fn invalid_params(id: Option<Value>, detail: &str) -> Self {
+        Self::error(
+            id,
+            error_codes::INVALID_PARAMS,
+            format!("Invalid params: {detail}"),
+        )
+    }
+
     pub fn internal_error(id: Option<Value>, msg: impl Into<String>) -> Self {
         Self::error(id, error_codes::INTERNAL_ERROR, msg)
+    }
+}
+
+impl JsonRpcNotification {
+    /// Build a notification with an explicit params payload.
+    pub fn new(method: impl Into<String>, params: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            method: method.into(),
+            params: Some(params),
+        }
     }
 }

--- a/crates/dcc-mcp-jsonrpc/src/lib.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lib.rs
@@ -1,10 +1,11 @@
-//! MCP JSON-RPC 2.0 protocol types (2025-03-26 Streamable HTTP spec).
+//! Transport-neutral JSON-RPC 2.0 envelopes and MCP protocol types.
 //!
 //! Reference: <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports>
 //!
-//! Extracted from `dcc-mcp-http` so that downstream crates (clients,
-//! CLIs, alternative transports) can depend on the wire types without
-//! pulling in axum/tokio/reqwest.
+//! Generic envelopes and standard error codes are shared by MCP and other
+//! JSON-RPC application protocols. MCP-specific payloads follow the 2025-03-26
+//! Streamable HTTP spec. Downstream crates can depend on both without pulling
+//! in axum/tokio/reqwest.
 //!
 //! ## Maintainer layout
 //!

--- a/crates/dcc-mcp-jsonrpc/tests/envelopes.rs
+++ b/crates/dcc-mcp-jsonrpc/tests/envelopes.rs
@@ -1,0 +1,71 @@
+use dcc_mcp_jsonrpc::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, error_codes};
+use serde_json::{Value, json};
+
+#[test]
+fn request_without_id_deserializes_as_notification() {
+    let request: JsonRpcRequest = serde_json::from_value(json!({
+        "jsonrpc": "2.0",
+        "method": "marketplace.installed.changed"
+    }))
+    .expect("notification-shaped request should deserialize");
+
+    assert_eq!(request.jsonrpc, "2.0");
+    assert_eq!(request.id, None);
+    assert_eq!(request.params, None);
+}
+
+#[test]
+fn response_builders_preserve_json_rpc_wire_shape() {
+    let success = serde_json::to_value(JsonRpcResponse::success(
+        Some(json!(7)),
+        json!({"status": "ok"}),
+    ))
+    .expect("success response should serialize");
+    assert_eq!(
+        success,
+        json!({"jsonrpc": "2.0", "id": 7, "result": {"status": "ok"}})
+    );
+
+    let error = serde_json::to_value(JsonRpcResponse::error_with_data(
+        Some(json!(7)),
+        error_codes::INVALID_PARAMS,
+        "Invalid params: topics array required",
+        Some(json!({"field": "topics"})),
+    ))
+    .expect("error response should serialize");
+    assert_eq!(
+        error,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "error": {
+                "code": -32602,
+                "message": "Invalid params: topics array required",
+                "data": {"field": "topics"}
+            }
+        })
+    );
+}
+
+#[test]
+fn standard_error_and_notification_builders_are_transport_neutral() {
+    let parse_error =
+        serde_json::to_value(JsonRpcResponse::parse_error()).expect("parse error should serialize");
+    assert_eq!(parse_error["error"]["code"], error_codes::PARSE_ERROR);
+    assert_eq!(parse_error["id"], Value::Null);
+
+    let notification = serde_json::to_value(JsonRpcNotification::new(
+        "marketplace.operation.completed",
+        json!({"operation_id": "op-1"}),
+    ))
+    .expect("notification should serialize");
+    assert_eq!(
+        notification,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "marketplace.operation.completed",
+            "params": {"operation_id": "op-1"}
+        })
+    );
+    assert!(notification.get("id").is_none());
+}

--- a/docs/adr/027-protocol-type-ownership.md
+++ b/docs/adr/027-protocol-type-ownership.md
@@ -1,0 +1,73 @@
+# ADR 027: Assign One Owner to Every Cross-Crate Protocol Type
+
+## Status
+
+Accepted
+
+## Context
+
+The workspace has accumulated structurally similar request, response, error,
+configuration, and search types in multiple crates. Identical names do not
+guarantee identical semantics, while identical wire shapes implemented twice
+can drift without a compiler error. The marketplace WebSocket bridge, for
+example, declared a second set of JSON-RPC envelopes even though the gateway
+already depends on `dcc-mcp-jsonrpc`.
+
+A single catch-all protocol crate would reverse the workspace's dependency
+boundaries and recreate the former `utils` problem. Ownership therefore needs
+to follow semantic responsibility rather than type-name similarity.
+
+## Decision
+
+Every cross-crate type has one canonical definition. Other crates consume that
+type directly, re-export it for compatibility, or define an explicit adapter
+with `From`/`TryFrom`; they do not repeat its fields.
+
+| Concern | Canonical owner |
+| --- | --- |
+| DCC domain models and domain failures | `dcc-mcp-models` |
+| MCP tool, resource, prompt, and adapter models | `dcc-mcp-protocols` |
+| Generic JSON-RPC envelopes, standard codes, and builders | `dcc-mcp-jsonrpc` |
+| MCP/REST call-envelope normalization | `dcc-mcp-wire` |
+| Transport-neutral HTTP configuration DTOs | `dcc-mcp-http-types` |
+| IPC/network transport mechanics and their failures | `dcc-mcp-transport` |
+| Tunnel registration and relay wire contract | `dcc-mcp-tunnel-protocol` |
+| Pure gateway capability/search domain | `dcc-mcp-gateway-core` |
+| Leaf gateway scoring implementation | `dcc-mcp-gateway-search` |
+| Product-catalog search results | `dcc-mcp-catalog` |
+
+Same-named types may remain distinct only when their invariants differ. The
+distinction must be documented at the definition and conversion must be
+explicit. Application crates such as `dcc-mcp-gateway` own orchestration and
+state, not copies of generic protocol envelopes.
+
+As the first migration, the marketplace WebSocket bridge now serializes and
+deserializes `dcc-mcp-jsonrpc` envelopes directly. Marketplace method names,
+parameters, operation phases, and application error codes remain gateway-owned
+because they are specific to that application protocol.
+
+Crate consolidation is not required by this decision. A future merge of
+`wire`, `jsonrpc`, or `protocols` needs separate dependency and compatibility
+evidence; removing duplicate definitions is sufficient.
+
+## Consequences
+
+- Wire-shape fixes and JSON-RPC helpers have one implementation and one test
+  surface.
+- Type migrations can proceed one family at a time without a flag-day rewrite.
+- Compatibility re-exports are allowed, but new field-for-field wrappers are
+  rejected during review.
+- Similar names such as gateway capability hits and catalog product hits are
+  not merged unless their invariants and consumers are actually the same.
+- Application-specific error codes stay next to the application while their
+  outer JSON-RPC envelope stays generic.
+
+## Alternatives Considered
+
+- **Merge every protocol-related crate immediately:** rejected because the
+  crates have different dependency ceilings and compatibility surfaces.
+- **Choose ownership by the shortest dependency path:** rejected because that
+  moves semantics into incidental consumers.
+- **Keep duplicate DTOs and compare JSON in tests:** rejected because tests do
+  not provide compile-time identity and both implementations can drift in the
+  same direction.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ Decision / Consequences / Alternatives considered.
 | 024 | [Immutable Marketplace Install Sources](./024-immutable-marketplace-install-sources.md) | Accepted |
 | 025 | [Pinned Pip Adapter Artifacts](./025-pinned-pip-adapter-artifacts.md) | Accepted |
 | 026 | [Verify Official Release Metadata with Sigstore](./026-sigstore-release-metadata.md) | Accepted |
+| 027 | [Assign One Owner to Every Cross-Crate Protocol Type](./027-protocol-type-ownership.md) | Accepted |
 
 > Numbering is strictly sequential and never reused. ADR 001 is reserved for
 > the first historical record; filling it in is tracked separately from any

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -1157,6 +1157,12 @@ When you reach for a "tiny shared helper" ask in this order:
    new utility module just to share three lines of code, and never
    resurrect a `utils` / `common` crate.
 
+For cross-crate protocol types, follow
+[ADR-027](../adr/027-protocol-type-ownership.md): use the canonical owner
+directly or add an explicit conversion when invariants differ. Application
+crates must not repeat generic JSON-RPC envelopes, MCP models, wire
+normalizers, or transport errors field-for-field.
+
 ### Compile-time invariants
 
 - `cargo tree -p dcc-mcp-models --no-default-features` MUST NOT list

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -63,7 +63,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-actions       # ToolRegistry, EventBus, ToolDispatcher, validation
 ├── dcc-mcp-skills        # SkillScanner, SkillCatalog, SkillWatcher, resolver
 ├── dcc-mcp-protocols     # MCP-facing Tool/Resource/Prompt/DccAdapter models
-├── dcc-mcp-jsonrpc       # MCP 2025-03-26 JSON-RPC builders
+├── dcc-mcp-jsonrpc       # Canonical JSON-RPC envelopes + MCP builders
 ├── dcc-mcp-wire          # Canonical MCP/REST call envelopes, validation, normalization
 ├── dcc-mcp-job           # Async job tracking + optional persistence
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API

--- a/llms.txt
+++ b/llms.txt
@@ -252,7 +252,7 @@ Rust workspace with package membership defined by the root `Cargo.toml`, using P
 
 The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New code should import the extracted crates directly:
 
-- **`dcc-mcp-jsonrpc`** — MCP 2025-03-26 JSON-RPC builders. Zero axum/tokio dependency, so standalone clients/CLIs can use it.
+- **`dcc-mcp-jsonrpc`** — canonical transport-neutral JSON-RPC envelopes, standard error codes, and MCP builders. Zero axum/tokio dependency, so gateway applications and standalone clients/CLIs share one wire shape.
 - **`dcc-mcp-wire`** — canonical MCP/REST call envelopes, validation, and argument/meta normalization shared by JSON-RPC, gateway, REST, and Python host wrappers.
 - **`dcc-mcp-job`** — async job tracker + pluggable persistence. Owns the optional `job-persist-sqlite` feature; `dcc-mcp-http` forwards the flag.
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
@@ -271,7 +271,7 @@ crates/
 ├── dcc-mcp-actions/        # ToolRegistry, ToolDispatcher, EventBus, validation
 ├── dcc-mcp-skills/         # SkillScanner, SkillCatalog, SkillWatcher, resolver
 ├── dcc-mcp-protocols/      # MCP Tool/Resource/Prompt/DccAdapter models
-├── dcc-mcp-jsonrpc/        # JSON-RPC builders
+├── dcc-mcp-jsonrpc/        # Canonical JSON-RPC envelopes + MCP builders
 ├── dcc-mcp-wire/           # Canonical MCP/REST call envelopes + normalization
 ├── dcc-mcp-job/            # Async job tracker + optional persistence
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API

--- a/skills/dcc-mcp-creator/references/CORE_ESCALATION_CHECKLIST.md
+++ b/skills/dcc-mcp-creator/references/CORE_ESCALATION_CHECKLIST.md
@@ -20,6 +20,12 @@ Open a core issue when the adapter needs:
 - common artefact/file handoff and retention behavior;
 - policy, audit, telemetry, or debug bundle fields.
 
+Before adding a protocol DTO, check
+[`ADR-027`](../../../docs/adr/027-protocol-type-ownership.md). Adapters and
+gateway applications consume the canonical core type directly, re-export it
+for compatibility, or use an explicit conversion when their invariants differ;
+they do not copy generic JSON-RPC, MCP, wire, or transport fields locally.
+
 ## Keep Local to the Adapter
 
 Keep code adapter-local when it is only:


### PR DESCRIPTION
## Summary
- make `dcc-mcp-jsonrpc` the canonical JSON-RPC envelope owner
- migrate the marketplace WebSocket bridge to the shared types
- record cross-crate protocol ownership in ADR-027

## Validation
- `vx just preflight`
- `vx cargo test -p dcc-mcp-gateway --features admin marketplace_ws`
- `vx cargo clippy -p dcc-mcp-gateway --all-targets --all-features -- -A clippy::items-after-test-module -D warnings`
- VitePress production build

Part of #2196.