### PR TITLE
refactor: centralize Python semver parsing

### DIFF
--- a/docs/adr/027-protocol-type-ownership.md
+++ b/docs/adr/027-protocol-type-ownership.md
@@ -90,6 +90,11 @@ collision resolution, and its fixed vocabulary. The gateway module's former
 `naming` path is a deprecated compatibility alias. Validation remains delegated
 to `dcc-mcp-naming`; the gateway layer does not redefine its regex contract.
 
+Python runtime version decisions use the import-light
+`dcc_mcp_core._version_util.parse_semver` helper. Invalid numeric cores return
+`None`; lifecycle planning reports unknown drift and gateway takeover fails
+closed instead of coercing malformed segments to zero.
+
 Crate consolidation is not required by this decision. A future merge of
 `wire`, `jsonrpc`, or `protocols` needs separate dependency and compatibility
 evidence; removing duplicate definitions is sufficient.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -138,6 +138,8 @@ crates/
 
 Rust naming ownership: use `dcc_mcp_naming` for ecosystem-wide tool/action name validation and `dcc_mcp_gateway_core::capability_naming` for gateway instance/skill projection, codecs, and bare-name collision policy. The former gateway-core `naming` module path is a deprecated compatibility alias.
 
+Python version ownership: use the import-light `dcc_mcp_core._version_util.parse_semver` helper for lifecycle and guardian decisions. It returns `None` for malformed numeric cores; callers must preserve unknown/fail-closed behavior rather than coercing invalid segments to zero.
+
 **Key import pattern** (always use the top-level package):
 ```python
 from dcc_mcp_core import ToolRegistry, success_result, SkillScanner

--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -20,6 +20,7 @@ from urllib.request import Request
 from urllib.request import urlopen
 import uuid
 
+from dcc_mcp_core._version_util import parse_semver as _parse_semver
 from dcc_mcp_core.daemon_launch import launch_detached
 from dcc_mcp_core.install_lifecycle import default_registry_dir
 
@@ -740,32 +741,11 @@ class GatewayDaemonGuardian:
         return payload
 
 
-# ── Semver helpers (aligned with Rust crates/dcc-mcp-gateway/src/gateway/version.rs) ──
-
-
-def _parse_semver(v: str) -> tuple[int, int, int]:
-    """Parse a semver string like ``"0.18.15"`` or ``"v1.2.3-rc1"`` into a triple.
-
-    Handles leading ``v`` prefixes and pre-release suffixes.
-    Missing components default to 0.
-    """
-    stripped = v.strip().lstrip("vV")
-    parts: list[int] = []
-    for segment in stripped.split("."):
-        # Strip pre-release suffix (everything after first '-')
-        numeric = segment.split("-")[0]
-        try:
-            parts.append(int(numeric))
-        except (ValueError, TypeError):
-            parts.append(0)
-    while len(parts) < 3:
-        parts.append(0)
-    return (parts[0], parts[1], parts[2])
-
-
 def _is_newer_version(candidate: str, current: str) -> bool:
     """Return True when *candidate* is strictly newer than *current*."""
-    return _parse_semver(candidate) > _parse_semver(current)
+    candidate_semver = _parse_semver(candidate)
+    current_semver = _parse_semver(current)
+    return candidate_semver is not None and current_semver is not None and candidate_semver > current_semver
 
 
 def _get_core_version() -> str:

--- a/python/dcc_mcp_core/_version_util.py
+++ b/python/dcc_mcp_core/_version_util.py
@@ -1,0 +1,18 @@
+"""Shared version parsing helpers for Python runtime decisions."""
+
+from __future__ import annotations
+
+import re
+
+
+def parse_semver(value: str) -> tuple[int, int, int] | None:
+    """Return the numeric SemVer core, or ``None`` for an invalid version."""
+    text = str(value).strip().lstrip("vV")
+    text = re.split(r"[-+]", text, maxsplit=1)[0]
+    parts = text.split(".")
+    if not parts or any(not part.isdigit() for part in parts[:3]):
+        return None
+    padded = [int(part) for part in parts[:3]]
+    while len(padded) < 3:
+        padded.append(0)
+    return tuple(padded[:3])

--- a/python/dcc_mcp_core/install_lifecycle.py
+++ b/python/dcc_mcp_core/install_lifecycle.py
@@ -41,6 +41,7 @@ from ._install_lifecycle_runtime import query_runtime_state
 from ._install_lifecycle_sidecar import build_sidecar_command
 from ._install_lifecycle_sidecar import launch_sidecar
 from ._install_lifecycle_sidecar import sidecar_host_rpc_dispatch_contract
+from ._version_util import parse_semver as _parse_semver
 
 REZ_CACHE_ROOT_ENV = "DCC_MCP_REZ_LOCAL_CACHE_ROOT"
 DEPLOYMENT_MODE_ENV = "DCC_MCP_DEPLOYMENT_MODE"
@@ -515,18 +516,6 @@ def _compare_version(current: Optional[str], target: Optional[str]) -> str:
     if current_semver > target_semver:
         return "newer"
     return "equal"
-
-
-def _parse_semver(value: str) -> Optional[Tuple[int, int, int]]:
-    text = str(value).strip().lstrip("vV")
-    text = re.split(r"[-+]", text, maxsplit=1)[0]
-    parts = text.split(".")
-    if not parts or any(not part.isdigit() for part in parts[:3]):
-        return None
-    padded = [int(part) for part in parts[:3]]
-    while len(padded) < 3:
-        padded.append(0)
-    return tuple(padded[:3])
 
 
 def _restart_action(

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -951,11 +951,18 @@ def test_parse_semver_with_prerelease():
     assert gg._parse_semver("v2.3.4-beta.2") == (2, 3, 4)
 
 
+def test_parse_semver_rejects_invalid_numeric_core():
+    assert gg._parse_semver("release") is None
+    assert gg._parse_semver("1.two.3") is None
+
+
 def test_is_newer_version():
     assert gg._is_newer_version("1.0.0", "0.9.0") is True
     assert gg._is_newer_version("0.18.15", "0.18.6") is True
     assert gg._is_newer_version("0.18.6", "0.18.15") is False
     assert gg._is_newer_version("1.0.0", "1.0.0") is False
+    assert gg._is_newer_version("release", "0.18.6") is False
+    assert gg._is_newer_version("1.0.0", "unknown") is False
 
 
 def test_get_core_version_env_override(monkeypatch):

--- a/tests/test_install_lifecycle.py
+++ b/tests/test_install_lifecycle.py
@@ -1893,6 +1893,11 @@ def test_plan_runtime_updates_does_not_treat_dcc_version_as_core_version() -> No
     assert plan["verification_required_count"] == 1
 
 
+def test_compare_version_reports_malformed_numeric_core_as_unknown() -> None:
+    assert lifecycle._compare_version("release", "0.17.21") == "unknown"
+    assert lifecycle._compare_version("0.17.20", "1.two.3") == "unknown"
+
+
 def test_plan_runtime_updates_marks_host_only_runtime_manual() -> None:
     plan = lifecycle.plan_runtime_updates(
         [

--- a/tests/test_version_util.py
+++ b/tests/test_version_util.py
@@ -1,0 +1,18 @@
+"""Tests for shared Python version helpers."""
+
+from dcc_mcp_core._version_util import parse_semver
+
+
+def test_parse_semver_normalizes_supported_versions():
+    assert parse_semver("0.18.15") == (0, 18, 15)
+    assert parse_semver("v2.3") == (2, 3, 0)
+    assert parse_semver("5") == (5, 0, 0)
+    assert parse_semver("V1.2.3-rc1") == (1, 2, 3)
+    assert parse_semver("1.2.3+studio.4") == (1, 2, 3)
+
+
+def test_parse_semver_rejects_invalid_numeric_core():
+    assert parse_semver("") is None
+    assert parse_semver("release") is None
+    assert parse_semver("1.two.3") is None
+    assert parse_semver("1..3") is None


### PR DESCRIPTION
## Summary

- centralize Python SemVer parsing in one import-light helper
- make malformed gateway versions fail closed instead of coercing segments to zero
- document the ownership contract and cover lifecycle and guardian decisions

## Validation

- Python suite: 10124 passed, 134 skipped, 3 xfailed
- Python 3.7 syntax check: 515 files passed
- `vx just preflight` (3562 Rust tests, strict Clippy, formatting, doctests)
- `vx npm --prefix docs run docs:build`
- creator skill guidance unchanged; adapter wiring and agent workflows are unaffected

Refs #2196
