### PR TITLE
refactor: decouple executor errors from HTTP

### DIFF
--- a/crates/dcc-mcp-http-server/README.md
+++ b/crates/dcc-mcp-http-server/README.md
@@ -20,7 +20,8 @@ dcc-mcp-http-types  (wire/config/value types)
 ## What lives here
 
 - fixed core-tool descriptor builders (`build_core_tools`),
-- host/main-thread execution bridges (`DccExecutorHandle`, `DeferredExecutor`),
+- host/main-thread execution bridges (`DccExecutorHandle`, `DeferredExecutor`)
+  with their transport-neutral `ExecutorError` contract,
 - session state and connection-scoped `tools/list` cache,
 - in-flight request cancellation and progress routing,
 - job/workflow notifications,

--- a/crates/dcc-mcp-http-server/src/executor.rs
+++ b/crates/dcc-mcp-http-server/src/executor.rs
@@ -28,7 +28,30 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use dcc_mcp_host::{QueueStats, WaitTimeSamples};
-use dcc_mcp_http_types::error::HttpError;
+use thiserror::Error;
+
+/// Errors produced by the DCC main-thread execution bridge.
+///
+/// This contract is transport-neutral. HTTP, MCP, or embedded callers map it
+/// into their own boundary error taxonomy instead of making the executor
+/// depend on one transport's error type.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ExecutorError {
+    /// The executor channel or a task's result channel was closed.
+    #[error("executor channel closed")]
+    Closed,
+
+    /// The bounded queue did not drain before the configured send timeout.
+    #[error("queue overloaded (depth={depth}/{capacity}); retry in {retry_after_secs}s")]
+    QueueOverloaded {
+        /// Current queue depth at the moment the dispatch was rejected.
+        depth: usize,
+        /// Maximum queue depth.
+        capacity: usize,
+        /// Suggested delay before retrying.
+        retry_after_secs: u64,
+    },
+}
 
 /// Backward-compatible name for the shared dispatcher queue snapshot.
 pub type ExecutorQueueStats = QueueStats;
@@ -46,7 +69,7 @@ pub(crate) struct ExecutorStats {
     /// Configured channel capacity (`send_timeout` blocks when full).
     pub capacity: usize,
     /// How long `execute` will block on a full channel before
-    /// surfacing [`HttpError::QueueOverloaded`].
+    /// surfacing [`ExecutorError::QueueOverloaded`].
     pub send_timeout: Duration,
     pub total_enqueued: AtomicU64,
     pub total_dequeued: AtomicU64,
@@ -188,15 +211,15 @@ impl DccExecutorHandle {
     /// capacity, the caller blocks for up to the handle's configured
     /// send-timeout (default 2 s) waiting for the main thread to
     /// drain. If it still does not drain, the call returns
-    /// [`HttpError::QueueOverloaded`] — callers can
-    /// distinguish this from [`HttpError::ExecutorClosed`]
+    /// [`ExecutorError::QueueOverloaded`] — callers can
+    /// distinguish this from [`ExecutorError::Closed`]
     /// and decide whether to retry or fail over.
-    pub async fn execute(&self, func: DccTaskFn) -> Result<String, HttpError> {
+    pub async fn execute(&self, func: DccTaskFn) -> Result<String, ExecutorError> {
         self.execute_typed(func).await
     }
 
     /// Submit a typed task without serializing its result inside the process.
-    pub async fn execute_typed<T, F>(&self, func: F) -> Result<T, HttpError>
+    pub async fn execute_typed<T, F>(&self, func: F) -> Result<T, ExecutorError>
     where
         T: Send + 'static,
         F: FnOnce() -> T + Send + 'static,
@@ -208,10 +231,10 @@ impl DccExecutorHandle {
             }),
         };
         self.enqueue(task).await?;
-        result_rx.await.map_err(|_| HttpError::ExecutorClosed)
+        result_rx.await.map_err(|_| ExecutorError::Closed)
     }
 
-    async fn enqueue(&self, task: DccTask) -> Result<(), HttpError> {
+    async fn enqueue(&self, task: DccTask) -> Result<(), ExecutorError> {
         let submit_attempted_at = Instant::now();
         let timeout = self.stats.send_timeout;
         let send_res = if timeout.is_zero() {
@@ -225,7 +248,7 @@ impl DccExecutorHandle {
                     // Timed out waiting on a full channel. Canonical
                     // overload signal.
                     self.stats.record_reject();
-                    return Err(HttpError::QueueOverloaded {
+                    return Err(ExecutorError::QueueOverloaded {
                         depth: self.stats.pending(),
                         capacity: self.stats.capacity,
                         retry_after_secs: 1,
@@ -239,7 +262,7 @@ impl DccExecutorHandle {
             }
             Err(()) => {
                 self.stats.record_reject();
-                return Err(HttpError::ExecutorClosed);
+                return Err(ExecutorError::Closed);
             }
         }
 
@@ -409,7 +432,7 @@ impl DccExecutorHandle {
     /// ```
     ///
     /// Returns `Err` if the executor has been shut down.
-    pub async fn yield_frame(&self) -> Result<(), HttpError> {
+    pub async fn yield_frame(&self) -> Result<(), ExecutorError> {
         self.execute(Box::new(String::new)).await.map(|_| ())
     }
 }

--- a/crates/dcc-mcp-http-server/src/executor/tests.rs
+++ b/crates/dcc-mcp-http-server/src/executor/tests.rs
@@ -231,7 +231,7 @@ async fn execute_returns_queue_overloaded_on_saturation() {
         .await
         .expect_err("saturation must fail");
     match err {
-        HttpError::QueueOverloaded {
+        ExecutorError::QueueOverloaded {
             depth,
             capacity,
             retry_after_secs,

--- a/crates/dcc-mcp-http-server/src/host_bridge.rs
+++ b/crates/dcc-mcp-http-server/src/host_bridge.rs
@@ -9,10 +9,9 @@
 //! cross-DCC dispatcher trait lives in `dcc-mcp-host`. Both solve the
 //! same "tokio worker → DCC main thread" problem, with different
 //! contracts and ownership stories. Rather than unify them into a
-//! single trait — which would drag HTTP-specific concerns
-//! (`dcc_mcp_http_types::HttpError`, the `DccTaskFn` string-return
-//! convention) into the host-runtime abstraction — we keep both and
-//! provide a one-directional adapter here.
+//! single trait — which would drag the server queue's `DccTaskFn`
+//! string-return convention into the host-runtime abstraction — we
+//! keep both and provide a one-directional adapter here.
 //!
 //! # Responsibility (SRP)
 //!
@@ -152,10 +151,7 @@ mod tests {
             .execute(Box::new(|| panic!("boom in closure")))
             .await
             .unwrap_err();
-        assert!(matches!(
-            error,
-            dcc_mcp_http_types::error::HttpError::ExecutorClosed
-        ));
+        assert!(matches!(error, crate::executor::ExecutorError::Closed));
     }
 
     /// After dispatcher shutdown, typed task result channels close.
@@ -170,9 +166,6 @@ mod tests {
             .execute(Box::new(|| "never runs".to_string()))
             .await
             .unwrap_err();
-        assert!(matches!(
-            error,
-            dcc_mcp_http_types::error::HttpError::ExecutorClosed
-        ));
+        assert!(matches!(error, crate::executor::ExecutorError::Closed));
     }
 }

--- a/crates/dcc-mcp-http-server/src/lib.rs
+++ b/crates/dcc-mcp-http-server/src/lib.rs
@@ -47,7 +47,7 @@ pub use dynamic_tools::{
     build_register_tool_descriptor, handle_deregister_tool, handle_list_dynamic_tools,
     handle_register_tool,
 };
-pub use executor::{DccExecutorHandle, DeferredExecutor, ExecutorQueueStats};
+pub use executor::{DccExecutorHandle, DeferredExecutor, ExecutorError, ExecutorQueueStats};
 pub use handlers::{build_core_tools, build_core_tools_inner};
 pub use host_bridge::{
     DEFAULT_BRIDGE_QUEUE_DEPTH, dispatcher_to_executor_handle,

--- a/crates/dcc-mcp-http-types/src/config/queue.rs
+++ b/crates/dcc-mcp-http-types/src/config/queue.rs
@@ -13,7 +13,7 @@ pub struct QueueConfig {
     /// full, the HTTP worker blocks for up to [`Self::queue_send_timeout_ms`]
     /// waiting for the DCC main thread to drain; if the drain does not
     /// happen in time, the call returns a structured
-    /// `HttpError::QueueOverloaded`.
+    /// transport-neutral executor overload error.
     ///
     /// Default: `16`. Override via
     /// `--queue-deferred-cap=<N>` / `MCP_QUEUE_DEFERRED_CAP`.
@@ -46,7 +46,7 @@ pub struct QueueConfig {
     pub host_queue_depth: usize,
 
     /// How long an HTTP worker will block on a full executor channel
-    /// before returning `HttpError::QueueOverloaded`
+    /// before returning the executor's structured overload error
     /// (issue #715).
     ///
     /// Chose "block with timeout" over "immediate error" so healthy

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -89,7 +89,7 @@ pub use dcc_mcp_skill_rest::{
 };
 pub use dynamic_tools::{DYNAMIC_TOOL_PREFIX, DynamicToolError, SessionDynamicTools, ToolSpec};
 pub use error::{HttpError, HttpResult};
-pub use executor::{DccExecutorHandle, DeferredExecutor, ExecutorQueueStats};
+pub use executor::{DccExecutorHandle, DeferredExecutor, ExecutorError, ExecutorQueueStats};
 pub use job::{Job, JobEvent, JobManager, JobProgress, JobStatus, JobSubscriber};
 #[cfg(feature = "job-persist-sqlite")]
 pub use job_storage::SqliteStorage;

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -417,7 +417,9 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 
 **Key Components**:
 - `build_core_tools` — constructs the fixed core MCP tool descriptors.
-- `DccExecutorHandle`, `DeferredExecutor` — host/main-thread execution bridge.
+- `DccExecutorHandle`, `DeferredExecutor`, `ExecutorError` — host/main-thread
+  execution bridge with a transport-neutral error contract; protocol/HTTP
+  callers translate failures at their boundary.
 - `McpSession`, `SessionManager`, `ToolListSnapshot` — session state and connection-scoped `tools/list` cache.
 - `InFlightRequests`, `CancelToken`, `ProgressReporter` — cancellation/progress routing.
 - `JobNotifier`, `WorkflowUpdate`, `WorkspaceRoots` — job/workflow notifications and root resolution.


### PR DESCRIPTION
## Summary
- give the main-thread executor its own transport-neutral error contract
- preserve queue overload diagnostics and compatibility re-exports
- document boundary-owned error translation

## Validation
- `vx just preflight`
- `vx cargo test -p dcc-mcp-http-server executor --lib`
- `vx cargo test -p dcc-mcp-http-server host_bridge --lib`
- VitePress production build

Adapter skill guidance is unchanged because adapters use `HostExecutionBridge` and do not handle the former HTTP-specific executor result.

Part of #2199