### PR TITLE
refactor: extract gateway admin analytics

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/analytics.rs
+++ b/crates/dcc-mcp-gateway-admin/src/analytics.rs
@@ -1,0 +1,661 @@
+//! Pure analytics projections over admin audit records.
+
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::{AdminAuditRecord, LlmUsage, TokenTelemetry};
+
+/// Analytics query parameters shared by the admin and compatibility routes.
+#[derive(Debug, Deserialize)]
+pub struct AnalyticsQuery {
+    /// Time range: `7d`, `30d`, `90d`, `180d`, or `365d`.
+    #[serde(default = "default_range")]
+    pub range: String,
+    /// Aggregation granularity: `day` or `hour`.
+    #[serde(default = "default_granularity")]
+    pub granularity: String,
+    /// Export format: `json` or `csv`.
+    #[serde(default)]
+    pub format: String,
+}
+
+fn default_range() -> String {
+    "30d".into()
+}
+
+fn default_granularity() -> String {
+    "day".into()
+}
+
+/// Parse a supported analytics range, falling back to 30 days.
+#[must_use]
+pub fn analytics_range_duration(range: &str) -> Duration {
+    let days: u64 = match range.trim_end_matches('d') {
+        "7" => 7,
+        "30" => 30,
+        "90" => 90,
+        "180" => 180,
+        "365" => 365,
+        _ => 30,
+    };
+    Duration::from_secs(days * 86_400)
+}
+
+#[derive(Debug, Clone)]
+struct DayAggregate {
+    date: String,
+    dcc_type: String,
+    hour: Option<u32>,
+    calls_total: u64,
+    calls_success: u64,
+    calls_failed: u64,
+    tokens_input: u64,
+    tokens_output: u64,
+    tokens_saved: u64,
+    llm_prompt: u64,
+    llm_completion: u64,
+    llm_total: u64,
+    duration_ms_sum: u64,
+    duration_ms_min: u64,
+    duration_ms_max: u64,
+    instance_ids: Vec<String>,
+    agent_ids: Vec<String>,
+}
+
+impl DayAggregate {
+    fn new(date: String, dcc_type: String, hour: Option<u32>) -> Self {
+        Self {
+            date,
+            dcc_type,
+            hour,
+            calls_total: 0,
+            calls_success: 0,
+            calls_failed: 0,
+            tokens_input: 0,
+            tokens_output: 0,
+            tokens_saved: 0,
+            llm_prompt: 0,
+            llm_completion: 0,
+            llm_total: 0,
+            duration_ms_sum: 0,
+            duration_ms_min: u64::MAX,
+            duration_ms_max: 0,
+            instance_ids: Vec::new(),
+            agent_ids: Vec::new(),
+        }
+    }
+
+    fn ingest(
+        &mut self,
+        success: bool,
+        duration_ms: Option<u64>,
+        tokens: &TokenTelemetry,
+        llm: Option<&LlmUsage>,
+        instance_id: Option<&str>,
+        agent_id: Option<&str>,
+    ) {
+        self.calls_total += 1;
+        if success {
+            self.calls_success += 1;
+        } else {
+            self.calls_failed += 1;
+        }
+
+        let duration_ms = duration_ms.unwrap_or(0);
+        self.duration_ms_sum += duration_ms;
+        self.duration_ms_min = self.duration_ms_min.min(duration_ms);
+        self.duration_ms_max = self.duration_ms_max.max(duration_ms);
+        self.tokens_input += tokens.original_tokens as u64;
+        self.tokens_output += tokens.returned_tokens as u64;
+        self.tokens_saved += tokens.saved_tokens as u64;
+
+        if let Some(llm) = llm {
+            self.llm_prompt += llm.prompt_tokens.unwrap_or(0);
+            self.llm_completion += llm.completion_tokens.unwrap_or(0);
+            self.llm_total += llm.total_tokens.unwrap_or(0);
+        }
+
+        push_unique(&mut self.instance_ids, instance_id);
+        push_unique(&mut self.agent_ids, agent_id);
+    }
+
+    fn avg_duration_ms(&self) -> f64 {
+        if self.calls_total == 0 {
+            0.0
+        } else {
+            self.duration_ms_sum as f64 / self.calls_total as f64
+        }
+    }
+}
+
+fn push_unique(values: &mut Vec<String>, candidate: Option<&str>) {
+    if let Some(candidate) = candidate
+        && !candidate.is_empty()
+        && !values.iter().any(|value| value == candidate)
+    {
+        values.push(candidate.to_string());
+    }
+}
+
+fn days_to_ymd(mut days: i64) -> (i64, u32, u32) {
+    days += 719_468;
+    let era = if days >= 0 { days } else { days - 146_096 } / 146_097;
+    let day_of_era = days - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1460 + day_of_era / 36524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = (day_of_year - (153 * month_prime + 2) / 5 + 1) as u32;
+    let month = if month_prime < 10 {
+        month_prime + 3
+    } else {
+        month_prime - 9
+    } as u32;
+    (if month <= 2 { year + 1 } else { year }, month, day)
+}
+
+fn format_day(time: SystemTime) -> String {
+    let seconds = time
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    let (year, month, day) = days_to_ymd((seconds / 86_400) as i64);
+    format!("{year:04}-{month:02}-{day:02}")
+}
+
+fn format_day_ms(timestamp_ms: u64) -> String {
+    let (year, month, day) = days_to_ymd((timestamp_ms / 1000 / 86_400) as i64);
+    format!("{year:04}-{month:02}-{day:02}")
+}
+
+fn hour_from_ms(timestamp_ms: i64) -> u32 {
+    ((timestamp_ms / 1000 % 86_400) / 3600) as u32
+}
+
+fn weekday_from_ms(timestamp_ms: i64) -> u32 {
+    ((timestamp_ms / 1000 / 86_400 + 4) % 7) as u32
+}
+
+fn aggregate_audits(
+    audits: &[AdminAuditRecord],
+) -> HashMap<(String, String, Option<u32>), DayAggregate> {
+    let mut aggregates = HashMap::new();
+    for audit in audits {
+        let timestamp_ms = audit
+            .timestamp
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis() as i64)
+            .unwrap_or(0);
+        let date = format_day(audit.timestamp);
+        let dcc_type = audit
+            .dcc_type
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .unwrap_or("unknown")
+            .to_string();
+        let hour = Some(hour_from_ms(timestamp_ms));
+        let aggregate = aggregates
+            .entry((date.clone(), dcc_type.clone(), hour))
+            .or_insert_with(|| DayAggregate::new(date, dcc_type, hour));
+        let default_tokens = TokenTelemetry {
+            response_format: String::new(),
+            token_estimator: String::new(),
+            original_bytes: 0,
+            returned_bytes: 0,
+            original_tokens: 0,
+            returned_tokens: 0,
+            saved_tokens: 0,
+            savings_pct: 0.0,
+        };
+        aggregate.ingest(
+            audit.success,
+            audit.duration_ms,
+            audit.token_accounting.as_ref().unwrap_or(&default_tokens),
+            audit.llm_usage.as_ref(),
+            audit.instance_id.as_deref(),
+            audit.agent_id.as_deref(),
+        );
+    }
+    aggregates
+}
+
+fn merge_daily(
+    aggregates: &HashMap<(String, String, Option<u32>), DayAggregate>,
+) -> Vec<DayAggregate> {
+    let mut by_day = HashMap::new();
+    for aggregate in aggregates.values() {
+        let entry = by_day
+            .entry(aggregate.date.clone())
+            .or_insert_with(|| DayAggregate::new(aggregate.date.clone(), "all".to_string(), None));
+        entry.calls_total += aggregate.calls_total;
+        entry.calls_success += aggregate.calls_success;
+        entry.calls_failed += aggregate.calls_failed;
+        entry.tokens_input += aggregate.tokens_input;
+        entry.tokens_output += aggregate.tokens_output;
+        entry.tokens_saved += aggregate.tokens_saved;
+        entry.llm_prompt += aggregate.llm_prompt;
+        entry.llm_completion += aggregate.llm_completion;
+        entry.llm_total += aggregate.llm_total;
+        entry.duration_ms_sum += aggregate.duration_ms_sum;
+        entry.duration_ms_min = entry.duration_ms_min.min(aggregate.duration_ms_min);
+        entry.duration_ms_max = entry.duration_ms_max.max(aggregate.duration_ms_max);
+    }
+    let mut result: Vec<_> = by_day.into_values().collect();
+    result.sort_by(|left, right| left.date.cmp(&right.date));
+    result
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct HeatmapCell {
+    weekday: u32,
+    hour: u32,
+    calls: u64,
+    failures: u64,
+    avg_duration_ms: f64,
+    tokens_total: u64,
+}
+
+fn compute_heatmap(audits: &[AdminAuditRecord]) -> Vec<HeatmapCell> {
+    let mut cells = HashMap::new();
+    for audit in audits {
+        let timestamp_ms = audit
+            .timestamp
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis() as i64)
+            .unwrap_or(0);
+        let weekday = weekday_from_ms(timestamp_ms);
+        let hour = hour_from_ms(timestamp_ms);
+        let cell = cells.entry((weekday, hour)).or_insert(HeatmapCell {
+            weekday,
+            hour,
+            calls: 0,
+            failures: 0,
+            avg_duration_ms: 0.0,
+            tokens_total: 0,
+        });
+        cell.calls += 1;
+        if !audit.success {
+            cell.failures += 1;
+        }
+        let duration_ms = audit.duration_ms.unwrap_or(0) as f64;
+        cell.avg_duration_ms =
+            (cell.avg_duration_ms * (cell.calls - 1) as f64 + duration_ms) / cell.calls as f64;
+        if let Some(tokens) = &audit.token_accounting {
+            cell.tokens_total += tokens.original_tokens as u64 + tokens.returned_tokens as u64;
+        }
+        if let Some(llm) = &audit.llm_usage {
+            cell.tokens_total += llm.total_tokens.unwrap_or(0);
+        }
+    }
+    let mut result: Vec<_> = cells.into_values().collect();
+    result.sort_by(|left, right| {
+        left.weekday
+            .cmp(&right.weekday)
+            .then(left.hour.cmp(&right.hour))
+    });
+    result
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct TopEntry {
+    name: String,
+    calls: u64,
+    failures: u64,
+    success_rate_pct: f64,
+    avg_duration_ms: f64,
+}
+
+fn compute_top_tools(audits: &[AdminAuditRecord], top_n: usize) -> Vec<TopEntry> {
+    let mut tools = HashMap::new();
+    for audit in audits {
+        let entry = tools.entry(audit.action.clone()).or_insert((0, 0, 0));
+        entry.0 += 1;
+        if !audit.success {
+            entry.1 += 1;
+        }
+        entry.2 += audit.duration_ms.unwrap_or(0);
+    }
+    let mut entries: Vec<_> = tools
+        .into_iter()
+        .map(|(name, (calls, failures, duration_sum))| TopEntry {
+            name,
+            calls,
+            failures,
+            success_rate_pct: if calls > 0 {
+                (calls - failures) as f64 / calls as f64 * 100.0
+            } else {
+                100.0
+            },
+            avg_duration_ms: if calls > 0 {
+                duration_sum as f64 / calls as f64
+            } else {
+                0.0
+            },
+        })
+        .collect();
+    entries.sort_by_key(|entry| std::cmp::Reverse(entry.calls));
+    entries.truncate(top_n);
+    entries
+}
+
+/// Build the overview response body for a bounded audit slice.
+#[must_use]
+pub fn analytics_overview_payload(
+    audits: &[AdminAuditRecord],
+    range: &str,
+    now: SystemTime,
+) -> Value {
+    let daily = merge_daily(&aggregate_audits(audits));
+    let total_calls: u64 = daily.iter().map(|day| day.calls_total).sum();
+    let total_failed: u64 = daily.iter().map(|day| day.calls_failed).sum();
+    let total_input: u64 = daily.iter().map(|day| day.tokens_input).sum();
+    let total_output: u64 = daily.iter().map(|day| day.tokens_output).sum();
+    let total_saved: u64 = daily.iter().map(|day| day.tokens_saved).sum();
+    let total_llm: u64 = daily.iter().map(|day| day.llm_total).sum();
+    let total_duration_ms: u64 = daily.iter().map(|day| day.duration_ms_sum).sum();
+    let unique_instances = count_unique(
+        audits
+            .iter()
+            .filter_map(|audit| audit.instance_id.as_deref()),
+    );
+    let unique_agents = count_unique(audits.iter().filter_map(|audit| audit.agent_id.as_deref()));
+    let period_start = now
+        .checked_sub(analytics_range_duration(range))
+        .map(|cutoff| {
+            format_day_ms(
+                cutoff
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64,
+            )
+        })
+        .unwrap_or_default();
+
+    json!({
+        "range": range,
+        "period_start": period_start,
+        "period_end": format_day(now),
+        "kpi": {
+            "calls_total": total_calls,
+            "calls_failed": total_failed,
+            "failure_rate_pct": format_2dp(if total_calls > 0 { total_failed as f64 / total_calls as f64 * 100.0 } else { 0.0 }),
+            "success_rate_pct": format_2dp(if total_calls > 0 { (total_calls - total_failed) as f64 / total_calls as f64 * 100.0 } else { 100.0 }),
+            "tokens_input_total": total_input,
+            "tokens_output_total": total_output,
+            "tokens_response_saved": total_saved,
+            "tokens_total": total_input + total_output,
+            "llm_tokens_total": total_llm,
+            "avg_duration_ms": format!("{:.1}", if total_calls > 0 { total_duration_ms as f64 / total_calls as f64 } else { 0.0 }),
+            "avg_tokens_per_call": format!("{:.1}", if total_calls > 0 { (total_input + total_output) as f64 / total_calls as f64 } else { 0.0 }),
+            "unique_instances": unique_instances,
+            "unique_agents": unique_agents,
+        },
+        "top_tools": compute_top_tools(audits, 10),
+        "daily_series": daily.iter().map(|day| json!({
+            "date": day.date,
+            "dcc_type": day.dcc_type,
+            "calls": day.calls_total,
+            "failures": day.calls_failed,
+            "tokens_input": day.tokens_input,
+            "tokens_output": day.tokens_output,
+            "avg_duration_ms": format!("{:.1}", day.avg_duration_ms()),
+            "max_duration_ms": day.duration_ms_max,
+        })).collect::<Vec<_>>(),
+    })
+}
+
+/// Build the hourly or daily time-series response body.
+#[must_use]
+pub fn analytics_timeseries_payload(
+    audits: &[AdminAuditRecord],
+    range: &str,
+    granularity: &str,
+) -> Value {
+    let aggregates = aggregate_audits(audits);
+    if granularity == "hour" {
+        let mut series: Vec<Value> = aggregates
+            .values()
+            .map(|aggregate| {
+                json!({
+                    "date": aggregate.date,
+                    "hour": aggregate.hour,
+                    "dcc_type": aggregate.dcc_type,
+                    "calls": aggregate.calls_total,
+                    "failures": aggregate.calls_failed,
+                    "tokens_input": aggregate.tokens_input,
+                    "tokens_output": aggregate.tokens_output,
+                    "avg_duration_ms": format!("{:.1}", aggregate.avg_duration_ms()),
+                    "max_duration_ms": aggregate.duration_ms_max,
+                })
+            })
+            .collect();
+        series.sort_by_key(|row| {
+            format!(
+                "{}|{:02}|{}",
+                row["date"].as_str().unwrap_or(""),
+                row["hour"].as_u64().unwrap_or(0),
+                row["dcc_type"].as_str().unwrap_or("")
+            )
+        });
+        json!({ "range": range, "granularity": "hour", "series": series })
+    } else {
+        let daily = merge_daily(&aggregates);
+        let series: Vec<Value> = daily
+            .iter()
+            .map(|day| {
+                json!({
+                    "date": day.date,
+                    "calls": day.calls_total,
+                    "failures": day.calls_failed,
+                    "tokens_input": day.tokens_input,
+                    "tokens_output": day.tokens_output,
+                    "avg_duration_ms": format!("{:.1}", day.avg_duration_ms()),
+                    "max_duration_ms": day.duration_ms_max,
+                })
+            })
+            .collect();
+        json!({ "range": range, "granularity": "day", "series": series })
+    }
+}
+
+/// Build the weekday-by-hour heatmap response body.
+#[must_use]
+pub fn analytics_heatmap_payload(audits: &[AdminAuditRecord], range: &str) -> Value {
+    json!({ "range": range, "heatmap": compute_heatmap(audits) })
+}
+
+/// Build the metadata-only JSON Lines analytics export.
+#[must_use]
+pub fn analytics_jsonl_export(audits: &[AdminAuditRecord]) -> String {
+    let mut output = String::new();
+    for audit in audits {
+        output.push_str(
+            &json!({
+                "request_id": audit.request_id,
+                "timestamp": audit.timestamp.duration_since(UNIX_EPOCH).map(|duration| duration.as_secs()).unwrap_or(0),
+                "action": audit.action,
+                "dcc_type": audit.dcc_type,
+                "success": audit.success,
+                "duration_ms": audit.duration_ms,
+                "instance_id": audit.instance_id,
+                "agent_id": audit.agent_id,
+                "agent_name": audit.agent_name,
+                "agent_model": audit.agent_model,
+            })
+            .to_string(),
+        );
+        output.push('\n');
+    }
+    output
+}
+
+/// Build the spreadsheet-safe CSV analytics export.
+#[must_use]
+pub fn analytics_csv_export(audits: &[AdminAuditRecord]) -> String {
+    let mut output = String::from(
+        "request_id,timestamp,action,dcc_type,success,duration_ms,instance_id,agent_id,agent_name,tokens_input,tokens_output,tokens_saved,llm_prompt,llm_completion,llm_total\n",
+    );
+    for audit in audits {
+        let timestamp = audit
+            .timestamp
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0);
+        let (tokens_input, tokens_output, tokens_saved) = audit
+            .token_accounting
+            .as_ref()
+            .map(|tokens| {
+                (
+                    tokens.original_tokens as u64,
+                    tokens.returned_tokens as u64,
+                    tokens.saved_tokens as u64,
+                )
+            })
+            .unwrap_or_default();
+        let (llm_prompt, llm_completion, llm_total) = audit
+            .llm_usage
+            .as_ref()
+            .map(|llm| {
+                (
+                    llm.prompt_tokens.unwrap_or(0),
+                    llm.completion_tokens.unwrap_or(0),
+                    llm.total_tokens.unwrap_or(0),
+                )
+            })
+            .unwrap_or_default();
+        output.push_str(&csv_row(&[
+            audit.request_id.as_str(),
+            &timestamp.to_string(),
+            audit.action.as_str(),
+            audit.dcc_type.as_deref().unwrap_or(""),
+            &(audit.success as u8).to_string(),
+            &audit.duration_ms.unwrap_or(0).to_string(),
+            audit.instance_id.as_deref().unwrap_or(""),
+            audit.agent_id.as_deref().unwrap_or(""),
+            audit.agent_name.as_deref().unwrap_or(""),
+            &tokens_input.to_string(),
+            &tokens_output.to_string(),
+            &tokens_saved.to_string(),
+            &llm_prompt.to_string(),
+            &llm_completion.to_string(),
+            &llm_total.to_string(),
+        ]));
+        output.push('\n');
+    }
+    output
+}
+
+fn format_2dp(value: f64) -> String {
+    format!("{value:.2}")
+}
+
+fn count_unique<'a>(values: impl Iterator<Item = &'a str>) -> usize {
+    values
+        .filter(|value| !value.trim().is_empty())
+        .collect::<HashSet<_>>()
+        .len()
+}
+
+fn csv_row(cells: &[&str]) -> String {
+    cells
+        .iter()
+        .map(|cell| csv_cell(cell))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn csv_cell(raw: &str) -> String {
+    let mut value = raw.to_string();
+    if value
+        .chars()
+        .next()
+        .is_some_and(|first| matches!(first, '=' | '+' | '-' | '@' | '\t' | '\r'))
+    {
+        value.insert(0, '\'');
+    }
+    if value.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn audit_record(request_id: &str, timestamp: SystemTime, success: bool) -> AdminAuditRecord {
+        AdminAuditRecord {
+            timestamp,
+            request_id: request_id.to_string(),
+            trace_id: Some(format!("trace-{request_id}")),
+            span_id: None,
+            parent_span_id: None,
+            method: Some("tools/call".to_string()),
+            instance_id: Some("maya-instance".to_string()),
+            session_id: None,
+            transport: Some("rest".to_string()),
+            agent_id: Some("agent-1".to_string()),
+            agent_name: Some("Scene Agent".to_string()),
+            agent_model: None,
+            actor_id: None,
+            actor_name: None,
+            actor_email_hash: None,
+            client_platform: None,
+            client_os: None,
+            client_host: None,
+            auth_subject: None,
+            source_ip: None,
+            attribution_trust: None,
+            parent_request_id: None,
+            action: "maya.scene__info".to_string(),
+            dcc_type: Some("maya".to_string()),
+            success,
+            error: (!success).then(|| "boom".to_string()),
+            duration_ms: Some(40),
+            token_accounting: None,
+            llm_usage: None,
+        }
+    }
+
+    #[test]
+    fn range_parser_falls_back_to_thirty_days() {
+        assert_eq!(
+            analytics_range_duration("7d"),
+            Duration::from_secs(7 * 86_400)
+        );
+        assert_eq!(
+            analytics_range_duration("invalid"),
+            Duration::from_secs(30 * 86_400)
+        );
+    }
+
+    #[test]
+    fn csv_cells_block_spreadsheet_formulas_and_quote_newlines() {
+        assert_eq!(csv_cell("@agent"), "'@agent");
+        assert_eq!(csv_cell("=cmd,tool\nline"), "\"'=cmd,tool\nline\"");
+    }
+
+    #[test]
+    fn timeseries_and_heatmap_share_the_same_audit_aggregation() {
+        let timestamp = UNIX_EPOCH + Duration::from_secs(4 * 86_400 + 2 * 3_600);
+        let audits = [
+            audit_record("req-ok", timestamp, true),
+            audit_record("req-failed", timestamp, false),
+        ];
+
+        let timeseries = analytics_timeseries_payload(&audits, "7d", "hour");
+        assert_eq!(timeseries["series"][0]["calls"], 2);
+        assert_eq!(timeseries["series"][0]["failures"], 1);
+        assert_eq!(timeseries["series"][0]["hour"], 2);
+
+        let heatmap = analytics_heatmap_payload(&audits, "7d");
+        assert_eq!(heatmap["heatmap"][0]["calls"], 2);
+        assert_eq!(heatmap["heatmap"][0]["failures"], 1);
+        assert_eq!(heatmap["heatmap"][0]["hour"], 2);
+    }
+}

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -1,12 +1,13 @@
 //! Domain and embedded frontend boundary for the DCC-MCP gateway admin dashboard.
 //!
 //! This crate owns admin-facing audit, trace, caller-context, compact projection,
-//! link, issue-report, and statistics contracts independently of gateway routing state.
+//! link, issue-report, statistics, and analytics contracts independently of gateway routing state.
 //! It also owns the Vite/npm build script and generated dashboard payload; the Node.js
 //! toolchain only runs when `embed` is enabled.
 
 #![forbid(unsafe_code)]
 
+mod analytics;
 mod audit;
 /// Admin trace and caller-attribution value types.
 pub mod domain;
@@ -16,6 +17,10 @@ mod projection;
 mod stats;
 mod trace_log;
 
+pub use analytics::{
+    AnalyticsQuery, analytics_csv_export, analytics_heatmap_payload, analytics_jsonl_export,
+    analytics_overview_payload, analytics_range_duration, analytics_timeseries_payload,
+};
 pub use audit::{AdminAuditRecord, AuditLog};
 pub use domain::agent_context::{
     AgentContext, AgentContextTrust, INTERNAL_AUTH_SUBJECT_HEADER, INTERNAL_FORWARDED_FOR_HEADER,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/analytics.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/analytics.rs
@@ -1,698 +1,113 @@
-//! Analytics aggregation for the executive dashboard (PIP-494 P1).
-//!
-//! Computes daily call aggregates from persisted audit rows and returns
-//! overview KPI, time series, and weekday×hour heatmap data.
+//! Gateway adapters for admin analytics projections.
 
-use std::collections::{HashMap, HashSet};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
 use axum::extract::{Query, State};
 use axum::http::HeaderValue;
 use axum::http::{StatusCode, header};
 use axum::response::IntoResponse;
-use serde::Deserialize;
-use serde_json::{Value, json};
 
-use super::state::AdminState;
+use super::state::{AdminAuditRecord, AdminState};
 
-/// Analytics query parameters.
-#[derive(Deserialize)]
-pub struct AnalyticsQuery {
-    /// Time range: "7d", "30d", "90d", "180d", "365d". Default "30d".
-    #[serde(default = "default_range")]
-    pub range: String,
-    /// Aggregation granularity: "day" or "hour". Default "day".
-    #[serde(default = "default_granularity")]
-    pub granularity: String,
-    /// Export format: "json" or "csv". Only valid for /export.
-    #[serde(default)]
-    pub format: String,
-}
-
-fn default_range() -> String {
-    "30d".into()
-}
-
-fn default_granularity() -> String {
-    "day".into()
-}
-
-/// Parse a range string into a Duration.
-fn parse_range_duration(range: &str) -> Duration {
-    let days: u64 = match range.trim_end_matches('d') {
-        "7" => 7,
-        "30" => 30,
-        "90" => 90,
-        "180" => 180,
-        "365" => 365,
-        _ => 30,
-    };
-    Duration::from_secs(days * 86_400)
-}
-
-/// One aggregated data point keyed by (date, dcc_type, hour).
-#[derive(Debug, Clone)]
-struct DayAggregate {
-    date: String,
-    dcc_type: String,
-    hour: Option<u32>,
-    calls_total: u64,
-    calls_success: u64,
-    calls_failed: u64,
-    tokens_input: u64,  // original_tokens (before compaction)
-    tokens_output: u64, // returned_tokens (after compaction)
-    tokens_saved: u64,
-    llm_prompt: u64,
-    llm_completion: u64,
-    llm_total: u64,
-    duration_ms_sum: u64,
-    duration_ms_min: u64,
-    duration_ms_max: u64,
-    instance_ids: Vec<String>,
-    agent_ids: Vec<String>,
-}
-
-impl DayAggregate {
-    fn new(date: String, dcc_type: String, hour: Option<u32>) -> Self {
-        Self {
-            date,
-            dcc_type,
-            hour,
-            calls_total: 0,
-            calls_success: 0,
-            calls_failed: 0,
-            tokens_input: 0,
-            tokens_output: 0,
-            tokens_saved: 0,
-            llm_prompt: 0,
-            llm_completion: 0,
-            llm_total: 0,
-            duration_ms_sum: 0,
-            duration_ms_min: u64::MAX,
-            duration_ms_max: 0,
-            instance_ids: Vec::new(),
-            agent_ids: Vec::new(),
-        }
-    }
-
-    fn ingest(
-        &mut self,
-        success: bool,
-        duration_ms: Option<u64>,
-        tokens: &super::trace::TokenTelemetry,
-        llm: Option<&super::trace::LlmUsage>,
-        instance_id: Option<&str>,
-        agent_id: Option<&str>,
-    ) {
-        self.calls_total += 1;
-        if success {
-            self.calls_success += 1;
-        } else {
-            self.calls_failed += 1;
-        }
-
-        let dms = duration_ms.unwrap_or(0);
-        self.duration_ms_sum += dms;
-        self.duration_ms_min = self.duration_ms_min.min(dms);
-        self.duration_ms_max = self.duration_ms_max.max(dms);
-
-        self.tokens_input += tokens.original_tokens as u64;
-        self.tokens_output += tokens.returned_tokens as u64;
-        self.tokens_saved += tokens.saved_tokens as u64;
-
-        if let Some(llm) = llm {
-            self.llm_prompt += llm.prompt_tokens.unwrap_or(0);
-            self.llm_completion += llm.completion_tokens.unwrap_or(0);
-            self.llm_total += llm.total_tokens.unwrap_or(0);
-        }
-
-        if let Some(id) = instance_id
-            && !id.is_empty()
-            && !self.instance_ids.iter().any(|i| i == id)
-        {
-            self.instance_ids.push(id.to_string());
-        }
-        if let Some(id) = agent_id
-            && !id.is_empty()
-            && !self.agent_ids.iter().any(|i| i == id)
-        {
-            self.agent_ids.push(id.to_string());
-        }
-    }
-
-    fn avg_duration_ms(&self) -> f64 {
-        if self.calls_total == 0 {
-            0.0
-        } else {
-            self.duration_ms_sum as f64 / self.calls_total as f64
-        }
-    }
-}
-
-/// Compute the "all dcc" rollup key from a dcc_type field.
-fn dcc_rollup_key(dcc: &Option<String>) -> String {
-    dcc.as_deref()
-        .filter(|s| !s.is_empty())
-        .unwrap_or("unknown")
-        .to_string()
-}
-
-// ── Date helpers ──────────────────────────────────────────────────────────
-
-fn days_to_ymd(mut days: i64) -> (i64, u32, u32) {
-    days += 719_468;
-    let era = if days >= 0 { days } else { days - 146_096 } / 146_097;
-    let doe = days - era * 146_097;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
-    (if m <= 2 { y + 1 } else { y }, m, d)
-}
-
-fn format_day(t: SystemTime) -> String {
-    let secs = t
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    let days_since_epoch = secs / 86_400;
-    let (y, m, d) = days_to_ymd(days_since_epoch as i64);
-    format!("{y:04}-{m:02}-{d:02}")
-}
-
-fn format_day_ts(ts_ms: u64) -> String {
-    let secs = ts_ms / 1000;
-    let days_since_epoch = secs / 86_400;
-    let (y, m, d) = days_to_ymd(days_since_epoch as i64);
-    format!("{y:04}-{m:02}-{d:02}")
-}
-
-fn hour_from_ms(ts_ms: i64) -> u32 {
-    let secs = ts_ms / 1000;
-    ((secs % 86_400) / 3600) as u32
-}
-
-fn weekday_from_ms(ts_ms: i64) -> u32 {
-    let secs = ts_ms / 1000;
-    let days = secs / 86_400;
-    ((days + 4) % 7) as u32
-}
-
-/// Aggregate audits into daily buckets.
-fn aggregate_audits(
-    audits: &[super::state::AdminAuditRecord],
-) -> HashMap<(String, String, Option<u32>), DayAggregate> {
-    let mut map: HashMap<(String, String, Option<u32>), DayAggregate> = HashMap::new();
-
-    for a in audits {
-        let ts_ms = a
-            .timestamp
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis() as i64)
-            .unwrap_or(0);
-        let day = format_day(a.timestamp);
-        let dcc = dcc_rollup_key(&a.dcc_type);
-        let hour = Some(hour_from_ms(ts_ms));
-
-        let key = (day.clone(), dcc.clone(), hour);
-        let entry = map
-            .entry(key)
-            .or_insert_with(|| DayAggregate::new(day, dcc, hour));
-
-        // Default empty token telemetry when not present
-        let default_tokens = super::trace::TokenTelemetry {
-            response_format: String::new(),
-            token_estimator: String::new(),
-            original_bytes: 0,
-            returned_bytes: 0,
-            original_tokens: 0,
-            returned_tokens: 0,
-            saved_tokens: 0,
-            savings_pct: 0.0,
-        };
-        let tokens = a.token_accounting.as_ref().unwrap_or(&default_tokens);
-
-        entry.ingest(
-            a.success,
-            a.duration_ms,
-            tokens,
-            a.llm_usage.as_ref(),
-            a.instance_id.as_deref(),
-            a.agent_id.as_deref(),
-        );
-    }
-
-    map
-}
-
-// ── Heatmap aggregation ───────────────────────────────────────────────────
-
-#[derive(Debug, Clone, serde::Serialize)]
-struct HeatmapCell {
-    weekday: u32,
-    hour: u32,
-    calls: u64,
-    failures: u64,
-    avg_duration_ms: f64,
-    tokens_total: u64,
-}
-
-fn compute_heatmap(audits: &[super::state::AdminAuditRecord]) -> Vec<HeatmapCell> {
-    let mut cells: HashMap<(u32, u32), HeatmapCell> = HashMap::new();
-
-    for a in audits {
-        let ts_ms = a
-            .timestamp
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis() as i64)
-            .unwrap_or(0);
-        let wd = weekday_from_ms(ts_ms);
-        let h = hour_from_ms(ts_ms);
-
-        let cell = cells.entry((wd, h)).or_insert(HeatmapCell {
-            weekday: wd,
-            hour: h,
-            calls: 0,
-            failures: 0,
-            avg_duration_ms: 0.0,
-            tokens_total: 0,
-        });
-
-        cell.calls += 1;
-        if !a.success {
-            cell.failures += 1;
-        }
-        let dms = a.duration_ms.unwrap_or(0) as f64;
-        cell.avg_duration_ms =
-            (cell.avg_duration_ms * (cell.calls - 1) as f64 + dms) / cell.calls as f64;
-
-        if let Some(t) = &a.token_accounting {
-            cell.tokens_total += t.original_tokens as u64;
-            cell.tokens_total += t.returned_tokens as u64;
-        }
-        if let Some(llm) = &a.llm_usage {
-            cell.tokens_total += llm.total_tokens.unwrap_or(0);
-        }
-    }
-
-    let mut result: Vec<_> = cells.into_values().collect();
-    result.sort_by(|a, b| a.weekday.cmp(&b.weekday).then(a.hour.cmp(&b.hour)));
-    result
-}
-
-// ── Top-N helpers ─────────────────────────────────────────────────────────
-
-#[derive(Debug, Clone, serde::Serialize)]
-struct TopEntry {
-    name: String,
-    calls: u64,
-    failures: u64,
-    success_rate_pct: f64,
-    avg_duration_ms: f64,
-}
-
-fn compute_top_tools(audits: &[super::state::AdminAuditRecord], top_n: usize) -> Vec<TopEntry> {
-    let mut map: HashMap<String, (u64, u64, u64)> = HashMap::new();
-    for a in audits {
-        let key = a.action.clone();
-        let entry = map.entry(key).or_insert((0, 0, 0));
-        entry.0 += 1;
-        if !a.success {
-            entry.1 += 1;
-        }
-        entry.2 += a.duration_ms.unwrap_or(0);
-    }
-    let mut entries: Vec<_> = map
-        .into_iter()
-        .map(|(name, (calls, failures, dsum))| TopEntry {
-            name,
-            calls,
-            failures,
-            success_rate_pct: if calls > 0 {
-                ((calls - failures) as f64 / calls as f64) * 100.0
-            } else {
-                100.0
-            },
-            avg_duration_ms: if calls > 0 {
-                dsum as f64 / calls as f64
-            } else {
-                0.0
-            },
-        })
-        .collect();
-    entries.sort_by_key(|b| std::cmp::Reverse(b.calls));
-    entries.truncate(top_n);
-    entries
-}
-
-// ── Helper: merge aggregates into daily rollup ────────────────────────────
-
-fn merge_daily(
-    aggregates: &HashMap<(String, String, Option<u32>), DayAggregate>,
-) -> Vec<DayAggregate> {
-    let mut day_map: HashMap<String, DayAggregate> = HashMap::new();
-    for agg in aggregates.values() {
-        let entry = day_map
-            .entry(agg.date.clone())
-            .or_insert_with(|| DayAggregate::new(agg.date.clone(), "all".to_string(), None));
-        entry.calls_total += agg.calls_total;
-        entry.calls_success += agg.calls_success;
-        entry.calls_failed += agg.calls_failed;
-        entry.tokens_input += agg.tokens_input;
-        entry.tokens_output += agg.tokens_output;
-        entry.tokens_saved += agg.tokens_saved;
-        entry.llm_prompt += agg.llm_prompt;
-        entry.llm_completion += agg.llm_completion;
-        entry.llm_total += agg.llm_total;
-        entry.duration_ms_sum += agg.duration_ms_sum;
-        entry.duration_ms_min = entry.duration_ms_min.min(agg.duration_ms_min);
-        entry.duration_ms_max = entry.duration_ms_max.max(agg.duration_ms_max);
-    }
-    let mut result: Vec<_> = day_map.into_values().collect();
-    result.sort_by(|a, b| a.date.cmp(&b.date));
-    result
-}
-
-// ── Handler: overview ─────────────────────────────────────────────────────
+pub use dcc_mcp_gateway_admin::AnalyticsQuery;
+use dcc_mcp_gateway_admin::{
+    analytics_csv_export, analytics_heatmap_payload, analytics_jsonl_export,
+    analytics_overview_payload, analytics_range_duration, analytics_timeseries_payload,
+};
 
 pub async fn handle_admin_analytics_overview(
-    State(s): State<AdminState>,
-    Query(params): Query<AnalyticsQuery>,
+    State(state): State<AdminState>,
+    Query(query): Query<AnalyticsQuery>,
 ) -> impl IntoResponse {
-    let range_duration = parse_range_duration(&params.range);
-    let cutoff = SystemTime::now().checked_sub(range_duration);
-
-    let audits = fetch_audits(&s, cutoff);
-
-    let aggregates = aggregate_audits(&audits);
-    let daily = merge_daily(&aggregates);
-
-    let total_calls: u64 = daily.iter().map(|d| d.calls_total).sum();
-    let total_failed: u64 = daily.iter().map(|d| d.calls_failed).sum();
-    let total_input: u64 = daily.iter().map(|d| d.tokens_input).sum();
-    let total_output: u64 = daily.iter().map(|d| d.tokens_output).sum();
-    let total_saved: u64 = daily.iter().map(|d| d.tokens_saved).sum();
-    let total_llm: u64 = daily.iter().map(|d| d.llm_total).sum();
-    let total_dur_ms: u64 = daily.iter().map(|d| d.duration_ms_sum).sum();
-    let unique_instances = count_unique(audits.iter().filter_map(|a| a.instance_id.as_deref()));
-    let unique_agents = count_unique(audits.iter().filter_map(|a| a.agent_id.as_deref()));
-
-    let top_tools = compute_top_tools(&audits, 10);
-    let period_start = cutoff
-        .map(|c| format_day_ts(c.duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64))
-        .unwrap_or_default();
-    let period_end = format_day(SystemTime::now());
-
-    let body = json!({
-        "range": params.range,
-        "period_start": period_start,
-        "period_end": period_end,
-        "kpi": {
-            "calls_total": total_calls,
-            "calls_failed": total_failed,
-            "failure_rate_pct": format_2dp(if total_calls > 0 { (total_failed as f64 / total_calls as f64) * 100.0 } else { 0.0 }),
-            "success_rate_pct": format_2dp(if total_calls > 0 { ((total_calls - total_failed) as f64 / total_calls as f64) * 100.0 } else { 100.0 }),
-            "tokens_input_total": total_input,
-            "tokens_output_total": total_output,
-            "tokens_response_saved": total_saved,
-            "tokens_total": total_input + total_output,
-            "llm_tokens_total": total_llm,
-            "avg_duration_ms": format!("{:.1}", if total_calls > 0 { total_dur_ms as f64 / total_calls as f64 } else { 0.0 }),
-            "avg_tokens_per_call": format!("{:.1}", if total_calls > 0 { (total_input + total_output) as f64 / total_calls as f64 } else { 0.0 }),
-            "unique_instances": unique_instances,
-            "unique_agents": unique_agents,
-        },
-        "top_tools": top_tools,
-        "daily_series": daily.iter().map(|d| json!({
-            "date": d.date,
-            "dcc_type": d.dcc_type,
-            "calls": d.calls_total,
-            "failures": d.calls_failed,
-            "tokens_input": d.tokens_input,
-            "tokens_output": d.tokens_output,
-            "avg_duration_ms": format!("{:.1}", d.avg_duration_ms()),
-            "max_duration_ms": d.duration_ms_max,
-        })).collect::<Vec<_>>(),
-    });
-
-    (StatusCode::OK, axum::Json(body)).into_response()
+    let now = SystemTime::now();
+    let audits = fetch_audits(
+        &state,
+        now.checked_sub(analytics_range_duration(&query.range)),
+    );
+    (
+        StatusCode::OK,
+        axum::Json(analytics_overview_payload(&audits, &query.range, now)),
+    )
+        .into_response()
 }
-
-// ── Handler: timeseries ───────────────────────────────────────────────────
 
 pub async fn handle_admin_analytics_timeseries(
-    State(s): State<AdminState>,
-    Query(params): Query<AnalyticsQuery>,
+    State(state): State<AdminState>,
+    Query(query): Query<AnalyticsQuery>,
 ) -> impl IntoResponse {
-    let range_duration = parse_range_duration(&params.range);
-    let cutoff = SystemTime::now().checked_sub(range_duration);
-
-    let audits = fetch_audits(&s, cutoff);
-
-    if params.granularity == "hour" {
-        let aggregates = aggregate_audits(&audits);
-        let mut series: Vec<Value> = aggregates
-            .values()
-            .map(|agg| {
-                json!({
-                    "date": agg.date,
-                    "hour": agg.hour,
-                    "dcc_type": agg.dcc_type,
-                    "calls": agg.calls_total,
-                    "failures": agg.calls_failed,
-                    "tokens_input": agg.tokens_input,
-                    "tokens_output": agg.tokens_output,
-                    "avg_duration_ms": format!("{:.1}", agg.avg_duration_ms()),
-                    "max_duration_ms": agg.duration_ms_max,
-                })
-            })
-            .collect();
-        series.sort_by(|a, b| {
-            let ak = format!(
-                "{}|{:02}|{}",
-                a["date"].as_str().unwrap_or(""),
-                a["hour"].as_u64().unwrap_or(0),
-                a["dcc_type"].as_str().unwrap_or("")
-            );
-            let bk = format!(
-                "{}|{:02}|{}",
-                b["date"].as_str().unwrap_or(""),
-                b["hour"].as_u64().unwrap_or(0),
-                b["dcc_type"].as_str().unwrap_or("")
-            );
-            ak.cmp(&bk)
-        });
-
-        let body = json!({ "range": params.range, "granularity": "hour", "series": series });
-        (StatusCode::OK, axum::Json(body)).into_response()
-    } else {
-        let aggregates = aggregate_audits(&audits);
-        let daily = merge_daily(&aggregates);
-        let mut series: Vec<Value> = daily
-            .iter()
-            .map(|d| {
-                json!({
-                    "date": d.date,
-                    "calls": d.calls_total,
-                    "failures": d.calls_failed,
-                    "tokens_input": d.tokens_input,
-                    "tokens_output": d.tokens_output,
-                    "avg_duration_ms": format!("{:.1}", d.avg_duration_ms()),
-                    "max_duration_ms": d.duration_ms_max,
-                })
-            })
-            .collect();
-        series.sort_by(|a, b| {
-            a["date"]
-                .as_str()
-                .unwrap_or("")
-                .cmp(b["date"].as_str().unwrap_or(""))
-        });
-
-        let body = json!({ "range": params.range, "granularity": "day", "series": series });
-        (StatusCode::OK, axum::Json(body)).into_response()
-    }
+    let audits = fetch_audits(
+        &state,
+        SystemTime::now().checked_sub(analytics_range_duration(&query.range)),
+    );
+    (
+        StatusCode::OK,
+        axum::Json(analytics_timeseries_payload(
+            &audits,
+            &query.range,
+            &query.granularity,
+        )),
+    )
+        .into_response()
 }
-
-// ── Handler: heatmap ──────────────────────────────────────────────────────
 
 pub async fn handle_admin_analytics_heatmap(
-    State(s): State<AdminState>,
-    Query(params): Query<AnalyticsQuery>,
+    State(state): State<AdminState>,
+    Query(query): Query<AnalyticsQuery>,
 ) -> impl IntoResponse {
-    let range_duration = parse_range_duration(&params.range);
-    let cutoff = SystemTime::now().checked_sub(range_duration);
-
-    let audits = fetch_audits(&s, cutoff);
-    let heatmap = compute_heatmap(&audits);
-
-    let body = json!({ "range": params.range, "heatmap": heatmap });
-    (StatusCode::OK, axum::Json(body)).into_response()
+    let audits = fetch_audits(
+        &state,
+        SystemTime::now().checked_sub(analytics_range_duration(&query.range)),
+    );
+    (
+        StatusCode::OK,
+        axum::Json(analytics_heatmap_payload(&audits, &query.range)),
+    )
+        .into_response()
 }
-
-// ── Handler: export ───────────────────────────────────────────────────────
 
 pub async fn handle_admin_analytics_export(
-    State(s): State<AdminState>,
-    Query(params): Query<AnalyticsQuery>,
+    State(state): State<AdminState>,
+    Query(query): Query<AnalyticsQuery>,
 ) -> impl IntoResponse {
-    let range_duration = parse_range_duration(&params.range);
-    let cutoff = SystemTime::now().checked_sub(range_duration);
-
-    let audits = fetch_audits(&s, cutoff);
-
-    let fmt = if params.format.is_empty() {
-        "json"
+    let audits = fetch_audits(
+        &state,
+        SystemTime::now().checked_sub(analytics_range_duration(&query.range)),
+    );
+    let (body, content_type, extension) = if query.format == "csv" {
+        (
+            analytics_csv_export(&audits),
+            "text/csv; charset=utf-8",
+            "csv",
+        )
     } else {
-        &params.format
+        (
+            analytics_jsonl_export(&audits),
+            "application/x-ndjson; charset=utf-8",
+            "jsonl",
+        )
     };
-
-    if fmt == "csv" {
-        let mut csv = String::from(
-            "request_id,timestamp,action,dcc_type,success,duration_ms,instance_id,agent_id,agent_name,tokens_input,tokens_output,tokens_saved,llm_prompt,llm_completion,llm_total\n",
-        );
-        for a in &audits {
-            let ts = a
-                .timestamp
-                .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
-            let (ti, to, tsaved) = if let Some(t) = &a.token_accounting {
-                (
-                    t.original_tokens as u64,
-                    t.returned_tokens as u64,
-                    t.saved_tokens as u64,
-                )
-            } else {
-                (0, 0, 0)
-            };
-            let (lp, lc, lt) = if let Some(llm) = &a.llm_usage {
-                (
-                    llm.prompt_tokens.unwrap_or(0),
-                    llm.completion_tokens.unwrap_or(0),
-                    llm.total_tokens.unwrap_or(0),
-                )
-            } else {
-                (0, 0, 0)
-            };
-
-            csv.push_str(&csv_row(&[
-                a.request_id.as_str(),
-                &ts.to_string(),
-                a.action.as_str(),
-                a.dcc_type.as_deref().unwrap_or(""),
-                &(a.success as u8).to_string(),
-                &a.duration_ms.unwrap_or(0).to_string(),
-                a.instance_id.as_deref().unwrap_or(""),
-                a.agent_id.as_deref().unwrap_or(""),
-                a.agent_name.as_deref().unwrap_or(""),
-                &ti.to_string(),
-                &to.to_string(),
-                &tsaved.to_string(),
-                &lp.to_string(),
-                &lc.to_string(),
-                &lt.to_string(),
-            ]));
-            csv.push('\n');
-        }
-
-        let filename = format!("dcc-mcp-analytics-export-{}.csv", params.range);
-        let mut response = axum::response::Response::new(axum::body::Body::from(csv));
-        response.headers_mut().insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("text/csv; charset=utf-8"),
-        );
-        response.headers_mut().insert(
-            header::CONTENT_DISPOSITION,
-            HeaderValue::from_str(&format!("attachment; filename=\"{filename}\""))
-                .unwrap_or_else(|_| HeaderValue::from_static("attachment")),
-        );
-        response
-    } else {
-        let mut jsonl = String::new();
-        for a in &audits {
-            let obj = json!({
-                "request_id": a.request_id,
-                "timestamp": a.timestamp.duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0),
-                "action": a.action,
-                "dcc_type": a.dcc_type,
-                "success": a.success,
-                "duration_ms": a.duration_ms,
-                "instance_id": a.instance_id,
-                "agent_id": a.agent_id,
-                "agent_name": a.agent_name,
-                "agent_model": a.agent_model,
-            });
-            jsonl.push_str(&obj.to_string());
-            jsonl.push('\n');
-        }
-
-        let filename = format!("dcc-mcp-analytics-export-{}.jsonl", params.range);
-        let mut response = axum::response::Response::new(axum::body::Body::from(jsonl));
-        response.headers_mut().insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/x-ndjson; charset=utf-8"),
-        );
-        response.headers_mut().insert(
-            header::CONTENT_DISPOSITION,
-            HeaderValue::from_str(&format!("attachment; filename=\"{filename}\""))
-                .unwrap_or_else(|_| HeaderValue::from_static("attachment")),
-        );
-        response
-    }
+    let filename = format!("dcc-mcp-analytics-export-{}.{}", query.range, extension);
+    let mut response = axum::response::Response::new(axum::body::Body::from(body));
+    response
+        .headers_mut()
+        .insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
+    response.headers_mut().insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_str(&format!("attachment; filename=\"{filename}\""))
+            .unwrap_or_else(|_| HeaderValue::from_static("attachment")),
+    );
+    response
 }
 
-// ── helpers ───────────────────────────────────────────────────────────────
-
-fn format_2dp(v: f64) -> String {
-    format!("{:.2}", v)
-}
-
-fn count_unique<'a>(values: impl Iterator<Item = &'a str>) -> usize {
-    values
-        .filter(|value| !value.trim().is_empty())
-        .collect::<HashSet<_>>()
-        .len()
-}
-
-fn csv_row(cells: &[&str]) -> String {
-    cells
-        .iter()
-        .map(|cell| csv_cell(cell))
-        .collect::<Vec<_>>()
-        .join(",")
-}
-
-fn csv_cell(raw: &str) -> String {
-    let mut value = raw.to_string();
-    if value
-        .chars()
-        .next()
-        .is_some_and(|first| matches!(first, '=' | '+' | '-' | '@' | '\t' | '\r'))
-    {
-        value.insert(0, '\'');
-    }
-
-    if value.contains([',', '"', '\n', '\r']) {
-        format!("\"{}\"", value.replace('"', "\"\""))
-    } else {
-        value
-    }
-}
-
-/// Fetch audit records from SQLite or in-memory ring buffer.
-fn fetch_audits(s: &AdminState, cutoff: Option<SystemTime>) -> Vec<super::state::AdminAuditRecord> {
-    if let Some(ref lane) = s.admin_sqlite_lane {
-        let reader = lane.reader();
-        reader.list_audits_since(cutoff, 50_000)
-    } else if let Some(ref log) = s.audit_log {
+fn fetch_audits(state: &AdminState, cutoff: Option<SystemTime>) -> Vec<AdminAuditRecord> {
+    if let Some(ref lane) = state.admin_sqlite_lane {
+        lane.reader().list_audits_since(cutoff, 50_000)
+    } else if let Some(ref log) = state.audit_log {
         log.lock()
             .iter()
-            .filter(|a| cutoff.is_none_or(|c| a.timestamp >= c))
+            .filter(|audit| cutoff.is_none_or(|cutoff| audit.timestamp >= cutoff))
             .cloned()
-            .collect::<Vec<_>>()
+            .collect()
     } else {
         Vec::new()
     }

--- a/crates/dcc-mcp-gateway/src/lib.rs
+++ b/crates/dcc-mcp-gateway/src/lib.rs
@@ -11,7 +11,7 @@
 //!    DCC adapters that never participate in gateway election) no
 //!    longer have to compile the gateway code path.
 //!
-//! The admin audit/trace domain, compact response, link, issue-report, and statistics
+//! The admin audit/trace domain, compact response, link, issue-report, statistics, and analytics
 //! projections, optional dashboard frontend, and Node/Vite build lifecycle are
 //! isolated in `dcc-mcp-gateway-admin`. This crate contains only the gateway
 //! application and its Rust-side admin adapters; builds without the `admin`

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, and statistics projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, and audit-analytics projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,7 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats domain + optional embedded dashboard asset
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -122,7 +122,7 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats domain + optional embedded dashboard asset
+dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics domain + optional embedded dashboard asset
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
@@ -392,7 +392,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, and pure statistics contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence adapters and compatibility paths remain in the gateway crate.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, and audit-analytics contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
 
 **Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约与纯统计 projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计与 audit analytics projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,7 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats 领域和可选嵌入式 dashboard 资产
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -102,7 +102,7 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats 领域和可选嵌入式 dashboard 资产
+dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics 领域和可选嵌入式 dashboard 资产
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
@@ -293,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私与纯统计契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化 adapter 和兼容导入路径。
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计与 audit analytics 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, and pure statistics projections, and optional embedded dashboard asset.
+- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, and audit-analytics projections, plus the optional embedded dashboard asset.
 - **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
@@ -282,7 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move audit analytics aggregation and safe exports into `dcc-mcp-gateway-admin`
- keep gateway-only persistence and HTTP response adapters in the gateway crate
- preserve Admin and `/v1/debug` endpoint contracts

Part of #2187.

## Validation
- `vx just preflight`
- `vx cargo nextest run -p dcc-mcp-gateway-admin -p dcc-mcp-gateway --features dcc-mcp-gateway/admin,dcc-mcp-gateway/admin-persist-sqlite --no-fail-fast`
- `vx cargo test -p dcc-mcp-gateway --features admin-persist-sqlite gateway::admin::analytics_tests --lib`
- `vx cargo clippy -p dcc-mcp-gateway-admin --all-features --all-targets -- -D warnings`
- `vx cargo check -p dcc-mcp-gateway --no-default-features`
- `vx cargo hakari verify`
- public documentation scan contains no `_thm` or `rez_local_cache` paths

Creator Skills do not need changes because adapter and skill-authoring workflows are unchanged.