### PR TITLE
test: add shared Rust integration fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,9 @@ jobs:
       - name: Rust tests
         if: matrix.rust-validation == 'full'
         run: vx just test-rust
+      - name: Shared fixture feature tests
+        if: matrix.rust-validation == 'full'
+        run: vx cargo test -p dcc-mcp-test-utils --features skill-rest
       - name: Rust compile smoke
         if: matrix.rust-validation == 'smoke'
         run: vx cargo check --workspace --all-targets
@@ -257,18 +260,22 @@ jobs:
           vx cargo check -p dcc-mcp-server --no-default-features --features gateway-daemon,admin
           vx cargo check -p dcc-mcp-server --no-default-features --features server,gateway-auto,gateway-daemon,admin
 
-      # `dcc-mcp-semantic` with `python-bindings` / `fastembed-backend`
-      # is the only path that touches `pyo3 0.28` and `fastembed 5`'s
-      # `&mut self` ONNX session API. It is gated off in the default
-      # workspace check so PRs do not pay the ORT runtime download
-      # cost — but that also means API drift only shows up at release
-      # wheel-build time. `cargo check` (no codegen for the C++ ORT
-      # runtime) is enough to catch the drift on every PR. See the
-      # v0.17.45/0.17.46 release postmortems.
-      - name: Semantic crate feature check
+      # `dcc-mcp-semantic` with `fastembed-backend` is the only path that
+      # touches fastembed 5's `&mut self` ONNX session API. It is gated off
+      # in the default workspace check so PRs do not pay the ORT runtime
+      # download cost. Run the native backend's unit tests so feature-gated
+      # code has an executable correctness path on every PR rather than
+      # waiting for a release wheel build. The Python extension feature is
+      # intentionally excluded because it disables libpython linking on Unix.
+      - name: Semantic crate backend tests
         if: matrix.rust-validation == 'full'
         shell: bash
-        run: vx cargo check -p dcc-mcp-semantic --features python-bindings,ext-module,abi3-py38
+        # Keep this outside the shared Rust cache. Older check-only runs can
+        # cache ort-sys with its deferred link_error path, which is valid for
+        # `cargo check` but cannot link the executable test binary.
+        env:
+          CARGO_TARGET_DIR: target/semantic-backend-tests
+        run: vx cargo test -p dcc-mcp-semantic --features fastembed-backend --lib
 
   # ── Dependency policy gate (cargo-deny) ───────────────────────────────────
   # Independent of `rust-check` so its install of `cargo-deny` does not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,6 +1919,9 @@ dependencies = [
 name = "dcc-mcp-test-utils"
 version = "0.20.8"
 dependencies = [
+ "dcc-mcp-skill-rest",
+ "serde_json",
+ "tokio",
  "workspace-hack",
 ]
 

--- a/crates/dcc-mcp-job/tests/job_lifecycle.rs
+++ b/crates/dcc-mcp-job/tests/job_lifecycle.rs
@@ -1,0 +1,65 @@
+use std::sync::{Arc, Mutex};
+
+use dcc_mcp_job::job::{JobManager, JobProgress, JobStatus};
+use serde_json::json;
+
+#[test]
+fn native_lifecycle_emits_ordered_terminal_snapshots() {
+    let manager = JobManager::new();
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let events = observed.clone();
+    manager.subscribe(move |event| events.lock().unwrap().push(event));
+
+    let job = manager.create("maya__bake_simulation");
+    let id = job.read().id.clone();
+    assert_eq!(job.read().status, JobStatus::Pending);
+
+    manager.start(&id).unwrap();
+    manager
+        .update_progress(
+            &id,
+            JobProgress {
+                current: 24,
+                total: 48,
+                message: Some("baking".to_string()),
+            },
+        )
+        .unwrap();
+    manager.complete(&id, json!({"frames": 48})).unwrap();
+
+    let snapshot = manager.get(&id).unwrap();
+    let snapshot = snapshot.read();
+    assert_eq!(snapshot.status, JobStatus::Completed);
+    assert_eq!(snapshot.result, Some(json!({"frames": 48})));
+    assert!(snapshot.completed_at.is_some());
+
+    let statuses: Vec<_> = observed
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|event| event.status)
+        .collect();
+    assert_eq!(
+        statuses,
+        [
+            JobStatus::Pending,
+            JobStatus::Running,
+            JobStatus::Running,
+            JobStatus::Completed,
+        ]
+    );
+}
+
+#[test]
+fn parent_cancellation_reaches_cross_host_child() {
+    let manager = JobManager::new();
+    let parent = manager.create("photoshop__export_document");
+    let parent_id = parent.read().id.clone();
+    let child =
+        manager.create_with_parent("blender__convert_exported_asset", Some(parent_id.clone()));
+
+    manager.cancel(&parent_id).unwrap();
+
+    assert!(parent.read().cancel_token.is_cancelled());
+    assert!(child.read().cancel_token.is_cancelled());
+}

--- a/crates/dcc-mcp-skill-rest/Cargo.toml
+++ b/crates/dcc-mcp-skill-rest/Cargo.toml
@@ -36,6 +36,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 # OpenAPI generation
 utoipa = { version = "5.4", features = ["axum_extras"] }
 utoipa-scalar = "0.3"
+axum-test = { version = "20", optional = true }
 
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
@@ -43,3 +44,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 axum-test = "20"
 dcc-mcp-test-utils = { workspace = true }
+
+[features]
+default = []
+test-fixtures = ["dep:axum-test"]

--- a/crates/dcc-mcp-skill-rest/src/lib.rs
+++ b/crates/dcc-mcp-skill-rest/src/lib.rs
@@ -74,6 +74,9 @@ mod search_index;
 mod service;
 mod thread_affinity_diagnostics;
 
+#[cfg(any(test, feature = "test-fixtures"))]
+pub mod testing;
+
 #[cfg(test)]
 mod tests;
 

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -1,97 +1,6 @@
 use super::*;
+use crate::testing::{InMemorySkillCatalog as FakeCatalog, RecordingToolInvoker as FakeInvoker};
 use std::sync::Mutex;
-
-/// In-memory test fake. Lets us drive the service without spinning
-/// up a real SkillCatalog/ToolDispatcher — keeps unit tests
-/// dependency-free.
-#[derive(Default)]
-struct FakeCatalog {
-    actions: Mutex<Vec<CatalogAction>>,
-}
-
-impl FakeCatalog {
-    fn push(&self, a: CatalogAction) {
-        self.actions.lock().unwrap().push(a);
-    }
-}
-
-impl SkillCatalogSource for FakeCatalog {
-    fn list_actions(&self) -> Vec<CatalogAction> {
-        self.actions.lock().unwrap().clone()
-    }
-    fn is_loaded(&self, name: &str) -> bool {
-        self.actions
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|a| a.skill_name == name && a.loaded)
-    }
-    fn load_skill(&self, skill_name: &str) -> Result<Vec<String>, ServiceError> {
-        let mut actions = self.actions.lock().unwrap();
-        let mut loaded = Vec::new();
-        for action in actions.iter_mut().filter(|a| a.skill_name == skill_name) {
-            action.loaded = true;
-            loaded.push(action.action_name.clone());
-        }
-        if loaded.is_empty() {
-            Err(ServiceError::new(
-                ServiceErrorKind::NotFound,
-                format!("skill not found: {skill_name}"),
-            ))
-        } else {
-            Ok(loaded)
-        }
-    }
-    fn unload_skill(&self, skill_name: &str) -> Result<usize, ServiceError> {
-        let mut actions = self.actions.lock().unwrap();
-        let mut removed = 0usize;
-        for action in actions.iter_mut().filter(|a| a.skill_name == skill_name) {
-            action.loaded = false;
-            removed += 1;
-        }
-        if removed == 0 {
-            Err(ServiceError::new(
-                ServiceErrorKind::NotFound,
-                format!("skill not found: {skill_name}"),
-            ))
-        } else {
-            Ok(removed)
-        }
-    }
-}
-
-#[derive(Default)]
-struct FakeInvoker {
-    calls: Mutex<Vec<(String, Value, Option<Value>)>>,
-    next: Mutex<Option<Result<Value, ServiceError>>>,
-}
-
-impl FakeInvoker {
-    fn set_next(&self, r: Result<Value, ServiceError>) {
-        *self.next.lock().unwrap() = Some(r);
-    }
-}
-
-#[async_trait::async_trait]
-impl ToolInvoker for FakeInvoker {
-    async fn invoke(
-        &self,
-        name: &str,
-        params: Value,
-        meta: Option<Value>,
-    ) -> Result<CallOutcome, ServiceError> {
-        self.calls
-            .lock()
-            .unwrap()
-            .push((name.to_owned(), params.clone(), meta));
-        let r = self.next.lock().unwrap().take().unwrap_or(Ok(Value::Null));
-        r.map(|v| CallOutcome {
-            slug: ToolSlug(name.to_owned()),
-            output: v,
-            validation_skipped: false,
-        })
-    }
-}
 
 fn sphere_action(loaded: bool) -> CatalogAction {
     CatalogAction {
@@ -121,10 +30,7 @@ fn sphere_action(loaded: bool) -> CatalogAction {
 }
 
 fn build_service(actions: Vec<CatalogAction>) -> (SkillRestService, Arc<FakeInvoker>) {
-    let cat = Arc::new(FakeCatalog::default());
-    for a in actions {
-        cat.push(a);
-    }
+    let cat = Arc::new(FakeCatalog::new(actions));
     let inv = Arc::new(FakeInvoker::default());
     let svc = SkillRestService::new(cat, inv.clone());
     (svc, inv)
@@ -789,10 +695,10 @@ async fn call_dispatches_and_normalises_slug() {
         .unwrap();
     assert_eq!(out.slug.0, "maya.spheres.create_sphere");
     assert_eq!(out.output["created"], 1);
-    let calls = inv.calls.lock().unwrap();
+    let calls = inv.calls();
     assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].0, "create_sphere");
-    assert_eq!(calls[0].1["radius"], 1.5);
+    assert_eq!(calls[0].action_name, "create_sphere");
+    assert_eq!(calls[0].params["radius"], 1.5);
 }
 
 #[tokio::test]

--- a/crates/dcc-mcp-skill-rest/src/testing.rs
+++ b/crates/dcc-mcp-skill-rest/src/testing.rs
@@ -1,0 +1,269 @@
+//! Reusable in-memory fixtures for the per-DCC REST contracts.
+//!
+//! The implementations live beside the traits so `dcc-mcp-skill-rest` can use
+//! them in its own unit tests without a dependency cycle. Downstream workspace
+//! tests use the canonical `dcc_mcp_test_utils::skill_rest` re-export.
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum_test::TestServer;
+use parking_lot::Mutex;
+use serde_json::{Value, json};
+
+use crate::audit::VecAuditSink;
+use crate::auth::{AuthContext, AuthGate, Principal};
+use crate::errors::{ServiceError, ServiceErrorKind};
+use crate::readiness::StaticReadiness;
+use crate::router::{SkillRestConfig, build_skill_rest_router};
+use crate::service::{
+    CallOutcome, CatalogAction, SkillCatalogSource, SkillRestService, ToolInvoker, ToolSlug,
+};
+
+/// Thread-safe in-memory implementation of [`SkillCatalogSource`].
+#[derive(Default)]
+pub struct InMemorySkillCatalog {
+    actions: Mutex<Vec<CatalogAction>>,
+}
+
+impl InMemorySkillCatalog {
+    #[must_use]
+    pub fn new(actions: impl IntoIterator<Item = CatalogAction>) -> Self {
+        Self {
+            actions: Mutex::new(actions.into_iter().collect()),
+        }
+    }
+
+    pub fn push(&self, action: CatalogAction) {
+        self.actions.lock().push(action);
+    }
+
+    #[must_use]
+    pub fn actions(&self) -> Vec<CatalogAction> {
+        self.actions.lock().clone()
+    }
+}
+
+impl SkillCatalogSource for InMemorySkillCatalog {
+    fn list_actions(&self) -> Vec<CatalogAction> {
+        self.actions()
+    }
+
+    fn is_loaded(&self, skill_name: &str) -> bool {
+        self.actions
+            .lock()
+            .iter()
+            .any(|action| action.skill_name == skill_name && action.loaded)
+    }
+
+    fn load_skill(&self, skill_name: &str) -> Result<Vec<String>, ServiceError> {
+        let mut actions = self.actions.lock();
+        let mut loaded = Vec::new();
+        for action in actions
+            .iter_mut()
+            .filter(|action| action.skill_name == skill_name)
+        {
+            action.loaded = true;
+            loaded.push(action.action_name.clone());
+        }
+        if loaded.is_empty() {
+            Err(ServiceError::new(
+                ServiceErrorKind::NotFound,
+                format!("skill not found: {skill_name}"),
+            ))
+        } else {
+            Ok(loaded)
+        }
+    }
+
+    fn unload_skill(&self, skill_name: &str) -> Result<usize, ServiceError> {
+        let mut actions = self.actions.lock();
+        let mut removed = 0;
+        for action in actions
+            .iter_mut()
+            .filter(|action| action.skill_name == skill_name)
+        {
+            action.loaded = false;
+            removed += 1;
+        }
+        if removed == 0 {
+            Err(ServiceError::new(
+                ServiceErrorKind::NotFound,
+                format!("skill not found: {skill_name}"),
+            ))
+        } else {
+            Ok(removed)
+        }
+    }
+}
+
+/// One invocation captured by [`RecordingToolInvoker`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecordedInvocation {
+    pub action_name: String,
+    pub params: Value,
+    pub meta: Option<Value>,
+}
+
+/// In-memory invoker with a configurable one-shot result and call history.
+#[derive(Default)]
+pub struct RecordingToolInvoker {
+    calls: Mutex<Vec<RecordedInvocation>>,
+    next: Mutex<Option<Result<Value, ServiceError>>>,
+}
+
+impl RecordingToolInvoker {
+    pub fn set_next(&self, result: Result<Value, ServiceError>) {
+        *self.next.lock() = Some(result);
+    }
+
+    #[must_use]
+    pub fn calls(&self) -> Vec<RecordedInvocation> {
+        self.calls.lock().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl ToolInvoker for RecordingToolInvoker {
+    async fn invoke(
+        &self,
+        action_name: &str,
+        params: Value,
+        meta: Option<Value>,
+    ) -> Result<CallOutcome, ServiceError> {
+        self.calls.lock().push(RecordedInvocation {
+            action_name: action_name.to_owned(),
+            params,
+            meta,
+        });
+        self.next
+            .lock()
+            .take()
+            .unwrap_or(Ok(Value::Null))
+            .map(|output| CallOutcome {
+                slug: ToolSlug(action_name.to_owned()),
+                output,
+                validation_skipped: false,
+            })
+    }
+}
+
+/// Deterministic auth fixture that either returns one principal or rejects.
+#[derive(Debug, Clone)]
+pub struct StaticAuthGate {
+    principal: Option<Principal>,
+    denial: String,
+}
+
+impl StaticAuthGate {
+    #[must_use]
+    pub fn allow(subject: impl Into<String>) -> Self {
+        Self {
+            principal: Some(Principal {
+                subject: subject.into(),
+                roles: vec!["test".to_string()],
+            }),
+            denial: String::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn deny(message: impl Into<String>) -> Self {
+        Self {
+            principal: None,
+            denial: message.into(),
+        }
+    }
+}
+
+impl AuthGate for StaticAuthGate {
+    fn authorize(&self, _ctx: &AuthContext<'_>) -> Result<Principal, ServiceError> {
+        self.principal
+            .clone()
+            .ok_or_else(|| ServiceError::new(ServiceErrorKind::Unauthorized, self.denial.clone()))
+    }
+}
+
+/// Explicit test-oriented name for the production in-memory audit sink.
+pub type RecordingAuditSink = VecAuditSink;
+
+/// Minimal real-router harness with deterministic auth, readiness, and audit.
+pub struct SkillRestTestHarness {
+    pub server: TestServer,
+    pub audit: Arc<VecAuditSink>,
+}
+
+impl SkillRestTestHarness {
+    #[must_use]
+    pub fn new(service: SkillRestService) -> Self {
+        let audit = Arc::new(VecAuditSink::new());
+        let config = SkillRestConfig::new(service)
+            .with_audit(audit.clone())
+            .with_readiness(Arc::new(StaticReadiness::fully_ready()))
+            .with_auth(Arc::new(StaticAuthGate::allow("test")));
+        let app: Router = build_skill_rest_router(config);
+        Self {
+            server: TestServer::new(app),
+            audit,
+        }
+    }
+}
+
+/// Compact multi-DCC action fixture with production defaults.
+#[must_use]
+pub fn catalog_action(
+    action_name: impl Into<String>,
+    skill_name: impl Into<String>,
+    dcc: impl Into<String>,
+    loaded: bool,
+) -> CatalogAction {
+    CatalogAction {
+        action_name: action_name.into(),
+        skill_name: skill_name.into(),
+        dcc: dcc.into(),
+        description: "Fixture action".to_string(),
+        tags: Vec::new(),
+        search_aliases: Vec::new(),
+        search_tokens: Vec::new(),
+        input_schema: json!({"type": "object"}),
+        loaded,
+        scope: "repo".to_string(),
+        layer: None,
+        path_source: "unknown".to_string(),
+        annotations: Default::default(),
+        execution: Default::default(),
+        timeout_hint_secs: None,
+        job_strategy: Default::default(),
+        thread_affinity: Default::default(),
+        enforce_thread_affinity: false,
+        available_groups: Vec::new(),
+        runtime: None,
+        next_tools: Default::default(),
+        call_examples: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_fixture_loads_and_unloads_skills() {
+        let catalog = InMemorySkillCatalog::new([
+            catalog_action("create_sphere", "geometry", "maya", false),
+            catalog_action("export_layer", "geometry", "photoshop", false),
+        ]);
+
+        assert_eq!(catalog.load_skill("geometry").unwrap().len(), 2);
+        assert!(catalog.is_loaded("geometry"));
+        assert_eq!(catalog.unload_skill("geometry").unwrap(), 2);
+        assert!(!catalog.is_loaded("geometry"));
+    }
+
+    #[test]
+    fn audit_alias_implements_sink_contract() {
+        let sink = RecordingAuditSink::new();
+        assert!(sink.is_empty());
+        let _sink: &dyn crate::AuditSink = &sink;
+    }
+}

--- a/crates/dcc-mcp-skill-rest/src/tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/tests.rs
@@ -17,7 +17,6 @@
 
 use std::sync::Arc;
 
-use axum::Router;
 use axum_test::TestServer;
 use serde_json::{Value, json};
 
@@ -36,6 +35,7 @@ use super::service::{
     CallOutcome, CatalogSource, DispatcherInvoker, PendingCall, SkillRestService, ToolInvoker,
     ToolSlug,
 };
+use super::testing::SkillRestTestHarness;
 
 // ── Fixture ──────────────────────────────────────────────────────────
 
@@ -91,14 +91,8 @@ fn fixture_loaded_spheres() -> (SkillRestService, Arc<ToolRegistry>, Arc<ToolDis
 }
 
 fn build_server(service: SkillRestService) -> (TestServer, Arc<VecAuditSink>) {
-    let sink = Arc::new(VecAuditSink::new());
-    let cfg = SkillRestConfig::new(service)
-        .with_audit(sink.clone())
-        .with_readiness(Arc::new(StaticReadiness::fully_ready()))
-        .with_auth(Arc::new(AllowLocalhostGate::new()));
-    let app: Router = build_skill_rest_router(cfg);
-    let server = TestServer::new(app);
-    (server, sink)
+    let harness = SkillRestTestHarness::new(service);
+    (harness.server, harness.audit)
 }
 
 // ── High-value scenarios ─────────────────────────────────────────────

--- a/crates/dcc-mcp-test-utils/Cargo.toml
+++ b/crates/dcc-mcp-test-utils/Cargo.toml
@@ -9,4 +9,13 @@ repository.workspace = true
 description = "Shared test utilities for dcc-mcp-core workspace crates"
 
 [dependencies]
+dcc-mcp-skill-rest = { workspace = true, optional = true, features = ["test-fixtures"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[features]
+default = []
+skill-rest = ["dep:dcc-mcp-skill-rest"]
+
+[dev-dependencies]
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/dcc-mcp-test-utils/src/lib.rs
+++ b/crates/dcc-mcp-test-utils/src/lib.rs
@@ -6,6 +6,21 @@
 //! must use [`EnvVarGuard`] or [`EnvVarsGuard`] to safely save/restore the
 //! previous value and to serialise concurrent access within the same crate.
 //!
+//! # Feature-gated domain fixtures
+//!
+//! Enable `skill-rest` for the canonical in-memory catalog, recording
+//! invoker, deterministic auth gate, audit sink, and real-router harness:
+//!
+//! ```ignore
+//! use dcc_mcp_test_utils::skill_rest::{
+//!     InMemorySkillCatalog, RecordingToolInvoker, SkillRestTestHarness,
+//! };
+//! ```
+//!
+//! Trait-specific implementations remain physically owned by
+//! `dcc-mcp-skill-rest`; this crate re-exports them so workspace tests have one
+//! fixture entry point without introducing a production dependency cycle.
+//!
 //! ```ignore
 //! use dcc_mcp_test_utils::{EnvVarGuard, EnvVarsGuard};
 //!
@@ -17,6 +32,13 @@
 //! ```
 
 use std::sync::{Mutex, MutexGuard};
+
+/// Per-DCC REST fixtures, re-exported from their trait owner to keep the
+/// production dependency graph acyclic.
+#[cfg(feature = "skill-rest")]
+pub mod skill_rest {
+    pub use dcc_mcp_skill_rest::testing::*;
+}
 
 /// Global lock that serialises all env-var mutations within this crate's
 /// test binary.  Without this, concurrent tests that call `set_var` /
@@ -150,5 +172,46 @@ mod tests {
         ]);
         assert_eq!(std::env::var("DCC_MCP_TEST_UTILS_A").unwrap(), "1");
         assert_eq!(std::env::var("DCC_MCP_TEST_UTILS_B").unwrap(), "2");
+    }
+}
+
+#[cfg(all(test, feature = "skill-rest"))]
+mod skill_rest_fixture_tests {
+    use std::sync::Arc;
+
+    use dcc_mcp_skill_rest::SkillRestService;
+    use serde_json::{Value, json};
+
+    use crate::skill_rest::{
+        InMemorySkillCatalog, RecordingToolInvoker, SkillRestTestHarness, catalog_action,
+    };
+
+    #[tokio::test]
+    async fn shared_harness_exercises_real_router_and_records_invocation() {
+        let mut action = catalog_action("create_sphere", "geometry", "maya", true);
+        action.description = "Create a polygon sphere".to_string();
+        let catalog = Arc::new(InMemorySkillCatalog::new([action]));
+        let invoker = Arc::new(RecordingToolInvoker::default());
+        invoker.set_next(Ok(json!({"name": "pSphere1"})));
+        let service = SkillRestService::new(catalog, invoker.clone());
+        let harness = SkillRestTestHarness::new(service);
+
+        let search = harness
+            .server
+            .post("/v1/search")
+            .json(&json!({"query": "sphere"}))
+            .await;
+        search.assert_status_ok();
+        let body: Value = search.json();
+        let slug = body["hits"][0]["slug"].as_str().unwrap();
+
+        let call = harness
+            .server
+            .post("/v1/call")
+            .json(&json!({"tool_slug": slug, "params": {"radius": 2.0}}))
+            .await;
+        call.assert_status_ok();
+        assert_eq!(invoker.calls()[0].action_name, "create_sphere");
+        assert_eq!(harness.audit.len(), 2);
     }
 }

--- a/crates/dcc-mcp-usd/tests/scene_exchange.rs
+++ b/crates/dcc-mcp-usd/tests/scene_exchange.rs
@@ -1,0 +1,61 @@
+use dcc_mcp_protocols::adapters::{SceneInfo, SceneStatistics};
+use dcc_mcp_usd::bridge::{scene_info_to_stage, stage_to_scene_info};
+use dcc_mcp_usd::{SdfPath, UsdStage, VtValue};
+
+fn scene(dcc: &str) -> SceneInfo {
+    SceneInfo {
+        file_path: format!("/show/shot010/scene.{dcc}"),
+        name: format!("shot010-{dcc}"),
+        format: format!(".{dcc}"),
+        frame_range: Some((1001.0, 1050.0)),
+        current_frame: Some(1012.0),
+        fps: Some(24.0),
+        up_axis: Some(if dcc == "blender" { "z" } else { "y" }.to_string()),
+        units: Some(if dcc == "blender" { "m" } else { "cm" }.to_string()),
+        statistics: SceneStatistics {
+            object_count: 12,
+            vertex_count: 4_096,
+            polygon_count: 2_048,
+            material_count: 3,
+            light_count: 2,
+            camera_count: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[test]
+fn maya_and_blender_scene_contracts_round_trip_natively() {
+    for dcc in ["maya", "blender"] {
+        let source = scene(dcc);
+        let stage = scene_info_to_stage(&source, dcc);
+        let wire = stage.to_json().unwrap();
+        let restored = UsdStage::from_json(&wire).unwrap();
+        let recovered = stage_to_scene_info(&restored);
+
+        assert_eq!(restored.metadata["dcc:type"], dcc);
+        assert_eq!(recovered.file_path, source.file_path);
+        assert_eq!(recovered.frame_range, source.frame_range);
+        assert_eq!(recovered.statistics.vertex_count, 4_096);
+        assert!(restored.export_usda().contains("#usda 1.0"));
+    }
+}
+
+#[test]
+fn stage_edit_and_json_transport_preserve_attributes() {
+    let mut stage = UsdStage::new("custom-host-scene");
+    stage.define_prim(SdfPath::new("/World").unwrap(), "Xform");
+    stage.define_prim(SdfPath::new("/World/Hero").unwrap(), "Mesh");
+    stage
+        .set_attribute("/World/Hero", "displayColor", VtValue::Vec3f(0.2, 0.4, 0.8))
+        .unwrap();
+
+    let restored = UsdStage::from_json(&stage.to_json().unwrap()).unwrap();
+    assert_eq!(
+        restored
+            .get_attribute("/World/Hero", "displayColor")
+            .unwrap(),
+        Some(&VtValue::Vec3f(0.2, 0.4, 0.8))
+    );
+}


### PR DESCRIPTION
## Summary
- add reusable skill REST catalog, invoker, auth, audit, and HTTP fixtures behind a test-only feature
- replace duplicated REST doubles and add native Job/USD integration coverage
- execute shared-fixture and semantic backend tests in CI

## Validation
- `vx just preflight` (3555 tests passed)
- `vx cargo test -p dcc-mcp-test-utils --features skill-rest`
- targeted `clippy -D warnings` for all changed crates and features

Creator Skills do not need updates because adapter and skill-authoring workflows are unchanged.

Closes #2198