### PR TITLE
refactor: unify Python exception hierarchy

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -192,6 +192,7 @@ export default defineConfig({
             {
               text: 'Agent Tools',
               items: [
+                { text: 'Errors', link: '/api/errors' },
                 { text: 'Cancellation', link: '/api/cancellation' },
                 { text: 'Checkpoint', link: '/api/checkpoint' },
                 { text: 'Docs Resources', link: '/api/docs-resources' },

--- a/docs/adr/027-protocol-type-ownership.md
+++ b/docs/adr/027-protocol-type-ownership.md
@@ -114,6 +114,11 @@ Import-light environment parsing uses `dcc_mcp_core.env`: `env_flag`,
 names in `dcc_mcp_core.constants` and pass caller-specific truth tokens or
 numeric bounds explicitly.
 
+Public Python exceptions share the import-light `dcc_mcp_core.DccMcpError`
+root. Specialized exceptions retain their prior built-in exception category
+through multiple inheritance. The Python class is an API-level catch boundary,
+not an alias for the Rust `dcc_mcp_models::DccMcpError` domain enum.
+
 Crate consolidation is not required by this decision. A future merge of
 `wire`, `jsonrpc`, or `protocols` needs separate dependency and compatibility
 evidence; removing duplicate definitions is sufficient.

--- a/docs/api/cancellation.md
+++ b/docs/api/cancellation.md
@@ -50,7 +50,10 @@ token.cancelled  # True
 from dcc_mcp_core import CancelledError
 ```
 
-Raised by `check_cancelled()` when the active request was cancelled. Deliberately a plain `Exception` subclass — the `@skill_entry` decorator's generic `except Exception` branch will convert an unhandled `CancelledError` into a standard skill error dict.
+Raised by `check_cancelled()` when the active request was cancelled. It derives
+from `DccMcpError` and remains in the plain `Exception` lineage, so the
+`@skill_entry` decorator's generic `except Exception` branch converts an
+unhandled cancellation into a standard skill error dict.
 
 ## check_cancelled
 

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -1,0 +1,30 @@
+# Errors
+
+**Module:** `dcc_mcp_core.errors`  
+**Exported symbol:** `DccMcpError`
+
+## DccMcpError
+
+```python
+from dcc_mcp_core import DccMcpError
+```
+
+`DccMcpError` is the shared base class for public Python exceptions raised by
+`dcc-mcp-core`. Catch it when a boundary needs to handle any library-owned
+failure without also swallowing unrelated application exceptions.
+
+```python
+try:
+    descriptor.validate()
+except DccMcpError as exc:
+    report_adapter_failure(str(exc))
+```
+
+Specialized errors preserve their previous built-in categories through
+multiple inheritance. For example, `AssetImportValidationError` remains a
+`ValueError`, `AssetSyncConflictError` remains a `RuntimeError`, and
+`ScriptExecutionSerializationError` remains a `TypeError`.
+
+The Python exception root is import-light and does not load the native
+extension. It is separate from the Rust `dcc_mcp_models::DccMcpError` enum,
+which classifies failures inside the Rust workspace.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -148,6 +148,8 @@ Python lifecycle registry ownership: use `dcc_mcp_core._install_lifecycle_runtim
 
 Python environment parsing ownership: use the import-light `dcc_mcp_core.env` helpers (`env_flag`, `env_int`, `env_float`, `env_path`) and declare core runtime environment names in `dcc_mcp_core.constants`. Preserve caller policy through explicit truth tokens, numeric defaults, and bounds.
 
+Python exception ownership: public Python exceptions derive from the import-light `dcc_mcp_core.DccMcpError` root while retaining compatibility bases such as `ValueError`, `RuntimeError`, and `TypeError`. This Python class is distinct from the Rust `dcc_mcp_models::DccMcpError` enum.
+
 **Key import pattern** (always use the top-level package):
 ```python
 from dcc_mcp_core import ToolRegistry, success_result, SkillScanner

--- a/llms.txt
+++ b/llms.txt
@@ -605,9 +605,15 @@ tools:
 
 ### Cancellation (`dcc_mcp_core.cancellation`)
 
+All public Python exceptions derive from the import-light
+`dcc_mcp_core.DccMcpError` root. Specialized exceptions also retain their
+existing built-in base (`ValueError`, `RuntimeError`, or `TypeError`) so
+existing handlers remain compatible. This Python root is distinct from the
+Rust `dcc_mcp_models::DccMcpError` enum.
+
 - `CancellationProbe` (`Protocol`, runtime-checkable) — read-only contract exposed to skill code: `.cancelled -> bool`, `.job_id -> str | None`
 - `CancelToken(job_id=None)` — mutable pure-Python implementation for dispatchers; `.cancel()`, `.cancelled -> bool`, `.job_id -> str | None`
-- `CancelledError(Exception)` — raised by `check_cancelled()` / `check_dcc_cancelled()` when cancellation was signalled
+- `CancelledError(DccMcpError)` — raised by `check_cancelled()` / `check_dcc_cancelled()` when cancellation was signalled; remains an `Exception` subtype
 - `check_cancelled() -> None` — raise `CancelledError` if the active MCP request was cancelled (no-op outside request context)
 - `check_dcc_cancelled() -> None` (#522) — combines `check_cancelled()` with a per-job check; raises if either the MCP token OR the per-job `JobHandle` reports cancellation; use this in skills launched from a DCC dispatcher rather than an MCP request
 - `JobHandle` (`Protocol`, runtime-checkable) — contract for the per-job handle a host dispatcher publishes; only `cancelled: bool` is contractual

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -68,6 +68,7 @@ _LAZY: dict[str, str] = {
     "DccError": "dcc_mcp_core._core",
     "DccErrorCode": "dcc_mcp_core._core",
     "DccInfo": "dcc_mcp_core._core",
+    "DccMcpError": "dcc_mcp_core.errors",
     "DccLinkFrame": "dcc_mcp_core._core",
     "EventBus": "dcc_mcp_core._core",
     "FileLoggingConfig": "dcc_mcp_core._core",

--- a/python/dcc_mcp_core/asset_import.py
+++ b/python/dcc_mcp_core/asset_import.py
@@ -55,6 +55,8 @@ from typing import List
 from typing import Mapping
 from typing import Optional
 
+from dcc_mcp_core.errors import DccMcpError
+
 __all__ = [
     "AssetAttribution",
     "AssetDescriptor",
@@ -157,7 +159,7 @@ class ImportWarningCode:
 # ---------------------------------------------------------------------------
 
 
-class AssetImportValidationError(ValueError):
+class AssetImportValidationError(DccMcpError, ValueError):
     """Raised by :meth:`AssetDescriptor.validate` on hard validation failures.
 
     Inherits from :class:`ValueError` so callers that already catch ``ValueError``

--- a/python/dcc_mcp_core/asset_sync.py
+++ b/python/dcc_mcp_core/asset_sync.py
@@ -27,6 +27,8 @@ from typing import Mapping
 from typing import Optional
 from typing import Union
 
+from dcc_mcp_core.errors import DccMcpError
+
 __all__ = [
     "AssetSyncConflictError",
     "AssetSyncRevision",
@@ -35,11 +37,11 @@ __all__ = [
 ]
 
 
-class AssetSyncValidationError(ValueError):
+class AssetSyncValidationError(DccMcpError, ValueError):
     """Raised when a sync request or manifest violates the public contract."""
 
 
-class AssetSyncConflictError(RuntimeError):
+class AssetSyncConflictError(DccMcpError, RuntimeError):
     """Raised when optimistic revision preconditions do not match the head."""
 
 

--- a/python/dcc_mcp_core/auth.py
+++ b/python/dcc_mcp_core/auth.py
@@ -57,6 +57,8 @@ import os
 import secrets
 from typing import Any
 
+from dcc_mcp_core.errors import DccMcpError
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -69,7 +71,7 @@ __all__ = [
 ]
 
 
-class TokenValidationError(Exception):
+class TokenValidationError(DccMcpError):
     """Raised when a Bearer token fails validation."""
 
 

--- a/python/dcc_mcp_core/bridge.py
+++ b/python/dcc_mcp_core/bridge.py
@@ -44,6 +44,7 @@ import uuid
 from dcc_mcp_core import json_dumps
 from dcc_mcp_core import json_loads
 from dcc_mcp_core._version_util import package_version
+from dcc_mcp_core.errors import DccMcpError
 
 # Keep native loading deferred: bridge construction only reuses an extension
 # that is already loaded, then falls back to distribution metadata.
@@ -55,7 +56,7 @@ logger = logging.getLogger(__name__)
 # ── Exceptions ────────────────────────────────────────────────────────────────
 
 
-class BridgeError(Exception):
+class BridgeError(DccMcpError):
     """Base class for all DccBridge errors."""
 
 

--- a/python/dcc_mcp_core/cancellation.py
+++ b/python/dcc_mcp_core/cancellation.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
 # type is only used for static analysis and runtime `isinstance` on 3.8+).
 from dcc_mcp_core._typing import Protocol
 from dcc_mcp_core._typing import runtime_checkable
+from dcc_mcp_core.errors import DccMcpError
 
 __all__ = [
     "CancelToken",
@@ -70,10 +71,10 @@ __all__ = [
 ]
 
 
-class CancelledError(Exception):
+class CancelledError(DccMcpError):
     """Raised by :func:`check_cancelled` when the active request was cancelled.
 
-    This is deliberately a plain :class:`Exception` subclass (not
+    This remains in the plain :class:`Exception` lineage (not
     :class:`concurrent.futures.CancelledError` or
     :class:`asyncio.CancelledError`) because skill scripts may run in
     synchronous contexts that do not import either module.  The

--- a/python/dcc_mcp_core/cua_cli.py
+++ b/python/dcc_mcp_core/cua_cli.py
@@ -27,6 +27,8 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 
+from dcc_mcp_core.errors import DccMcpError
+
 CUA_BINARY_ENV = "DCC_MCP_CUA_BINARY"
 MINIMUM_CUA_VERSION = (0, 4, 0)
 MINIMUM_CUA_VERSION_TEXT = ".".join(str(part) for part in MINIMUM_CUA_VERSION)
@@ -43,7 +45,7 @@ _SHARED_IMAGE_MAGIC = 0x4355_4100_5348_4D01
 _STABLE_SEMVER = re.compile(r"^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(?:[+][0-9A-Za-z.-]+)?$")
 
 
-class CuaCliError(RuntimeError):
+class CuaCliError(DccMcpError, RuntimeError):
     """Structured failure at the standalone CUA process boundary."""
 
     def __init__(self, code: str, message: str) -> None:

--- a/python/dcc_mcp_core/errors.py
+++ b/python/dcc_mcp_core/errors.py
@@ -1,0 +1,10 @@
+"""Shared Python exception hierarchy for dcc-mcp-core."""
+
+from __future__ import annotations
+
+
+class DccMcpError(Exception):
+    """Base class for public dcc-mcp-core Python exceptions."""
+
+
+__all__ = ["DccMcpError"]

--- a/python/dcc_mcp_core/guardrails.py
+++ b/python/dcc_mcp_core/guardrails.py
@@ -14,6 +14,8 @@ from typing import Callable
 from typing import Iterable
 from typing import Mapping
 
+from dcc_mcp_core.errors import DccMcpError
+
 __all__ = [
     "DccBlockedCall",
     "DccGuardrailError",
@@ -21,7 +23,7 @@ __all__ = [
 ]
 
 
-class DccGuardrailError(RuntimeError):
+class DccGuardrailError(DccMcpError, RuntimeError):
     """Raised when a weak guardrail blocks a known-dangerous call."""
 
 

--- a/python/dcc_mcp_core/host/_fallback.py
+++ b/python/dcc_mcp_core/host/_fallback.py
@@ -9,8 +9,10 @@ import threading
 from typing import Any
 from typing import Callable
 
+from dcc_mcp_core.errors import DccMcpError
 
-class DispatchError(RuntimeError):
+
+class DispatchError(DccMcpError, RuntimeError):
     """Fallback dispatch error raised by the Python host dispatcher."""
 
 

--- a/python/dcc_mcp_core/lifecycle_hooks.py
+++ b/python/dcc_mcp_core/lifecycle_hooks.py
@@ -23,6 +23,8 @@ import logging
 from typing import Any
 from typing import Callable
 
+from dcc_mcp_core.errors import DccMcpError
+
 logger = logging.getLogger(__name__)
 
 
@@ -64,7 +66,7 @@ class HookContext:
     session_id: str | None = None
 
 
-class HookDeny(Exception):
+class HookDeny(DccMcpError):
     """Raised by a policy hook to veto a discovery, load, or call event.
 
     Only meaningful for events listed in :meth:`HookEvent.policy_events`. The

--- a/python/dcc_mcp_core/script_execution.py
+++ b/python/dcc_mcp_core/script_execution.py
@@ -29,6 +29,7 @@ from typing import Any
 from typing import Sequence
 from typing import TextIO
 
+from dcc_mcp_core.errors import DccMcpError
 from dcc_mcp_core.result_envelope import ToolResultEnvelope
 from dcc_mcp_core.script_materialization import MaterializedScript
 from dcc_mcp_core.script_materialization import cleanup_materialized_scripts
@@ -39,7 +40,7 @@ ScriptMaterializationPolicy = str
 _SCRIPT_MATERIALIZATION_POLICIES = {"off", "auto", "require"}
 
 
-class ScriptExecutionSerializationError(TypeError):
+class ScriptExecutionSerializationError(DccMcpError, TypeError):
     """Raised when a strict script result cannot be JSON-encoded."""
 
     pass

--- a/python/dcc_mcp_core/skills_helper.py
+++ b/python/dcc_mcp_core/skills_helper.py
@@ -20,9 +20,10 @@ from typing import Any
 
 from dcc_mcp_core._lazy import lazy_dir
 from dcc_mcp_core._lazy import resolve_lazy_symbol
+from dcc_mcp_core.errors import DccMcpError
 
 
-class SkillHelperError(Exception):
+class SkillHelperError(DccMcpError):
     """Base exception for skill-helper failures raised by future helpers."""
 
 

--- a/python/dcc_mcp_core/vector_embedder.py
+++ b/python/dcc_mcp_core/vector_embedder.py
@@ -47,6 +47,7 @@ from typing import Mapping
 
 from dcc_mcp_core._typing import Protocol
 from dcc_mcp_core._typing import runtime_checkable
+from dcc_mcp_core.errors import DccMcpError
 
 __all__ = [
     "DEFAULT_DIM",
@@ -81,7 +82,7 @@ def _char_ngrams(token: str, n: int) -> list[str]:
     return [token[i : i + n] for i in range(len(token) - n + 1)]
 
 
-class EmbedderError(RuntimeError):
+class EmbedderError(DccMcpError, RuntimeError):
     """Raised when an embedder backend cannot be constructed or invoked."""
 
 

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -205,7 +205,7 @@ def test_explicit_none_clears_inherited_token() -> None:
 
 
 def test_cancelled_error_is_exception_subclass() -> None:
-    """CancelledError is a plain Exception subclass (not BaseException-only)."""
+    """CancelledError stays in the Exception lineage (not BaseException-only)."""
     assert issubclass(CancelledError, Exception)
     # Ensure @skill_entry's `except Exception` branch can catch it.
     try:

--- a/tests/test_error_hierarchy.py
+++ b/tests/test_error_hierarchy.py
@@ -1,0 +1,88 @@
+"""Tests for the shared Python exception hierarchy."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from dcc_mcp_core import DccMcpError
+from dcc_mcp_core.asset_import import AssetImportValidationError
+from dcc_mcp_core.asset_sync import AssetSyncConflictError
+from dcc_mcp_core.asset_sync import AssetSyncValidationError
+from dcc_mcp_core.auth import TokenValidationError
+from dcc_mcp_core.bridge import BridgeConnectionError
+from dcc_mcp_core.bridge import BridgeError
+from dcc_mcp_core.bridge import BridgeRpcError
+from dcc_mcp_core.bridge import BridgeTimeoutError
+from dcc_mcp_core.cancellation import CancelledError
+from dcc_mcp_core.cua_cli import CuaCliError
+from dcc_mcp_core.guardrails import DccGuardrailError
+from dcc_mcp_core.host._fallback import DispatchError
+from dcc_mcp_core.lifecycle_hooks import HookDeny
+from dcc_mcp_core.script_execution import ScriptExecutionSerializationError
+from dcc_mcp_core.skills_helper import HttpStatusError
+from dcc_mcp_core.skills_helper import SkillCodecError
+from dcc_mcp_core.skills_helper import SkillFileError
+from dcc_mcp_core.skills_helper import SkillHelperError
+from dcc_mcp_core.skills_helper import SkillHttpError
+from dcc_mcp_core.vector_embedder import EmbedderError
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_error_module_does_not_load_core_in_fresh_process() -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT / "python")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import json, sys; from dcc_mcp_core import DccMcpError; "
+            'print(json.dumps({"core_loaded": "dcc_mcp_core._core" in sys.modules, '
+            '"name": DccMcpError.__name__}))',
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(result.stdout) == {"core_loaded": False, "name": "DccMcpError"}
+
+
+def test_public_errors_share_one_root() -> None:
+    error_types = (
+        AssetImportValidationError,
+        AssetSyncConflictError,
+        AssetSyncValidationError,
+        BridgeConnectionError,
+        BridgeError,
+        BridgeRpcError,
+        BridgeTimeoutError,
+        CancelledError,
+        CuaCliError,
+        DccGuardrailError,
+        DispatchError,
+        EmbedderError,
+        HookDeny,
+        HttpStatusError,
+        ScriptExecutionSerializationError,
+        SkillCodecError,
+        SkillFileError,
+        SkillHelperError,
+        SkillHttpError,
+        TokenValidationError,
+    )
+    assert all(issubclass(error_type, DccMcpError) for error_type in error_types)
+
+
+def test_builtin_exception_contracts_are_preserved() -> None:
+    assert issubclass(AssetImportValidationError, ValueError)
+    assert issubclass(AssetSyncValidationError, ValueError)
+    assert issubclass(AssetSyncConflictError, RuntimeError)
+    assert issubclass(CuaCliError, RuntimeError)
+    assert issubclass(DccGuardrailError, RuntimeError)
+    assert issubclass(DispatchError, RuntimeError)
+    assert issubclass(EmbedderError, RuntimeError)
+    assert issubclass(ScriptExecutionSerializationError, TypeError)


### PR DESCRIPTION
## Summary

- add an import-light `DccMcpError` Python root
- reparent public exceptions while preserving built-in catch contracts
- document the Python and Rust error ownership boundary

## Validation

- Python: 10141 passed, 134 skipped, 3 xfailed
- error and consumer tests: 184 passed, 1 skipped
- Python 3.7 syntax: 521 files
- `vx just preflight`: 3562 Rust tests, strict Clippy, fmt, doctests
- VitePress docs build
- a marketplace HTTP fixture transiently failed under concurrency twice; its exact test passed alone and the final full preflight passed
- creator skills unchanged; no adapter wiring or agent workflow change

Refs #2196
