### PR TITLE
refactor: centralize Python package version resolution

### DIFF
--- a/docs/adr/027-protocol-type-ownership.md
+++ b/docs/adr/027-protocol-type-ownership.md
@@ -95,6 +95,11 @@ Python runtime version decisions use the import-light
 `None`; lifecycle planning reports unknown drift and gateway takeover fails
 closed instead of coercing malformed segments to zero.
 
+Python package-version reporting uses
+`dcc_mcp_core._version_util.package_version`. It reuses an already-loaded core,
+optionally loads the native extension for server construction, then checks
+distribution metadata before applying the caller's explicit fallback.
+
 Import-light lifecycle path coercion uses
 `dcc_mcp_core._path_util.to_resolved_path`. It expands user paths and resolves
 them when possible, while preserving the lexical absolute-path fallback for

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -140,6 +140,8 @@ Rust naming ownership: use `dcc_mcp_naming` for ecosystem-wide tool/action name 
 
 Python version ownership: use the import-light `dcc_mcp_core._version_util.parse_semver` helper for lifecycle and guardian decisions. It returns `None` for malformed numeric cores; callers must preserve unknown/fail-closed behavior rather than coercing invalid segments to zero.
 
+Python package version ownership: use `dcc_mcp_core._version_util.package_version`, with an explicit caller fallback and `load_core=True` only where native extension loading is already allowed. Import-light callers reuse a loaded core or distribution metadata without importing the extension.
+
 Python lifecycle path ownership: use the import-light `dcc_mcp_core._path_util.to_resolved_path` helper. It returns `None` for empty values, expands user paths, resolves when possible, and falls back to a lexical absolute path after filesystem resolution errors.
 
 **Key import pattern** (always use the top-level package):

--- a/python/dcc_mcp_core/_version_util.py
+++ b/python/dcc_mcp_core/_version_util.py
@@ -2,7 +2,47 @@
 
 from __future__ import annotations
 
+import importlib
 import re
+import sys
+from typing import Any
+
+
+def package_version(*, fallback: str, load_core: bool = False) -> str:
+    """Return the core package version without requiring the native module.
+
+    An already-loaded native extension is authoritative. ``load_core=True``
+    additionally permits importing it; import-light callers leave that option
+    disabled. Distribution metadata is the shared fallback before the caller's
+    explicit final value.
+    """
+    core_version = _core_version(load_core)
+    if core_version is not None:
+        return core_version
+
+    try:
+        importlib_metadata = importlib.import_module("importlib.metadata")
+    except ImportError:
+        try:
+            importlib_metadata = importlib.import_module("importlib_metadata")
+        except ImportError:
+            return str(fallback)
+
+    try:
+        return str(importlib_metadata.version("dcc-mcp-core"))
+    except Exception:
+        return str(fallback)
+
+
+def _core_version(load_core: bool) -> str | None:
+    core: Any = sys.modules.get("dcc_mcp_core._core")
+    if core is None and load_core:
+        try:
+            core = importlib.import_module("dcc_mcp_core._core")
+        except Exception:
+            core = None
+    version = getattr(core, "__version__", None) if core is not None else None
+    return str(version) if version is not None else None
 
 
 def parse_semver(value: str) -> tuple[int, int, int] | None:

--- a/python/dcc_mcp_core/bridge.py
+++ b/python/dcc_mcp_core/bridge.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 from concurrent.futures import Future
 from dataclasses import dataclass
+from functools import partial
 import logging
 import queue
 import threading
@@ -42,19 +43,11 @@ import uuid
 
 from dcc_mcp_core import json_dumps
 from dcc_mcp_core import json_loads
+from dcc_mcp_core._version_util import package_version
 
-
-# NOTE: dcc_mcp_core.__version__ is deferred to avoid a potential import-time
-# circular dependency if bridge.py is ever imported before _core is ready.
-# We only need the version string at DccBridge.__init__ call time, not at
-# module import time, so this is safe.
-def _package_version() -> str:
-    try:
-        from dcc_mcp_core import __version__
-
-        return __version__
-    except Exception:
-        return "0.0.0"
+# Keep native loading deferred: bridge construction only reuses an extension
+# that is already loaded, then falls back to distribution metadata.
+_package_version = partial(package_version, fallback="0.0.0")
 
 
 logger = logging.getLogger(__name__)

--- a/python/dcc_mcp_core/host_errors.py
+++ b/python/dcc_mcp_core/host_errors.py
@@ -8,6 +8,7 @@ native ``dcc_mcp_core._core`` extension or their adapter package.
 from __future__ import annotations
 
 import contextlib
+from functools import partial
 import json
 import logging
 from logging.handlers import RotatingFileHandler
@@ -23,23 +24,14 @@ from typing import Dict
 from typing import Iterator
 from typing import Optional
 
+from ._version_util import package_version
+
 _ERROR_LOG_LOCK = threading.Lock()
 _MAX_MESSAGE_CHARS = 8192
 _MAX_TRACEBACK_CHARS = 32768
 
 
-def _package_version() -> str:
-    try:
-        importlib_metadata = __import__("importlib.metadata", fromlist=["metadata"])
-    except ImportError:
-        try:
-            importlib_metadata = __import__("importlib_metadata")
-        except ImportError:
-            return "unknown"
-    try:
-        return str(importlib_metadata.version("dcc-mcp-core"))
-    except Exception:
-        return "unknown"
+_package_version = partial(package_version, fallback="unknown")
 
 
 def _default_log_dir() -> Path:

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -15,6 +15,7 @@ The class delegates to seam controllers and instance-owned runtime components (P
 
 from __future__ import annotations
 
+from functools import partial
 import logging
 import sys
 from typing import Any
@@ -40,6 +41,7 @@ from dcc_mcp_core._server.inprocess_executor import HostExecutionBridge
 from dcc_mcp_core._server.minimal_mode import MinimalModeConfig
 from dcc_mcp_core._server.options import DccServerOptions
 from dcc_mcp_core._server.skill_discovery import SkillDiscoveryController
+from dcc_mcp_core._version_util import package_version
 from dcc_mcp_core.checkpoint import CheckpointStore
 from dcc_mcp_core.feedback import FeedbackStore
 from dcc_mcp_core.script_execution import ScriptExecutionContext
@@ -77,30 +79,7 @@ def create_skill_server(
     return server
 
 
-def _package_version() -> str:
-    try:
-        import dcc_mcp_core
-    except Exception:
-        dcc_mcp_core = None
-
-    if is_core_extension_available() and dcc_mcp_core is not None:
-        core = getattr(dcc_mcp_core, "_core", None)
-        version = getattr(core, "__version__", None)
-        if version is not None:
-            return str(version)
-
-    try:
-        from importlib import metadata as importlib_metadata
-    except ImportError:
-        try:
-            import importlib_metadata  # type: ignore[import-not-found]
-        except ImportError:
-            return _PKG_VERSION
-
-    try:
-        return importlib_metadata.version("dcc-mcp-core")
-    except Exception:
-        return _PKG_VERSION
+_package_version = partial(package_version, fallback=_PKG_VERSION, load_core=True)
 
 
 class DccServerBase:

--- a/tests/test_sidecar_http_codecov.py
+++ b/tests/test_sidecar_http_codecov.py
@@ -309,36 +309,20 @@ class TestSidecarSkillServerCoverage:
 
 class TestServerBasePackageVersion:
     def test_uses_core_version_when_extension_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import types
-
-        import dcc_mcp_core
-
-        fake_core = types.ModuleType("dcc_mcp_core._core")
-        fake_core.__version__ = "9.9.9-core"
-        monkeypatch.setattr(dcc_mcp_core, "_core", fake_core)
-        monkeypatch.setattr(
-            "dcc_mcp_core.server_base.is_core_extension_available",
-            lambda: True,
-        )
+        monkeypatch.setattr("dcc_mcp_core._version_util._core_version", lambda _load: "9.9.9-core")
         from dcc_mcp_core.server_base import _package_version
 
         assert _package_version() == "9.9.9-core"
 
     def test_uses_distribution_metadata_when_core_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(
-            "dcc_mcp_core.server_base.is_core_extension_available",
-            lambda: False,
-        )
+        monkeypatch.setattr("dcc_mcp_core._version_util._core_version", lambda _load: None)
         monkeypatch.setattr(importlib_metadata, "version", lambda _name: "0.19.7")
         from dcc_mcp_core.server_base import _package_version
 
         assert _package_version() == "0.19.7"
 
     def test_falls_back_when_metadata_lookup_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(
-            "dcc_mcp_core.server_base.is_core_extension_available",
-            lambda: False,
-        )
+        monkeypatch.setattr("dcc_mcp_core._version_util._core_version", lambda _load: None)
 
         def _boom(_name: str) -> str:
             raise RuntimeError("no dist")

--- a/tests/test_version_util.py
+++ b/tests/test_version_util.py
@@ -1,5 +1,9 @@
 """Tests for shared Python version helpers."""
 
+import types
+
+import dcc_mcp_core._version_util as version_util
+from dcc_mcp_core._version_util import package_version
 from dcc_mcp_core._version_util import parse_semver
 
 
@@ -16,3 +20,48 @@ def test_parse_semver_rejects_invalid_numeric_core():
     assert parse_semver("release") is None
     assert parse_semver("1.two.3") is None
     assert parse_semver("1..3") is None
+
+
+def test_package_version_prefers_loaded_core(monkeypatch):
+    core = types.ModuleType("dcc_mcp_core._core")
+    core.__version__ = "9.9.9-core"
+    monkeypatch.setitem(version_util.sys.modules, "dcc_mcp_core._core", core)
+
+    assert package_version(fallback="unknown") == "9.9.9-core"
+
+
+def test_package_version_loads_core_only_when_allowed(monkeypatch):
+    monkeypatch.delitem(version_util.sys.modules, "dcc_mcp_core._core", raising=False)
+    core = types.SimpleNamespace(__version__="8.8.8-core")
+    imported = []
+
+    def import_module(name):
+        imported.append(name)
+        return core
+
+    monkeypatch.setattr(version_util.importlib, "import_module", import_module)
+
+    assert version_util._core_version(False) is None
+    assert imported == []
+    assert version_util._core_version(True) == "8.8.8-core"
+    assert imported == ["dcc_mcp_core._core"]
+
+
+def test_package_version_uses_distribution_metadata(monkeypatch):
+    monkeypatch.setattr(version_util, "_core_version", lambda _load: None)
+    metadata = types.SimpleNamespace(version=lambda _name: "0.19.7")
+    monkeypatch.setattr(version_util.importlib, "import_module", lambda _name: metadata)
+
+    assert package_version(fallback="unknown") == "0.19.7"
+
+
+def test_package_version_preserves_explicit_fallback(monkeypatch):
+    monkeypatch.setattr(version_util, "_core_version", lambda _load: None)
+
+    def fail_version(_name):
+        raise RuntimeError("no dist")
+
+    metadata = types.SimpleNamespace(version=fail_version)
+    monkeypatch.setattr(version_util.importlib, "import_module", lambda _name: metadata)
+
+    assert package_version(fallback="0.0.0-dev") == "0.0.0-dev"


### PR DESCRIPTION
## Summary

- centralize Python package version resolution
- preserve import-light and native-loading boundaries
- keep caller-specific fallback values explicit

## Validation

- Python: 10133 passed, 134 skipped, 3 xfailed
- Python 3.7 syntax: 517 files
- `vx just preflight`: 3562 Rust tests, strict Clippy, fmt, doctests
- VitePress docs build
- creator skills unchanged; no adapter wiring or agent workflow change

Refs #2196
