### PR TITLE
refactor: distinguish gateway settings

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -5,8 +5,9 @@ use dcc_mcp_gateway_core::policy::GatewayPolicy;
 
 pub use super::relay_registration::RelaySourceConfig;
 
-// Keep aligned with dcc_mcp_http_types::config::GatewayConfig. Render and
-// simulation tools routinely exceed the former 10-second gateway default.
+// Keep the shared timeout default aligned with
+// dcc_mcp_http_types::config::GatewaySettings. Render and simulation tools
+// routinely exceed the former 10-second gateway default.
 const DEFAULT_BACKEND_TIMEOUT_MS: u64 = 120_000;
 
 fn official_update_manifest_url() -> Option<String> {

--- a/crates/dcc-mcp-http-py/src/config.rs
+++ b/crates/dcc-mcp-http-py/src/config.rs
@@ -349,7 +349,7 @@ impl PyMcpHttpConfig {
         self.inner.features.standalone_main_thread_execution = v;
     }
 
-    // ── GatewayConfig getters/setters ───────────────────────────────
+    // ── GatewaySettings getters/setters ─────────────────────────────
 
     /// Gateway port to compete for. ``0`` disables the gateway.
     #[getter]

--- a/crates/dcc-mcp-http-py/src/config/tests.rs
+++ b/crates/dcc-mcp-http-py/src/config/tests.rs
@@ -59,7 +59,7 @@ fn all_mcp_http_config_fields_have_py_getters() {
     let _ = cfg.enable_prompts();
     let _ = cfg.standalone_main_thread_execution();
 
-    // ── GatewayConfig ────────────────────────────────────────────
+    // ── GatewaySettings ──────────────────────────────────────────
     let _ = cfg.gateway_port();
     let _ = cfg.gateway_remote_host();
     let _ = cfg.gateway_remote_port();

--- a/crates/dcc-mcp-http-types/src/config.rs
+++ b/crates/dcc-mcp-http-types/src/config.rs
@@ -24,7 +24,9 @@ mod workflow;
 
 pub use aggregate::McpHttpConfig;
 pub use feature_flags::FeatureFlags;
-pub use gateway::{GatewayConfig, RelaySourceConfig};
+#[allow(deprecated)]
+pub use gateway::GatewayConfig;
+pub use gateway::{GatewaySettings, RelaySourceConfig};
 pub use instance::InstanceConfig;
 pub use job::{JobConfig, JobRecoveryPolicy};
 pub use queue::QueueConfig;

--- a/crates/dcc-mcp-http-types/src/config/aggregate.rs
+++ b/crates/dcc-mcp-http-types/src/config/aggregate.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use dcc_mcp_gateway_core::policy::GatewayPolicy;
 
 use super::{
-    FeatureFlags, GatewayConfig, InstanceConfig, JobConfig, JobRecoveryPolicy, QueueConfig,
+    FeatureFlags, GatewaySettings, InstanceConfig, JobConfig, JobRecoveryPolicy, QueueConfig,
     RelaySourceConfig, ServerConfig, ServerSpawnMode, SessionConfig, TelemetryConfig,
     WorkflowConfig,
 };
@@ -26,7 +26,7 @@ use super::{
 /// | `server` | [`ServerConfig`] | Core server identity & transport |
 /// | `instance` | [`InstanceConfig`] | DCC registration metadata |
 /// | `session` | [`SessionConfig`] | Session lifecycle & tool-cache |
-/// | `gateway` | [`GatewayConfig`] | Gateway election, routing, discovery |
+/// | `gateway` | [`GatewaySettings`] | Gateway election, routing, discovery |
 /// | `queue` | [`QueueConfig`] | Queue depth & backpressure |
 /// | `telemetry` | [`TelemetryConfig`] | Prometheus metrics |
 /// | `features` | [`FeatureFlags`] | Opt-in capability switches |
@@ -50,7 +50,7 @@ pub struct McpHttpConfig {
     pub session: SessionConfig,
 
     /// Gateway election, routing, and discovery.
-    pub gateway: GatewayConfig,
+    pub gateway: GatewaySettings,
 
     /// Queue depth & backpressure.
     pub queue: QueueConfig,

--- a/crates/dcc-mcp-http-types/src/config/gateway.rs
+++ b/crates/dcc-mcp-http-types/src/config/gateway.rs
@@ -16,10 +16,17 @@ pub struct RelaySourceConfig {
     pub poll_interval_secs: Option<u64>,
 }
 
-/// Gateway election, routing, and discovery configuration.
+/// Serializable gateway settings embedded in [`McpHttpConfig`].
+///
+/// These operator-facing settings are projected into the complete runtime
+/// `dcc_mcp_gateway::GatewayConfig` by the HTTP server boundary. Runtime-only
+/// middleware, authentication, persistence, and lifecycle state do not belong
+/// in this transport-neutral value type.
+///
+/// [`McpHttpConfig`]: super::McpHttpConfig
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
-pub struct GatewayConfig {
+pub struct GatewaySettings {
     /// Gateway port to compete for. First process to bind wins the gateway
     /// and starts serving `/instances`, `/mcp`, `/mcp/{id}`, `/mcp/dcc/{type}`.
     /// `0` disables the gateway entirely. Default: 0 (disabled).
@@ -131,7 +138,7 @@ pub struct GatewayConfig {
     pub admin_path: String,
 }
 
-impl Default for GatewayConfig {
+impl Default for GatewaySettings {
     fn default() -> Self {
         Self {
             gateway_port: 0,
@@ -157,3 +164,14 @@ impl Default for GatewayConfig {
         }
     }
 }
+
+/// Compatibility name for HTTP server gateway settings.
+///
+/// The complete runtime configuration with this historical name is owned by
+/// `dcc-mcp-gateway`. New HTTP configuration code should use
+/// [`GatewaySettings`].
+#[deprecated(
+    since = "0.20.9",
+    note = "use GatewaySettings; dcc_mcp_gateway::GatewayConfig is the runtime type"
+)]
+pub type GatewayConfig = GatewaySettings;

--- a/crates/dcc-mcp-http-types/src/config/session.rs
+++ b/crates/dcc-mcp-http-types/src/config/session.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-// ── SessionConfig / GatewayConfig ─────────────────────────────────────────
+// ── SessionConfig ──────────────────────────────────────────────────────────
 
 /// Session lifecycle & tool-cache configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/dcc-mcp-http-types/src/lib.rs
+++ b/crates/dcc-mcp-http-types/src/lib.rs
@@ -25,7 +25,7 @@
 //! |-------------|-----------------------------------------------------------|
 //! | crate root  | [`TruncationEnvelope`], [`SseChunkFrame`] + chunk helpers |
 //! | [`error`]   | [`HttpError`] / [`HttpResult`] error taxonomy             |
-//! | [`config`]  | [`McpHttpConfig`], [`ServerConfig`], [`SessionConfig`], [`GatewayConfig`], [`ServerSpawnMode`], [`JobRecoveryPolicy`], [`JobConfig`], [`WorkflowConfig`], [`TelemetryConfig`], [`FeatureFlags`], [`InstanceConfig`], [`QueueConfig`] |
+//! | [`config`]  | [`McpHttpConfig`], [`ServerConfig`], [`SessionConfig`], [`GatewaySettings`], [`ServerSpawnMode`], [`JobRecoveryPolicy`], [`JobConfig`], [`WorkflowConfig`], [`TelemetryConfig`], [`FeatureFlags`], [`InstanceConfig`], [`QueueConfig`] |
 //! | [`dynamic_tools`] | [`dynamic_tools::ToolSpec`] dynamic-tool registration wire type |
 //! | [`debug_session`] | [`debug_session::DebugSessionDescriptor`] optional debugger attach metadata |
 //! | [`output`]  | [`output::OutputStream`] and [`output::OutputEntry`] output capture wire types |
@@ -47,7 +47,7 @@
 //! | [`error::HttpError`]        |                                  |
 //! | [`config::ServerConfig`]    |                                  |
 //! | [`config::SessionConfig`]   |                                  |
-//! | [`config::GatewayConfig`]   |                                  |
+//! | [`config::GatewaySettings`] |                                  |
 //! | [`config::ServerSpawnMode`] |                                  |
 //! | [`config::JobRecoveryPolicy`]|                                 |
 //! | [`config::JobConfig`]       |                                  |

--- a/crates/dcc-mcp-http-types/tests/gateway_settings.rs
+++ b/crates/dcc-mcp-http-types/tests/gateway_settings.rs
@@ -1,0 +1,27 @@
+use dcc_mcp_http_types::config::GatewaySettings;
+
+fn accepts_settings(_: GatewaySettings) {}
+
+#[test]
+#[allow(deprecated)]
+fn historical_gateway_config_aliases_gateway_settings() {
+    let legacy = dcc_mcp_http_types::config::GatewayConfig::default();
+    accepts_settings(legacy);
+}
+
+#[test]
+fn settings_preserve_the_serialized_http_contract() {
+    let settings = GatewaySettings {
+        gateway_port: 9765,
+        remote_host: Some("127.0.0.1".into()),
+        ..GatewaySettings::default()
+    };
+
+    let value = serde_json::to_value(&settings).unwrap();
+    let decoded: GatewaySettings = serde_json::from_value(value.clone()).unwrap();
+
+    assert_eq!(value["gateway_port"], 9765);
+    assert_eq!(value["remote_host"], "127.0.0.1");
+    assert_eq!(decoded.gateway_port, settings.gateway_port);
+    assert_eq!(decoded.remote_host, settings.remote_host);
+}

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -5,7 +5,9 @@
 //! round-trip HTTP configuration without depending on axum / tokio / reqwest /
 //! pyo3. This module preserves the historical `dcc_mcp_http::config::*` path.
 
+#[allow(deprecated)]
+pub use dcc_mcp_http_types::config::GatewayConfig;
 pub use dcc_mcp_http_types::config::{
-    FeatureFlags, GatewayConfig, InstanceConfig, JobConfig, JobRecoveryPolicy, McpHttpConfig,
+    FeatureFlags, GatewaySettings, InstanceConfig, JobConfig, JobRecoveryPolicy, McpHttpConfig,
     QueueConfig, ServerConfig, ServerSpawnMode, SessionConfig, TelemetryConfig, WorkflowConfig,
 };

--- a/docs/adr/027-protocol-type-ownership.md
+++ b/docs/adr/027-protocol-type-ownership.md
@@ -68,6 +68,14 @@ re-export the shared implementation and retain their former `TransportError`
 names as deprecated aliases. The broader `dcc_mcp_transport::TransportError`
 continues to own IPC sessions, pools, reconnects, and registry failures.
 
+`dcc_mcp_gateway::GatewayConfig` owns the complete gateway runtime
+configuration, including middleware, authentication, persistence, and
+lifecycle controls. The transport-neutral settings nested under
+`McpHttpConfig.gateway` are named
+`dcc_mcp_http_types::config::GatewaySettings` and are explicitly projected
+into the runtime type by `dcc-mcp-http`. The HTTP type's former
+`GatewayConfig` name is a deprecated compatibility alias.
+
 Crate consolidation is not required by this decision. A future merge of
 `wire`, `jsonrpc`, or `protocols` needs separate dependency and compatibility
 evidence; removing duplicate definitions is sufficient.

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -72,7 +72,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
-├── dcc-mcp-http-types    # Pure HTTP wire/config/value types, McpHttpConfig
+├── dcc-mcp-http-types    # Pure HTTP wire/config/value types, McpHttpConfig + GatewaySettings
 ├── dcc-mcp-http-server   # Reusable HTTP runtime support
 ├── dcc-mcp-http-py       # PyO3 binding boundary for HTTP APIs
 ├── dcc-mcp-http          # Embedded MCP HTTP facade + compatibility re-exports

--- a/llms.txt
+++ b/llms.txt
@@ -1129,6 +1129,7 @@ Full guide: `docs/guide/remote-server.md`. Per-module API: `docs/api/{auth,batch
 | Add audit/quota/redact to gateway calls | `GatewayConfig::middleware_chain` with built-in middleware |
 | Gateway admin dashboard | Default ON for the elected gateway: `GET /admin`; disable with `--no-admin`, `DCC_MCP_NO_ADMIN=true`, or `cfg.admin_enabled = False`; agent panel map: `docs/guide/admin-ui.md#agent-facing-panel-map` |
 | Enforce payload size + SSE chunking | `McpHttpConfig.queue.max_request_body_bytes` (default 4 MiB) |
+| Configure the embedded HTTP gateway | `McpHttpConfig.gateway: dcc_mcp_http_types::config::GatewaySettings`; `dcc-mcp-http` projects these serializable settings into the complete runtime `dcc_mcp_gateway::GatewayConfig` |
 | Wire OTLP distributed tracing | Set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` at startup |
 | Watch gateway contention events | MCP resource `resources://gateway/events` (JSONL ring buffer) |
 


### PR DESCRIPTION
## Summary
- rename the transport-neutral HTTP projection to \GatewaySettings\
- reserve \dcc_mcp_gateway::GatewayConfig\ for complete runtime configuration
- preserve the former HTTP type name as a deprecated compatibility alias

## Validation
- \x just preflight\ (3559 tests)
- focused HTTP types, HTTP facade, and Python binding tests
- strict Clippy for the owning HTTP types crate
- VitePress production build
- serialized HTTP contract and compatibility alias regression tests
- ADR updated; existing creator guidance already covers type ownership

Part of #2196.