### PR TITLE
refactor: disambiguate Python cancellation error

### DIFF
--- a/docs/adr/027-protocol-type-ownership.md
+++ b/docs/adr/027-protocol-type-ownership.md
@@ -118,6 +118,8 @@ Public Python exceptions share the import-light `dcc_mcp_core.DccMcpError`
 root. Specialized exceptions retain their prior built-in exception category
 through multiple inheritance. The Python class is an API-level catch boundary,
 not an alias for the Rust `dcc_mcp_models::DccMcpError` domain enum.
+Cooperative cancellation raises `DccMcpCancelledError`; the former ambiguous
+`CancelledError` name remains only as a deprecated compatibility alias.
 
 Crate consolidation is not required by this decision. A future merge of
 `wire`, `jsonrpc`, or `protocols` needs separate dependency and compatibility

--- a/docs/api/cancellation.md
+++ b/docs/api/cancellation.md
@@ -4,7 +4,7 @@ Cooperative cancellation support for DCC-MCP skill scripts (issue #318, #332, #5
 
 Skill scripts executed inside a `tools/call` request run as regular Python code and cannot be interrupted by the dispatcher. The MCP spec's `notifications/cancelled` message only helps if the running code checks for cancellation at appropriate points.
 
-**Exported symbols:** `CancellationProbe`, `CancelToken`, `CancelledError`, `JobHandle`, `check_cancelled`, `check_dcc_cancelled`, `current_cancel_token`, `current_job_id`, `current_job`, `reset_cancel_token`, `reset_current_job`, `set_cancel_token`, `set_current_job`
+**Exported symbols:** `CancellationProbe`, `CancelToken`, `DccMcpCancelledError`, `CancelledError`, `JobHandle`, `check_cancelled`, `check_dcc_cancelled`, `current_cancel_token`, `current_job_id`, `current_job`, `reset_cancel_token`, `reset_current_job`, `set_cancel_token`, `set_current_job`
 
 ## CancellationProbe
 
@@ -44,10 +44,10 @@ token.cancelled  # True
 | `cancelled` (property) | `bool` | Whether `cancel()` has been invoked |
 | `job_id` (property) | `str \| None` | Associated server-owned job id, when available |
 
-## CancelledError
+## DccMcpCancelledError
 
 ```python
-from dcc_mcp_core import CancelledError
+from dcc_mcp_core import DccMcpCancelledError
 ```
 
 Raised by `check_cancelled()` when the active request was cancelled. It derives
@@ -55,26 +55,30 @@ from `DccMcpError` and remains in the plain `Exception` lineage, so the
 `@skill_entry` decorator's generic `except Exception` branch converts an
 unhandled cancellation into a standard skill error dict.
 
+`CancelledError` remains as a deprecated compatibility alias. New code should
+use `DccMcpCancelledError` so catches cannot be confused with
+`asyncio.CancelledError` or `concurrent.futures.CancelledError`.
+
 ## check_cancelled
 
 ```python
 check_cancelled() -> None
 ```
 
-Raise `CancelledError` if the active request has been cancelled. No-op when invoked outside of a request context (e.g. from a REPL or unit test).
+Raise `DccMcpCancelledError` if the active request has been cancelled. No-op when invoked outside of a request context (e.g. from a REPL or unit test).
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | (none) | | |
 
-**Raises:** `CancelledError` — if a `CancelToken` is installed and its `cancelled` property is `True`.
+**Raises:** `DccMcpCancelledError` — if a `CancelToken` is installed and its `cancelled` property is `True`.
 
 ```python
 from dcc_mcp_core import check_cancelled, skill_success
 
 def run(iterations: int = 100) -> dict:
     for _ in range(iterations):
-        check_cancelled()  # raises CancelledError when cancelled
+        check_cancelled()  # raises DccMcpCancelledError when cancelled
         do_one_unit_of_work()
     return skill_success("done")
 ```
@@ -156,7 +160,7 @@ Concrete implementations are free to expose additional fields (request id, progr
 check_dcc_cancelled() -> None
 ```
 
-Cheap probe that raises `CancelledError` if **either** the active MCP `CancelToken` *or* the per-job `JobHandle` reports cancellation. Skill scripts that can run outside a request context should call this instead of `check_cancelled`.
+Cheap probe that raises `DccMcpCancelledError` if **either** the active MCP `CancelToken` *or* the per-job `JobHandle` reports cancellation. Skill scripts that can run outside a request context should call this instead of `check_cancelled`.
 
 ```python
 from dcc_mcp_core import check_dcc_cancelled, skill_success

--- a/docs/api/dispatcher.md
+++ b/docs/api/dispatcher.md
@@ -399,7 +399,7 @@ def main(frames):
         check_dcc_cancelled()      # honours both MCP token AND callable-job flag
         # equivalent manual probe:
         # job = current_callable_job.get()
-        # if job is not None and job.cancelled: raise CancelledError()
+        # if job is not None and job.cancelled: raise DccMcpCancelledError()
         render_frame(frame)
 ```
 

--- a/docs/zh/api/cancellation.md
+++ b/docs/zh/api/cancellation.md
@@ -4,7 +4,7 @@
 
 协作式取消机制，用于在技能脚本和工具调度中支持请求级别的取消操作。基于 `contextvars` 实现，调度器自动设置 `CancelToken`，脚本通过 `check_cancelled()` 检查取消状态。
 
-**导出符号：** `CancelToken`, `CancelledError`, `check_cancelled`, `set_cancel_token`, `reset_cancel_token`, `current_cancel_token`
+**导出符号：** `CancelToken`, `DccMcpCancelledError`, `CancelledError`, `check_cancelled`, `set_cancel_token`, `reset_cancel_token`, `current_cancel_token`
 
 ## CancelToken
 
@@ -13,13 +13,13 @@
 - `.cancel()` — 标记为已取消
 - `.cancelled -> bool` — 是否已取消
 
-## CancelledError
+## DccMcpCancelledError
 
-当活动请求被取消时，由 `check_cancelled()` 抛出的异常。
+当活动请求被取消时，由 `check_cancelled()` 抛出的异常。`CancelledError` 是保留的弃用兼容别名。
 
 ## check_cancelled()
 
-检查当前请求是否已被取消。如已取消则抛出 `CancelledError`，否则无操作（no-op）。在请求上下文外调用为安全空操作。
+检查当前请求是否已被取消。如已取消则抛出 `DccMcpCancelledError`，否则无操作（no-op）。在请求上下文外调用为安全空操作。
 
 ## set_cancel_token / reset_cancel_token
 

--- a/llms.txt
+++ b/llms.txt
@@ -110,7 +110,7 @@ legacy unsigned staging, and does not replace a running server.
 | Inline chart / table / image result (MCP Apps, issue #409) | `skill_success_with_chart(msg, spec)` / `skill_success_with_table(msg, headers, rows)` / `skill_success_with_image(msg, image_data=...)` |
 | Run skill scripts inside embedded DCC (no subprocess) | `SkillCatalog.set_in_process_executor(callable)` on the server's catalog — callable receives `(script_path, params) -> dict` |
 | Claude Code one-click plugin bundle (issue #410) | `build_plugin_manifest(dcc_name, mcp_url, skill_paths, api_key=...)` + `export_plugin_manifest(manifest, path)` or `server.plugin_manifest(version=...)` |
-| Cooperative cancellation in in-process skill scripts (MCP + REST) | `check_dcc_cancelled()` — raises `CancelledError` when the server-owned async job is cancelled; `current_job_id()` returns that job id; `current_cancel_token()` exposes a read-only `CancellationProbe` (`cancelled`, `job_id`) |
+| Cooperative cancellation in in-process skill scripts (MCP + REST) | `check_dcc_cancelled()` — raises `DccMcpCancelledError` when the server-owned async job is cancelled; `current_job_id()` returns that job id; `current_cancel_token()` exposes a read-only `CancellationProbe` (`cancelled`, `job_id`) |
 | Cooperative cancellation in DCC dispatcher skills (#522) | `check_dcc_cancelled()` — also honours per-job `JobHandle` published via `set_current_job(handle)`; required for skills launched outside an MCP request context (queued batch render, `scriptJob` callback, simulation runner) |
 | Detect a misconfigured GUI binary on `DCC_MCP_PYTHON_EXECUTABLE` (#524) | `is_gui_executable(path)` → `GuiExecutableHint(gui_path, dcc_kind, recommended_replacement)` or `None` for python/unknown binaries; covers maya/houdini/unreal/blender/3dsmax/nuke/modo/motionbuilder/c4d/katana |
 | Auto-correct a GUI binary to its headless sibling (#524) | `correct_python_executable(path)` — returns `mayapy.exe` next to `maya.exe`, `hython` next to `houdini`, `UnrealEditor-Cmd.exe` next to `UnrealEditor.exe`; falls back to original path when no sibling is found on disk |
@@ -613,8 +613,8 @@ Rust `dcc_mcp_models::DccMcpError` enum.
 
 - `CancellationProbe` (`Protocol`, runtime-checkable) — read-only contract exposed to skill code: `.cancelled -> bool`, `.job_id -> str | None`
 - `CancelToken(job_id=None)` — mutable pure-Python implementation for dispatchers; `.cancel()`, `.cancelled -> bool`, `.job_id -> str | None`
-- `CancelledError(DccMcpError)` — raised by `check_cancelled()` / `check_dcc_cancelled()` when cancellation was signalled; remains an `Exception` subtype
-- `check_cancelled() -> None` — raise `CancelledError` if the active MCP request was cancelled (no-op outside request context)
+- `DccMcpCancelledError(DccMcpError)` — raised by `check_cancelled()` / `check_dcc_cancelled()` when cancellation was signalled; remains an `Exception` subtype; `CancelledError` is a deprecated compatibility alias
+- `check_cancelled() -> None` — raise `DccMcpCancelledError` if the active MCP request was cancelled (no-op outside request context)
 - `check_dcc_cancelled() -> None` (#522) — combines `check_cancelled()` with a per-job check; raises if either the MCP token OR the per-job `JobHandle` reports cancellation; use this in skills launched from a DCC dispatcher rather than an MCP request
 - `JobHandle` (`Protocol`, runtime-checkable) — contract for the per-job handle a host dispatcher publishes; only `cancelled: bool` is contractual
 - `current_job: ContextVar[JobHandle | None]` — read-only contextvar (default `None`) holding the active per-job handle

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -454,6 +454,7 @@ _LAZY: dict[str, str] = {
     "CancellationProbe": "dcc_mcp_core.cancellation",
     "CancelToken": "dcc_mcp_core.cancellation",
     "CancelledError": "dcc_mcp_core.cancellation",
+    "DccMcpCancelledError": "dcc_mcp_core.cancellation",
     "JobHandle": "dcc_mcp_core.cancellation",
     "check_cancelled": "dcc_mcp_core.cancellation",
     "check_dcc_cancelled": "dcc_mcp_core.cancellation",

--- a/python/dcc_mcp_core/_server/host_ui_dispatcher.py
+++ b/python/dcc_mcp_core/_server/host_ui_dispatcher.py
@@ -31,7 +31,7 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 
-from dcc_mcp_core.cancellation import CancelledError
+from dcc_mcp_core.cancellation import DccMcpCancelledError
 from dcc_mcp_core.cancellation import reset_current_job
 from dcc_mcp_core.cancellation import set_current_job
 from dcc_mcp_core.chunked_runner import ChunkedRunner
@@ -166,7 +166,7 @@ class HostUiJobEntry:
                 output=output,
                 job_id=self.job_id,
             )
-        except CancelledError:
+        except DccMcpCancelledError:
             self.outcome = host_ui_outcome(
                 self.request_id,
                 self.affinity,

--- a/python/dcc_mcp_core/cancellation.py
+++ b/python/dcc_mcp_core/cancellation.py
@@ -15,7 +15,7 @@ sprinkle inside long-running loops:
 
     def run(iterations: int = 100) -> dict:
         for _ in range(iterations):
-            check_cancelled()  # raises CancelledError when the caller cancels
+            check_cancelled()  # raises DccMcpCancelledError when cancelled
             do_one_unit_of_work()
         return skill_success("done")
 
@@ -58,6 +58,7 @@ __all__ = [
     "CancelToken",
     "CancellationProbe",
     "CancelledError",
+    "DccMcpCancelledError",
     "JobHandle",
     "check_cancelled",
     "check_dcc_cancelled",
@@ -71,7 +72,7 @@ __all__ = [
 ]
 
 
-class CancelledError(DccMcpError):
+class DccMcpCancelledError(DccMcpError):
     """Raised by :func:`check_cancelled` when the active request was cancelled.
 
     This remains in the plain :class:`Exception` lineage (not
@@ -79,9 +80,14 @@ class CancelledError(DccMcpError):
     :class:`asyncio.CancelledError`) because skill scripts may run in
     synchronous contexts that do not import either module.  The
     ``@skill_entry`` decorator's generic ``except Exception`` branch will
-    convert an unhandled :class:`CancelledError` into a standard skill
+    convert an unhandled :class:`DccMcpCancelledError` into a standard skill
     error dict, so most authors will never need to catch it directly.
     """
+
+
+# Deprecated compatibility alias. New code should use DccMcpCancelledError so
+# it cannot be confused with asyncio or concurrent.futures cancellation.
+CancelledError = DccMcpCancelledError
 
 
 @runtime_checkable
@@ -165,7 +171,7 @@ _current_job_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
 
 
 def check_cancelled() -> None:
-    """Raise :class:`CancelledError` if the active request has been cancelled.
+    """Raise :class:`DccMcpCancelledError` if the request was cancelled.
 
     This is a no-op when invoked outside of a request context (for
     example from an interactive REPL, a unit test, or a DCC host that
@@ -174,14 +180,14 @@ def check_cancelled() -> None:
     the script harder to test in isolation.
 
     Raises:
-        CancelledError: If a :class:`CancelToken` is installed in the
+        DccMcpCancelledError: If a :class:`CancelToken` is installed in the
             current context and its :attr:`CancelToken.cancelled`
             property is ``True``.
 
     """
     token = _current_token.get()
     if token is not None and token.cancelled:
-        raise CancelledError("Request cancelled by client")
+        raise DccMcpCancelledError("Request cancelled by client")
 
 
 def current_cancel_token() -> CancellationProbe | None:
@@ -300,7 +306,7 @@ current_job: contextvars.ContextVar[JobHandle | None] = contextvars.ContextVar(
 def check_dcc_cancelled() -> None:
     """Honour both MCP-request and DCC-dispatcher cancellation signals.
 
-    Raises :class:`CancelledError` when either the active MCP request or
+    Raises :class:`DccMcpCancelledError` when either the active MCP request or
     the owning host dispatcher has signalled cancellation. Two layers
     are checked in order:
 
@@ -318,14 +324,14 @@ def check_dcc_cancelled() -> None:
     :func:`check_cancelled` so dispatcher-driven cancels are honoured.
 
     Raises:
-        CancelledError: If the MCP token or the per-job handle reports
+        DccMcpCancelledError: If the MCP token or the per-job handle reports
             cancellation.
 
     """
     check_cancelled()
     job = current_job.get()
     if job is not None and job.cancelled:
-        raise CancelledError("Job cancelled by dispatcher")
+        raise DccMcpCancelledError("Job cancelled by dispatcher")
 
 
 def set_current_job(job: JobHandle | None) -> contextvars.Token:

--- a/python/dcc_mcp_core/chunked_runner.py
+++ b/python/dcc_mcp_core/chunked_runner.py
@@ -10,8 +10,8 @@ from typing import Callable
 from typing import Iterable
 from typing import Iterator
 
-from dcc_mcp_core.cancellation import CancelledError
 from dcc_mcp_core.cancellation import CancelToken
+from dcc_mcp_core.cancellation import DccMcpCancelledError
 from dcc_mcp_core.cancellation import current_cancel_token
 
 logger = logging.getLogger(__name__)
@@ -141,7 +141,7 @@ class ChunkedRunner:
         except StopIteration:
             self._publish_terminal("completed")
             return False
-        except CancelledError:
+        except DccMcpCancelledError:
             self._publish_terminal("cancelled")
             return False
         except Exception as exc:

--- a/python/dcc_mcp_core/skills_helper.py
+++ b/python/dcc_mcp_core/skills_helper.py
@@ -789,6 +789,7 @@ _LAZY_EXPORTS: dict[str, str] = {
     # Cooperative cancellation.
     "CancellationProbe": "dcc_mcp_core.cancellation",
     "CancelledError": "dcc_mcp_core.cancellation",
+    "DccMcpCancelledError": "dcc_mcp_core.cancellation",
     "check_cancelled": "dcc_mcp_core.cancellation",
     "check_dcc_cancelled": "dcc_mcp_core.cancellation",
     "current_job_id": "dcc_mcp_core.cancellation",

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -14,6 +14,7 @@ import pytest
 from dcc_mcp_core import CancellationProbe
 from dcc_mcp_core import CancelledError
 from dcc_mcp_core import CancelToken
+from dcc_mcp_core import DccMcpCancelledError
 from dcc_mcp_core import JobHandle
 from dcc_mcp_core import check_cancelled
 from dcc_mcp_core import check_dcc_cancelled
@@ -35,6 +36,7 @@ def test_exports_available() -> None:
         "CancelToken",
         "CancelledError",
         "CancellationProbe",
+        "DccMcpCancelledError",
         "check_cancelled",
         "current_cancel_token",
         "current_job_id",
@@ -63,7 +65,7 @@ def test_raises_when_cancelled() -> None:
         check_cancelled()  # not cancelled yet → no raise
         token.cancel()
         assert token.cancelled is True
-        with pytest.raises(CancelledError):
+        with pytest.raises(DccMcpCancelledError):
             check_cancelled()
     finally:
         reset_cancel_token(reset)
@@ -139,7 +141,7 @@ def test_two_concurrent_contexts_do_not_leak() -> None:
         try:
             check_cancelled()
             return False
-        except CancelledError:
+        except DccMcpCancelledError:
             return True
 
     assert ctx_a.run(_check_raises) is True
@@ -204,14 +206,16 @@ def test_explicit_none_clears_inherited_token() -> None:
         reset_cancel_token(outer)
 
 
-def test_cancelled_error_is_exception_subclass() -> None:
-    """CancelledError stays in the Exception lineage (not BaseException-only)."""
-    assert issubclass(CancelledError, Exception)
+def test_cancellation_error_name_and_compatibility_alias() -> None:
+    """The canonical name is unambiguous and the old alias remains compatible."""
+    assert DccMcpCancelledError.__name__ == "DccMcpCancelledError"
+    assert CancelledError is DccMcpCancelledError
+    assert issubclass(DccMcpCancelledError, Exception)
     # Ensure @skill_entry's `except Exception` branch can catch it.
     try:
-        raise CancelledError("x")
+        raise DccMcpCancelledError("x")
     except Exception as exc:
-        assert isinstance(exc, CancelledError)
+        assert isinstance(exc, DccMcpCancelledError)
 
 
 # ── check_dcc_cancelled / JobHandle (issue #522) ───────────────────────────
@@ -251,7 +255,7 @@ def test_check_dcc_cancelled_honours_mcp_token() -> None:
     reset_token = set_cancel_token(token)
     try:
         token.cancel()
-        with pytest.raises(CancelledError, match="Request cancelled"):
+        with pytest.raises(DccMcpCancelledError, match="Request cancelled"):
             check_dcc_cancelled()
     finally:
         reset_cancel_token(reset_token)
@@ -264,7 +268,7 @@ def test_check_dcc_cancelled_honours_per_job_handle() -> None:
     try:
         check_dcc_cancelled()  # not yet cancelled → no-op
         job.cancelled = True
-        with pytest.raises(CancelledError, match="Job cancelled by dispatcher"):
+        with pytest.raises(DccMcpCancelledError, match="Job cancelled by dispatcher"):
             check_dcc_cancelled()
     finally:
         reset_current_job(reset)
@@ -282,7 +286,7 @@ def test_check_dcc_cancelled_clears_per_thread() -> None:
             # New OS thread → fresh contextvar copy is empty → no-op.
             try:
                 check_dcc_cancelled()
-            except CancelledError:
+            except DccMcpCancelledError:
                 seen.append(False)
             else:
                 seen.append(True)
@@ -323,7 +327,7 @@ def test_check_dcc_cancelled_token_takes_priority_over_job() -> None:
     reset_t = set_cancel_token(token)
     reset_j = set_current_job(job)
     try:
-        with pytest.raises(CancelledError, match="Request cancelled"):
+        with pytest.raises(DccMcpCancelledError, match="Request cancelled"):
             check_dcc_cancelled()
     finally:
         reset_current_job(reset_j)

--- a/tests/test_error_hierarchy.py
+++ b/tests/test_error_hierarchy.py
@@ -15,7 +15,7 @@ from dcc_mcp_core.bridge import BridgeConnectionError
 from dcc_mcp_core.bridge import BridgeError
 from dcc_mcp_core.bridge import BridgeRpcError
 from dcc_mcp_core.bridge import BridgeTimeoutError
-from dcc_mcp_core.cancellation import CancelledError
+from dcc_mcp_core.cancellation import DccMcpCancelledError
 from dcc_mcp_core.cua_cli import CuaCliError
 from dcc_mcp_core.guardrails import DccGuardrailError
 from dcc_mcp_core.host._fallback import DispatchError
@@ -60,7 +60,7 @@ def test_public_errors_share_one_root() -> None:
         BridgeError,
         BridgeRpcError,
         BridgeTimeoutError,
-        CancelledError,
+        DccMcpCancelledError,
         CuaCliError,
         DccGuardrailError,
         DispatchError,

--- a/tests/test_host_ui_dispatcher.py
+++ b/tests/test_host_ui_dispatcher.py
@@ -13,7 +13,6 @@ from dcc_mcp_core._server.host_ui_dispatcher import HostUiDispatcherBase
 from dcc_mcp_core._server.host_ui_dispatcher import HostUiJobEntry
 from dcc_mcp_core._server.host_ui_dispatcher import host_ui_outcome
 from dcc_mcp_core._server.host_ui_dispatcher import normalize_affinity
-from dcc_mcp_core.cancellation import CancelledError
 from dcc_mcp_core.cancellation import check_dcc_cancelled
 
 

--- a/tests/test_inprocess_executor.py
+++ b/tests/test_inprocess_executor.py
@@ -648,7 +648,7 @@ def test_host_execution_bridge_connects_cooperative_cancel_token(tmp_path: Path)
         result = call.result(timeout=2)
 
     assert result["success"] is False
-    assert result["error"] == "CancelledError"
+    assert result["error"] == "DccMcpCancelledError"
     assert current_job_id() is None
 
 


### PR DESCRIPTION
## Summary

- introduce `DccMcpCancelledError` as the unambiguous cancellation exception
- retain `CancelledError` as a deprecated compatibility alias
- migrate Core consumers, error reporting, tests, and documentation

## Validation

- Python: 10141 passed, 134 skipped, 3 xfailed
- cancellation and dispatcher tests: 117 passed
- Python 3.7 syntax: 521 files
- `vx just preflight`: 3562 Rust tests, strict Clippy, fmt, doctests
- VitePress docs build
- creator skills unchanged; no adapter wiring or agent workflow change

Refs #2196