### PR TITLE
refactor: distinguish catalog search hits

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -1,7 +1,8 @@
 //! Public DCC-MCP catalog for ecosystem discovery.
 //!
-//! Provides [`CatalogEntry`] (a typed YAML/JSON record), and two discovery
-//! functions — [`search`] and [`describe`] — that can be wired up as
+//! Provides [`CatalogEntry`] (a typed YAML/JSON record), lightweight
+//! [`CatalogSearchHit`] results, and two discovery functions — [`search`] and
+//! [`describe`] — that can be wired up as
 //! gateway MCP tools (`dcc_catalog__search` / `dcc_catalog__describe`).
 //!
 //! # YAML format (`dcc-mcp-catalog.yml`)
@@ -281,12 +282,19 @@ pub fn load_from_str(text: &str) -> Result<Vec<CatalogEntry>, CatalogError> {
 /// Storing indices instead of full [`CatalogEntry`] clones avoids allocating
 /// hundreds of entries before the caller trims to a paginated page.
 #[derive(Debug, Clone, Copy)]
-pub struct SearchHit {
+pub struct CatalogSearchHit {
     /// Index into the source `&[CatalogEntry]` slice.
     pub index: usize,
     /// Match quality score (higher = better match).
     pub score: u32,
 }
+
+/// Deprecated name for [`CatalogSearchHit`].
+///
+/// This catalog-local index reference is intentionally distinct from the
+/// record-bearing `dcc_mcp_gateway_search::SearchHit` ranking result.
+#[deprecated(since = "0.20.9", note = "use CatalogSearchHit")]
+pub type SearchHit = CatalogSearchHit;
 
 #[derive(Clone, Copy)]
 struct CatalogSearchRecord<'a> {
@@ -387,12 +395,12 @@ fn catalog_search_tokens(entry: &CatalogEntry) -> Vec<String> {
 ///
 /// Non-empty results are already ordered by descending relevance. Callers can
 /// paginate the lightweight hits before cloning entries via [`materialise_page`].
-pub fn search_hits(entries: &[CatalogEntry], query: &str) -> Vec<SearchHit> {
+pub fn search_hits(entries: &[CatalogEntry], query: &str) -> Vec<CatalogSearchHit> {
     if query.trim().is_empty() {
         return entries
             .iter()
             .enumerate()
-            .map(|(i, _)| SearchHit { index: i, score: 1 })
+            .map(|(i, _)| CatalogSearchHit { index: i, score: 1 })
             .collect();
     }
 
@@ -417,19 +425,19 @@ pub fn search_hits(entries: &[CatalogEntry], query: &str) -> Vec<SearchHit> {
 
     ranked
         .into_iter()
-        .map(|hit| SearchHit {
+        .map(|hit| CatalogSearchHit {
             index: hit.record.index,
             score: hit.score,
         })
         .collect()
 }
 
-/// Clone entries for a sorted page of [`SearchHit`]s.
+/// Clone entries for a sorted page of [`CatalogSearchHit`]s.
 ///
 /// `hits` is typically the result of [`search_hits`] after sorting and
 /// slicing to `offset..offset+limit`. Only the entries referenced by the
 /// final window are cloned.
-pub fn materialise_page(entries: &[CatalogEntry], hits: &[SearchHit]) -> Vec<CatalogEntry> {
+pub fn materialise_page(entries: &[CatalogEntry], hits: &[CatalogSearchHit]) -> Vec<CatalogEntry> {
     hits.iter().map(|h| entries[h.index].clone()).collect()
 }
 

--- a/crates/dcc-mcp-catalog/tests/catalog_search_hit.rs
+++ b/crates/dcc-mcp-catalog/tests/catalog_search_hit.rs
@@ -1,0 +1,36 @@
+use dcc_mcp_catalog::{CatalogSearchHit, load_from_str, materialise_page};
+
+#[allow(deprecated)]
+use dcc_mcp_catalog::SearchHit;
+
+fn assert_canonical_hit(_: CatalogSearchHit) {}
+
+#[test]
+#[allow(deprecated)]
+fn legacy_search_hit_is_the_canonical_catalog_type() {
+    let legacy = SearchHit { index: 0, score: 7 };
+
+    assert_canonical_hit(legacy);
+}
+
+#[test]
+fn materialise_page_accepts_catalog_search_hits() {
+    let entries = load_from_str(
+        r#"{
+            "entries": [
+                {"name": "dcc-mcp-maya", "description": "Maya adapter", "dcc": ["maya"]},
+                {"name": "dcc-mcp-photoshop", "description": "Photoshop adapter", "dcc": ["photoshop"]}
+            ]
+        }"#,
+    )
+    .expect("catalog fixture should parse");
+    let hits = [
+        CatalogSearchHit { index: 1, score: 9 },
+        CatalogSearchHit { index: 0, score: 4 },
+    ];
+
+    let page = materialise_page(&entries, &hits);
+
+    assert_eq!(page[0].name, "dcc-mcp-photoshop");
+    assert_eq!(page[1].name, "dcc-mcp-maya");
+}

--- a/docs/adr/027-protocol-type-ownership.md
+++ b/docs/adr/027-protocol-type-ownership.md
@@ -76,6 +76,13 @@ lifecycle controls. The transport-neutral settings nested under
 into the runtime type by `dcc-mcp-http`. The HTTP type's former
 `GatewayConfig` name is a deprecated compatibility alias.
 
+`dcc_mcp_catalog::CatalogSearchHit` is a lightweight index-and-score reference
+into one product-catalog slice. It is intentionally distinct from the generic,
+record-bearing `dcc_mcp_gateway_search::SearchHit<R>` ranking result. The
+catalog type's former `SearchHit` name is a deprecated compatibility alias;
+catalog APIs use the explicit name so imports cannot imply that the two search
+domains share a contract.
+
 Crate consolidation is not required by this decision. A future merge of
 `wire`, `jsonrpc`, or `protocols` needs separate dependency and compatibility
 evidence; removing duplicate definitions is sufficient.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3761,6 +3761,8 @@ dcc-mcp-server catalog describe --name dcc-mcp-maya-skills
 # Override: DCC_MCP_CATALOG_PATH=/path/to/dcc-mcp-catalog.yml
 ```
 
+Rust API: `dcc_mcp_catalog::search_hits` returns lightweight `CatalogSearchHit` index/score references; the former catalog-local `SearchHit` name is a deprecated compatibility alias and is unrelated to `dcc_mcp_gateway_search::SearchHit<R>`.
+
 ### Gateway Observability (#766)
 
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -1201,6 +1201,7 @@ dcc-mcp-server catalog describe --name dcc-mcp-maya-skills
 MCP resources (#813 phase 2): `resources/read uri=gateway://catalog?query=...`, `resources/read uri=gateway://catalog/{name}`.
 Gateway-native agent guide: `resources/read uri=gateway://docs/agent-workflows` (MCP + resources + prompts + describe_tool hints + efficiency; JSON envelope with markdown `document` field).
 Override catalog path: `DCC_MCP_CATALOG_PATH=/path/to/dcc-mcp-catalog.yml`.
+Rust API: `dcc_mcp_catalog::search_hits` returns lightweight `CatalogSearchHit` index/score references; the former catalog-local `SearchHit` name is a deprecated compatibility alias and is unrelated to `dcc_mcp_gateway_search::SearchHit<R>`.
 
 ### Gateway Observability (#766)
 


### PR DESCRIPTION
## Summary
- rename the catalog-local hit type to `CatalogSearchHit`
- retain `SearchHit` as a deprecated source-compatible alias
- document its distinct contract from gateway search hits

## Validation
- `vx just preflight` (3561 tests)
- `vx cargo test -p dcc-mcp-catalog`
- `vx cargo clippy -p dcc-mcp-catalog --all-targets -- -D warnings`
- `vx npm --prefix docs run docs:build`

No creator skill update is needed because adapter wiring, gateway behavior, and agent workflows are unchanged.

Refs #2196