### PR TITLE
refactor: distinguish gateway capability naming

### DIFF
--- a/crates/dcc-mcp-gateway-core/src/capability/record.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/record.rs
@@ -20,7 +20,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::naming::{instance_short, is_cursor_safe_alphabet};
+use crate::capability_naming::{instance_short, is_cursor_safe_alphabet};
 
 /// Placeholder annotation key signalling that an action has an input
 /// schema on its owning backend but the index does not carry it yet.

--- a/crates/dcc-mcp-gateway-core/src/lib.rs
+++ b/crates/dcc-mcp-gateway-core/src/lib.rs
@@ -42,8 +42,13 @@
 #![warn(missing_docs)]
 
 pub mod capability;
+#[path = "naming/mod.rs"]
+pub mod capability_naming;
 pub mod event;
-pub mod naming;
+
+/// Deprecated name for [`capability_naming`].
+#[deprecated(since = "0.20.9", note = "use capability_naming")]
+pub use capability_naming as naming;
 pub mod openapi;
 pub mod policy;
 pub mod resource_uri;

--- a/crates/dcc-mcp-gateway-core/src/naming/bare.rs
+++ b/crates/dcc-mcp-gateway-core/src/naming/bare.rs
@@ -45,7 +45,7 @@ pub struct BareNameInput<'a> {
 ///
 /// # Examples
 /// ```
-/// # use dcc_mcp_gateway_core::naming::{resolve_bare_names, BareNameInput};
+/// # use dcc_mcp_gateway_core::capability_naming::{resolve_bare_names, BareNameInput};
 /// let inputs = [
 ///     BareNameInput { skill_name: "maya-anim", action_name: "maya_anim__set_keyframe" },
 ///     BareNameInput { skill_name: "maya-geo",  action_name: "maya_geo__create_sphere" },

--- a/crates/dcc-mcp-gateway-core/src/naming/encode.rs
+++ b/crates/dcc-mcp-gateway-core/src/naming/encode.rs
@@ -26,7 +26,7 @@ use super::primitives::{instance_short, is_cursor_safe_alphabet};
 ///
 /// # Examples
 /// ```
-/// # use dcc_mcp_gateway_core::naming::extract_bare_tool_name;
+/// # use dcc_mcp_gateway_core::capability_naming::extract_bare_tool_name;
 /// assert_eq!(extract_bare_tool_name("maya-animation", "maya_animation__set_keyframe"),
 ///            "set_keyframe");
 /// assert_eq!(extract_bare_tool_name("", "get_scene_info"), "get_scene_info");
@@ -46,7 +46,7 @@ pub fn extract_bare_tool_name<'a>(skill_name: &str, action_name: &'a str) -> &'a
 ///
 /// # Examples
 /// ```
-/// # use dcc_mcp_gateway_core::naming::skill_tool_name;
+/// # use dcc_mcp_gateway_core::capability_naming::skill_tool_name;
 /// assert_eq!(skill_tool_name("maya-animation", "maya_animation__set_keyframe"),
 ///            Some("maya-animation__set_keyframe".to_string()));
 /// assert_eq!(skill_tool_name("", "set_keyframe"), None);

--- a/crates/dcc-mcp-gateway-core/src/naming/mod.rs
+++ b/crates/dcc-mcp-gateway-core/src/naming/mod.rs
@@ -23,7 +23,7 @@
 //! All third-party deps are pure: `uuid`, `tracing` (facade only),
 //! `dcc-mcp-naming` (validator only). No HTTP, no async, no `GatewayState`.
 //!
-//! Consumers import directly from `dcc_mcp_gateway_core::naming::*`.
+//! Consumers import directly from `dcc_mcp_gateway_core::capability_naming::*`.
 
 mod bare;
 mod constants;

--- a/crates/dcc-mcp-gateway-core/src/naming/observability.rs
+++ b/crates/dcc-mcp-gateway-core/src/naming/observability.rs
@@ -1,8 +1,8 @@
 //! One-shot warning helpers for the naming domain.
 //!
 //! These functions own the only piece of mutable global state in
-//! [`crate::naming`]. They are intentionally separated from the pure
-//! resolver in [`crate::naming::bare`] so the pure path stays free of
+//! [`crate::capability_naming`]. They are intentionally separated from the
+//! pure resolver so the pure path stays free of
 //! interior mutability and can be reasoned about as a mathematical
 //! function.
 //!
@@ -30,7 +30,7 @@ fn warned_prefixed_slot() -> &'static Mutex<HashSet<String>> {
 /// keep the hot path quiet when multiple skills intentionally overlap
 /// (e.g. both `maya-anim` and `blender-anim` expose `set_keyframe`).
 ///
-/// Intended for use by [`crate::naming::resolve_bare_names`]; not part
+/// Intended for use by [`crate::capability_naming::resolve_bare_names`]; not part
 /// of the published surface because the collision shape is an
 /// implementation detail of the resolver.
 pub(super) fn warn_bare_collision_once(bare: &str, skills: &[&str]) {

--- a/crates/dcc-mcp-gateway-core/src/naming/primitives.rs
+++ b/crates/dcc-mcp-gateway-core/src/naming/primitives.rs
@@ -3,7 +3,7 @@
 //! These are the smallest building blocks of the gateway naming contract.
 //! They depend only on `uuid` and describe encoding *invariants* — no
 //! transport, no logging, no shared state. Every other module in
-//! [`crate::naming`] builds on top of them.
+//! [`crate::capability_naming`] builds on top of them.
 
 use uuid::Uuid;
 
@@ -31,7 +31,7 @@ pub fn instance_short(id: &Uuid) -> String {
 /// `[A-Za-z0-9_]` *and* `s` is non-empty.
 ///
 /// This is the stricter regex some MCP clients (notably Cursor) enforce
-/// on tool names. The [`crate::naming::encode`] module guarantees that
+/// on tool names. The capability naming codec guarantees that
 /// every name it emits passes this predicate; debug builds assert on
 /// any violation.
 #[must_use]

--- a/crates/dcc-mcp-gateway-core/src/resource_uri.rs
+++ b/crates/dcc-mcp-gateway-core/src/resource_uri.rs
@@ -13,7 +13,7 @@
 
 use uuid::Uuid;
 
-use crate::naming::{ID_PREFIX_LEN, instance_short};
+use crate::capability_naming::{ID_PREFIX_LEN, instance_short};
 
 /// Encode a backend resource URI for gateway aggregation:
 /// `<scheme>://<rest>` → `<scheme>://<id8>/<rest>`.

--- a/crates/dcc-mcp-gateway-core/tests/capability_naming.rs
+++ b/crates/dcc-mcp-gateway-core/tests/capability_naming.rs
@@ -1,0 +1,21 @@
+use dcc_mcp_gateway_core::capability_naming;
+use uuid::Uuid;
+
+#[allow(deprecated)]
+use dcc_mcp_gateway_core::naming;
+
+#[test]
+#[allow(deprecated)]
+fn legacy_naming_module_projects_the_canonical_api() {
+    let instance_id =
+        Uuid::parse_str("9c8e57c1-3849-4a7f-a586-e550537ca085").expect("fixture UUID should parse");
+
+    assert_eq!(
+        naming::instance_short(&instance_id),
+        capability_naming::instance_short(&instance_id)
+    );
+    assert_eq!(
+        naming::skill_tool_name("maya-rigging", "create_joint"),
+        capability_naming::skill_tool_name("maya-rigging", "create_joint")
+    );
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/handlers.rs
@@ -8,7 +8,7 @@ use axum::Json;
 use axum::extract::{OriginalUri, Path, Query, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
-use dcc_mcp_gateway_core::naming::instance_short;
+use dcc_mcp_gateway_core::capability_naming::instance_short;
 use serde::Deserialize;
 use serde_json::{Value, json};
 

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -15,7 +15,7 @@ pub(in crate::gateway::admin) mod admin_tests {
     use tokio::sync::{RwLock, broadcast, oneshot, watch};
     use tower::ServiceExt;
 
-    use dcc_mcp_gateway_core::naming::instance_short;
+    use dcc_mcp_gateway_core::capability_naming::instance_short;
 
     use crate::gateway::admin::router::{build_admin_router, build_v1_debug_router};
     use crate::gateway::admin::state::{AdminAuditRecord, AdminState, AuditLog};

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
@@ -48,7 +48,7 @@ use futures::future::join_all;
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use dcc_mcp_gateway_core::naming::instance_short;
+use dcc_mcp_gateway_core::capability_naming::instance_short;
 
 use super::backend_client::{call_backend, fetch_tools};
 use super::state::GatewayState;

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/list.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/list.rs
@@ -16,7 +16,7 @@ use super::*;
 /// Pagination uses the same cursor scheme as the per-DCC server:
 /// `cursor` is an opaque hex-encoded offset into the flat tool list.
 ///
-/// [`GATEWAY_LOCAL_TOOLS`]: dcc_mcp_gateway_core::naming::GATEWAY_LOCAL_TOOLS
+/// [`GATEWAY_LOCAL_TOOLS`]: dcc_mcp_gateway_core::capability_naming::GATEWAY_LOCAL_TOOLS
 pub async fn aggregate_tools_list(gs: &GatewayState, cursor: Option<&str>) -> Value {
     // Touch `gs` so clippy stops warning about the unused argument; future
     // expansions (auth-aware filtering etc.) will consume it again.

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/prompts.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/prompts.rs
@@ -15,7 +15,7 @@
 //! logged at WARN level and skipped, matching the `tools/list`
 //! contract so one stale DCC never 500s the whole gateway endpoint.
 
-use dcc_mcp_gateway_core::naming::{decode_tool_name, encode_tool_name_cursor_safe};
+use dcc_mcp_gateway_core::capability_naming::{decode_tool_name, encode_tool_name_cursor_safe};
 
 use super::*;
 

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -840,12 +840,14 @@ fn resolve_loaded_target_slug(
     let requested_action = crate::gateway::capability::parse_slug(requested_slug)
         .map(|(_, _, action)| action)
         .unwrap_or(requested_slug);
-    let requested_bare =
-        dcc_mcp_gateway_core::naming::extract_bare_tool_name(skill_name, requested_action)
-            .replace('-', "_");
+    let requested_bare = dcc_mcp_gateway_core::capability_naming::extract_bare_tool_name(
+        skill_name,
+        requested_action,
+    )
+    .replace('-', "_");
     let mut matches = loaded_tool_slugs.iter().filter(|candidate| {
         crate::gateway::capability::parse_slug(candidate).is_some_and(|(_, _, action)| {
-            dcc_mcp_gateway_core::naming::extract_bare_tool_name(skill_name, action)
+            dcc_mcp_gateway_core::capability_naming::extract_bare_tool_name(skill_name, action)
                 .replace('-', "_")
                 == requested_bare
         })

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
@@ -27,7 +27,7 @@ fn action_matches_group_tool(action: &str, group_tool_name: &str) -> bool {
         return true;
     }
     // Try the bare action name (strip skill prefix) for comparison.
-    dcc_mcp_gateway_core::naming::decode_skill_tool_name(action)
+    dcc_mcp_gateway_core::capability_naming::decode_skill_tool_name(action)
         .is_some_and(|(_, bare)| bare == group_tool_name)
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -21,7 +21,7 @@ use serde_json::{Value, json};
 use uuid::Uuid;
 
 use dcc_mcp_gateway_core::capability::compute_fingerprint;
-use dcc_mcp_gateway_core::naming::{
+use dcc_mcp_gateway_core::capability_naming::{
     decode_skill_tool_name, extract_bare_tool_name, is_core_tool, is_local_tool,
 };
 use dcc_mcp_jsonrpc::McpTool;

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -47,7 +47,7 @@ use super::capability::{
 };
 use super::request_meta::meta_with_agent_context;
 use super::state::{GatewayState, ResolveInstanceError};
-use dcc_mcp_gateway_core::naming::instance_short;
+use dcc_mcp_gateway_core::capability_naming::instance_short;
 
 const PROFILING_TARGET: &str = "dcc_mcp::profiling";
 

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
@@ -363,7 +363,7 @@ pub fn compact_instance_json(e: &ServiceEntry, stale_timeout: std::time::Duratio
 
     json!({
         "instance_id":    e.instance_id.to_string(),
-        "instance_short": dcc_mcp_gateway_core::naming::instance_short(&e.instance_id),
+        "instance_short": dcc_mcp_gateway_core::capability_naming::instance_short(&e.instance_id),
         "display_id":     e.display_id(),
         "dcc_type":       e.dcc_type,
         "version":        e.version,
@@ -397,7 +397,7 @@ pub fn instance_matches_query(e: &ServiceEntry, query_lower: &str) -> bool {
         || e.version
             .as_ref()
             .is_some_and(|v| v.to_ascii_lowercase().contains(query_lower))
-        || dcc_mcp_gateway_core::naming::instance_short(&e.instance_id)
+        || dcc_mcp_gateway_core::capability_naming::instance_short(&e.instance_id)
             .to_ascii_lowercase()
             .contains(query_lower)
         || e.scene

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -49,7 +49,7 @@ use serde_json::{Value, json};
 use tokio::sync::{RwLock, broadcast, watch};
 use uuid::Uuid;
 
-use dcc_mcp_gateway_core::naming::instance_short;
+use dcc_mcp_gateway_core::capability_naming::instance_short;
 use dcc_mcp_gateway_core::policy::GatewayPolicy;
 
 use super::event_log::EventLog;

--- a/crates/dcc-mcp-http-server/src/mcp_tool_catalog.rs
+++ b/crates/dcc-mcp-http-server/src/mcp_tool_catalog.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use serde_json::{Map, Value, json};
 
 use dcc_mcp_actions::registry::{ToolMeta, ToolRegistry};
-use dcc_mcp_gateway_core::naming::{
+use dcc_mcp_gateway_core::capability_naming::{
     decode_skill_tool_name, extract_bare_tool_name, skill_tool_name,
 };
 use dcc_mcp_jsonrpc::{McpTool, McpToolAnnotations};

--- a/crates/dcc-mcp-http-server/src/mcp_tool_list_builder.rs
+++ b/crates/dcc-mcp-http-server/src/mcp_tool_list_builder.rs
@@ -4,7 +4,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashSet};
 use std::hash::{Hash, Hasher};
 
-use dcc_mcp_gateway_core::naming::{BareNameInput, resolve_bare_names};
+use dcc_mcp_gateway_core::capability_naming::{BareNameInput, resolve_bare_names};
 use dcc_mcp_jsonrpc::{McpTool, TOOLS_LIST_PAGE_SIZE, decode_cursor, encode_cursor};
 use dcc_mcp_naming::validate_tool_name;
 

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/dynamic.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/dynamic.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{Value, json};
 
-use dcc_mcp_gateway_core::naming::skill_tool_name;
+use dcc_mcp_gateway_core::capability_naming::skill_tool_name;
 use dcc_mcp_jsonrpc::{CallToolResult, ToolContent};
 use dcc_mcp_protocols::error_envelope::ToolCallErrorEnvelope;
 

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/helpers.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/helpers.rs
@@ -5,7 +5,7 @@ use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use serde_json::{Value, json};
 
 use dcc_mcp_actions::registry::ToolMeta;
-use dcc_mcp_gateway_core::naming::{decode_skill_tool_name, extract_bare_tool_name};
+use dcc_mcp_gateway_core::capability_naming::{decode_skill_tool_name, extract_bare_tool_name};
 use dcc_mcp_jsonrpc::{
     CallToolResult, DELTA_TOOLS_METHOD, NotificationBuilder, ToolContent,
     error_codes::{BACKEND_NOT_READY, CAPABILITY_MISSING},

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -591,7 +591,7 @@ impl ServiceEntry {
     /// # Stability
     ///
     /// The 8-char hex short ID must match
-    /// `dcc_mcp_gateway_core::naming::instance_short` byte-for-byte
+    /// `dcc_mcp_gateway_core::capability_naming::instance_short` byte-for-byte
     /// so a `display_id` and the cursor-safe tool slug for the same
     /// instance always reference the same 8 hex characters. Tests
     /// pin this in [`tests::display_id_short_matches_gateway_naming`].
@@ -1041,7 +1041,7 @@ mod tests {
     #[test]
     fn display_id_short_matches_gateway_naming() {
         // Pinning the 8-char prefix contract — must stay byte-for-byte
-        // aligned with `dcc_mcp_gateway_core::naming::instance_short`
+        // aligned with `dcc_mcp_gateway_core::capability_naming::instance_short`
         // (8 leading hex chars of the simple-form UUID). If
         // `instance_short` ever changes its length or alphabet, this
         // test fails loudly so both surfaces get re-aligned in lock

--- a/docs/adr/027-protocol-type-ownership.md
+++ b/docs/adr/027-protocol-type-ownership.md
@@ -83,6 +83,13 @@ catalog type's former `SearchHit` name is a deprecated compatibility alias;
 catalog APIs use the explicit name so imports cannot imply that the two search
 domains share a contract.
 
+`dcc-mcp-naming` owns ecosystem-wide validation for MCP tool names and internal
+action ids. `dcc_mcp_gateway_core::capability_naming` owns the narrower gateway
+projection policy: instance prefixes, skill-qualified tool codecs, bare-name
+collision resolution, and its fixed vocabulary. The gateway module's former
+`naming` path is a deprecated compatibility alias. Validation remains delegated
+to `dcc-mcp-naming`; the gateway layer does not redefine its regex contract.
+
 Crate consolidation is not required by this decision. A future merge of
 `wire`, `jsonrpc`, or `protocols` needs separate dependency and compatibility
 evidence; removing duplicate definitions is sufficient.

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -367,6 +367,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `PendingCall` — gateway-to-backend cancellation correlation primitive.
 - `CapabilityRecord` — compact per-tool search/dispatch record.
 - `SearchQuery`, `SearchHit`, `SearchPage`, `SearchMode` — token-budgeted capability search contract.
+- `capability_naming` — gateway instance/skill name projection and bare-name collision policy; delegates wire-name validation to `dcc-mcp-naming`.
 - `ExactScorer`, `FuzzyScorer`, `SubstringScorer`, `StrategyScorer` — pluggable ranking strategies.
 
 **Dependencies**: `serde`, `uuid`, `nucleo-matcher` only where the pure ranking strategy needs it.

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -279,6 +279,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `PendingCall` — gateway 到 backend 的取消关联值对象
 - `CapabilityRecord` — 紧凑的每工具 search/dispatch record
 - `SearchQuery`、`SearchHit`、`SearchPage`、`SearchMode` — 面向 agent 的低 token 搜索契约
+- `capability_naming` — gateway instance/skill 名称投影与 bare-name 冲突策略；wire 名称校验委托给 `dcc-mcp-naming`
 - `ExactScorer`、`FuzzyScorer`、`SubstringScorer`、`StrategyScorer` — 可组合 ranking 策略
 
 ### dcc-mcp-gateway

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -136,6 +136,8 @@ crates/
 └── workspace-hack/       # Cargo-hakari feature unification
 ```
 
+Rust naming ownership: use `dcc_mcp_naming` for ecosystem-wide tool/action name validation and `dcc_mcp_gateway_core::capability_naming` for gateway instance/skill projection, codecs, and bare-name collision policy. The former gateway-core `naming` module path is a deprecated compatibility alias.
+
 **Key import pattern** (always use the top-level package):
 ```python
 from dcc_mcp_core import ToolRegistry, success_result, SkillScanner

--- a/llms.txt
+++ b/llms.txt
@@ -1130,6 +1130,7 @@ Full guide: `docs/guide/remote-server.md`. Per-module API: `docs/api/{auth,batch
 | Gateway admin dashboard | Default ON for the elected gateway: `GET /admin`; disable with `--no-admin`, `DCC_MCP_NO_ADMIN=true`, or `cfg.admin_enabled = False`; agent panel map: `docs/guide/admin-ui.md#agent-facing-panel-map` |
 | Enforce payload size + SSE chunking | `McpHttpConfig.queue.max_request_body_bytes` (default 4 MiB) |
 | Configure the embedded HTTP gateway | `McpHttpConfig.gateway: dcc_mcp_http_types::config::GatewaySettings`; `dcc-mcp-http` projects these serializable settings into the complete runtime `dcc_mcp_gateway::GatewayConfig` |
+| Encode gateway capability names | `dcc_mcp_gateway_core::capability_naming`; use `dcc-mcp-naming` only for ecosystem-wide tool/action name validation |
 | Wire OTLP distributed tracing | Set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` at startup |
 | Watch gateway contention events | MCP resource `resources://gateway/events` (JSONL ring buffer) |
 


### PR DESCRIPTION
## Summary

- expose gateway projection helpers through the explicit `capability_naming` module
- preserve `naming` as a deprecated compatibility alias
- migrate workspace consumers and document naming ownership

## Validation

- `vx just preflight` (3562 tests passed, strict Clippy, formatting, doctests)
- `vx cargo test -p dcc-mcp-gateway-core --test capability_naming`
- `vx npm --prefix docs run docs:build`
- creator skill guidance unchanged; adapter wiring and agent workflows are unaffected

Refs #2196
