### PR TITLE
refactor: extract gateway admin trace domain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,13 @@ dependencies = [
 name = "dcc-mcp-gateway-admin"
 version = "0.20.8"
 dependencies = [
+ "axum",
  "dunce",
+ "parking_lot",
+ "proptest",
+ "serde",
+ "serde_json",
+ "uuid",
  "workspace-hack",
 ]
 
@@ -8533,10 +8539,12 @@ dependencies = [
  "percent-encoding",
  "phf 0.11.3",
  "phf_shared 0.11.3",
+ "ppv-lite86",
  "proc-macro2",
  "quote",
  "rand 0.8.6",
  "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "rand_core 0.6.4",
  "regex",
  "regex-automata",

--- a/crates/dcc-mcp-gateway-admin/Cargo.toml
+++ b/crates/dcc-mcp-gateway-admin/Cargo.toml
@@ -6,13 +6,18 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Build boundary and embedded frontend asset for the DCC-MCP gateway admin dashboard."
+description = "Admin domain and embedded frontend boundary for the DCC-MCP gateway."
 build = "build.rs"
 
 [lints]
 workspace = true
 
 [dependencies]
+axum.workspace = true
+parking_lot.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+uuid.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [features]
@@ -21,3 +26,6 @@ embed = []
 
 [build-dependencies]
 dunce = "1.0"
+
+[dev-dependencies]
+proptest = "1.5"

--- a/crates/dcc-mcp-gateway-admin/src/domain/agent_context.rs
+++ b/crates/dcc-mcp-gateway-admin/src/domain/agent_context.rs
@@ -8,10 +8,17 @@ use axum::http::HeaderMap;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::gateway::admin::domain::trace::{
+use super::trace::{
     MAX_AGENT_CONTEXT_LIST_ITEMS, MAX_AGENT_CONTEXT_METADATA_BYTES, MAX_AGENT_CONTEXT_STRING_BYTES,
     parse_traceparent,
 };
+
+/// Internal ingress header populated with the server-derived source address.
+pub const INTERNAL_SOURCE_IP_HEADER: &str = "x-dcc-mcp-internal-source-ip";
+/// Internal ingress header populated with the trusted forwarded-for chain.
+pub const INTERNAL_FORWARDED_FOR_HEADER: &str = "x-dcc-mcp-internal-forwarded-for";
+/// Internal ingress header populated with an authenticated subject.
+pub const INTERNAL_AUTH_SUBJECT_HEADER: &str = "x-dcc-mcp-internal-auth-subject";
 
 // ── Trust constants ──────────────────────────────────────────────────────────
 
@@ -65,6 +72,7 @@ pub struct AgentContextTrust {
 }
 
 impl AgentContextTrust {
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.actor_id.is_none()
             && self.actor_name.is_none()
@@ -363,6 +371,7 @@ impl AgentContext {
         }
     }
 
+    #[must_use]
     pub fn from_request_parts(
         headers: &HeaderMap,
         body: Option<&Value>,
@@ -378,17 +387,29 @@ impl AgentContext {
         if ctx.is_empty() { None } else { Some(ctx) }
     }
 
+    #[must_use]
     pub fn from_request_parts_with_server_network(
         headers: &HeaderMap,
         body: Option<&Value>,
         meta: Option<&Value>,
     ) -> Option<Self> {
         let mut ctx = Self::from_request_parts(headers, body, meta).unwrap_or_default();
-        let network = crate::gateway::caller_attribution::internal_network_attribution(headers);
-        ctx = ctx.with_server_network_source(network.source_ip, network.forwarded_for);
+        let source_ip = header_str(headers, INTERNAL_SOURCE_IP_HEADER);
+        let forwarded_for = header_str(headers, INTERNAL_FORWARDED_FOR_HEADER)
+            .map(|value| {
+                value
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+        ctx = ctx.with_server_network_source(source_ip, forwarded_for);
         if ctx.is_empty() { None } else { Some(ctx) }
     }
 
+    #[must_use]
     pub fn display_name(&self) -> Option<&str> {
         self.actor_name
             .as_deref()
@@ -708,11 +729,7 @@ fn merge_header_agent_context(ctx: &mut AgentContext, headers: &HeaderMap) {
         headers,
         "x-dcc-mcp-client-host",
     );
-    if let Some(value) = header_str(
-        headers,
-        crate::gateway::caller_attribution::INTERNAL_AUTH_SUBJECT_HEADER,
-    )
-    .map(bound_context_string)
+    if let Some(value) = header_str(headers, INTERNAL_AUTH_SUBJECT_HEADER).map(bound_context_string)
     {
         ctx.auth_subject = Some(value);
         set_trust(&mut ctx.trust.auth_subject, TRUST_AUTH);
@@ -888,7 +905,7 @@ fn sanitize_context_metadata(value: Value) -> Value {
     }
 }
 
-pub(crate) fn is_high_sensitivity_agent_key(key: &str) -> bool {
+pub fn is_high_sensitivity_agent_key(key: &str) -> bool {
     let normalised = key
         .chars()
         .filter(|ch| *ch != '_' && *ch != '-' && *ch != ' ')

--- a/crates/dcc-mcp-gateway-admin/src/domain/mod.rs
+++ b/crates/dcc-mcp-gateway-admin/src/domain/mod.rs
@@ -1,0 +1,6 @@
+//! Admin domain types with no dependency on gateway application state.
+
+pub mod agent_context;
+pub mod trace;
+
+pub use trace::*;

--- a/crates/dcc-mcp-gateway-admin/src/domain/trace.rs
+++ b/crates/dcc-mcp-gateway-admin/src/domain/trace.rs
@@ -20,12 +20,13 @@ use axum::http::HeaderMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-pub use crate::gateway::admin::trace_log::TraceLog;
+pub use crate::trace_log::TraceLog;
 
 // Re-export agent context types from the split module.
 pub use super::agent_context::{
-    AgentContext, AgentContextTrust, TRUST_AUTH, TRUST_HEADER, TRUST_SELF_REPORTED,
-    TRUST_SERVER_DERIVED, TRUST_TRUSTED_PROXY,
+    AgentContext, AgentContextTrust, INTERNAL_AUTH_SUBJECT_HEADER, INTERNAL_FORWARDED_FOR_HEADER,
+    INTERNAL_SOURCE_IP_HEADER, TRUST_AUTH, TRUST_HEADER, TRUST_SELF_REPORTED, TRUST_SERVER_DERIVED,
+    TRUST_TRUSTED_PROXY,
 };
 
 // ── Trace Context ────────────────────────────────────────────────────────────
@@ -57,6 +58,7 @@ pub struct TraceContext {
 impl TraceContext {
     /// Build context for an HTTP request, preserving `x-request-id` separately
     /// from any W3C `traceparent` trace id.
+    #[must_use]
     pub fn from_headers(headers: &HeaderMap) -> Self {
         let request_id = header_str(headers, "x-request-id")
             .or_else(|| header_str(headers, "x-correlation-id"))
@@ -121,6 +123,7 @@ impl TraceContext {
         }
     }
 
+    #[must_use]
     pub fn traceparent(&self) -> Option<String> {
         let span_id = self.span_id.as_deref()?;
         Some(format!(
@@ -139,6 +142,7 @@ struct ParsedTraceParent {
     trace_flags: String,
 }
 
+#[must_use]
 pub fn parse_traceparent(value: &str) -> Option<TraceContextHeader> {
     parse_traceparent_inner(value).map(|p| TraceContextHeader {
         trace_id: p.trace_id,
@@ -236,11 +240,12 @@ pub struct TracePayload {
 
 impl TracePayload {
     /// Build a `TracePayload`, truncating at `cap` bytes if necessary.
+    #[must_use]
     pub fn from_value(v: &Value, cap: usize) -> Self {
         let raw = serde_json::to_string(v).unwrap_or_default();
         let original_size = raw.len();
         let truncated = original_size > cap;
-        let estimated_tokens = crate::gateway::response_codec::estimate_tokens(raw.as_bytes());
+        let estimated_tokens = estimate_tokens(raw.as_bytes());
         let content = if truncated {
             // Truncate at a valid UTF-8 boundary.
             let boundary = raw
@@ -267,12 +272,14 @@ impl TracePayload {
     /// The gateway stores request arguments for admin traces and audit rows.
     /// Ad-hoc script source can be large and sensitive, so default capture
     /// keeps the shape and records that source existed without storing it.
+    #[must_use]
     pub fn from_input_value(v: &Value, cap: usize) -> Self {
         let mut redacted = v.clone();
         redact_sensitive_input_fields(&mut redacted);
         Self::from_value(&redacted, cap)
     }
 
+    #[must_use]
     pub fn from_str(s: &str, cap: usize) -> Self {
         let original_size = s.len();
         let truncated = original_size > cap;
@@ -293,9 +300,7 @@ impl TracePayload {
             mime_type: "text/plain".to_string(),
             truncated,
             original_size,
-            estimated_tokens: Some(crate::gateway::response_codec::estimate_tokens(
-                s.as_bytes(),
-            )),
+            estimated_tokens: Some(estimate_tokens(s.as_bytes())),
         }
     }
 }
@@ -368,25 +373,45 @@ pub struct TokenTelemetry {
 }
 
 impl TokenTelemetry {
-    pub(crate) fn from_accounting(
-        format: crate::gateway::response_codec::ResponseFormat,
-        accounting: crate::gateway::response_codec::TokenAccounting,
+    /// Build telemetry from response-codec accounting primitives.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_parts(
+        response_format: impl Into<String>,
+        original_bytes: usize,
+        returned_bytes: usize,
+        original_tokens: usize,
+        returned_tokens: usize,
+        saved_tokens: usize,
+        savings_percent: f64,
     ) -> Self {
         Self {
-            response_format: format.as_str().to_string(),
-            token_estimator: crate::gateway::response_codec::TOKEN_ESTIMATOR.to_string(),
-            original_bytes: accounting.original_bytes,
-            returned_bytes: accounting.returned_bytes,
-            original_tokens: accounting.original_tokens,
-            returned_tokens: accounting.returned_tokens,
-            saved_tokens: accounting.saved_tokens,
-            savings_pct: round_two(accounting.savings_percent()),
+            response_format: response_format.into(),
+            token_estimator: TOKEN_ESTIMATOR.to_string(),
+            original_bytes,
+            returned_bytes,
+            original_tokens,
+            returned_tokens,
+            saved_tokens,
+            savings_pct: round_two(savings_percent),
         }
     }
 
     #[must_use]
     pub fn is_legacy_json(&self) -> bool {
         self.response_format == "json" && self.saved_tokens == 0
+    }
+}
+
+/// Stable identifier for the gateway's deterministic byte-based estimator.
+pub const TOKEN_ESTIMATOR: &str = "dcc-mcp-byte4-v1";
+
+/// Estimate token count without a tokenizer runtime.
+#[must_use]
+pub fn estimate_tokens(body: &[u8]) -> usize {
+    if body.is_empty() {
+        0
+    } else {
+        body.len().div_ceil(4)
     }
 }
 
@@ -475,6 +500,7 @@ impl TraceSpan {
         }
     }
 
+    #[must_use]
     pub fn with_error(mut self) -> Self {
         self.ok = false;
         self
@@ -556,26 +582,32 @@ pub struct DispatchTrace {
 }
 
 impl DispatchTrace {
+    #[must_use]
     pub fn span_count(&self) -> usize {
         self.spans.len()
     }
 
+    #[must_use]
     pub fn input_bytes(&self) -> Option<usize> {
         self.input.as_ref().map(|p| p.original_size)
     }
 
+    #[must_use]
     pub fn output_bytes(&self) -> Option<usize> {
         self.output.as_ref().map(|p| p.original_size)
     }
 
+    #[must_use]
     pub fn input_tokens(&self) -> Option<usize> {
         self.input.as_ref().and_then(|p| p.estimated_tokens)
     }
 
+    #[must_use]
     pub fn output_tokens(&self) -> Option<usize> {
         self.output.as_ref().and_then(|p| p.estimated_tokens)
     }
 
+    #[must_use]
     pub fn total_tokens(&self) -> Option<usize> {
         match (self.input_tokens(), self.output_tokens()) {
             (Some(input), Some(output)) => Some(input.saturating_add(output)),
@@ -585,6 +617,7 @@ impl DispatchTrace {
         }
     }
 
+    #[must_use]
     pub fn slowest_span(&self) -> Option<(&TraceSpan, u64)> {
         self.spans
             .iter()

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -1,11 +1,27 @@
-//! Embedded frontend boundary for the DCC-MCP gateway admin dashboard.
+//! Domain and embedded frontend boundary for the DCC-MCP gateway admin dashboard.
 //!
-//! This crate deliberately owns the Vite/npm build script and the generated
-//! dashboard payload. The gateway application depends on this crate only when
-//! its `admin` feature is enabled, so non-admin gateway builds never execute a
-//! Node.js toolchain.
+//! This crate owns admin-facing trace and caller-context contracts independently
+//! of gateway routing state. It also owns the Vite/npm build script and generated
+//! dashboard payload; the Node.js toolchain only runs when `embed` is enabled.
 
 #![forbid(unsafe_code)]
+
+/// Admin trace and caller-attribution value types.
+pub mod domain;
+mod trace_log;
+
+pub use domain::agent_context::{
+    AgentContext, AgentContextTrust, INTERNAL_AUTH_SUBJECT_HEADER, INTERNAL_FORWARDED_FOR_HEADER,
+    INTERNAL_SOURCE_IP_HEADER, TRUST_AUTH, TRUST_HEADER, TRUST_SELF_REPORTED, TRUST_SERVER_DERIVED,
+    TRUST_TRUSTED_PROXY,
+};
+pub use domain::trace::{
+    DispatchTrace, LlmUsage, MAX_AGENT_CONTEXT_LIST_ITEMS, MAX_AGENT_CONTEXT_METADATA_BYTES,
+    MAX_AGENT_CONTEXT_STRING_BYTES, MAX_INPUT_BYTES, MAX_OUTPUT_BYTES, TOKEN_ESTIMATOR,
+    TokenTelemetry, TraceContext, TraceContextHeader, TracePayload, TraceSpan, estimate_tokens,
+    parse_traceparent,
+};
+pub use trace_log::TraceLog;
 
 /// The Vite-built React admin dashboard HTML page.
 #[cfg(feature = "embed")]

--- a/crates/dcc-mcp-gateway-admin/src/trace_log.rs
+++ b/crates/dcc-mcp-gateway-admin/src/trace_log.rs
@@ -2,7 +2,7 @@
 
 use parking_lot::Mutex;
 
-use super::trace::DispatchTrace;
+use crate::domain::trace::DispatchTrace;
 
 /// Bounded ring buffer of completed traces.
 pub struct TraceLog {
@@ -13,6 +13,7 @@ pub struct TraceLog {
 impl TraceLog {
     pub const DEFAULT_CAPACITY: usize = 200;
 
+    #[must_use]
     pub fn new(capacity: usize) -> Self {
         Self {
             buf: Mutex::new(Vec::with_capacity(capacity.min(TraceLog::DEFAULT_CAPACITY))),

--- a/crates/dcc-mcp-gateway-admin/src/trace_tests.rs
+++ b/crates/dcc-mcp-gateway-admin/src/trace_tests.rs
@@ -315,12 +315,9 @@ fn caller_attribution_network_source_can_be_added_by_server_boundary() {
 fn caller_attribution_reads_only_internal_server_network_headers() {
     let mut headers = HeaderMap::new();
     headers.insert("x-dcc-mcp-source-ip", "203.0.113.99".parse().unwrap());
+    headers.insert(INTERNAL_SOURCE_IP_HEADER, "192.0.2.44".parse().unwrap());
     headers.insert(
-        crate::gateway::caller_attribution::INTERNAL_SOURCE_IP_HEADER,
-        "192.0.2.44".parse().unwrap(),
-    );
-    headers.insert(
-        crate::gateway::caller_attribution::INTERNAL_FORWARDED_FOR_HEADER,
+        INTERNAL_FORWARDED_FOR_HEADER,
         "198.51.100.2, 203.0.113.3".parse().unwrap(),
     );
     let body = json!({
@@ -348,7 +345,7 @@ fn caller_attribution_auth_subject_prefers_internal_auth_boundary() {
     let mut headers = HeaderMap::new();
     headers.insert("x-dcc-mcp-auth-subject", "header:spoofed".parse().unwrap());
     headers.insert(
-        crate::gateway::caller_attribution::INTERNAL_AUTH_SUBJECT_HEADER,
+        INTERNAL_AUTH_SUBJECT_HEADER,
         "oauth:artist-1".parse().unwrap(),
     );
     let body = json!({
@@ -366,10 +363,7 @@ fn caller_attribution_auth_subject_prefers_internal_auth_boundary() {
 #[test]
 fn caller_attribution_ignores_mcp_meta_network_spoofing() {
     let mut headers = HeaderMap::new();
-    headers.insert(
-        crate::gateway::caller_attribution::INTERNAL_SOURCE_IP_HEADER,
-        "192.0.2.44".parse().unwrap(),
-    );
+    headers.insert(INTERNAL_SOURCE_IP_HEADER, "192.0.2.44".parse().unwrap());
     let meta = json!({
         "agent_context": {
             "actor_id": "artist-1",

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -17,7 +17,7 @@ dcc-mcp-db = { path = "../dcc-mcp-db", default-features = false }
 dcc-mcp-models = { workspace = true }
 dcc-mcp-actions = { workspace = true }
 dcc-mcp-gateway-core = { workspace = true }
-dcc-mcp-gateway-admin = { workspace = true, optional = true, features = ["embed"] }
+dcc-mcp-gateway-admin = { workspace = true }
 dcc-mcp-jsonrpc = { workspace = true }
 dcc-mcp-naming = { workspace = true }
 dcc-mcp-transport = { workspace = true }
@@ -74,7 +74,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 # (opentelemetry / opentelemetry_sdk / opentelemetry-stdout) still compiles via
 # `dcc-mcp-telemetry`; opt-in gating of the OTel stack is a separate follow-up.
 default = []
-admin = ["dep:dcc-mcp-gateway-admin"]
+admin = ["dcc-mcp-gateway-admin/embed"]
 admin-persist-sqlite = ["admin", "dcc-mcp-db/gateway-admin-sqlite"]
 telemetry = ["dep:dcc-mcp-telemetry", "dep:opentelemetry"]
 prometheus = ["telemetry", "dcc-mcp-telemetry/prometheus", "dep:prometheus"]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/domain/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/domain/mod.rs
@@ -1,8 +1,11 @@
-//! Pure data types — no I/O, no HTTP, no file access.
-//!
-//! Re-exports all trace types for backward compatibility.
+//! Compatibility paths for domain types owned by `dcc-mcp-gateway-admin`.
 
-pub mod agent_context;
-pub mod trace;
+pub mod agent_context {
+    pub use dcc_mcp_gateway_admin::domain::agent_context::*;
+}
+
+pub mod trace {
+    pub use dcc_mcp_gateway_admin::domain::trace::*;
+}
 
 pub use trace::*;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -118,7 +118,6 @@ pub mod sqlite_lane;
 pub mod state;
 pub mod stats;
 pub mod trace;
-mod trace_log;
 #[cfg(feature = "admin")]
 mod traffic;
 #[cfg(feature = "admin")]

--- a/crates/dcc-mcp-gateway/src/gateway/caller_attribution.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/caller_attribution.rs
@@ -14,10 +14,10 @@ use tokio::sync::RwLock;
 
 use super::http_limits::GatewayIngressState;
 use crate::gateway::admin::trace::AgentContext;
+pub(crate) use dcc_mcp_gateway_admin::{
+    INTERNAL_AUTH_SUBJECT_HEADER, INTERNAL_FORWARDED_FOR_HEADER, INTERNAL_SOURCE_IP_HEADER,
+};
 
-pub(crate) const INTERNAL_SOURCE_IP_HEADER: &str = "x-dcc-mcp-internal-source-ip";
-pub(crate) const INTERNAL_FORWARDED_FOR_HEADER: &str = "x-dcc-mcp-internal-forwarded-for";
-pub(crate) const INTERNAL_AUTH_SUBJECT_HEADER: &str = "x-dcc-mcp-internal-auth-subject";
 const MAX_MCP_CLIENT_SESSIONS: usize = 512;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -151,18 +151,6 @@ pub(crate) fn effective_client_ip(
         .source_ip
         .and_then(|value| value.parse::<IpAddr>().ok())
         .unwrap_or_else(|| connect.ip())
-}
-
-#[must_use]
-pub(crate) fn internal_network_attribution(headers: &HeaderMap) -> ClientNetworkAttribution {
-    ClientNetworkAttribution {
-        source_ip: header_str(headers, INTERNAL_SOURCE_IP_HEADER),
-        forwarded_for: headers
-            .get(INTERNAL_FORWARDED_FOR_HEADER)
-            .and_then(|value| value.to_str().ok())
-            .map(parse_ip_list)
-            .unwrap_or_default(),
-    }
 }
 
 fn effective_client_ip_from_chain(

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -11,7 +11,7 @@ use serde_json::{Map, Value, json};
 
 pub(crate) const TOON_MIME: &str = "application/toon";
 pub(crate) const JSON_MIME: &str = "application/json";
-pub(crate) const TOKEN_ESTIMATOR: &str = "dcc-mcp-byte4-v1";
+pub(crate) use dcc_mcp_gateway_admin::TOKEN_ESTIMATOR;
 pub(crate) const DEFAULT_RESPONSE_FORMAT_ENV: &str = "DCC_MCP_GATEWAY_RESPONSE_FORMAT";
 pub(crate) const LEGACY_RESPONSE_FORMAT_ENV: &str = "DCC_MCP_RESPONSE_FORMAT";
 
@@ -185,9 +185,15 @@ pub(crate) fn token_telemetry_for_response(
     encode_response(legacy_json, compact_json, format)
         .ok()
         .map(|encoded| {
-            crate::gateway::admin::trace::TokenTelemetry::from_accounting(
-                encoded.format,
-                encoded.accounting,
+            let accounting = encoded.accounting;
+            crate::gateway::admin::trace::TokenTelemetry::from_parts(
+                encoded.format.as_str(),
+                accounting.original_bytes,
+                accounting.returned_bytes,
+                accounting.original_tokens,
+                accounting.returned_tokens,
+                accounting.saved_tokens,
+                accounting.savings_percent(),
             )
         })
 }
@@ -471,13 +477,7 @@ fn accept_format(headers: &HeaderMap) -> Option<ResponseFormat> {
     None
 }
 
-pub(crate) fn estimate_tokens(body: &[u8]) -> usize {
-    if body.is_empty() {
-        0
-    } else {
-        body.len().div_ceil(4)
-    }
-}
+pub(crate) use dcc_mcp_gateway_admin::estimate_tokens;
 
 fn attach_accounting_headers(
     headers: &mut HeaderMap,

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -67,8 +67,10 @@ once_cell = { version = "1.21.4" }
 percent-encoding = { version = "2.3.2" }
 phf = { version = "0.11.3", features = ["macros"] }
 phf_shared = { version = "0.11.3" }
+ppv-lite86 = { version = "0.2.21", default-features = false, features = ["simd", "std"] }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9.4" }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8.6", features = ["small_rng"] }
+rand_chacha = { version = "0.9.0", default-features = false, features = ["std"] }
 rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 regex = { version = "1.12.3" }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
@@ -158,10 +160,12 @@ once_cell = { version = "1.21.4" }
 percent-encoding = { version = "2.3.2" }
 phf = { version = "0.11.3", features = ["macros"] }
 phf_shared = { version = "0.11.3" }
+ppv-lite86 = { version = "0.2.21", default-features = false, features = ["simd", "std"] }
 proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.45" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9.4" }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8.6", features = ["small_rng"] }
+rand_chacha = { version = "0.9.0", default-features = false, features = ["std"] }
 rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 regex = { version = "1.12.3" }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `crates/dcc-mcp-gateway-admin/build.rs` owns the optional frontend build and embedded asset. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the trace/caller domain plus the optional frontend build and embedded asset. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,6 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
+├── dcc-mcp-gateway-admin # Admin trace/caller domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -121,7 +122,9 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-wire, dcc-mcp-transport
+dcc-mcp-gateway-admin ← admin trace/caller domain + optional embedded dashboard asset
+       ↓
+dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
 dcc-mcp-sidecar ← dcc-mcp-gateway, dcc-mcp-host-rpc, dcc-mcp-transport
 
@@ -389,9 +392,9 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Trace, caller-context, token-telemetry, and bounded trace-log contracts are owned by `dcc-mcp-gateway-admin`; compatibility paths remain available from the gateway crate.
 
-**Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
+**Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 
 ### dcc-mcp-sidecar
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`crates/dcc-mcp-gateway-admin/build.rs` 负责可选的前端构建与嵌入资产。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 trace/caller 领域契约，并负责可选的前端构建与嵌入资产。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,6 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
+├── dcc-mcp-gateway-admin # Admin trace/caller 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -101,7 +102,9 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-wire, dcc-mcp-transport
+dcc-mcp-gateway-admin ← Admin trace/caller 领域和可选嵌入式 dashboard 资产
+       ↓
+dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
 dcc-mcp-http-types ← 纯 HTTP 线协议/配置/值类型
        ↓
@@ -290,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Trace、caller context、token telemetry 与有界 trace log 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,6 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
+├── dcc-mcp-gateway-admin/  # Admin trace/caller domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,8 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, and `dcc-mcp-wire`.
+- **`dcc-mcp-gateway-admin`** — admin trace/caller-context/token-telemetry domain, bounded trace log, and optional embedded dashboard asset.
+- **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
 
@@ -281,6 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
+├── dcc-mcp-gateway-admin/  # Admin trace/caller domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move admin trace, caller-context, token telemetry, and bounded trace storage into dcc-mcp-gateway-admin
- keep gateway compatibility re-exports while removing domain dependencies on gateway implementation details
- document the new crate boundary in English, Chinese, and agent indexes

## Validation
- vx just preflight
- vx cargo test -p dcc-mcp-gateway-admin --all-features
- vx cargo test -p dcc-mcp-gateway --features admin,admin-persist-sqlite --lib
- vx cargo check -p dcc-mcp-gateway --no-default-features
- vx cargo hakari verify
- verified public docs contain no _thm or rez_local_cache paths

Creator Skills unchanged: public adapter and skill-authoring workflows are unaffected.

Refs #2187