### PR TITLE
refactor: isolate gateway admin asset build

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -126,7 +126,7 @@ runs:
 
     # manylinux Docker builds do not have `vx` on PATH. Pre-bundle the Vite admin
     # UI on the GitHub runner (vx + Node from vx.toml), then tell
-    # `crates/dcc-mcp-gateway/build.rs` to skip `vx npm` inside the container.
+    # `crates/dcc-mcp-gateway-admin/build.rs` to skip `vx npm` inside the container.
     # This must run *before* stubgen: stubgen triggers `cargo` which compiles
     # `dcc-mcp-gateway` with the `admin` feature; without a pre-built bundle,
     # build.rs would invoke npm during stubgen (Windows CI failed on invalid
@@ -163,7 +163,7 @@ runs:
           vx npm --prefix admin-ui install "$LIGHTNING_PKG" --no-save --ignore-scripts
         fi
         vx npm --prefix admin-ui run build
-        test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
+        test -f crates/dcc-mcp-gateway-admin/src/generated/index.html
 
     - name: Generate type stubs
       if: inputs.generate-stubs == 'true' && inputs.python-version != '3.7'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: admin-ui-bundle
-          path: crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
+          path: crates/dcc-mcp-gateway-admin/src/generated/index.html
 
   # ── Rust checks ────────────────────────────────────────────────────────────
   # Keep the PR critical path focused:
@@ -184,7 +184,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: admin-ui-bundle
-          path: crates/dcc-mcp-gateway/src/gateway/admin/generated
+          path: crates/dcc-mcp-gateway-admin/src/generated
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
@@ -337,7 +337,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: admin-ui-bundle
-          path: crates/dcc-mcp-gateway/src/gateway/admin/generated
+          path: crates/dcc-mcp-gateway-admin/src/generated
       # Use the same composite wheel builder as release builds and py3.7 CI.
       # It owns Rust/Python setup, Cargo cache, sccache, feature resolution,
       # wheel-content validation, and artifact upload, avoiding duplicated
@@ -397,7 +397,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: admin-ui-bundle
-          path: crates/dcc-mcp-gateway/src/gateway/admin/generated
+          path: crates/dcc-mcp-gateway-admin/src/generated
       - uses: ./.github/actions/build-wheel
         with:
           target: ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: admin-ui-bundle
-          path: crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
+          path: crates/dcc-mcp-gateway-admin/src/generated/index.html
 
   # ── Build standalone binaries (raw Release assets + server PyPI wheel) ──
   #
@@ -233,7 +233,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: admin-ui-bundle
-          path: crates/dcc-mcp-gateway/src/gateway/admin/generated
+          path: crates/dcc-mcp-gateway-admin/src/generated
 
       - name: Use pre-built admin UI for Linux builds
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           tool: cargo-llvm-cov
       # `dcc-mcp-server` enables `dcc-mcp-gateway/admin` by default, so
-      # `cargo llvm-cov --workspace` triggers `crates/dcc-mcp-gateway/build.rs`
+      # `cargo llvm-cov --workspace` triggers `crates/dcc-mcp-gateway-admin/build.rs`
       # which runs `npm ci --ignore-scripts` inside `admin-ui/`. Concurrent
       # cargo + npm in coverage mode hits a known npm bug (`Exit handler
       # never called!`) that crashes the build script. Pre-build the admin

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ admin-ui/node_modules
 admin-ui/node_modules/
 admin-ui/playwright-report/
 admin-ui/test-results/
-crates/dcc-mcp-gateway/src/gateway/admin/generated/
+crates/dcc-mcp-gateway-admin/src/generated/
 /venv/
 /run_pycharm.bat
 /.nox/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,7 @@ dependencies = [
  "dcc-mcp-attestation",
  "dcc-mcp-catalog",
  "dcc-mcp-db",
+ "dcc-mcp-gateway-admin",
  "dcc-mcp-gateway-core",
  "dcc-mcp-jsonrpc",
  "dcc-mcp-marketplace",
@@ -1295,7 +1296,6 @@ dependencies = [
  "dcc-mcp-transport",
  "dcc-mcp-updater",
  "dcc-mcp-workflow",
- "dunce",
  "futures",
  "futures-util",
  "http",
@@ -1322,6 +1322,14 @@ dependencies = [
  "tower-http",
  "tracing",
  "uuid",
+ "workspace-hack",
+]
+
+[[package]]
+name = "dcc-mcp-gateway-admin"
+version = "0.20.8"
+dependencies = [
+ "dunce",
  "workspace-hack",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/dcc-mcp-job",
     "crates/dcc-mcp-skill-rest",
     "crates/dcc-mcp-gateway",
+    "crates/dcc-mcp-gateway-admin",
     "crates/dcc-mcp-gateway-core",
     "crates/dcc-mcp-gateway-ensure",
     "crates/dcc-mcp-gateway-search",
@@ -102,6 +103,7 @@ dcc-mcp-marketplace = { path = "crates/dcc-mcp-marketplace" }
 dcc-mcp-catalog = { path = "crates/dcc-mcp-catalog" }
 dcc-mcp-db = { path = "crates/dcc-mcp-db" }
 dcc-mcp-gateway = { path = "crates/dcc-mcp-gateway" }
+dcc-mcp-gateway-admin = { path = "crates/dcc-mcp-gateway-admin" }
 dcc-mcp-gateway-core = { path = "crates/dcc-mcp-gateway-core" }
 dcc-mcp-updater = { path = "crates/dcc-mcp-updater" }
 dcc-mcp-attestation = { path = "crates/dcc-mcp-attestation" }

--- a/admin-ui/vite.config.ts
+++ b/admin-ui/vite.config.ts
@@ -19,6 +19,6 @@ export default defineConfig({
     assetsInlineLimit: Number.MAX_SAFE_INTEGER,
     cssCodeSplit: false,
     emptyOutDir: true,
-    outDir: '../crates/dcc-mcp-gateway/src/gateway/admin/generated',
+    outDir: '../crates/dcc-mcp-gateway-admin/src/generated',
   },
 });

--- a/crates/dcc-mcp-gateway-admin/Cargo.toml
+++ b/crates/dcc-mcp-gateway-admin/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "dcc-mcp-gateway-admin"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Build boundary and embedded frontend asset for the DCC-MCP gateway admin dashboard."
+build = "build.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[features]
+default = []
+embed = []
+
+[build-dependencies]
+dunce = "1.0"

--- a/crates/dcc-mcp-gateway-admin/build.rs
+++ b/crates/dcc-mcp-gateway-admin/build.rs
@@ -1,6 +1,6 @@
-//! Materialise `src/gateway/admin/generated/index.html` via the Vite admin bundle.
+//! Materialise `src/generated/index.html` via the Vite admin bundle.
 //!
-//! When the `admin` feature is enabled, this script runs `vx npm …` from the
+//! When the `embed` feature is enabled, this script runs `vx npm …` from the
 //! `admin-ui` directory (Node is resolved via the parent `vx.toml`) or falls
 //! back to plain `npm` with `current_dir(admin-ui)` when `vx` is not on `PATH`.
 //! Build-only installs pass `--ignore-scripts` so the Playwright browser
@@ -22,7 +22,7 @@ fn workspace_root(manifest_dir: &Path) -> Result<PathBuf, String> {
         .parent()
         .and_then(Path::parent)
         .map(Path::to_path_buf)
-        .ok_or_else(|| "expected Cargo.toml under crates/dcc-mcp-gateway".to_string())
+        .ok_or_else(|| "expected Cargo.toml under crates/dcc-mcp-gateway-admin".to_string())
 }
 
 /// Run `vx npm …` from `admin-ui/`, or `npm …` from `admin-ui/` if `vx`
@@ -85,8 +85,49 @@ fn run_npm_or_vx(admin_ui: &Path, npm_args: &[&str]) -> Result<(), String> {
     Ok(())
 }
 
+/// Run a package-local JavaScript entry point with the vx-managed Node runtime.
+fn run_node_or_vx(admin_ui: &Path, script: &str, args: &[&str]) -> Result<(), String> {
+    let mut node_argv = vec![script];
+    node_argv.extend_from_slice(args);
+
+    let vx_result = Command::new("vx")
+        .arg("node")
+        .args(&node_argv)
+        .current_dir(admin_ui)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status();
+
+    match vx_result {
+        Ok(status) if status.success() => return Ok(()),
+        Ok(status) => println!(
+            "cargo:warning=`vx node {}` exited with {status}; trying plain `node`",
+            node_argv.join(" ")
+        ),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            println!("cargo:warning=vx not on PATH; trying plain `node`");
+        }
+        Err(e) => return Err(format!("failed to spawn `vx node`: {e}")),
+    }
+
+    let status = Command::new("node")
+        .args(&node_argv)
+        .current_dir(admin_ui)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .map_err(|e| format!("failed to spawn `node`: {e}"))?;
+    if !status.success() {
+        return Err(format!(
+            "`node {}` exited with {status}",
+            node_argv.join(" ")
+        ));
+    }
+    Ok(())
+}
+
 fn main() -> Result<(), String> {
-    if std::env::var_os("CARGO_FEATURE_ADMIN").is_none() {
+    if std::env::var_os("CARGO_FEATURE_EMBED").is_none() {
         return Ok(());
     }
 
@@ -96,7 +137,7 @@ fn main() -> Result<(), String> {
     let ws = workspace_root(&manifest_dir)?;
     let admin_ui = dunce::canonicalize(ws.join("admin-ui"))
         .map_err(|e| format!("failed to canonicalize admin-ui path: {e}"))?;
-    let out = manifest_dir.join("src/gateway/admin/generated/index.html");
+    let out = manifest_dir.join("src/generated/index.html");
 
     println!(
         "cargo:rerun-if-changed={}",
@@ -151,8 +192,10 @@ fn main() -> Result<(), String> {
         run_npm_or_vx(&admin_ui, &["ci", "--ignore-scripts"])?;
     }
 
-    println!("cargo:warning=Building admin-ui bundle (vx npm run build or npm run build)");
-    run_npm_or_vx(&admin_ui, &["run", "build"])?;
+    println!("cargo:warning=Type-checking admin-ui bundle");
+    run_node_or_vx(&admin_ui, "node_modules/typescript/bin/tsc", &["-b"])?;
+    println!("cargo:warning=Building admin-ui bundle");
+    run_node_or_vx(&admin_ui, "node_modules/vite/bin/vite.js", &["build"])?;
 
     if !out.is_file() {
         return Err(format!("admin build did not write {}", out.display()));

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -1,0 +1,28 @@
+//! Embedded frontend boundary for the DCC-MCP gateway admin dashboard.
+//!
+//! This crate deliberately owns the Vite/npm build script and the generated
+//! dashboard payload. The gateway application depends on this crate only when
+//! its `admin` feature is enabled, so non-admin gateway builds never execute a
+//! Node.js toolchain.
+
+#![forbid(unsafe_code)]
+
+/// The Vite-built React admin dashboard HTML page.
+#[cfg(feature = "embed")]
+pub const ADMIN_HTML: &str = include_str!("generated/index.html");
+
+/// Minimal fallback for direct builds that do not request embedded assets.
+#[cfg(not(feature = "embed"))]
+pub const ADMIN_HTML: &str = r#"<!doctype html><html><head><meta charset="utf-8"><title>DCC-MCP Gateway Admin</title></head><body><h1>DCC-MCP Gateway Admin</h1><p>The embedded admin UI is not available in this build.</p></body></html>"#;
+
+#[cfg(test)]
+mod tests {
+    use super::ADMIN_HTML;
+
+    #[test]
+    fn admin_html_is_a_complete_document() {
+        assert!(ADMIN_HTML.starts_with("<!doctype html>"));
+        assert!(ADMIN_HTML.contains("DCC-MCP"));
+        assert!(ADMIN_HTML.trim_end().ends_with("</html>"));
+    }
+}

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -7,7 +7,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Multi-DCC MCP gateway: aggregation, routing, capability index, REST/MCP dynamic-capability surface (#653/#654/#655) — extracted from dcc-mcp-http"
-build = "build.rs"
 
 [dependencies]
 # Internal
@@ -18,6 +17,7 @@ dcc-mcp-db = { path = "../dcc-mcp-db", default-features = false }
 dcc-mcp-models = { workspace = true }
 dcc-mcp-actions = { workspace = true }
 dcc-mcp-gateway-core = { workspace = true }
+dcc-mcp-gateway-admin = { workspace = true, optional = true, features = ["embed"] }
 dcc-mcp-jsonrpc = { workspace = true }
 dcc-mcp-naming = { workspace = true }
 dcc-mcp-transport = { workspace = true }
@@ -74,7 +74,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 # (opentelemetry / opentelemetry_sdk / opentelemetry-stdout) still compiles via
 # `dcc-mcp-telemetry`; opt-in gating of the OTel stack is a separate follow-up.
 default = []
-admin = []
+admin = ["dep:dcc-mcp-gateway-admin"]
 admin-persist-sqlite = ["admin", "dcc-mcp-db/gateway-admin-sqlite"]
 telemetry = ["dep:dcc-mcp-telemetry", "dep:opentelemetry"]
 prometheus = ["telemetry", "dcc-mcp-telemetry/prometheus", "dep:prometheus"]
@@ -95,6 +95,3 @@ harness = false
 [[bench]]
 name = "instance_query_bench"
 harness = false
-
-[build-dependencies]
-dunce = "1.0"

--- a/crates/dcc-mcp-gateway/src/gateway/admin/html.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/html.rs
@@ -1,14 +1,14 @@
 //! Standalone asset module — embedded admin UI frontend.
 //!
-//! This module is intentionally kept independent from the domain/application/infra
-//! split because `include_str!` embeds a 1.5MB build artifact at compile time.
+//! Asset generation and embedding are owned by `dcc-mcp-gateway-admin`, keeping
+//! the Node/Vite build boundary outside the gateway application crate.
 //! When `feature = "admin"` is off, the binary only carries a tiny fallback page.
 //!
 //! The asset is served by `general::handle_admin_ui` through `ADMIN_HTML`.
 
 /// The Vite-built React admin dashboard HTML page.
 #[cfg(feature = "admin")]
-pub const ADMIN_HTML: &str = include_str!("generated/index.html");
+pub use dcc_mcp_gateway_admin::ADMIN_HTML;
 
 /// Minimal fallback used when the gateway is compiled without embedded admin assets.
 #[cfg(not(feature = "admin"))]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -23,9 +23,9 @@
 //!
 //! # Architecture
 //!
-//! The entire UI is a single inline HTML string (`admin/html.rs`) bundled into
-//! the binary via a Rust `const`.  No `npm`, no CDN, no `build.rs`.
-//! Vanilla JS polls the JSON API endpoints every 5 seconds.
+//! The runtime UI is a single inline HTML string (`admin/html.rs`). The
+//! `dcc-mcp-gateway-admin` crate owns the Vite/npm build boundary and embedded
+//! asset; this module owns the gateway-specific HTTP adapter and API handlers.
 //!
 //! # Module layout (PIP-687 split)
 //!

--- a/crates/dcc-mcp-gateway/src/lib.rs
+++ b/crates/dcc-mcp-gateway/src/lib.rs
@@ -6,12 +6,15 @@
 //!
 //! It is published as its own crate so that:
 //! 1. Touching gateway code does not trigger a full recompile of the
-//!    embedded MCP HTTP server (and vice versa) — gateway is the
-//!    biggest module by far (~11k LoC across 53 files), so the
-//!    incremental-build win is substantial.
+//!    embedded MCP HTTP server (and vice versa).
 //! 2. Downstream binaries that *only* need an embedded server (e.g.
 //!    DCC adapters that never participate in gateway election) no
 //!    longer have to compile the gateway code path.
+//!
+//! The optional dashboard frontend and its Node/Vite build lifecycle are
+//! isolated in `dcc-mcp-gateway-admin`. This crate contains only the gateway
+//! application and its Rust-side admin adapter; builds without the `admin`
+//! feature do not compile or run the frontend build crate.
 //!
 //! For backwards compatibility the entire surface is re-exported from
 //! `dcc_mcp_http` under the historical `dcc_mcp_http::gateway` path —

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `crates/dcc-mcp-gateway/build.rs` embeds the built asset during Cargo builds.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `crates/dcc-mcp-gateway-admin/build.rs` owns the optional frontend build and embedded asset. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`crates/dcc-mcp-gateway/build.rs` 会在 Cargo 构建时生成并嵌入产物。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`crates/dcc-mcp-gateway-admin/build.rs` 负责可选的前端构建与嵌入资产。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/justfile
+++ b/justfile
@@ -54,10 +54,11 @@ print-wheel-features-py37:
 
 # ── Admin UI ──────────────────────────────────────────────────────────────────
 #
-# The Vite bundle is written to crates/dcc-mcp-gateway/src/gateway/admin/generated/
+# The Vite bundle is written to crates/dcc-mcp-gateway-admin/src/generated/
 # and is intentionally gitignored. It is rebuilt automatically whenever Cargo compiles
 # `dcc-mcp-gateway` with the `admin` feature (wheel builds, local `cargo check`, etc.);
-# `crates/dcc-mcp-gateway/build.rs` runs `vx npm ci` (if needed) and `vx npm run build`.
+# `crates/dcc-mcp-gateway-admin/build.rs` installs dependencies with `vx npm`
+# and builds with the vx-managed Node runtime.
 #
 # Use these recipes when you iterate on JSX/CSS only and want fast rebuilds without
 # recompiling the whole Rust workspace.
@@ -66,11 +67,12 @@ print-wheel-features-py37:
 # Note: npm ci skips optional deps by default; use --include=optional to
 # ensure native bindings (rolldown) are installed and the Vite build succeeds.
 admin-install:
-    vx npm --prefix admin-ui ci
+    cd admin-ui; vx npm ci --ignore-scripts --include=optional
 
 # Build the React admin UI into the Rust-embedded generated HTML
 admin-build: admin-install
-    vx npm --prefix admin-ui run build
+    vx node admin-ui/node_modules/typescript/bin/tsc -b admin-ui/tsconfig.json
+    vx node admin-ui/node_modules/vite/bin/vite.js build admin-ui --config admin-ui/vite.config.ts
 
 # ── Rust ──────────────────────────────────────────────────────────────────────
 

--- a/scripts/release/prebuild_admin_ui.sh
+++ b/scripts/release/prebuild_admin_ui.sh
@@ -37,7 +37,7 @@ if [ -n "$LIGHTNING_PKG" ]; then
 fi
 
 vx npm --prefix admin-ui run build
-test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
+test -f crates/dcc-mcp-gateway-admin/src/generated/index.html
 
 if [[ -n "${GITHUB_ENV:-}" ]]; then
   echo "DCC_MCP_ADMIN_UI_PREBUILT=1" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- add `dcc-mcp-gateway-admin` as the owner of the optional Vite build and embedded dashboard asset
- keep non-admin gateway builds free of the Node/Vite build boundary
- update CI, release, contributor docs, and generated-asset paths

## Validation
- `vx just preflight` (3,556 Rust tests plus doctests)
- gateway admin/sqlite tests (716 passed)
- admin UI build and Cargo-driven asset generation
- VitePress documentation build
- Hakari verification and workflow lint
- confirmed public deployment guidance uses Rez environment roots and contains no workstation-specific cache paths

Adapter and skill-authoring workflows are unchanged, so creator Skills require no update.

Refs #2187