### PR TITLE
refactor: centralize lifecycle path coercion

### DIFF
--- a/docs/adr/027-protocol-type-ownership.md
+++ b/docs/adr/027-protocol-type-ownership.md
@@ -95,6 +95,11 @@ Python runtime version decisions use the import-light
 `None`; lifecycle planning reports unknown drift and gateway takeover fails
 closed instead of coercing malformed segments to zero.
 
+Import-light lifecycle path coercion uses
+`dcc_mcp_core._path_util.to_resolved_path`. It expands user paths and resolves
+them when possible, while preserving the lexical absolute-path fallback for
+inaccessible or transient filesystem entries.
+
 Crate consolidation is not required by this decision. A future merge of
 `wire`, `jsonrpc`, or `protocols` needs separate dependency and compatibility
 evidence; removing duplicate definitions is sufficient.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -140,6 +140,8 @@ Rust naming ownership: use `dcc_mcp_naming` for ecosystem-wide tool/action name 
 
 Python version ownership: use the import-light `dcc_mcp_core._version_util.parse_semver` helper for lifecycle and guardian decisions. It returns `None` for malformed numeric cores; callers must preserve unknown/fail-closed behavior rather than coercing invalid segments to zero.
 
+Python lifecycle path ownership: use the import-light `dcc_mcp_core._path_util.to_resolved_path` helper. It returns `None` for empty values, expands user paths, resolves when possible, and falls back to a lexical absolute path after filesystem resolution errors.
+
 **Key import pattern** (always use the top-level package):
 ```python
 from dcc_mcp_core import ToolRegistry, success_result, SkillScanner

--- a/python/dcc_mcp_core/_install_lifecycle_process.py
+++ b/python/dcc_mcp_core/_install_lifecycle_process.py
@@ -12,6 +12,8 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
+from ._path_util import to_resolved_path as _to_path
+
 _WINDOWS_LOCK_WINERRORS = {5, 32, 33}
 _LOCK_ERRNOS = {errno.EACCES, errno.EPERM}
 
@@ -82,15 +84,6 @@ def terminate_pid(pid: int, timeout_secs: float, target_kind: str) -> Dict[str, 
 
 def sys_platform_is_windows() -> bool:
     return os.name == "nt"
-
-
-def _to_path(path: Any) -> Optional[Path]:
-    if path in (None, ""):
-        return None
-    try:
-        return Path(str(path)).expanduser().resolve()
-    except OSError:
-        return Path(str(path)).expanduser().absolute()
 
 
 def _sentinel_owner_dead(sentinel_path: Any) -> Optional[bool]:

--- a/python/dcc_mcp_core/_install_lifecycle_runtime.py
+++ b/python/dcc_mcp_core/_install_lifecycle_runtime.py
@@ -15,6 +15,7 @@ from typing import List
 from typing import Optional
 
 from ._install_lifecycle_process import entry_runtime_alive as _entry_runtime_alive
+from ._path_util import to_resolved_path as _to_path
 
 ROLE_METADATA_KEY = "dcc_mcp_role"
 ROLE_PER_DCC_SIDECAR = "per-dcc-sidecar"
@@ -173,15 +174,6 @@ def _normalise_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
         "metadata": metadata,
         "install_roots": install_roots,
     }
-
-
-def _to_path(path: Any) -> Optional[Path]:
-    if path in (None, ""):
-        return None
-    try:
-        return Path(str(path)).expanduser().resolve()
-    except OSError:
-        return Path(str(path)).expanduser().absolute()
 
 
 def _path_under(path: Optional[Path], root: Optional[Path]) -> bool:

--- a/python/dcc_mcp_core/_install_lifecycle_sidecar.py
+++ b/python/dcc_mcp_core/_install_lifecycle_sidecar.py
@@ -23,6 +23,8 @@ from typing import Tuple
 from urllib.parse import urlsplit
 from uuid import UUID
 
+from ._path_util import to_resolved_path as _to_path
+
 REGISTRY_ENV = "DCC_MCP_REGISTRY_DIR"
 ROLE_PER_DCC_SIDECAR = "per-dcc-sidecar"
 SUPPORTED_DISPATCH_HOST_RPC_SCHEMES = ("commandport", "qtserver", "ws", "wss")
@@ -437,15 +439,6 @@ def launch_sidecar(
 def default_registry_dir() -> str:
     """Return the shared FileRegistry directory without importing ``_core``."""
     return os.environ.get(REGISTRY_ENV) or str(Path(tempfile.gettempdir()) / "dcc-mcp-registry")
-
-
-def _to_path(path: Any) -> Optional[Path]:
-    if path in (None, ""):
-        return None
-    try:
-        return Path(str(path)).expanduser().resolve()
-    except OSError:
-        return Path(str(path)).expanduser().absolute()
 
 
 def _merged_env(env: Optional[Dict[str, str]]) -> Dict[str, str]:

--- a/python/dcc_mcp_core/_path_util.py
+++ b/python/dcc_mcp_core/_path_util.py
@@ -1,0 +1,25 @@
+"""Import-light path coercion helpers."""
+
+# ruff: noqa: UP045
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from typing import Optional
+
+
+def to_resolved_path(value: Any) -> Optional[Path]:
+    """Return an expanded absolute path, or ``None`` for an empty value.
+
+    ``Path.resolve`` can fail for inaccessible or transient filesystem
+    entries. In that case the lexical absolute path remains useful to
+    lifecycle diagnostics and subprocess configuration.
+    """
+    if value in (None, ""):
+        return None
+    path = Path(str(value)).expanduser()
+    try:
+        return path.resolve()
+    except OSError:
+        return path.absolute()

--- a/python/dcc_mcp_core/install_lifecycle.py
+++ b/python/dcc_mcp_core/install_lifecycle.py
@@ -41,6 +41,7 @@ from ._install_lifecycle_runtime import query_runtime_state
 from ._install_lifecycle_sidecar import build_sidecar_command
 from ._install_lifecycle_sidecar import launch_sidecar
 from ._install_lifecycle_sidecar import sidecar_host_rpc_dispatch_contract
+from ._path_util import to_resolved_path as _to_path
 from ._version_util import parse_semver as _parse_semver
 
 REZ_CACHE_ROOT_ENV = "DCC_MCP_REZ_LOCAL_CACHE_ROOT"
@@ -87,15 +88,6 @@ __all__ = [
     "stop_runtime_entries",
     "wait_for_sidecar_ready",
 ]
-
-
-def _to_path(path: Any) -> Optional[Path]:
-    if path in (None, ""):
-        return None
-    try:
-        return Path(str(path)).expanduser().resolve()
-    except OSError:
-        return Path(str(path)).expanduser().absolute()
 
 
 def _path_under(path: Optional[Path], root: Optional[Path]) -> bool:

--- a/tests/test_path_util.py
+++ b/tests/test_path_util.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from dcc_mcp_core import install_lifecycle
+import dcc_mcp_core._install_lifecycle_process as process_lifecycle
+import dcc_mcp_core._install_lifecycle_runtime as runtime_lifecycle
+import dcc_mcp_core._install_lifecycle_sidecar as sidecar_lifecycle
+from dcc_mcp_core._path_util import to_resolved_path
+
+
+def test_to_resolved_path_rejects_empty_values() -> None:
+    assert to_resolved_path(None) is None
+    assert to_resolved_path("") is None
+
+
+def test_to_resolved_path_expands_and_resolves(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    assert to_resolved_path("~/assets/../scene.ma") == (tmp_path / "scene.ma").resolve()
+
+
+def test_to_resolved_path_falls_back_when_resolve_fails(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "transient" / "scene.ma"
+
+    def fail_resolve(_path: Path, *args, **kwargs) -> Path:
+        raise OSError("filesystem unavailable")
+
+    monkeypatch.setattr(Path, "resolve", fail_resolve)
+
+    assert to_resolved_path(path) == path.absolute()
+
+
+def test_install_lifecycle_modules_share_path_coercion() -> None:
+    assert install_lifecycle._to_path is to_resolved_path
+    assert process_lifecycle._to_path is to_resolved_path
+    assert runtime_lifecycle._to_path is to_resolved_path
+    assert sidecar_lifecycle._to_path is to_resolved_path


### PR DESCRIPTION
## Summary

- centralize import-light lifecycle path coercion
- preserve empty-value and filesystem-error fallback behavior
- document Python path helper ownership

## Validation

- Python: 10129 passed, 134 skipped, 3 xfailed
- Python 3.7 syntax: 517 files
- `vx just preflight`: 3562 Rust tests, strict Clippy, fmt, doctests
- VitePress docs build
- creator skills unchanged; no adapter wiring or agent workflow change

Refs #2196
