### PR TITLE
refactor: move capability refresh logic to core

### DIFF
--- a/crates/dcc-mcp-gateway-core/README.md
+++ b/crates/dcc-mcp-gateway-core/README.md
@@ -22,6 +22,9 @@ async refresh gates without leaking those runtime concerns inward.
 The deterministic capability builder translates transport-neutral
 `dcc-mcp-jsonrpc` `McpTool` values into indexed domain records; backend HTTP
 fetching and lifecycle orchestration remain in `dcc-mcp-gateway`.
+Refresh assembly combines those live records with instance-scoped unloaded
+skill hints, then sorts and fingerprints the complete slice. The gateway
+runtime only performs I/O, observability, synchronization, and the final upsert.
 
 ## Stability
 

--- a/crates/dcc-mcp-gateway-core/src/capability/mod.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/mod.rs
@@ -9,7 +9,7 @@
 //! | [`search_ranking`] | Re-exports scorers / [`SearchRecord`] from `dcc-mcp-gateway-search` |
 //! | [`index`]          | lock-free index state, snapshots, fingerprints, tombstones  |
 //! | [`builder`]        | Pure per-instance MCP tool-to-capability record builder      |
-//! | [`refresh`]        | `RefreshReason` — why a refresh cycle is running             |
+//! | [`refresh`]        | Pure refresh-slice assembly, no-op policy, and reason types  |
 //!
 //! The concurrent `CapabilityIndex` wrapper (which owns synchronization
 //! and refresh gates) and the `refresh_instance` lifecycle driver (which
@@ -47,7 +47,9 @@ pub use record::{
     CapabilityAnnotations, CapabilityGroupInfo, CapabilityMetadata, CapabilityRecord,
     SCHEMA_AVAILABLE, is_valid_dcc_bucket, parse_slug, tool_slug,
 };
-pub use refresh::RefreshReason;
+pub use refresh::{
+    RefreshBuildOutcome, RefreshReason, UnloadedCapabilityHint, build_refresh_records,
+};
 pub use search::{
     DEFAULT_LIMIT, MAX_LIMIT, RANKER_VERSION, SearchHit, SearchMode, SearchPage, SearchQuery,
     search, search_page,

--- a/crates/dcc-mcp-gateway-core/src/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/refresh.rs
@@ -1,14 +1,118 @@
-//! Refresh-cycle telemetry types (issue #845).
+//! Pure capability refresh assembly and telemetry types.
 //!
-//! The mutable refresh loop — `refresh_instance`, `remove_instance`,
-//! and the I/O it drives via `reqwest` — stays in `dcc-mcp-gateway`
-//! because it carries runtime state. Only the *enum that classifies
-//! why a refresh ran* lives here, so external Rust tooling
-//! (operator dashboards, CLI inspectors) can match on the reason
-//! without depending on the gateway crate's tokio / reqwest /
-//! parking_lot footprint.
+//! The mutable refresh loop and its `reqwest` I/O stay in
+//! `dcc-mcp-gateway`. This module owns the deterministic part: combining
+//! loaded builder output with unloaded skill hints, assigning
+//! instance-scoped slugs, sorting, fingerprinting, and classifying no-op
+//! refreshes.
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::builder::BuildOutcome;
+use super::index::{InstanceFingerprint, compute_fingerprint};
+use super::record::{CapabilityGroupInfo, CapabilityRecord, tool_slug};
+
+/// Search metadata for one tool belonging to an unloaded skill.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnloadedCapabilityHint {
+    /// Owning skill package name.
+    pub skill_name: String,
+    /// Backend callable name that becomes routable after loading.
+    pub tool_name: String,
+    /// Search summary shown before the skill is loaded.
+    pub summary: String,
+    /// Extra non-wire search tokens.
+    pub search_tokens: Vec<String>,
+    /// Progressive groups advertised by the skill.
+    pub available_groups: Vec<CapabilityGroupInfo>,
+    /// Progressive group containing this tool, when known.
+    pub tool_group: Option<String>,
+}
+
+/// Fully assembled per-instance slice ready for an index upsert.
+#[derive(Debug, Clone, Default)]
+pub struct RefreshBuildOutcome {
+    /// Loaded and unloaded records, sorted by stable tool slug.
+    pub records: Vec<CapabilityRecord>,
+    /// Fingerprint covering the complete sorted slice.
+    pub fingerprint: InstanceFingerprint,
+    /// Number of records built from the live backend tool list.
+    pub loaded: usize,
+    /// Number of valid unloaded hints converted to records.
+    pub unloaded: usize,
+    /// Number of live backend tools rejected by the builder.
+    pub skipped: usize,
+}
+
+impl RefreshBuildOutcome {
+    /// Return whether a non-empty slice matches the currently indexed fingerprint.
+    ///
+    /// Empty slices deliberately return `false`: the runtime must upsert them so a
+    /// backend that removed every capability also removes its stale index slice.
+    #[must_use]
+    pub fn is_unchanged(&self, previous: Option<InstanceFingerprint>) -> bool {
+        !self.records.is_empty() && previous == Some(self.fingerprint)
+    }
+}
+
+/// Combine live builder output with unloaded skill hints for one DCC instance.
+#[must_use]
+pub fn build_refresh_records(
+    loaded: BuildOutcome,
+    unloaded_hints: Vec<UnloadedCapabilityHint>,
+    instance_id: Uuid,
+    dcc_type: &str,
+) -> RefreshBuildOutcome {
+    let BuildOutcome {
+        mut records,
+        skipped,
+        ..
+    } = loaded;
+    let loaded = records.len();
+    records.extend(build_unloaded_records(
+        unloaded_hints,
+        instance_id,
+        dcc_type,
+    ));
+    records.sort_by(|a, b| a.tool_slug.cmp(&b.tool_slug));
+    let unloaded = records.len().saturating_sub(loaded);
+    let fingerprint = compute_fingerprint(&records);
+    RefreshBuildOutcome {
+        records,
+        fingerprint,
+        loaded,
+        unloaded,
+        skipped,
+    }
+}
+
+fn build_unloaded_records(
+    unloaded_hints: Vec<UnloadedCapabilityHint>,
+    instance_id: Uuid,
+    dcc_type: &str,
+) -> Vec<CapabilityRecord> {
+    unloaded_hints
+        .into_iter()
+        .filter_map(|hint| {
+            if hint.tool_name.is_empty() {
+                return None;
+            }
+            let mut record = CapabilityRecord::from_skill_tool(
+                &hint.skill_name,
+                &hint.tool_name,
+                &hint.summary,
+                dcc_type,
+                hint.tool_group,
+            )
+            .with_available_groups(hint.available_groups)
+            .with_search_tokens(hint.search_tokens);
+            record.instance_id = instance_id;
+            record.tool_slug = tool_slug(dcc_type, &instance_id, &hint.tool_name);
+            Some(record)
+        })
+        .collect()
+}
 
 /// Why a refresh cycle is running.
 ///
@@ -46,6 +150,7 @@ impl RefreshReason {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::capability::record::CapabilityRecord;
 
     #[test]
     fn refresh_reason_as_str_is_stable() {
@@ -79,5 +184,77 @@ mod tests {
 
         let back: RefreshReason = serde_json::from_str("\"periodic\"").unwrap();
         assert_eq!(back, RefreshReason::Periodic);
+    }
+
+    fn hint(skill: &str, tool: &str) -> UnloadedCapabilityHint {
+        UnloadedCapabilityHint {
+            skill_name: skill.to_string(),
+            tool_name: tool.to_string(),
+            summary: format!("Discover {tool}"),
+            search_tokens: vec!["discover".to_string()],
+            available_groups: Vec::new(),
+            tool_group: None,
+        }
+    }
+
+    #[test]
+    fn refresh_records_merge_loaded_and_unloaded_photoshop_tools() {
+        let instance_id = Uuid::from_u128(0xfeed_0000_0000_0000_0000_0000_0000_0001);
+        let loaded_record = CapabilityRecord::new(
+            tool_slug("photoshop", &instance_id, "read_document"),
+            "read_document".to_string(),
+            "read_document".to_string(),
+            Some("photoshop-document".to_string()),
+            "Read the active document",
+            vec!["read".to_string()],
+            "photoshop".to_string(),
+            instance_id,
+            false,
+            true,
+            None,
+        );
+        let outcome = build_refresh_records(
+            BuildOutcome {
+                records: vec![loaded_record],
+                fingerprint: InstanceFingerprint(1),
+                skipped: 2,
+            },
+            vec![
+                hint("photoshop-export", "export_document"),
+                hint("broken", ""),
+            ],
+            instance_id,
+            "photoshop",
+        );
+
+        assert_eq!(outcome.loaded, 1);
+        assert_eq!(outcome.unloaded, 1);
+        assert_eq!(outcome.skipped, 2);
+        assert_eq!(outcome.records.len(), 2);
+        assert_eq!(outcome.records[0].backend_tool, "export_document");
+        assert!(!outcome.records[0].loaded);
+        assert!(outcome.records[0].tool_slug.contains(".feed0000."));
+        assert_eq!(outcome.records[1].backend_tool, "read_document");
+        assert_ne!(outcome.fingerprint, InstanceFingerprint::default());
+    }
+
+    #[test]
+    fn unchanged_policy_preserves_empty_slice_removal() {
+        let empty = build_refresh_records(
+            BuildOutcome::default(),
+            Vec::new(),
+            Uuid::from_u128(7),
+            "zbrush",
+        );
+        assert!(!empty.is_unchanged(Some(empty.fingerprint)));
+
+        let non_empty = build_refresh_records(
+            BuildOutcome::default(),
+            vec![hint("custom-inspection", "inspect_scene")],
+            Uuid::from_u128(8),
+            "custom",
+        );
+        assert!(non_empty.is_unchanged(Some(non_empty.fingerprint)));
+        assert!(!non_empty.is_unchanged(None));
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
@@ -2,10 +2,10 @@ use std::time::Duration;
 
 use serde_json::{Value, json};
 
+use dcc_mcp_gateway_core::capability::CapabilityGroupInfo;
 use dcc_mcp_jsonrpc::{McpPrompt, McpTool};
 
 use crate::gateway::admin::trace::TraceContext;
-use crate::gateway::capability::CapabilityGroupInfo;
 use crate::gateway::metrics::record_gateway_backend_error_kind;
 use crate::gateway::resilience::{
     GatewayResilienceState, is_circuit_worthy_rest_error, is_retryable_rest_error, jittered_backoff,
@@ -31,15 +31,7 @@ fn action_matches_group_tool(action: &str, group_tool_name: &str) -> bool {
         .is_some_and(|(_, bare)| bare == group_tool_name)
 }
 
-#[derive(Debug, Clone)]
-pub struct UnloadedCapabilityHint {
-    pub skill_name: String,
-    pub tool_name: String,
-    pub summary: String,
-    pub search_tokens: Vec<String>,
-    pub available_groups: Vec<CapabilityGroupInfo>,
-    pub tool_group: Option<String>,
-}
+pub use dcc_mcp_gateway_core::capability::UnloadedCapabilityHint;
 
 async fn rest_get_idempotent(
     client: &reqwest::Client,

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -1,30 +1,26 @@
 //! Lifecycle glue between the backend registry and the capability
 //! index.
 //!
-//! The refresh layer is intentionally thin: it delegates the pure
-//! work of "given a backend tools/list, produce records" to
-//! [`super::builder::build_records_from_backend`] and only adds the
-//! I/O — `fetch_tools` on demand, and tracing on lifecycle
-//! transitions.
+//! The refresh layer is intentionally thin: it fetches backend state,
+//! delegates deterministic record building and refresh-slice assembly to
+//! `dcc-mcp-gateway-core`, then applies the result to the concurrent index.
+//! Resilience, diagnostics, metrics, and lifecycle tracing stay here.
 //!
 //! # Wire type relocation (issue #845)
 //!
-//! [`RefreshReason`] was migrated to
-//! [`dcc_mcp_gateway_core::capability::refresh`] so external Rust
-//! tooling (admin dashboards, CLI inspectors, log scrapers) can
-//! match on the reason without depending on this crate's tokio /
-//! reqwest footprint. Re-exported below to keep the historical
-//! `crate::gateway::capability::refresh::RefreshReason` path working
-//! unchanged.
+//! Pure refresh types and assembly rules live in
+//! [`dcc_mcp_gateway_core::capability::refresh`] so tests and tooling do
+//! not depend on this crate's Tokio/Reqwest footprint. `RefreshReason` is
+//! re-exported below to keep its historical path working unchanged.
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use uuid::Uuid;
 
-use dcc_mcp_gateway_core::capability::compute_fingerprint;
+use dcc_mcp_gateway_core::capability::build_refresh_records;
 
-use crate::gateway::backend_client::{UnloadedCapabilityHint, try_fetch_tools};
+use crate::gateway::backend_client::try_fetch_tools;
 use crate::gateway::instance_diagnostics::InstanceDiagnosticsStore;
 use crate::gateway::resilience::GatewayResilienceState;
 
@@ -32,7 +28,6 @@ use super::builder::{
     BuildInput, backend_job_status_tool, build_records_from_backend, is_backend_job_tool,
 };
 use super::index::CapabilityIndex;
-use super::record::{CapabilityRecord, tool_slug};
 
 pub use dcc_mcp_gateway_core::capability::refresh::RefreshReason;
 
@@ -107,36 +102,34 @@ pub async fn refresh_instance(
             backend_tools: &tools,
         })
     });
-    let mut records = outcome.records;
-    let loaded_records_len = records.len();
-    let mut unloaded_records = build_unloaded_records(unloaded_hints, instance_id, dcc_type);
-    let unloaded_count = unloaded_records.len();
-    records.append(&mut unloaded_records);
-    records.sort_by(|a, b| a.tool_slug.cmp(&b.tool_slug));
-    let fingerprint = tracing::trace_span!(
+    let refresh = tracing::trace_span!(
         target: PROFILING_TARGET,
         "capability.discovery.fingerprint",
         instance = %instance_id,
-        records = records.len(),
+        loaded = outcome.records.len(),
+        unloaded_hints = unloaded_hints.len(),
     )
-    .in_scope(|| compute_fingerprint(&records));
+    .in_scope(|| build_refresh_records(outcome, unloaded_hints, instance_id, dcc_type));
 
     // Short-circuit when nothing changed. This is the common path —
     // most periodic refreshes find an identical tool list.
-    if let Some(prev) = index.fingerprint_for(instance_id)
-        && prev == fingerprint
-        && !records.is_empty()
-    {
+    let previous = index.fingerprint_for(instance_id);
+    if refresh.is_unchanged(previous) {
         tracing::trace!(
             instance = %instance_id,
             reason = reason.as_str(),
-            records = records.len(),
+            records = refresh.records.len(),
             "capability index: no-op refresh (fingerprint unchanged)",
         );
         return false;
     }
 
-    let records_len = records.len();
+    let records_len = refresh.records.len();
+    let fingerprint = refresh.fingerprint;
+    let loaded_count = refresh.loaded;
+    let unloaded_count = refresh.unloaded;
+    let skipped_count = refresh.skipped;
+    let records = refresh.records;
     let prev = tracing::trace_span!(
         target: PROFILING_TARGET,
         "capability.discovery.upsert",
@@ -150,40 +143,13 @@ pub async fn refresh_instance(
         dcc = dcc_type,
         reason = reason.as_str(),
         records = records_len,
-        loaded = loaded_records_len,
+        loaded = loaded_count,
         unloaded = unloaded_count,
-        skipped = outcome.skipped,
+        skipped = skipped_count,
         fingerprint_changed = ?prev.map(|f| f != fingerprint),
         "capability index: refreshed",
     );
     true
-}
-
-fn build_unloaded_records(
-    unloaded_hints: Vec<UnloadedCapabilityHint>,
-    instance_id: Uuid,
-    dcc_type: &str,
-) -> Vec<CapabilityRecord> {
-    unloaded_hints
-        .into_iter()
-        .filter_map(|hint| {
-            if hint.tool_name.is_empty() {
-                return None;
-            }
-            let mut rec = CapabilityRecord::from_skill_tool(
-                &hint.skill_name,
-                &hint.tool_name,
-                &hint.summary,
-                dcc_type,
-                hint.tool_group.clone(),
-            )
-            .with_available_groups(hint.available_groups)
-            .with_search_tokens(hint.search_tokens);
-            rec.instance_id = instance_id;
-            rec.tool_slug = tool_slug(dcc_type, &instance_id, &hint.tool_name);
-            Some(rec)
-        })
-        .collect()
 }
 
 /// Drop every record for `instance_id`. Safe to call even if the
@@ -212,7 +178,18 @@ pub fn remove_instance_with_status(
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use dcc_mcp_gateway_core::capability::index::InstanceFingerprint;
+    use dcc_mcp_gateway_core::capability::{
+        BuildOutcome, CapabilityRecord, UnloadedCapabilityHint, compute_fingerprint,
+        index::InstanceFingerprint,
+    };
+
+    fn build_unloaded_records(
+        hints: Vec<UnloadedCapabilityHint>,
+        instance_id: Uuid,
+        dcc_type: &str,
+    ) -> Vec<CapabilityRecord> {
+        build_refresh_records(BuildOutcome::default(), hints, instance_id, dcc_type).records
+    }
 
     #[test]
     fn refresh_reason_label_is_stable() {

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -361,13 +361,14 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 
 ### dcc-mcp-gateway-core
 
-**Purpose**: Pure gateway domain layer for capability records, lock-free index state, deterministic MCP tool-to-record building, slug helpers, search queries/pages/hits, and ranking/scoring. It has no direct HTTP, async-runtime, file-registry, or `dcc-mcp-gateway` dependency.
+**Purpose**: Pure gateway domain layer for capability records, lock-free index state, deterministic MCP tool-to-record building and refresh-slice assembly, slug helpers, search queries/pages/hits, and ranking/scoring. It has no direct HTTP, async-runtime, file-registry, or `dcc-mcp-gateway` dependency.
 
 **Key Components**:
 - `PendingCall` — gateway-to-backend cancellation correlation primitive.
 - `CapabilityRecord` — compact per-tool search/dispatch record.
 - `CapabilityIndexState`, `IndexSnapshot`, `InstanceFingerprint`, `InstanceTombstone` — synchronization-free per-instance mutation, snapshot, and lifecycle rules.
 - `BuildInput`, `BuildOutcome`, `build_records_from_backend` — deterministic translation from transport-neutral MCP `tools/list` values into sorted capability records; HTTP fetching remains in `dcc-mcp-gateway`.
+- `UnloadedCapabilityHint`, `RefreshBuildOutcome`, `build_refresh_records` — instance-scoped unloaded-tool projection, complete-slice sorting/fingerprinting, and no-op policy; resilience, diagnostics, metrics, and index synchronization remain in `dcc-mcp-gateway`.
 - `SearchQuery`, `SearchHit`, `SearchPage`, `SearchMode` — token-budgeted capability search contract.
 - `capability_naming` — gateway instance/skill name projection and bare-name collision policy; delegates wire-name validation to `dcc-mcp-naming`.
 - `ExactScorer`, `FuzzyScorer`, `SubstringScorer`, `StrategyScorer` — pluggable ranking strategies.


### PR DESCRIPTION
## Summary
- move unloaded capability hints and refresh-slice assembly into gateway-core
- preserve empty-slice removal and fingerprint no-op semantics
- keep HTTP, resilience, diagnostics, metrics, tracing, and index synchronization in gateway

## Validation
- `vx cargo nextest run --workspace --test-threads 8` (3578 tests)
- `vx cargo test --workspace --doc`
- `vx cargo test -p dcc-mcp-gateway-core capability::refresh`
- `vx cargo test -p dcc-mcp-gateway capability::refresh --lib`
- `vx cargo clippy -p dcc-mcp-gateway-core --all-targets -- -D warnings`
- VitePress production build

Adapter skill guidance is unchanged because this refactors internal gateway layering without changing adapter runtime contracts.

Part of #2192