### PR TITLE
refactor: centralize lifecycle registry path

### DIFF
--- a/docs/adr/027-protocol-type-ownership.md
+++ b/docs/adr/027-protocol-type-ownership.md
@@ -105,6 +105,10 @@ Import-light lifecycle path coercion uses
 them when possible, while preserving the lexical absolute-path fallback for
 inaccessible or transient filesystem entries.
 
+The import-light lifecycle runtime module owns `default_registry_dir`.
+Install and sidecar helpers re-export that callable instead of independently
+reconstructing the environment and temporary-directory fallback contract.
+
 Crate consolidation is not required by this decision. A future merge of
 `wire`, `jsonrpc`, or `protocols` needs separate dependency and compatibility
 evidence; removing duplicate definitions is sufficient.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -144,6 +144,8 @@ Python package version ownership: use `dcc_mcp_core._version_util.package_versio
 
 Python lifecycle path ownership: use the import-light `dcc_mcp_core._path_util.to_resolved_path` helper. It returns `None` for empty values, expands user paths, resolves when possible, and falls back to a lexical absolute path after filesystem resolution errors.
 
+Python lifecycle registry ownership: use `dcc_mcp_core._install_lifecycle_runtime.default_registry_dir`. Public install-lifecycle and internal sidecar callers re-export the same import-light callable so the environment and temporary-directory fallback contract cannot drift.
+
 **Key import pattern** (always use the top-level package):
 ```python
 from dcc_mcp_core import ToolRegistry, success_result, SkillScanner

--- a/python/dcc_mcp_core/_install_lifecycle_sidecar.py
+++ b/python/dcc_mcp_core/_install_lifecycle_sidecar.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
-import tempfile
 import time
 from typing import Any
 from typing import Dict
@@ -23,6 +22,7 @@ from typing import Tuple
 from urllib.parse import urlsplit
 from uuid import UUID
 
+from ._install_lifecycle_runtime import default_registry_dir
 from ._path_util import to_resolved_path as _to_path
 
 REGISTRY_ENV = "DCC_MCP_REGISTRY_DIR"
@@ -434,11 +434,6 @@ def launch_sidecar(
         result["ready"] = bool(result["readiness"].get("ready"))
         result["readiness_checked"] = True
     return result
-
-
-def default_registry_dir() -> str:
-    """Return the shared FileRegistry directory without importing ``_core``."""
-    return os.environ.get(REGISTRY_ENV) or str(Path(tempfile.gettempdir()) / "dcc-mcp-registry")
 
 
 def _merged_env(env: Optional[Dict[str, str]]) -> Dict[str, str]:

--- a/tests/test_install_lifecycle.py
+++ b/tests/test_install_lifecycle.py
@@ -99,6 +99,11 @@ print(json.dumps({"after_lifecycle": "dcc_mcp_core._core" in sys.modules}))
     assert rows == [{"after_package": False}, {"after_lifecycle": False}]
 
 
+def test_default_registry_dir_has_one_runtime_owner() -> None:
+    assert lifecycle.default_registry_dir is runtime_lifecycle.default_registry_dir
+    assert sidecar_lifecycle.default_registry_dir is runtime_lifecycle.default_registry_dir
+
+
 def test_top_level_lifecycle_export_does_not_load_core_in_fresh_process() -> None:
     script = """
 import json


### PR DESCRIPTION
## Summary

- make the import-light runtime module the registry path owner
- reuse the same callable from public lifecycle and sidecar helpers
- add identity regression coverage and ownership guidance

## Validation

- Python: 10180 passed, 88 skipped, 3 xfailed
- lifecycle tests: 64 passed
- Python 3.7 syntax: 517 files
- `vx just preflight`: 3562 Rust tests, strict Clippy, fmt, doctests
- VitePress docs build
- creator skills unchanged; no adapter wiring or agent workflow change

An unrelated gateway sentinel timing test passed standalone and in the full preflight rerun.

Refs #2196
