### PR TITLE
refactor: move instance status policy to models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,6 +1927,7 @@ version = "0.20.8"
 dependencies = [
  "criterion",
  "dashmap",
+ "dcc-mcp-models",
  "dcc-mcp-pybridge",
  "fs4",
  "ipckit",

--- a/crates/dcc-mcp-cli/src/application/local_instance.rs
+++ b/crates/dcc-mcp-cli/src/application/local_instance.rs
@@ -10,7 +10,7 @@ use std::time::SystemTime;
 use anyhow::Context;
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 use dcc_mcp_transport::discovery::types::{
-    GATEWAY_SENTINEL_DCC_TYPE, InstanceStatus, ServiceEntry, ServiceStatus,
+    GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceStatus, instance_status_from_entry,
 };
 use serde_json::{Value, json};
 
@@ -236,7 +236,7 @@ pub(crate) fn direct_control_ready(entry: &ServiceEntry) -> bool {
         .metadata
         .get(ROLE_METADATA_KEY)
         .is_some_and(|role| role == ROLE_PER_DCC_SIDECAR);
-    let instance_status = InstanceStatus::from_entry(entry, false, is_sidecar);
+    let instance_status = instance_status_from_entry(entry, false);
     let status_ok = matches!(
         instance_status.status,
         ServiceStatus::Available | ServiceStatus::Busy
@@ -253,8 +253,7 @@ pub(crate) fn direct_control_ready(entry: &ServiceEntry) -> bool {
 
 pub(crate) fn direct_control_report(entry: &ServiceEntry) -> Value {
     let role = entry.metadata.get(ROLE_METADATA_KEY).map(String::as_str);
-    let is_sidecar = role == Some(ROLE_PER_DCC_SIDECAR);
-    let instance_status = InstanceStatus::from_entry(entry, false, is_sidecar);
+    let instance_status = instance_status_from_entry(entry, false);
     let ready = direct_control_ready(entry);
     let reason = if ready {
         Value::Null

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -26,7 +26,7 @@ use dcc_mcp_gateway_core::policy::{GatewayPolicy, GatewayPolicyDenial, GatewayPo
 use dcc_mcp_jsonrpc::McpTool;
 use dcc_mcp_transport::discovery::{
     file_registry::FileRegistry,
-    types::{InstanceStatus, ServiceEntry},
+    types::{ServiceEntry, instance_status_from_entry},
 };
 
 use crate::gateway::admin::trace::TraceContext;
@@ -508,11 +508,7 @@ fn unroutable_instance_error(
     known_entry: Option<&ServiceEntry>,
 ) -> ServiceError {
     if let Some(entry) = known_entry {
-        let status = InstanceStatus::from_entry(
-            entry,
-            entry.is_stale(gs.stale_timeout),
-            entry_uses_sidecar_dispatch(entry),
-        );
+        let status = instance_status_from_entry(entry, entry.is_stale(gs.stale_timeout));
         return ServiceError::new(
             "instance-offline",
             format!(

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
@@ -16,7 +16,7 @@
 
 use serde_json::{Value, json};
 
-use dcc_mcp_transport::discovery::types::{InstanceStatus, ServiceEntry};
+use dcc_mcp_transport::discovery::types::{ServiceEntry, instance_status_from_entry};
 
 use super::super::state::GatewayState;
 use super::util::{parse_bool, parse_query, split_uri};
@@ -355,11 +355,7 @@ pub fn compact_instance_json(e: &ServiceEntry, stale_timeout: std::time::Duratio
     };
 
     // ADR 018: unified instance_status block (canonical status representation).
-    let instance_status = InstanceStatus::from_entry(
-        e,
-        stale,
-        super::super::http_registration::entry_uses_sidecar_dispatch(e),
-    );
+    let instance_status = instance_status_from_entry(e, stale);
 
     json!({
         "instance_id":    e.instance_id.to_string(),

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -63,7 +63,9 @@ use super::relay_registration::RelayInstanceRegistry;
 use super::resilience::GatewayResilienceState;
 
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
-use dcc_mcp_transport::discovery::types::{InstanceStatus, ServiceEntry, ServiceStatus};
+use dcc_mcp_transport::discovery::types::{
+    ServiceEntry, ServiceStatus, instance_status_from_entry,
+};
 
 use super::middleware::MiddlewareChain;
 
@@ -756,11 +758,7 @@ fn dispatch_json(e: &ServiceEntry, stale: bool) -> Value {
 /// is kept alongside it for backward compatibility and will be removed in a
 /// future release.
 fn instance_status_json(e: &ServiceEntry, stale: bool) -> Value {
-    let is = InstanceStatus::from_entry(
-        e,
-        stale,
-        super::http_registration::entry_uses_sidecar_dispatch(e),
-    );
+    let is = instance_status_from_entry(e, stale);
     json!({
         "status": is.status.to_string(),
         "dispatch_status": is.dispatch_status.to_string(),

--- a/crates/dcc-mcp-models/src/instance_status.rs
+++ b/crates/dcc-mcp-models/src/instance_status.rs
@@ -1,0 +1,191 @@
+//! Service and dispatch status policy shared by gateway-facing applications.
+
+use serde::{Deserialize, Serialize};
+
+/// Status of a discovered DCC service instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceStatus {
+    /// Service is available and accepting connections.
+    #[default]
+    Available,
+    /// Service is busy processing a request.
+    Busy,
+    /// Service is unreachable after a health check failed.
+    Unreachable,
+    /// Service is shutting down.
+    ShuttingDown,
+    /// Service is alive while its embedded DCC host is still initialising.
+    Booting,
+    /// Service was explicitly marked stale and is no longer routable.
+    Stale,
+}
+
+impl std::fmt::Display for ServiceStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Available => write!(f, "available"),
+            Self::Busy => write!(f, "busy"),
+            Self::Unreachable => write!(f, "unreachable"),
+            Self::ShuttingDown => write!(f, "shutting_down"),
+            Self::Booting => write!(f, "booting"),
+            Self::Stale => write!(f, "stale"),
+        }
+    }
+}
+
+/// Application-level dispatch readiness for a DCC instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DispatchStatus {
+    /// Instance has reported dispatch-ready.
+    Ready,
+    /// Instance is alive but has not yet reported dispatch-ready.
+    Pending,
+    /// Instance reported a dispatch failure.
+    Failed,
+    /// Instance has not reported dispatch status.
+    #[default]
+    Unknown,
+}
+
+impl std::fmt::Display for DispatchStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ready => write!(f, "ready"),
+            Self::Pending => write!(f, "pending"),
+            Self::Failed => write!(f, "failed"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+/// Application-facing interpretation of discovery and dispatch state.
+///
+/// Transport code reports [`ServiceStatus`] and [`DispatchStatus`] facts.
+/// This model owns the retry policy and agent-facing recovery guidance derived
+/// from those facts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstanceStatus {
+    /// Transport-level connection state.
+    pub status: ServiceStatus,
+    /// Application-level dispatch readiness.
+    pub dispatch_status: DispatchStatus,
+    /// Whether the current state is safe to retry.
+    pub retryable: bool,
+    /// Human-readable recommended next step.
+    pub recommended_next_action: String,
+}
+
+impl InstanceStatus {
+    /// Interpret a transport status and dispatch status using the canonical
+    /// application policy.
+    #[must_use]
+    pub fn from_states(status: ServiceStatus, dispatch_status: DispatchStatus) -> Self {
+        let (retryable, recommended_next_action) = actionability(status, dispatch_status);
+        Self {
+            status,
+            dispatch_status,
+            retryable,
+            recommended_next_action: recommended_next_action.to_string(),
+        }
+    }
+}
+
+fn actionability(status: ServiceStatus, dispatch_status: DispatchStatus) -> (bool, &'static str) {
+    match (status, dispatch_status) {
+        (ServiceStatus::Available, DispatchStatus::Ready) => {
+            (true, "Instance is available for dispatch.")
+        }
+        (ServiceStatus::Available, DispatchStatus::Pending) => {
+            (true, "Wait for instance to report dispatch_status=ready.")
+        }
+        (ServiceStatus::Available, DispatchStatus::Failed) => (
+            false,
+            "Inspect instance failure stage/reason; the backend may need a restart.",
+        ),
+        (ServiceStatus::Available, DispatchStatus::Unknown) => (
+            true,
+            "Dispatch status not yet reported; try a direct MCP call.",
+        ),
+        (ServiceStatus::Busy, DispatchStatus::Ready) => {
+            (true, "Instance is busy; retry after current job completes.")
+        }
+        (ServiceStatus::Busy, DispatchStatus::Pending) => (
+            true,
+            "Instance is busy and not yet dispatch-ready; wait and retry.",
+        ),
+        (ServiceStatus::Busy, DispatchStatus::Failed) => (
+            false,
+            "Instance is busy but dispatch has failed; inspect failure details.",
+        ),
+        (ServiceStatus::Busy, DispatchStatus::Unknown) => (true, "Instance is busy; retry later."),
+        (ServiceStatus::Booting, _) => (true, "Instance is booting; wait for readiness and retry."),
+        (ServiceStatus::Unreachable, _) => (
+            false,
+            "Instance is unreachable; check logs and restart if needed.",
+        ),
+        (ServiceStatus::ShuttingDown, _) => {
+            (false, "Instance is shutting down; wait for a new instance.")
+        }
+        (ServiceStatus::Stale, _) => (
+            false,
+            "Instance is stale; it will be removed by the registry.",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn available_ready_is_dispatchable() {
+        let status = InstanceStatus::from_states(ServiceStatus::Available, DispatchStatus::Ready);
+        assert!(status.retryable);
+        assert_eq!(
+            status.recommended_next_action,
+            "Instance is available for dispatch."
+        );
+    }
+
+    #[test]
+    fn available_pending_tells_agent_to_wait() {
+        let status = InstanceStatus::from_states(ServiceStatus::Available, DispatchStatus::Pending);
+        assert!(status.retryable);
+        assert!(
+            status
+                .recommended_next_action
+                .contains("dispatch_status=ready")
+        );
+    }
+
+    #[test]
+    fn failed_dispatch_is_not_retryable() {
+        let status = InstanceStatus::from_states(ServiceStatus::Available, DispatchStatus::Failed);
+        assert!(!status.retryable);
+        assert!(status.recommended_next_action.contains("failure stage"));
+    }
+
+    #[test]
+    fn transport_failures_override_dispatch_state() {
+        for service_status in [
+            ServiceStatus::Unreachable,
+            ServiceStatus::ShuttingDown,
+            ServiceStatus::Stale,
+        ] {
+            let status = InstanceStatus::from_states(service_status, DispatchStatus::Ready);
+            assert!(!status.retryable);
+        }
+    }
+
+    #[test]
+    fn status_roundtrips_through_json() {
+        let status = InstanceStatus::from_states(ServiceStatus::Busy, DispatchStatus::Ready);
+        let json = serde_json::to_string(&status).unwrap();
+        let parsed: InstanceStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.status, ServiceStatus::Busy);
+        assert_eq!(parsed.dispatch_status, DispatchStatus::Ready);
+        assert!(parsed.retryable);
+    }
+}

--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -1,9 +1,10 @@
-//! dcc-mcp-models: ActionResultModel, SkillMetadata, SkillScope, DccMcpError, DccName,
-//! Session, ToolCallEvent, and aggregate statistics types for observability (PIP-2751).
+//! dcc-mcp-models: shared domain types for actions, skills, instance status,
+//! sessions, errors, and observability.
 
 mod action_result;
 mod dcc_name;
 mod error;
+mod instance_status;
 pub mod registry;
 pub mod session;
 mod skill_metadata;
@@ -21,6 +22,7 @@ pub use action_result::{
 };
 pub use dcc_name::DccName;
 pub use error::DccMcpError;
+pub use instance_status::{DispatchStatus, InstanceStatus, ServiceStatus};
 pub use registry::{DefaultRegistry, Registry, RegistryEntry, SearchQuery};
 pub use session::{Session, SessionEndReason, SessionStatus};
 #[allow(deprecated)]

--- a/crates/dcc-mcp-transport/Cargo.toml
+++ b/crates/dcc-mcp-transport/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { workspace = true }
 rmp-serde = { workspace = true }
 mdns-sd = { workspace = true, optional = true }
 dcc-mcp-pybridge = { workspace = true, optional = true }
+dcc-mcp-models = { workspace = true }
 sysinfo.workspace = true
 ipckit.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
+pub use dcc_mcp_models::{DispatchStatus, InstanceStatus, ServiceStatus};
+
 use crate::error::{TransportError, TransportResult};
 
 /// Schema version emitted for newly written [`ServiceEntry`] rows.
@@ -104,182 +106,29 @@ pub const SERVER_BINARY_VERSION_METADATA_KEY: &str = "dcc_mcp_server_version";
 /// preserve unknown values for forward compatibility.
 pub const INSTANCE_TYPE_METADATA_KEY: &str = "dcc_mcp_instance_type";
 
-/// Status of a discovered DCC service instance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ServiceStatus {
-    /// Service is available and accepting connections.
-    #[default]
-    Available,
-    /// Service is busy (processing a request).
-    Busy,
-    /// Service is unreachable (health check failed).
-    Unreachable,
-    /// Service is shutting down.
-    ShuttingDown,
-    /// Service process is alive but its embedded DCC host is still
-    /// initialising (`GET /v1/readyz` returns `503` with `dcc=false`
-    /// or `dispatcher=false`). Introduced in #713 to distinguish the
-    /// "Maya main thread busy with plugin init" window from a truly
-    /// dead backend — the row stays in the registry but no traffic
-    /// should be routed to it until readiness flips green.
-    Booting,
-    /// Service has already been marked stale by a probe or registry owner.
-    /// This is stronger than heartbeat age and must be treated as unroutable
-    /// immediately, even before the gateway's stale timeout elapses.
-    Stale,
-}
-
-/// Application-level dispatch readiness for a DCC instance.
+/// Interpret a discovery entry using application policy from `dcc-mcp-models`.
 ///
-/// ADR 018 replaces the free-form `dispatch_status` metadata string with this
-/// typed enum. Every surface — transport types, gateway output, CLI doctor —
-/// uses the same vocabulary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum DispatchStatus {
-    /// Instance has reported dispatch-ready (all readiness bits green).
-    Ready,
-    /// Instance is alive but has not yet reported dispatch-ready (booting,
-    /// sidecar waiting for host, etc.).
-    Pending,
-    /// Instance reported a dispatch failure (failure_stage + failure_reason
-    /// metadata set).
-    Failed,
-    /// Instance has not reported dispatch status (legacy / embedded / pre-sidecar).
-    #[default]
-    Unknown,
-}
-
-impl std::fmt::Display for DispatchStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Ready => write!(f, "ready"),
-            Self::Pending => write!(f, "pending"),
-            Self::Failed => write!(f, "failed"),
-            Self::Unknown => write!(f, "unknown"),
-        }
-    }
-}
-
-/// Unified instance status combining transport-level and application-level state.
-///
-/// ADR 018 defines this as the single source of truth for every surface that
-/// reports instance status: transport types, gateway output, CLI doctor,
-/// gateway resources, and admin UI.
-///
-/// # Discovery health ≠ dispatch availability
-///
-/// `ServiceStatus::Available` means the transport is healthy (TCP port open,
-/// MCP server responding). `DispatchStatus::Ready` means the application is
-/// ready to accept tool calls. Agents can distinguish "server is up but DCC
-/// is still loading" from "everything is ready."
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InstanceStatus {
-    /// Transport-level connection state.
-    pub status: ServiceStatus,
-    /// Application-level dispatch readiness.
-    pub dispatch_status: DispatchStatus,
-    /// Whether the current state is safe to retry.
-    pub retryable: bool,
-    /// Human + machine-readable recommended next step.
-    pub recommended_next_action: String,
-}
-
-impl InstanceStatus {
-    /// Derive `InstanceStatus` from a `ServiceEntry`, its staleness, and
-    /// whether sidecar dispatch is in use.
-    ///
-    /// `dispatch_status` is read from metadata key `"dispatch_status"`.
-    /// `stale` is `true` when the entry has passed the stale timeout or has
-    /// been explicitly marked `ServiceStatus::Stale`.
-    pub fn from_entry(entry: &ServiceEntry, stale: bool, _uses_sidecar: bool) -> Self {
-        let effective_status = if stale {
-            ServiceStatus::Stale
-        } else {
-            entry.status
-        };
-        let dispatch_status = dispatch_status_from_entry(entry);
-        let (retryable, recommended_next_action) = actionability(effective_status, dispatch_status);
-        Self {
-            status: effective_status,
-            dispatch_status,
-            retryable,
-            recommended_next_action: recommended_next_action.to_string(),
-        }
-    }
+/// This boundary keeps registry metadata parsing in transport while the
+/// retry decision and agent-facing guidance remain in the model layer.
+#[must_use]
+pub fn instance_status_from_entry(entry: &ServiceEntry, stale: bool) -> InstanceStatus {
+    let effective_status = if stale {
+        ServiceStatus::Stale
+    } else {
+        entry.status
+    };
+    InstanceStatus::from_states(effective_status, dispatch_status_from_entry(entry))
 }
 
 /// Read `DispatchStatus` from a `ServiceEntry`'s metadata.
-fn dispatch_status_from_entry(entry: &ServiceEntry) -> DispatchStatus {
+#[must_use]
+pub fn dispatch_status_from_entry(entry: &ServiceEntry) -> DispatchStatus {
     match entry.metadata.get("dispatch_status").map(String::as_str) {
         Some("ready") => DispatchStatus::Ready,
         Some("pending") => DispatchStatus::Pending,
         Some("failed") | Some("unavailable") => DispatchStatus::Failed,
         Some(_) => DispatchStatus::Unknown,
         None => DispatchStatus::Unknown,
-    }
-}
-
-/// Derive `retryable` and `recommended_next_action` from the status pairing.
-///
-/// ADR 018 status pairing table — the canonical mapping.
-fn actionability(status: ServiceStatus, dispatch_status: DispatchStatus) -> (bool, &'static str) {
-    match (status, dispatch_status) {
-        (ServiceStatus::Available, DispatchStatus::Ready) => {
-            (true, "Instance is available for dispatch.")
-        }
-        (ServiceStatus::Available, DispatchStatus::Pending) => {
-            (true, "Wait for instance to report dispatch_status=ready.")
-        }
-        (ServiceStatus::Available, DispatchStatus::Failed) => (
-            false,
-            "Inspect instance failure stage/reason; the backend may need a restart.",
-        ),
-        (ServiceStatus::Available, DispatchStatus::Unknown) => (
-            true,
-            "Dispatch status not yet reported; try a direct MCP call.",
-        ),
-        (ServiceStatus::Busy, DispatchStatus::Ready) => {
-            (true, "Instance is busy; retry after current job completes.")
-        }
-        (ServiceStatus::Busy, DispatchStatus::Pending) => (
-            true,
-            "Instance is busy and not yet dispatch-ready; wait and retry.",
-        ),
-        (ServiceStatus::Busy, DispatchStatus::Failed) => (
-            false,
-            "Instance is busy but dispatch has failed; inspect failure details.",
-        ),
-        (ServiceStatus::Busy, DispatchStatus::Unknown) => (true, "Instance is busy; retry later."),
-        (ServiceStatus::Booting, DispatchStatus::Pending) => {
-            (true, "Instance is booting; wait for readiness and retry.")
-        }
-        (ServiceStatus::Booting, _) => (true, "Instance is booting; wait for readiness and retry."),
-        (ServiceStatus::Unreachable, _) => (
-            false,
-            "Instance is unreachable; check logs and restart if needed.",
-        ),
-        (ServiceStatus::ShuttingDown, _) => {
-            (false, "Instance is shutting down; wait for a new instance.")
-        }
-        (ServiceStatus::Stale, _) => (
-            false,
-            "Instance is stale; it will be removed by the registry.",
-        ),
-    }
-}
-
-impl std::fmt::Display for ServiceStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Available => write!(f, "available"),
-            Self::Busy => write!(f, "busy"),
-            Self::Unreachable => write!(f, "unreachable"),
-            Self::ShuttingDown => write!(f, "shutting_down"),
-            Self::Booting => write!(f, "booting"),
-            Self::Stale => write!(f, "stale"),
-        }
     }
 }
 
@@ -1312,7 +1161,7 @@ mod tests {
         entry
             .metadata
             .insert("dispatch_status".into(), "ready".into());
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
         assert_eq!(status.status, ServiceStatus::Available);
         assert_eq!(status.dispatch_status, DispatchStatus::Ready);
         assert!(status.retryable);
@@ -1324,7 +1173,7 @@ mod tests {
         entry
             .metadata
             .insert("dispatch_status".into(), "pending".into());
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
         assert_eq!(status.dispatch_status, DispatchStatus::Pending);
         assert!(status.retryable);
     }
@@ -1335,7 +1184,7 @@ mod tests {
         entry
             .metadata
             .insert("dispatch_status".into(), "failed".into());
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
         assert_eq!(status.dispatch_status, DispatchStatus::Failed);
         assert!(!status.retryable);
     }
@@ -1346,14 +1195,14 @@ mod tests {
         entry
             .metadata
             .insert("dispatch_status".into(), "unavailable".into());
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
         assert_eq!(status.dispatch_status, DispatchStatus::Failed);
     }
 
     #[test]
     fn test_dispatch_status_from_entry_unknown_when_absent() {
         let entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
         assert_eq!(status.dispatch_status, DispatchStatus::Unknown);
     }
 
@@ -1363,7 +1212,7 @@ mod tests {
         entry
             .metadata
             .insert("dispatch_status".into(), "ready".into());
-        let status = InstanceStatus::from_entry(&entry, true, false);
+        let status = instance_status_from_entry(&entry, true);
         assert_eq!(status.status, ServiceStatus::Stale);
         assert!(!status.retryable);
         assert!(status.recommended_next_action.contains("Instance is stale"));
@@ -1373,7 +1222,7 @@ mod tests {
     fn test_instance_status_booting_retryable() {
         let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
         entry.status = ServiceStatus::Booting;
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
         assert_eq!(status.status, ServiceStatus::Booting);
         assert!(status.retryable);
         assert!(
@@ -1387,7 +1236,7 @@ mod tests {
     fn test_instance_status_unreachable_not_retryable() {
         let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
         entry.status = ServiceStatus::Unreachable;
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
         assert_eq!(status.status, ServiceStatus::Unreachable);
         assert!(!status.retryable);
         assert!(
@@ -1401,7 +1250,7 @@ mod tests {
     fn test_instance_status_shutting_down_not_retryable() {
         let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
         entry.status = ServiceStatus::ShuttingDown;
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
         assert_eq!(status.status, ServiceStatus::ShuttingDown);
         assert!(!status.retryable);
         assert!(
@@ -1417,7 +1266,7 @@ mod tests {
         entry
             .metadata
             .insert("dispatch_status".into(), "ready".into());
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
         assert_eq!(status.status, ServiceStatus::Available);
         assert_eq!(status.dispatch_status, DispatchStatus::Ready);
         assert!(status.retryable);
@@ -1434,7 +1283,7 @@ mod tests {
         entry
             .metadata
             .insert("dispatch_status".into(), "ready".into());
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
         assert_eq!(status.status, ServiceStatus::Busy);
         assert_eq!(status.dispatch_status, DispatchStatus::Ready);
         assert!(status.retryable);
@@ -1447,7 +1296,7 @@ mod tests {
         entry
             .metadata
             .insert("dispatch_status".into(), "ready".into());
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
 
         let json = serde_json::to_string(&status).unwrap();
         assert!(json.contains("\"status\":\"available\""));
@@ -1477,7 +1326,7 @@ mod tests {
         entry
             .metadata
             .insert("dispatch_status".into(), "pending".into());
-        let status = InstanceStatus::from_entry(&entry, false, false);
+        let status = instance_status_from_entry(&entry, false);
         assert_eq!(status.status, ServiceStatus::Available);
         assert_eq!(status.dispatch_status, DispatchStatus::Pending);
         // retryable = true because the instance is still booting, not broken

--- a/crates/dcc-mcp-transport/src/lib.rs
+++ b/crates/dcc-mcp-transport/src/lib.rs
@@ -55,6 +55,7 @@ pub use discovery::ServiceRegistry;
 pub use discovery::types::{
     DispatchStatus, InstanceStatus, SERVICE_ENTRY_LEGACY_SCHEMA_VERSION,
     SERVICE_ENTRY_SCHEMA_VERSION, ServiceEntry, ServiceKey, ServiceSnapshot, ServiceStatus,
+    dispatch_status_from_entry, instance_status_from_entry,
 };
 pub use error::{TransportError, TransportResult};
 pub use event_bridge::{EventBridge, EventBridgeService, NoopBridge};


### PR DESCRIPTION
Moves instance status and actionability policy into dcc-mcp-models.

- Keeps registry metadata parsing in dcc-mcp-transport
- Preserves gateway and CLI status output contracts
- Re-exports status types from transport for compatibility

Validation: vx just preflight

Adapter skill guidance: no update needed; runtime wiring and agent workflows are unchanged.

Refs #2199