### PR TITLE
refactor: extract gateway admin audit domain

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/audit.rs
+++ b/crates/dcc-mcp-gateway-admin/src/audit.rs
@@ -1,0 +1,73 @@
+//! Admin audit domain contracts.
+
+use std::time::SystemTime;
+
+use parking_lot::Mutex;
+
+use crate::{AgentContextTrust, LlmUsage, TokenTelemetry};
+
+/// Minimal audit record consumed by admin projections and persistence adapters.
+#[derive(Debug, Clone)]
+pub struct AdminAuditRecord {
+    /// Wall-clock time when the call completed.
+    pub timestamp: SystemTime,
+    /// Stable request id used to correlate with traces.
+    pub request_id: String,
+    /// End-to-end trace id shared by related requests.
+    pub trace_id: Option<String>,
+    /// Root gateway span id for this request, if known.
+    pub span_id: Option<String>,
+    /// Incoming parent span id, if known.
+    pub parent_span_id: Option<String>,
+    /// JSON-RPC / MCP method name.
+    pub method: Option<String>,
+    /// Target backend instance id, if resolved.
+    pub instance_id: Option<String>,
+    /// Originating MCP session id, if any.
+    pub session_id: Option<String>,
+    /// Transport surface that produced the request (`mcp`, `rest`, ...).
+    pub transport: Option<String>,
+    /// Agent/caller id supplied for telemetry correlation.
+    pub agent_id: Option<String>,
+    /// Human-readable agent/caller name.
+    pub agent_name: Option<String>,
+    /// Model or runtime name supplied by the caller.
+    pub agent_model: Option<String>,
+    /// Human/service actor id supplied for telemetry filtering.
+    pub actor_id: Option<String>,
+    /// Human/service actor name supplied for telemetry filtering.
+    pub actor_name: Option<String>,
+    /// Hashed actor email or stable user handle. Never store raw email here.
+    pub actor_email_hash: Option<String>,
+    /// Client platform/runtime such as `cursor`, `claude-desktop`, or `custom-http`.
+    pub client_platform: Option<String>,
+    /// Client operating system label.
+    pub client_os: Option<String>,
+    /// Client host label.
+    pub client_host: Option<String>,
+    /// Authentication subject when provided by middleware/auth integration.
+    pub auth_subject: Option<String>,
+    /// Server-derived source IP after proxy trust policy.
+    pub source_ip: Option<String>,
+    /// Server-computed trust source labels for attribution fields.
+    pub attribution_trust: Option<AgentContextTrust>,
+    /// Parent request id for request-chain correlation.
+    pub parent_request_id: Option<String>,
+    /// Tool slug or MCP method name.
+    pub action: String,
+    /// DCC type of the target backend (e.g. `"maya"`).
+    pub dcc_type: Option<String>,
+    /// Whether the call succeeded (`true`) or returned an error (`false`).
+    pub success: bool,
+    /// Error preview when `success == false`; otherwise `None`.
+    pub error: Option<String>,
+    /// Wall-clock call duration in milliseconds.
+    pub duration_ms: Option<u64>,
+    /// Token accounting for the client-visible response, if available.
+    pub token_accounting: Option<TokenTelemetry>,
+    /// Optional upstream LLM billing token counts, when supplied.
+    pub llm_usage: Option<LlmUsage>,
+}
+
+/// Bounded in-memory audit storage shared by gateway adapters.
+pub type AuditLog = Mutex<Vec<AdminAuditRecord>>;

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -1,12 +1,13 @@
 //! Domain and embedded frontend boundary for the DCC-MCP gateway admin dashboard.
 //!
-//! This crate owns admin-facing trace, caller-context, compact projection, link,
-//! issue-report, and statistics contracts independently of gateway routing state. It also
-//! owns the Vite/npm build script and generated dashboard payload; the Node.js
+//! This crate owns admin-facing audit, trace, caller-context, compact projection,
+//! link, issue-report, and statistics contracts independently of gateway routing state.
+//! It also owns the Vite/npm build script and generated dashboard payload; the Node.js
 //! toolchain only runs when `embed` is enabled.
 
 #![forbid(unsafe_code)]
 
+mod audit;
 /// Admin trace and caller-attribution value types.
 pub mod domain;
 mod issue_report;
@@ -15,6 +16,7 @@ mod projection;
 mod stats;
 mod trace_log;
 
+pub use audit::{AdminAuditRecord, AuditLog};
 pub use domain::agent_context::{
     AgentContext, AgentContextTrust, INTERNAL_AUTH_SUBJECT_HEADER, INTERNAL_FORWARDED_FOR_HEADER,
     INTERNAL_SOURCE_IP_HEADER, TRUST_AUTH, TRUST_HEADER, TRUST_SELF_REPORTED, TRUST_SERVER_DERIVED,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
@@ -19,73 +19,10 @@ use crate::gateway::state::GatewayState;
 use super::stats::StatsAggregator;
 use super::trace::{AgentContextTrust, DispatchTrace, LlmUsage, TokenTelemetry, TraceLog};
 
+pub use dcc_mcp_gateway_admin::{AdminAuditRecord, AuditLog};
+
 type SqliteTracePersistFn = Arc<dyn Fn(&DispatchTrace) + Send + Sync>;
 type SqliteAuditPersistFn = Arc<dyn Fn(&AdminAuditRecord) + Send + Sync>;
-
-/// Minimal audit record that the admin UI consumes.
-#[derive(Debug, Clone)]
-pub struct AdminAuditRecord {
-    /// Wall-clock time when the call completed.
-    pub timestamp: SystemTime,
-    /// Stable request id used to correlate with traces.
-    pub request_id: String,
-    /// End-to-end trace id shared by related requests.
-    pub trace_id: Option<String>,
-    /// Root gateway span id for this request, if known.
-    pub span_id: Option<String>,
-    /// Incoming parent span id, if known.
-    pub parent_span_id: Option<String>,
-    /// JSON-RPC / MCP method name.
-    pub method: Option<String>,
-    /// Target backend instance id, if resolved.
-    pub instance_id: Option<String>,
-    /// Originating MCP session id, if any.
-    pub session_id: Option<String>,
-    /// Transport surface that produced the request (`mcp`, `rest`, ...).
-    pub transport: Option<String>,
-    /// Agent/caller id supplied for telemetry correlation.
-    pub agent_id: Option<String>,
-    /// Human-readable agent/caller name.
-    pub agent_name: Option<String>,
-    /// Model or runtime name supplied by the caller.
-    pub agent_model: Option<String>,
-    /// Human/service actor id supplied for telemetry filtering.
-    pub actor_id: Option<String>,
-    /// Human/service actor name supplied for telemetry filtering.
-    pub actor_name: Option<String>,
-    /// Hashed actor email or stable user handle. Never store raw email here.
-    pub actor_email_hash: Option<String>,
-    /// Client platform/runtime such as `cursor`, `claude-desktop`, or `custom-http`.
-    pub client_platform: Option<String>,
-    /// Client operating system label.
-    pub client_os: Option<String>,
-    /// Client host label.
-    pub client_host: Option<String>,
-    /// Authentication subject when provided by middleware/auth integration.
-    pub auth_subject: Option<String>,
-    /// Server-derived source IP after proxy trust policy.
-    pub source_ip: Option<String>,
-    /// Server-computed trust source labels for attribution fields.
-    pub attribution_trust: Option<AgentContextTrust>,
-    /// Parent request id for request-chain correlation.
-    pub parent_request_id: Option<String>,
-    /// Tool slug or MCP method name.
-    pub action: String,
-    /// DCC type of the target backend (e.g. `"maya"`).
-    pub dcc_type: Option<String>,
-    /// Whether the call succeeded (`true`) or returned an error (`false`).
-    pub success: bool,
-    /// Error preview when `success == false`; otherwise `None`.
-    pub error: Option<String>,
-    /// Wall-clock call duration in milliseconds.
-    pub duration_ms: Option<u64>,
-    /// Token accounting for the client-visible response, if available.
-    pub token_accounting: Option<TokenTelemetry>,
-    /// Optional upstream LLM billing token counts, when supplied.
-    pub llm_usage: Option<LlmUsage>,
-}
-
-pub type AuditLog = Mutex<Vec<AdminAuditRecord>>;
 
 #[derive(Debug, Clone)]
 pub struct DurableAuditStore {

--- a/crates/dcc-mcp-gateway/src/lib.rs
+++ b/crates/dcc-mcp-gateway/src/lib.rs
@@ -11,7 +11,7 @@
 //!    DCC adapters that never participate in gateway election) no
 //!    longer have to compile the gateway code path.
 //!
-//! The admin trace domain, compact response, link, issue-report, and statistics
+//! The admin audit/trace domain, compact response, link, issue-report, and statistics
 //! projections, optional dashboard frontend, and Node/Vite build lifecycle are
 //! isolated in `dcc-mcp-gateway-admin`. This crate contains only the gateway
 //! application and its Rust-side admin adapters; builds without the `admin`

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the trace/caller domain, compact agent-facing, link, issue-report, and statistics projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, and statistics projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,7 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
-├── dcc-mcp-gateway-admin # Admin trace/caller/projection/report/stats domain + optional embedded dashboard asset
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -122,7 +122,7 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway-admin ← admin trace/caller/projection/report/stats domain + optional embedded dashboard asset
+dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats domain + optional embedded dashboard asset
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
@@ -392,7 +392,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Trace, caller-context, token-telemetry, bounded trace-log, compact agent-facing projection, link projection, issue-report privacy, and pure statistics contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific stores and compatibility paths remain in the gateway crate.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, and pure statistics contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence adapters and compatibility paths remain in the gateway crate.
 
 **Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约与纯统计 projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约与纯统计 projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,7 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
-├── dcc-mcp-gateway-admin # Admin trace/caller/projection/report/stats 领域和可选嵌入式 dashboard 资产
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -102,7 +102,7 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway-admin ← Admin trace/caller/projection/report/stats 领域和可选嵌入式 dashboard 资产
+dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats 领域和可选嵌入式 dashboard 资产
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
@@ -293,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Trace、caller context、token telemetry、有界 trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私与纯统计契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留数据源 adapter 和兼容导入路径。
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私与纯统计契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化 adapter 和兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin trace/caller/projection/report/stats domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway-admin`** — admin trace/caller-context/token-telemetry domain, bounded trace log, compact agent-facing, link, issue-report, and pure statistics projections, and optional embedded dashboard asset.
+- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, and pure statistics projections, and optional embedded dashboard asset.
 - **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
@@ -282,7 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin trace/caller/projection/report/stats domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move `AdminAuditRecord` and `AuditLog` into `dcc-mcp-gateway-admin`
- preserve gateway compatibility re-exports and persistence adapters
- update architecture ownership documentation

Part of #2187.

## Validation
- `vx just preflight`
- `vx cargo nextest run -p dcc-mcp-gateway-admin -p dcc-mcp-gateway --features dcc-mcp-gateway/admin,dcc-mcp-gateway/admin-persist-sqlite --no-fail-fast`
- `vx cargo clippy -p dcc-mcp-gateway-admin --all-features --all-targets -- -D warnings`
- `vx cargo check -p dcc-mcp-gateway --no-default-features`
- `vx cargo hakari verify`
- public documentation scan contains no `_thm` or `rez_local_cache` paths

Creator Skills do not need changes because adapter and skill-authoring workflows are unchanged.