### PR TITLE
refactor: move capability index state to core

### DIFF
--- a/crates/dcc-mcp-gateway-core/README.md
+++ b/crates/dcc-mcp-gateway-core/README.md
@@ -1,7 +1,7 @@
 # dcc-mcp-gateway-core
 
-Domain layer for the DCC MCP gateway — pure types with no HTTP, no async
-runtime, and no dependency on `dcc-mcp-gateway`.
+Domain layer for the DCC MCP gateway — pure types with no direct HTTP or
+async-runtime dependency, and no dependency on `dcc-mcp-gateway`.
 
 This crate is the innermost layer of the Clean-Architecture split called
 for in issue [#845]. The dependency direction is strictly inward:
@@ -15,6 +15,10 @@ dcc-mcp-gateway-core  (domain — this crate)
 
 Consumers in `dcc-mcp-gateway` re-export the types under stable paths so
 existing call sites keep compiling while the migration is in flight.
+The lock-free `CapabilityIndexState` owns per-instance slices, unloaded
+records, snapshots, fingerprints, and bounded lifecycle tombstones. The
+gateway wrapper supplies synchronization, cache generations, clocks, and
+async refresh gates without leaking those runtime concerns inward.
 
 ## Stability
 

--- a/crates/dcc-mcp-gateway-core/src/capability/index.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/index.rs
@@ -1,11 +1,10 @@
-//! Pure value types describing the gateway capability index snapshot.
+//! Pure state and value types for the gateway capability index.
 //!
 //! These are the *read-side* shapes a REST or MCP handler sees when it
-//! takes a snapshot of the capability index. The mutable
-//! `CapabilityIndex` itself — which owns a `parking_lot::RwLock` and a
-//! `BTreeMap` of per-instance state — stays in `dcc-mcp-gateway`
-//! because it carries runtime state the domain layer has no business
-//! holding (issue #845).
+//! takes a snapshot of the capability index. [`CapabilityIndexState`]
+//! owns the lock-free domain state and mutation rules. The gateway
+//! crate wraps it in synchronization and keeps refresh coordination,
+//! clocks, and async gates at the application boundary (issue #845).
 //!
 //! # Why split snapshot from index
 //!
@@ -17,14 +16,16 @@
 //! without depending on the gateway crate's tokio / axum / parking_lot
 //! footprint.
 
-use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use uuid::Uuid;
 
 use super::record::CapabilityRecord;
+
+const MAX_INSTANCE_TOMBSTONES: usize = 256;
 
 /// Stable fingerprint of one instance's contribution to the index.
 ///
@@ -95,6 +96,206 @@ pub struct IndexSnapshot {
     /// diagnostics can trace which `refresh_instance` cycles produced
     /// which snapshot.
     pub fingerprints: HashMap<Uuid, InstanceFingerprint>,
+}
+
+/// Bounded lifecycle provenance for an instance removed from the live index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceTombstone {
+    /// Removed gateway instance.
+    pub instance_id: Uuid,
+    /// Canonical DCC type associated with the last live record.
+    pub dcc_type: String,
+    /// Last observed lifecycle status, such as `exited` or `host-died`.
+    pub previous_status: String,
+}
+
+#[derive(Debug)]
+struct InstanceSlice {
+    records: Arc<[CapabilityRecord]>,
+    fingerprint: InstanceFingerprint,
+}
+
+/// Lock-free domain state behind the gateway's concurrent capability index.
+///
+/// This type deliberately knows nothing about async refreshes, wall clocks,
+/// HTTP clients, or synchronization. Callers provide exclusive access and
+/// use the returned `changed` flags to maintain their own cache generation.
+#[derive(Debug, Default)]
+pub struct CapabilityIndexState {
+    per_instance: BTreeMap<Uuid, InstanceSlice>,
+    tombstones: VecDeque<InstanceTombstone>,
+    unloaded: Arc<[CapabilityRecord]>,
+}
+
+impl CapabilityIndexState {
+    /// Replace an instance slice and report `(previous_fingerprint, changed)`.
+    pub fn upsert_instance(
+        &mut self,
+        instance_id: Uuid,
+        records: Vec<CapabilityRecord>,
+        fingerprint: InstanceFingerprint,
+    ) -> (Option<InstanceFingerprint>, bool) {
+        if records.is_empty() {
+            let previous = self
+                .per_instance
+                .remove(&instance_id)
+                .map(|slice| slice.fingerprint);
+            return (previous, previous.is_some());
+        }
+
+        self.tombstones.retain(|row| row.instance_id != instance_id);
+        if let Some(current) = self.per_instance.get(&instance_id)
+            && current.fingerprint == fingerprint
+            && current.records.as_ref() == records.as_slice()
+        {
+            return (Some(current.fingerprint), false);
+        }
+
+        let previous = self
+            .per_instance
+            .insert(
+                instance_id,
+                InstanceSlice {
+                    records: Arc::from(records),
+                    fingerprint,
+                },
+            )
+            .map(|slice| slice.fingerprint);
+        (previous, true)
+    }
+
+    /// Remove an instance slice.
+    pub fn remove_instance(&mut self, instance_id: Uuid) -> bool {
+        self.per_instance.remove(&instance_id).is_some()
+    }
+
+    /// Remove an instance while retaining bounded lifecycle provenance.
+    ///
+    /// Returns `(was_live, changed)`. A later status for an existing
+    /// tombstone changes provenance even when the instance is already absent.
+    pub fn remove_instance_with_status(
+        &mut self,
+        instance_id: Uuid,
+        previous_status: &str,
+    ) -> (bool, bool) {
+        let removed = self.per_instance.remove(&instance_id);
+        let dcc_type = removed
+            .as_ref()
+            .and_then(|slice| slice.records.first())
+            .map(|record| record.dcc_type.clone())
+            .or_else(|| {
+                self.tombstones
+                    .iter()
+                    .find(|row| row.instance_id == instance_id)
+                    .map(|row| row.dcc_type.clone())
+            });
+        let Some(dcc_type) = dcc_type else {
+            return (removed.is_some(), false);
+        };
+
+        self.tombstones.retain(|row| row.instance_id != instance_id);
+        if self.tombstones.len() == MAX_INSTANCE_TOMBSTONES {
+            self.tombstones.pop_front();
+        }
+        self.tombstones.push_back(InstanceTombstone {
+            instance_id,
+            dcc_type,
+            previous_status: previous_status.to_string(),
+        });
+        (removed.is_some(), true)
+    }
+
+    /// Resolve the newest unique lifecycle row by DCC and UUID/prefix.
+    #[must_use]
+    pub fn instance_tombstone(
+        &self,
+        dcc_type: &str,
+        instance_hint: &str,
+    ) -> Option<InstanceTombstone> {
+        let exact = Uuid::parse_str(instance_hint).ok();
+        let prefix = instance_hint.to_ascii_lowercase();
+        let mut matches = self.tombstones.iter().rev().filter(|row| {
+            row.dcc_type.eq_ignore_ascii_case(dcc_type)
+                && exact.map_or_else(
+                    || {
+                        row.instance_id
+                            .simple()
+                            .to_string()
+                            .starts_with(prefix.as_str())
+                    },
+                    |id| row.instance_id == id,
+                )
+        });
+        let row = matches.next()?.clone();
+        matches.next().is_none().then_some(row)
+    }
+
+    /// Return indexed instance ids in stable UUID order.
+    #[must_use]
+    pub fn instance_ids(&self) -> Vec<Uuid> {
+        self.per_instance.keys().copied().collect()
+    }
+
+    /// Build an immutable, deterministically ordered snapshot.
+    #[must_use]
+    pub fn snapshot(&self) -> IndexSnapshot {
+        let loaded_count: usize = self
+            .per_instance
+            .values()
+            .map(|slice| slice.records.len())
+            .sum();
+        let mut records = Vec::with_capacity(loaded_count + self.unloaded.len());
+        let mut fingerprints = HashMap::with_capacity(self.per_instance.len());
+        for (instance_id, slice) in &self.per_instance {
+            fingerprints.insert(*instance_id, slice.fingerprint);
+            records.extend_from_slice(&slice.records);
+        }
+        records.extend_from_slice(&self.unloaded);
+        records.sort_by(|a, b| a.tool_slug.cmp(&b.tool_slug));
+        IndexSnapshot {
+            records: Arc::from(records),
+            fingerprints,
+        }
+    }
+
+    /// Return the fingerprint stored for one instance.
+    #[must_use]
+    pub fn fingerprint_for(&self, instance_id: Uuid) -> Option<InstanceFingerprint> {
+        self.per_instance
+            .get(&instance_id)
+            .map(|slice| slice.fingerprint)
+    }
+
+    /// Count live records across all instances.
+    #[must_use]
+    pub fn total_records(&self) -> usize {
+        self.per_instance
+            .values()
+            .map(|slice| slice.records.len())
+            .sum()
+    }
+
+    /// Count tracked live instances.
+    #[must_use]
+    pub fn instance_count(&self) -> usize {
+        self.per_instance.len()
+    }
+
+    /// Replace unloaded-skill records, returning whether content changed.
+    pub fn set_unloaded_records(&mut self, mut records: Vec<CapabilityRecord>) -> bool {
+        records.sort_by(|a, b| a.tool_slug.cmp(&b.tool_slug));
+        if self.unloaded.as_ref() == records.as_slice() {
+            return false;
+        }
+        self.unloaded = Arc::from(records);
+        true
+    }
+
+    /// Count unloaded-skill records.
+    #[must_use]
+    pub fn unloaded_count(&self) -> usize {
+        self.unloaded.len()
+    }
 }
 
 impl IndexSnapshot {
@@ -258,6 +459,82 @@ mod tests {
         assert_eq!(
             snap.fingerprints.get(&iid),
             Some(&InstanceFingerprint(0xdead_beef))
+        );
+    }
+
+    #[test]
+    fn state_upsert_snapshot_and_remove_are_consistent() {
+        let maya = Uuid::from_u128(1);
+        let photoshop = Uuid::from_u128(2);
+        let mut state = CapabilityIndexState::default();
+        let mut maya_record = make_record("maya.00000000.create_sphere");
+        maya_record.instance_id = maya;
+        let mut photoshop_record = make_record("photoshop.00000000.open_document");
+        photoshop_record.instance_id = photoshop;
+        photoshop_record.dcc_type = "photoshop".into();
+
+        assert_eq!(
+            state.upsert_instance(maya, vec![maya_record], InstanceFingerprint(10)),
+            (None, true)
+        );
+        assert_eq!(
+            state.upsert_instance(photoshop, vec![photoshop_record], InstanceFingerprint(20)),
+            (None, true)
+        );
+        assert_eq!(state.instance_ids(), [maya, photoshop]);
+        assert_eq!(state.snapshot().records.len(), 2);
+        assert!(state.remove_instance(maya));
+        assert_eq!(state.fingerprint_for(maya), None);
+        assert_eq!(state.total_records(), 1);
+    }
+
+    #[test]
+    fn identical_upsert_and_unloaded_replacement_are_noops() {
+        let iid = Uuid::from_u128(3);
+        let record = make_record("custom.00000000.inspect");
+        let mut state = CapabilityIndexState::default();
+        assert!(
+            state
+                .upsert_instance(iid, vec![record.clone()], InstanceFingerprint(1))
+                .1
+        );
+        assert!(
+            !state
+                .upsert_instance(iid, vec![record.clone()], InstanceFingerprint(1))
+                .1
+        );
+        assert!(state.set_unloaded_records(vec![record.clone()]));
+        assert!(!state.set_unloaded_records(vec![record]));
+    }
+
+    #[test]
+    fn tombstones_track_latest_status_and_clear_on_return() {
+        let iid = Uuid::from_u128(4);
+        let mut record = make_record("zbrush.00000000.get_scene");
+        record.instance_id = iid;
+        record.dcc_type = "zbrush".into();
+        let mut state = CapabilityIndexState::default();
+        state.upsert_instance(iid, vec![record.clone()], InstanceFingerprint(1));
+
+        assert_eq!(
+            state.remove_instance_with_status(iid, "exited"),
+            (true, true)
+        );
+        assert_eq!(
+            state
+                .instance_tombstone("zbrush", &iid.to_string())
+                .map(|row| row.previous_status),
+            Some("exited".into())
+        );
+        assert_eq!(
+            state.remove_instance_with_status(iid, "host-died"),
+            (false, true)
+        );
+        state.upsert_instance(iid, vec![record], InstanceFingerprint(2));
+        assert!(
+            state
+                .instance_tombstone("zbrush", &iid.to_string())
+                .is_none()
         );
     }
 }

--- a/crates/dcc-mcp-gateway-core/src/capability/mod.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/mod.rs
@@ -7,13 +7,13 @@
 //! | [`record`]         | `CapabilityRecord`, slug encoding / parsing, validation      |
 //! | [`search`]         | `SearchQuery`, `SearchHit`, pagination — delegates to `dcc-mcp-gateway-search` |
 //! | [`search_ranking`] | Re-exports scorers / [`SearchRecord`] from `dcc-mcp-gateway-search` |
-//! | [`index`]          | `IndexSnapshot`, `InstanceFingerprint` — read-side snapshot  |
+//! | [`index`]          | lock-free index state, snapshots, fingerprints, tombstones  |
 //! | [`builder`]        | `BuildOutcome` — output of the per-instance record builder   |
 //! | [`refresh`]        | `RefreshReason` — why a refresh cycle is running             |
 //!
-//! The mutable `CapabilityIndex` (which owns a `parking_lot::RwLock`
-//! and a `BTreeMap` of per-instance state), the `build_records_from_backend`
-//! builder (which borrows backend `&[McpTool]`), and the
+//! The concurrent `CapabilityIndex` wrapper (which owns synchronization
+//! and refresh gates), the `build_records_from_backend` builder (which
+//! borrows backend `&[McpTool]`), and the
 //! `refresh_instance` lifecycle driver (which owns a `reqwest::Client`)
 //! all live in `dcc-mcp-gateway` because they carry runtime state the
 //! domain layer has no business holding. The *wire types* — query
@@ -37,7 +37,10 @@ pub mod search_ranking;
 // facade so historical paths (`dcc_mcp_gateway_core::capability::
 // CapabilityRecord` etc.) keep working verbatim.
 pub use builder::BuildOutcome;
-pub use index::{IndexSnapshot, InstanceFingerprint, compute_fingerprint};
+pub use index::{
+    CapabilityIndexState, IndexSnapshot, InstanceFingerprint, InstanceTombstone,
+    compute_fingerprint,
+};
 pub use record::{
     CapabilityAnnotations, CapabilityGroupInfo, CapabilityMetadata, CapabilityRecord,
     SCHEMA_AVAILABLE, is_valid_dcc_bucket, parse_slug, tool_slug,

--- a/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
@@ -13,7 +13,7 @@
 //!
 //! # Read-side wire types (issue #845)
 //!
-//! [`InstanceFingerprint`] and [`IndexSnapshot`] were migrated to
+//! The lock-free state, [`InstanceFingerprint`], and [`IndexSnapshot`] live in
 //! [`dcc_mcp_gateway_core::capability::index`] so external Rust
 //! tooling can consume the snapshot shape without depending on this
 //! crate's tokio / axum / parking_lot footprint. They are re-exported
@@ -21,7 +21,7 @@
 //! `crate::gateway::capability::index::{InstanceFingerprint,
 //! IndexSnapshot}` paths working unchanged.
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
@@ -33,16 +33,10 @@ use uuid::Uuid;
 
 use super::record::CapabilityRecord;
 
-pub use dcc_mcp_gateway_core::capability::index::{IndexSnapshot, InstanceFingerprint};
-
-const MAX_INSTANCE_TOMBSTONES: usize = 256;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct InstanceTombstone {
-    pub(crate) instance_id: Uuid,
-    pub(crate) dcc_type: String,
-    pub(crate) previous_status: String,
-}
+use dcc_mcp_gateway_core::capability::index::CapabilityIndexState;
+pub use dcc_mcp_gateway_core::capability::index::{
+    IndexSnapshot, InstanceFingerprint, InstanceTombstone,
+};
 
 /// The canonical gateway-scoped capability index.
 ///
@@ -56,7 +50,7 @@ pub struct CapabilityIndex {
     /// A `BTreeMap` keeps the ordering stable without paying for a
     /// `HashMap::iter` resort on every snapshot build — the index is
     /// small enough that the log-n insert cost is noise.
-    inner: RwLock<InnerState>,
+    inner: RwLock<CapabilityIndexState>,
     /// Process-unique identity plus a monotonic content revision.
     ///
     /// This keeps cache validation O(1): callers do not need to clone and hash
@@ -81,30 +75,11 @@ pub struct CapabilityIndex {
     search_refresh_completed: RwLock<HashMap<Uuid, Instant>>,
 }
 
-#[derive(Default)]
-struct InnerState {
-    per_instance: BTreeMap<Uuid, InstanceSlice>,
-    /// Bounded lifecycle provenance for slugs whose instance was removed.
-    ///
-    /// ponytail: linear lookup is bounded at 256 rows; add a secondary map
-    /// only if high-churn gateways make this measurable.
-    tombstones: VecDeque<InstanceTombstone>,
-    /// Records built from unloaded skill metadata (discovered but not
-    /// yet loaded). These are indexed so `search_tools` can find
-    /// skills that aren't connected yet.
-    unloaded: Arc<[CapabilityRecord]>,
-}
-
-struct InstanceSlice {
-    records: Arc<[CapabilityRecord]>,
-    fingerprint: InstanceFingerprint,
-}
-
 impl CapabilityIndex {
     /// Create an empty index.
     pub fn new() -> Self {
         Self {
-            inner: RwLock::new(InnerState::default()),
+            inner: RwLock::new(CapabilityIndexState::default()),
             generation_seed: Uuid::new_v4(),
             revision: AtomicU64::new(0),
             refresh_checkpoint: Mutex::new(None),
@@ -135,49 +110,23 @@ impl CapabilityIndex {
         records: Vec<CapabilityRecord>,
         fingerprint: InstanceFingerprint,
     ) -> Option<InstanceFingerprint> {
-        let mut guard = self.inner.write();
-        if records.is_empty() {
-            let previous = guard
-                .per_instance
-                .remove(&instance_id)
-                .map(|s| s.fingerprint);
-            if previous.is_some() {
-                self.bump_revision();
-            }
-            return previous;
+        let (previous, changed) =
+            self.inner
+                .write()
+                .upsert_instance(instance_id, records, fingerprint);
+        if changed {
+            self.bump_revision();
         }
-        guard
-            .tombstones
-            .retain(|row| row.instance_id != instance_id);
-        if let Some(current) = guard.per_instance.get(&instance_id)
-            && current.fingerprint == fingerprint
-            && current.records.as_ref() == records.as_slice()
-        {
-            return Some(current.fingerprint);
-        }
-        let previous = guard
-            .per_instance
-            .insert(
-                instance_id,
-                InstanceSlice {
-                    records: Arc::from(records),
-                    fingerprint,
-                },
-            )
-            .map(|s| s.fingerprint);
-        self.bump_revision();
         previous
     }
 
     /// Drop every record belonging to `instance_id`. Returns `true`
     /// if the instance was present.
     pub fn remove_instance(&self, instance_id: Uuid) -> bool {
-        let mut guard = self.inner.write();
-        let removed = guard.per_instance.remove(&instance_id).is_some();
+        let removed = self.inner.write().remove_instance(instance_id);
         if removed {
             self.bump_revision();
         }
-        drop(guard);
         self.search_refresh_completed.write().remove(&instance_id);
         removed
     }
@@ -188,36 +137,15 @@ impl CapabilityIndex {
         instance_id: Uuid,
         previous_status: &str,
     ) -> bool {
-        let mut guard = self.inner.write();
-        let removed = guard.per_instance.remove(&instance_id);
-        let dcc_type = removed
-            .as_ref()
-            .and_then(|slice| slice.records.first())
-            .map(|record| record.dcc_type.clone())
-            .or_else(|| {
-                guard
-                    .tombstones
-                    .iter()
-                    .find(|row| row.instance_id == instance_id)
-                    .map(|row| row.dcc_type.clone())
-            });
-        if let Some(dcc_type) = dcc_type {
-            guard
-                .tombstones
-                .retain(|row| row.instance_id != instance_id);
-            if guard.tombstones.len() == MAX_INSTANCE_TOMBSTONES {
-                guard.tombstones.pop_front();
-            }
-            guard.tombstones.push_back(InstanceTombstone {
-                instance_id,
-                dcc_type,
-                previous_status: previous_status.to_string(),
-            });
+        let (removed, changed) = self
+            .inner
+            .write()
+            .remove_instance_with_status(instance_id, previous_status);
+        if changed {
             self.bump_revision();
         }
-        drop(guard);
         self.search_refresh_completed.write().remove(&instance_id);
-        removed.is_some()
+        removed
     }
 
     /// Resolve the most recent lifecycle row by DCC and UUID/prefix.
@@ -226,28 +154,14 @@ impl CapabilityIndex {
         dcc_type: &str,
         instance_hint: &str,
     ) -> Option<InstanceTombstone> {
-        let guard = self.inner.read();
-        let exact = Uuid::parse_str(instance_hint).ok();
-        let prefix = instance_hint.to_ascii_lowercase();
-        let mut matches = guard.tombstones.iter().rev().filter(|row| {
-            row.dcc_type.eq_ignore_ascii_case(dcc_type)
-                && exact.map_or_else(
-                    || {
-                        row.instance_id
-                            .simple()
-                            .to_string()
-                            .starts_with(prefix.as_str())
-                    },
-                    |id| row.instance_id == id,
-                )
-        });
-        let row = matches.next()?.clone();
-        matches.next().is_none().then_some(row)
+        self.inner
+            .read()
+            .instance_tombstone(dcc_type, instance_hint)
     }
 
     /// Return indexed instance ids without cloning or sorting capability rows.
     pub(crate) fn instance_ids(&self) -> Vec<Uuid> {
-        self.inner.read().per_instance.keys().copied().collect()
+        self.inner.read().instance_ids()
     }
 
     pub(crate) fn search_refresh_is_recent(
@@ -295,7 +209,7 @@ impl CapabilityIndex {
     /// that aren't connected yet.
     pub fn snapshot(&self) -> IndexSnapshot {
         let guard = self.inner.read();
-        Self::snapshot_locked(&guard)
+        guard.snapshot()
     }
 
     /// Return a coherent owned snapshot and its generation.
@@ -305,7 +219,7 @@ impl CapabilityIndex {
     /// generation that produced them.
     pub fn snapshot_with_generation(&self) -> (IndexSnapshot, String) {
         let guard = self.inner.read();
-        let snapshot = Self::snapshot_locked(&guard);
+        let snapshot = guard.snapshot();
         let generation = self.generation_string(self.revision.load(Ordering::Acquire));
         (snapshot, generation)
     }
@@ -313,28 +227,6 @@ impl CapabilityIndex {
     /// Return the current opaque generation without cloning index records.
     pub fn generation(&self) -> String {
         self.generation_string(self.revision.load(Ordering::Acquire))
-    }
-
-    fn snapshot_locked(guard: &InnerState) -> IndexSnapshot {
-        let loaded_count: usize = guard.per_instance.values().map(|s| s.records.len()).sum();
-        let unloaded_count = guard.unloaded.len();
-        let mut records: Vec<CapabilityRecord> = Vec::with_capacity(loaded_count + unloaded_count);
-        let mut fingerprints: HashMap<Uuid, InstanceFingerprint> =
-            HashMap::with_capacity(guard.per_instance.len());
-        for (iid, slice) in guard.per_instance.iter() {
-            fingerprints.insert(*iid, slice.fingerprint);
-            records.extend_from_slice(&slice.records);
-        }
-        // Append unloaded skill records so they appear in search results.
-        records.extend_from_slice(&guard.unloaded);
-        // Stable order: by slug — the builder already sorts per-
-        // instance, so this sort is effectively a merge of sorted
-        // runs and stays cheap.
-        records.sort_by(|a, b| a.tool_slug.cmp(&b.tool_slug));
-        IndexSnapshot {
-            records: Arc::from(records),
-            fingerprints,
-        }
     }
 
     fn bump_revision(&self) {
@@ -349,26 +241,17 @@ impl CapabilityIndex {
     /// any. Used by the refresh loop to short-circuit when the
     /// backend reports an identical `tools/list` shape.
     pub fn fingerprint_for(&self, instance_id: Uuid) -> Option<InstanceFingerprint> {
-        self.inner
-            .read()
-            .per_instance
-            .get(&instance_id)
-            .map(|s| s.fingerprint)
+        self.inner.read().fingerprint_for(instance_id)
     }
 
     /// Count live records across every instance; diagnostics-only.
     pub fn total_records(&self) -> usize {
-        self.inner
-            .read()
-            .per_instance
-            .values()
-            .map(|s| s.records.len())
-            .sum()
+        self.inner.read().total_records()
     }
 
     /// Count tracked instances; diagnostics-only.
     pub fn instance_count(&self) -> usize {
-        self.inner.read().per_instance.len()
+        self.inner.read().instance_count()
     }
 
     /// Replace the unloaded-skill records with `records`.
@@ -382,21 +265,14 @@ impl CapabilityIndex {
     /// to avoid a direct dependency from `dcc-mcp-gateway` on
     /// `dcc-mcp-models`.
     pub fn set_unloaded_records(&self, records: Vec<CapabilityRecord>) {
-        let mut guard = self.inner.write();
-        // Keep unloaded records sorted so `snapshot()` doesn't need
-        // to re-sort them separately.
-        let mut sorted = records;
-        sorted.sort_by(|a, b| a.tool_slug.cmp(&b.tool_slug));
-        if guard.unloaded.as_ref() == sorted.as_slice() {
-            return;
+        if self.inner.write().set_unloaded_records(records) {
+            self.bump_revision();
         }
-        guard.unloaded = Arc::from(sorted);
-        self.bump_revision();
     }
 
     /// Number of unloaded skill records currently indexed; diagnostics-only.
     pub fn unloaded_count(&self) -> usize {
-        self.inner.read().unloaded.len()
+        self.inner.read().unloaded_count()
     }
 }
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -361,11 +361,12 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 
 ### dcc-mcp-gateway-core
 
-**Purpose**: Pure gateway domain layer for capability records, slug helpers, search queries/pages/hits, and ranking/scoring. It has no HTTP, async runtime, file-registry, or `dcc-mcp-gateway` dependency.
+**Purpose**: Pure gateway domain layer for capability records, lock-free index state, slug helpers, search queries/pages/hits, and ranking/scoring. It has no direct HTTP, async-runtime, file-registry, or `dcc-mcp-gateway` dependency.
 
 **Key Components**:
 - `PendingCall` — gateway-to-backend cancellation correlation primitive.
 - `CapabilityRecord` — compact per-tool search/dispatch record.
+- `CapabilityIndexState`, `IndexSnapshot`, `InstanceFingerprint`, `InstanceTombstone` — synchronization-free per-instance mutation, snapshot, and lifecycle rules.
 - `SearchQuery`, `SearchHit`, `SearchPage`, `SearchMode` — token-budgeted capability search contract.
 - `capability_naming` — gateway instance/skill name projection and bare-name collision policy; delegates wire-name validation to `dcc-mcp-naming`.
 - `ExactScorer`, `FuzzyScorer`, `SubstringScorer`, `StrategyScorer` — pluggable ranking strategies.
@@ -383,7 +384,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 **Purpose**: Multi-DCC gateway application/infrastructure: registry probing, dynamic MCP wrappers, `/v1/*` REST facade, routing, diagnostics, and admin surface.
 
 **Key Components**:
-- `CapabilityIndex` + refresh tasks — build records from live per-DCC instances and evict stale ones.
+- `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
 - Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health.


### PR DESCRIPTION
## Summary
- move lock-free capability index state and mutation rules into gateway-core
- keep synchronization, generations, clocks, and async refresh gates in gateway
- document the clean architecture boundary

## Validation
- `vx just preflight`
- `vx cargo test -p dcc-mcp-gateway --lib`
- `vx cargo test -p dcc-mcp-gateway-core`
- `vx cargo clippy -p dcc-mcp-gateway-core --all-targets -- -D warnings`
- VitePress production build

Adapter skill guidance is unchanged because this refactors internal gateway layering without changing adapter runtime contracts.

Part of #2192