### PR TITLE
refactor: extract gateway admin governance

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/governance.rs
+++ b/crates/dcc-mcp-gateway-admin/src/governance.rs
@@ -1,0 +1,426 @@
+//! Admin governance projections for policy, privacy, and pressure controls.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{Value, json};
+
+use crate::AdminAuditRecord;
+
+const SCHEMA_VERSION: &str = "dcc-mcp.admin.governance.v1";
+
+/// Backend-neutral capture decision consumed by governance projections.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GovernanceCaptureDecision {
+    pub timestamp: SystemTime,
+    pub request_id: Option<String>,
+    pub trace_id: Option<String>,
+    pub session_id: Option<String>,
+    pub transport: String,
+    pub mcp_method: Option<String>,
+    pub outcome: String,
+    pub reason: Option<String>,
+    pub redacted_paths: Vec<String>,
+}
+
+/// Backend-neutral middleware state consumed by governance projections.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GovernanceMiddlewareState {
+    /// Serialized middleware snapshot returned to admin clients.
+    pub snapshot: Value,
+    /// Whether a redaction control is active in the middleware chain.
+    pub redaction_active: bool,
+    /// Whether a quota control is active in the middleware chain.
+    pub quota_active: bool,
+}
+
+/// Build the read-only governance payload shared by Admin and debug routes.
+#[must_use]
+pub fn governance_payload(
+    policy: Value,
+    traffic_capture: Value,
+    middleware: GovernanceMiddlewareState,
+    audits: Vec<AdminAuditRecord>,
+    capture_decisions: Vec<GovernanceCaptureDecision>,
+    limit: usize,
+) -> Value {
+    let limit = limit.clamp(1, 1_000);
+    let recent_decisions =
+        recent_request_decisions(audits, capture_decisions.clone(), &middleware, limit);
+    let stats = governance_stats_from_decisions(&recent_decisions, &capture_decisions);
+
+    json!({
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "mode": {
+            "admin_mutations": "disabled",
+            "reason": "Admin has no authentication by default, so governance is exposed as an operator-readable control plane.",
+        },
+        "policy": policy,
+        "traffic_capture": traffic_capture,
+        "middleware": middleware.snapshot,
+        "stats": stats,
+        "recent_decisions": recent_decisions,
+    })
+}
+
+/// Build compact governance counters for the Admin statistics payload.
+#[must_use]
+pub fn governance_stats(
+    audits: Vec<AdminAuditRecord>,
+    capture_decisions: Vec<GovernanceCaptureDecision>,
+    middleware: &GovernanceMiddlewareState,
+    limit: usize,
+) -> Value {
+    let decisions = recent_request_decisions(
+        audits,
+        capture_decisions.clone(),
+        middleware,
+        limit.clamp(1, 1_000),
+    );
+    governance_stats_from_decisions(&decisions, &capture_decisions)
+}
+
+fn recent_request_decisions(
+    audits: Vec<AdminAuditRecord>,
+    capture_decisions: Vec<GovernanceCaptureDecision>,
+    middleware: &GovernanceMiddlewareState,
+    limit: usize,
+) -> Vec<Value> {
+    let mut capture_by_request = BTreeMap::<String, Vec<GovernanceCaptureDecision>>::new();
+    let mut capture_only = Vec::new();
+    for decision in capture_decisions {
+        if let Some(request_id) = &decision.request_id {
+            capture_by_request
+                .entry(request_id.clone())
+                .or_default()
+                .push(decision);
+        } else {
+            capture_only.push(decision);
+        }
+    }
+
+    let mut rows = Vec::new();
+    let redaction_active = middleware.redaction_active;
+    let quota_active = middleware.quota_active;
+
+    for audit in audits {
+        let capture = capture_by_request
+            .remove(&audit.request_id)
+            .unwrap_or_default();
+        rows.push(json!({
+            "timestamp": timestamp_string(audit.timestamp),
+            "request_id": audit.request_id,
+            "trace_id": audit.trace_id,
+            "session_id": audit.session_id,
+            "transport": audit.transport,
+            "agent_id": audit.agent_id,
+            "agent_name": audit.agent_name,
+            "agent_model": audit.agent_model,
+            "actor_id": audit.actor_id,
+            "actor_name": audit.actor_name,
+            "client_platform": audit.client_platform,
+            "source_ip": audit.source_ip,
+            "parent_request_id": audit.parent_request_id,
+            "tool": audit.action,
+            "dcc_type": audit.dcc_type,
+            "outcome": request_outcome(&audit),
+            "success": audit.success,
+            "reason": request_reason(&audit),
+            "duration_ms": audit.duration_ms,
+            "policy": {
+                "read_only": audit_error_text(&audit).contains("read-only"),
+                "denied": is_policy_denied(&audit),
+                "reason": policy_reason(&audit),
+            },
+            "traffic_capture": capture_summary(&capture),
+            "privacy": {
+                "redaction_middleware_active": redaction_active,
+                "redacted_paths": redacted_paths(&capture),
+            },
+            "pressure": {
+                "quota_active": quota_active,
+                "throttled": is_throttled(&audit),
+            },
+        }));
+    }
+
+    for capture in capture_by_request.into_values() {
+        if let Some(first) = capture.first() {
+            rows.push(json!({
+                "timestamp": timestamp_string(first.timestamp),
+                "request_id": first.request_id,
+                "trace_id": first.trace_id,
+                "session_id": first.session_id,
+                "transport": first.transport,
+                "tool": first.mcp_method,
+                "outcome": "capture-only",
+                "success": Value::Null,
+                "reason": "traffic-capture-frame-without-audit-row",
+                "traffic_capture": capture_summary(&capture),
+                "privacy": {
+                    "redaction_middleware_active": redaction_active,
+                    "redacted_paths": redacted_paths(&capture),
+                },
+                "pressure": {
+                    "quota_active": quota_active,
+                    "throttled": false,
+                },
+            }));
+        }
+    }
+
+    for decision in capture_only {
+        rows.push(json!({
+            "timestamp": timestamp_string(decision.timestamp),
+            "request_id": Value::Null,
+            "trace_id": decision.trace_id,
+            "session_id": decision.session_id,
+            "transport": decision.transport,
+            "tool": decision.mcp_method,
+            "outcome": "capture-only",
+            "success": Value::Null,
+            "reason": decision.reason,
+            "traffic_capture": capture_summary(std::slice::from_ref(&decision)),
+            "privacy": {
+                "redaction_middleware_active": redaction_active,
+                "redacted_paths": decision.redacted_paths,
+            },
+            "pressure": {
+                "quota_active": quota_active,
+                "throttled": false,
+            },
+        }));
+    }
+
+    rows.sort_by(|a, b| {
+        a.get("timestamp")
+            .and_then(Value::as_str)
+            .cmp(&b.get("timestamp").and_then(Value::as_str))
+    });
+    let overflow = rows.len().saturating_sub(limit);
+    if overflow > 0 {
+        rows.drain(0..overflow);
+    }
+    rows
+}
+
+fn capture_summary(decisions: &[GovernanceCaptureDecision]) -> Value {
+    let captured = decisions
+        .iter()
+        .filter(|decision| decision.outcome == "captured")
+        .count();
+    let skipped = decisions
+        .iter()
+        .filter(|decision| decision.outcome == "skipped")
+        .count();
+    let reasons: BTreeSet<String> = decisions
+        .iter()
+        .filter_map(|decision| decision.reason.clone())
+        .collect();
+    json!({
+        "frame_count": decisions.len(),
+        "captured": captured,
+        "skipped": skipped,
+        "reasons": reasons.into_iter().collect::<Vec<_>>(),
+    })
+}
+
+fn redacted_paths(decisions: &[GovernanceCaptureDecision]) -> Vec<String> {
+    decisions
+        .iter()
+        .flat_map(|decision| decision.redacted_paths.iter().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn governance_stats_from_decisions(
+    decisions: &[Value],
+    capture_decisions: &[GovernanceCaptureDecision],
+) -> Value {
+    let policy_denied = decisions
+        .iter()
+        .filter(|row| row.pointer("/policy/denied").and_then(Value::as_bool) == Some(true))
+        .count();
+    let throttled = decisions
+        .iter()
+        .filter(|row| row.pointer("/pressure/throttled").and_then(Value::as_bool) == Some(true))
+        .count();
+    let allowed = decisions
+        .iter()
+        .filter(|row| row.get("outcome").and_then(Value::as_str) == Some("allowed"))
+        .count();
+    let captured_frames = capture_decisions
+        .iter()
+        .filter(|decision| decision.outcome == "captured")
+        .count();
+    let skipped_frames = capture_decisions
+        .iter()
+        .filter(|decision| decision.outcome == "skipped")
+        .count();
+    let redacted_paths = redacted_paths(capture_decisions);
+    json!({
+        "recent_allowed": allowed,
+        "recent_policy_denied": policy_denied,
+        "recent_throttled": throttled,
+        "captured_frames": captured_frames,
+        "skipped_capture_frames": skipped_frames,
+        "redacted_path_count": redacted_paths.len(),
+        "redacted_paths": redacted_paths,
+    })
+}
+
+fn request_outcome(audit: &AdminAuditRecord) -> &'static str {
+    if audit.success {
+        "allowed"
+    } else if is_throttled(audit) {
+        "throttled"
+    } else if is_policy_denied(audit) {
+        "denied"
+    } else {
+        "failed"
+    }
+}
+
+fn request_reason(audit: &AdminAuditRecord) -> Option<String> {
+    if audit.success {
+        return Some("allowed".to_string());
+    }
+    audit.error.clone()
+}
+
+fn policy_reason(audit: &AdminAuditRecord) -> Option<String> {
+    let text = audit_error_text(audit);
+    for reason in [
+        "read-only",
+        "dcc-allowlist",
+        "skill-allowlist",
+        "tool-allowlist",
+    ] {
+        if text.contains(reason) {
+            return Some(reason.to_string());
+        }
+    }
+    None
+}
+
+fn is_policy_denied(audit: &AdminAuditRecord) -> bool {
+    let text = audit_error_text(audit);
+    text.contains("policy-denied") || text.contains("gateway policy denied")
+}
+
+fn is_throttled(audit: &AdminAuditRecord) -> bool {
+    let text = audit_error_text(audit);
+    text.contains("quota exceeded") || text.contains("throttled")
+}
+
+fn audit_error_text(audit: &AdminAuditRecord) -> String {
+    audit.error.clone().unwrap_or_default().to_ascii_lowercase()
+}
+
+fn timestamp_string(timestamp: SystemTime) -> String {
+    timestamp
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|_| chrono::DateTime::<chrono::Utc>::from(timestamp).to_rfc3339())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn audit(request_id: &str, success: bool, error: Option<&str>) -> AdminAuditRecord {
+        AdminAuditRecord {
+            timestamp: UNIX_EPOCH + std::time::Duration::from_secs(1),
+            request_id: request_id.to_string(),
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            method: None,
+            instance_id: None,
+            session_id: None,
+            transport: Some("rest".to_string()),
+            agent_id: None,
+            agent_name: None,
+            agent_model: None,
+            actor_id: None,
+            actor_name: None,
+            actor_email_hash: None,
+            client_platform: None,
+            client_os: None,
+            client_host: None,
+            auth_subject: None,
+            source_ip: None,
+            attribution_trust: None,
+            parent_request_id: None,
+            action: "maya__render".to_string(),
+            dcc_type: Some("maya".to_string()),
+            success,
+            error: error.map(str::to_string),
+            duration_ms: Some(5),
+            token_accounting: None,
+            llm_usage: None,
+        }
+    }
+
+    fn capture(request_id: Option<&str>, outcome: &str) -> GovernanceCaptureDecision {
+        GovernanceCaptureDecision {
+            timestamp: UNIX_EPOCH + std::time::Duration::from_secs(2),
+            request_id: request_id.map(str::to_string),
+            trace_id: None,
+            session_id: None,
+            transport: "mcp".to_string(),
+            mcp_method: Some("tools/call".to_string()),
+            outcome: outcome.to_string(),
+            reason: (outcome == "skipped").then(|| "filter".to_string()),
+            redacted_paths: vec!["$.arguments.secret".to_string()],
+        }
+    }
+
+    fn middleware() -> GovernanceMiddlewareState {
+        GovernanceMiddlewareState {
+            snapshot: json!({"controls": [{"kind": "redaction"}, {"kind": "quota"}]}),
+            redaction_active: true,
+            quota_active: true,
+        }
+    }
+
+    #[test]
+    fn payload_correlates_audits_and_capture_decisions() {
+        let payload = governance_payload(
+            json!({"read_only": true}),
+            json!({"enabled": true}),
+            middleware(),
+            vec![
+                audit("allowed", true, None),
+                audit("denied", false, Some("policy-denied: read-only")),
+                audit("throttled", false, Some("quota exceeded")),
+            ],
+            vec![
+                capture(Some("allowed"), "captured"),
+                capture(None, "skipped"),
+            ],
+            100,
+        );
+
+        assert_eq!(payload["stats"]["recent_allowed"], 1);
+        assert_eq!(payload["stats"]["recent_policy_denied"], 1);
+        assert_eq!(payload["stats"]["recent_throttled"], 1);
+        assert_eq!(payload["stats"]["captured_frames"], 1);
+        assert_eq!(payload["stats"]["skipped_capture_frames"], 1);
+        assert_eq!(
+            payload["recent_decisions"].as_array().map(Vec::len),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn stats_limit_is_clamped_and_middleware_flags_are_backend_neutral() {
+        let stats = governance_stats(vec![audit("allowed", true, None)], vec![], &middleware(), 0);
+
+        assert_eq!(stats["recent_allowed"], 1);
+        assert_eq!(stats["recent_throttled"], 0);
+    }
+}

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -1,7 +1,8 @@
 //! Domain and embedded frontend boundary for the DCC-MCP gateway admin dashboard.
 //!
 //! This crate owns admin-facing audit, trace, caller-context, compact projection,
-//! link, issue-report, statistics, and analytics contracts independently of gateway routing state.
+//! link, issue-report, statistics, analytics, and governance contracts independently of gateway
+//! routing state.
 //! It also owns the Vite/npm build script and generated dashboard payload; the Node.js
 //! toolchain only runs when `embed` is enabled.
 
@@ -11,6 +12,7 @@ mod analytics;
 mod audit;
 /// Admin trace and caller-attribution value types.
 pub mod domain;
+mod governance;
 mod issue_report;
 mod links;
 mod projection;
@@ -32,6 +34,9 @@ pub use domain::trace::{
     MAX_AGENT_CONTEXT_STRING_BYTES, MAX_INPUT_BYTES, MAX_OUTPUT_BYTES, TOKEN_ESTIMATOR,
     TokenTelemetry, TraceContext, TraceContextHeader, TracePayload, TraceSpan, estimate_tokens,
     parse_traceparent,
+};
+pub use governance::{
+    GovernanceCaptureDecision, GovernanceMiddlewareState, governance_payload, governance_stats,
 };
 pub use issue_report::{IssueReportMode, issue_report_filename, issue_report_json};
 pub use links::AdminLinkBuilder;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/governance.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/governance.rs
@@ -1,56 +1,43 @@
-//! Admin governance projection for traffic capture, privacy, policy, and pressure controls.
+//! Gateway adapters for admin governance projections.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::time::UNIX_EPOCH;
+use std::collections::BTreeMap;
 
+use dcc_mcp_gateway_admin::{
+    GovernanceCaptureDecision, GovernanceMiddlewareState, governance_payload, governance_stats,
+};
 use serde_json::{Value, json};
 
 use super::state::{AdminAuditRecord, AdminState};
-use crate::gateway::middleware::MiddlewareGovernanceSnapshot;
-use crate::gateway::traffic::TrafficCaptureDecision;
-
-const SCHEMA_VERSION: &str = "dcc-mcp.admin.governance.v1";
+use crate::gateway::traffic::{TrafficCaptureDecision, TrafficCaptureSnapshot};
 
 /// Build a read-only governance payload for Admin and `/v1/debug/governance`.
 pub async fn build_governance_payload(state: &AdminState, limit: usize) -> Value {
     let limit = limit.clamp(1, 1_000);
-    let policy = policy_snapshot(&state.gateway.policy);
     let middleware = state.gateway.middleware_chain.governance_snapshot();
     let traffic_capture = state.gateway.traffic_capture.governance_snapshot();
-    let recent_decisions = recent_request_decisions(
-        collect_recent_audits(state, limit).await,
-        traffic_capture.recent_decisions.clone(),
-        &middleware,
-        limit,
-    );
-    let stats =
-        governance_stats_from_decisions(&recent_decisions, &traffic_capture.recent_decisions);
+    let capture_decisions = governance_capture_decisions(&traffic_capture);
 
-    json!({
-        "schema_version": SCHEMA_VERSION,
-        "generated_at": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
-        "mode": {
-            "admin_mutations": "disabled",
-            "reason": "Admin has no authentication by default, so governance is exposed as an operator-readable control plane.",
-        },
-        "policy": policy,
-        "traffic_capture": traffic_capture,
-        "middleware": middleware,
-        "stats": stats,
-        "recent_decisions": recent_decisions,
-    })
+    governance_payload(
+        policy_snapshot(&state.gateway.policy),
+        serde_json::to_value(&traffic_capture)
+            .expect("gateway traffic governance snapshot must serialize"),
+        governance_middleware_state(&middleware),
+        collect_recent_audits(state, limit),
+        capture_decisions,
+        limit,
+    )
 }
 
 /// Compact governance counters that can be embedded in `/admin/api/stats`.
 pub fn build_governance_stats(state: &AdminState) -> Value {
-    let capture = state.gateway.traffic_capture.governance_snapshot();
-    let decisions = recent_request_decisions(
-        collect_recent_audits_sync(state, 1_000),
-        capture.recent_decisions.clone(),
-        &state.gateway.middleware_chain.governance_snapshot(),
+    let middleware = state.gateway.middleware_chain.governance_snapshot();
+    let traffic_capture = state.gateway.traffic_capture.governance_snapshot();
+    governance_stats(
+        collect_recent_audits(state, 1_000),
+        governance_capture_decisions(&traffic_capture),
+        &governance_middleware_state(&middleware),
         1_000,
-    );
-    governance_stats_from_decisions(&decisions, &capture.recent_decisions)
+    )
 }
 
 fn policy_snapshot(policy: &crate::gateway::GatewayPolicy) -> Value {
@@ -72,11 +59,7 @@ fn policy_snapshot(policy: &crate::gateway::GatewayPolicy) -> Value {
     })
 }
 
-async fn collect_recent_audits(state: &AdminState, limit: usize) -> Vec<AdminAuditRecord> {
-    collect_recent_audits_sync(state, limit)
-}
-
-fn collect_recent_audits_sync(state: &AdminState, limit: usize) -> Vec<AdminAuditRecord> {
+fn collect_recent_audits(state: &AdminState, limit: usize) -> Vec<AdminAuditRecord> {
     let mut rows = BTreeMap::<String, AdminAuditRecord>::new();
     if let Some(lane) = &state.admin_sqlite_lane {
         for row in lane
@@ -100,255 +83,43 @@ fn collect_recent_audits_sync(state: &AdminState, limit: usize) -> Vec<AdminAudi
     rows
 }
 
-fn recent_request_decisions(
-    audits: Vec<AdminAuditRecord>,
-    capture_decisions: Vec<TrafficCaptureDecision>,
-    middleware: &MiddlewareGovernanceSnapshot,
-    limit: usize,
-) -> Vec<Value> {
-    let mut capture_by_request: BTreeMap<String, Vec<TrafficCaptureDecision>> = BTreeMap::new();
-    let mut capture_only = Vec::new();
-    for decision in capture_decisions {
-        if let Some(request_id) = &decision.request_id {
-            capture_by_request
-                .entry(request_id.clone())
-                .or_default()
-                .push(decision);
-        } else {
-            capture_only.push(decision);
-        }
-    }
-
-    let mut rows = Vec::new();
-    let redaction_active = middleware
-        .controls
+fn governance_capture_decisions(
+    snapshot: &TrafficCaptureSnapshot,
+) -> Vec<GovernanceCaptureDecision> {
+    snapshot
+        .recent_decisions
         .iter()
-        .any(|control| control.kind == "redaction");
-    let quota_active = middleware
-        .controls
-        .iter()
-        .any(|control| control.kind == "quota");
-
-    for audit in audits {
-        let capture = capture_by_request
-            .remove(&audit.request_id)
-            .unwrap_or_default();
-        let capture_summary = capture_summary(&capture);
-        rows.push(json!({
-            "timestamp": timestamp_string(audit.timestamp),
-            "request_id": audit.request_id,
-            "trace_id": audit.trace_id,
-            "session_id": audit.session_id,
-            "transport": audit.transport,
-            "agent_id": audit.agent_id,
-            "agent_name": audit.agent_name,
-            "agent_model": audit.agent_model,
-            "actor_id": audit.actor_id,
-            "actor_name": audit.actor_name,
-            "client_platform": audit.client_platform,
-            "source_ip": audit.source_ip,
-            "parent_request_id": audit.parent_request_id,
-            "tool": audit.action,
-            "dcc_type": audit.dcc_type,
-            "outcome": request_outcome(&audit),
-            "success": audit.success,
-            "reason": request_reason(&audit),
-            "duration_ms": audit.duration_ms,
-            "policy": {
-                "read_only": audit_error_text(&audit).contains("read-only"),
-                "denied": is_policy_denied(&audit),
-                "reason": policy_reason(&audit),
-            },
-            "traffic_capture": capture_summary,
-            "privacy": {
-                "redaction_middleware_active": redaction_active,
-                "redacted_paths": redacted_paths(&capture),
-            },
-            "pressure": {
-                "quota_active": quota_active,
-                "throttled": is_throttled(&audit),
-            },
-        }));
-    }
-
-    for (_request_id, capture) in capture_by_request {
-        if let Some(first) = capture.first() {
-            rows.push(json!({
-                "timestamp": timestamp_string(first.timestamp),
-                "request_id": first.request_id,
-                "trace_id": first.trace_id,
-                "session_id": first.session_id,
-                "transport": first.transport,
-                "tool": first.mcp_method,
-                "outcome": "capture-only",
-                "success": Value::Null,
-                "reason": "traffic-capture-frame-without-audit-row",
-                "traffic_capture": capture_summary(&capture),
-                "privacy": {
-                    "redaction_middleware_active": redaction_active,
-                    "redacted_paths": redacted_paths(&capture),
-                },
-                "pressure": {
-                    "quota_active": quota_active,
-                    "throttled": false,
-                },
-            }));
-        }
-    }
-
-    for decision in capture_only {
-        rows.push(json!({
-            "timestamp": timestamp_string(decision.timestamp),
-            "request_id": Value::Null,
-            "trace_id": decision.trace_id,
-            "session_id": decision.session_id,
-            "transport": decision.transport,
-            "tool": decision.mcp_method,
-            "outcome": "capture-only",
-            "success": Value::Null,
-            "reason": decision.reason,
-            "traffic_capture": capture_summary(std::slice::from_ref(&decision)),
-            "privacy": {
-                "redaction_middleware_active": redaction_active,
-                "redacted_paths": decision.redacted_paths,
-            },
-            "pressure": {
-                "quota_active": quota_active,
-                "throttled": false,
-            },
-        }));
-    }
-
-    rows.sort_by(|a, b| {
-        a.get("timestamp")
-            .and_then(Value::as_str)
-            .cmp(&b.get("timestamp").and_then(Value::as_str))
-    });
-    let overflow = rows.len().saturating_sub(limit);
-    if overflow > 0 {
-        rows.drain(0..overflow);
-    }
-    rows
-}
-
-fn capture_summary(decisions: &[TrafficCaptureDecision]) -> Value {
-    let captured = decisions
-        .iter()
-        .filter(|decision| decision.outcome == "captured")
-        .count();
-    let skipped = decisions
-        .iter()
-        .filter(|decision| decision.outcome == "skipped")
-        .count();
-    let reasons: BTreeSet<String> = decisions
-        .iter()
-        .filter_map(|decision| decision.reason.clone())
-        .collect();
-    json!({
-        "frame_count": decisions.len(),
-        "captured": captured,
-        "skipped": skipped,
-        "reasons": reasons.into_iter().collect::<Vec<_>>(),
-    })
-}
-
-fn redacted_paths(decisions: &[TrafficCaptureDecision]) -> Vec<String> {
-    decisions
-        .iter()
-        .flat_map(|decision| decision.redacted_paths.iter().cloned())
-        .collect::<BTreeSet<_>>()
-        .into_iter()
+        .map(governance_capture_decision)
         .collect()
 }
 
-fn governance_stats_from_decisions(
-    decisions: &[Value],
-    capture_decisions: &[TrafficCaptureDecision],
-) -> Value {
-    let policy_denied = decisions
-        .iter()
-        .filter(|row| row.pointer("/policy/denied").and_then(Value::as_bool) == Some(true))
-        .count();
-    let throttled = decisions
-        .iter()
-        .filter(|row| row.pointer("/pressure/throttled").and_then(Value::as_bool) == Some(true))
-        .count();
-    let allowed = decisions
-        .iter()
-        .filter(|row| row.get("outcome").and_then(Value::as_str) == Some("allowed"))
-        .count();
-    let captured_frames = capture_decisions
-        .iter()
-        .filter(|decision| decision.outcome == "captured")
-        .count();
-    let skipped_frames = capture_decisions
-        .iter()
-        .filter(|decision| decision.outcome == "skipped")
-        .count();
-    let redacted_paths = redacted_paths(capture_decisions);
-    json!({
-        "recent_allowed": allowed,
-        "recent_policy_denied": policy_denied,
-        "recent_throttled": throttled,
-        "captured_frames": captured_frames,
-        "skipped_capture_frames": skipped_frames,
-        "redacted_path_count": redacted_paths.len(),
-        "redacted_paths": redacted_paths,
-    })
-}
-
-fn request_outcome(audit: &AdminAuditRecord) -> &'static str {
-    if audit.success {
-        "allowed"
-    } else if is_throttled(audit) {
-        "throttled"
-    } else if is_policy_denied(audit) {
-        "denied"
-    } else {
-        "failed"
+fn governance_capture_decision(decision: &TrafficCaptureDecision) -> GovernanceCaptureDecision {
+    GovernanceCaptureDecision {
+        timestamp: decision.timestamp,
+        request_id: decision.request_id.clone(),
+        trace_id: decision.trace_id.clone(),
+        session_id: decision.session_id.clone(),
+        transport: decision.transport.clone(),
+        mcp_method: decision.mcp_method.clone(),
+        outcome: decision.outcome.clone(),
+        reason: decision.reason.clone(),
+        redacted_paths: decision.redacted_paths.clone(),
     }
 }
 
-fn request_reason(audit: &AdminAuditRecord) -> Option<String> {
-    if audit.success {
-        return Some("allowed".to_string());
+fn governance_middleware_state(
+    snapshot: &crate::gateway::middleware::MiddlewareGovernanceSnapshot,
+) -> GovernanceMiddlewareState {
+    GovernanceMiddlewareState {
+        snapshot: serde_json::to_value(snapshot)
+            .expect("gateway middleware governance snapshot must serialize"),
+        redaction_active: snapshot
+            .controls
+            .iter()
+            .any(|control| control.kind == "redaction"),
+        quota_active: snapshot
+            .controls
+            .iter()
+            .any(|control| control.kind == "quota"),
     }
-    audit.error.clone()
-}
-
-fn policy_reason(audit: &AdminAuditRecord) -> Option<String> {
-    let text = audit_error_text(audit);
-    for reason in [
-        "read-only",
-        "dcc-allowlist",
-        "skill-allowlist",
-        "tool-allowlist",
-    ] {
-        if text.contains(reason) {
-            return Some(reason.to_string());
-        }
-    }
-    None
-}
-
-fn is_policy_denied(audit: &AdminAuditRecord) -> bool {
-    let text = audit_error_text(audit);
-    text.contains("policy-denied") || text.contains("gateway policy denied")
-}
-
-fn is_throttled(audit: &AdminAuditRecord) -> bool {
-    let text = audit_error_text(audit);
-    text.contains("quota exceeded") || text.contains("throttled")
-}
-
-fn audit_error_text(audit: &AdminAuditRecord) -> String {
-    audit.error.clone().unwrap_or_default().to_ascii_lowercase()
-}
-
-fn timestamp_string(timestamp: std::time::SystemTime) -> String {
-    timestamp
-        .duration_since(UNIX_EPOCH)
-        .ok()
-        .map(|_| chrono::DateTime::<chrono::Utc>::from(timestamp).to_rfc3339())
-        .unwrap_or_default()
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -25,9 +25,9 @@
 //!
 //! The runtime UI is a single inline HTML string (`admin/html.rs`). The
 //! `dcc-mcp-gateway-admin` crate owns the trace domain, compact, link,
-//! issue-report, and statistics projections, Vite/npm build boundary, and
-//! embedded asset; this module owns the gateway-specific data-source/HTTP
-//! adapters and API handlers.
+//! issue-report, statistics, analytics, and governance projections, Vite/npm
+//! build boundary, and embedded asset; this module owns the gateway-specific
+//! data-source/HTTP adapters and API handlers.
 //!
 //! # Module layout (PIP-687 split)
 //!

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, and audit-analytics projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, and governance projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,7 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics domain + optional embedded dashboard asset
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -122,7 +122,7 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics domain + optional embedded dashboard asset
+dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance domain + optional embedded dashboard asset
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
@@ -392,7 +392,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, and audit-analytics contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, and governance contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
 
 **Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计与 audit analytics projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics 与 governance projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,7 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics 领域和可选嵌入式 dashboard 资产
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -102,7 +102,7 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics 领域和可选嵌入式 dashboard 资产
+dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance 领域和可选嵌入式 dashboard 资产
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
@@ -293,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计与 audit analytics 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics 与 governance 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, and audit-analytics projections, plus the optional embedded dashboard asset.
+- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, and governance projections, plus the optional embedded dashboard asset.
 - **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
@@ -282,7 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move admin governance aggregation and decision projection into `dcc-mcp-gateway-admin`
- keep gateway state reads and traffic/middleware adapters in `dcc-mcp-gateway`
- preserve the existing admin and debug governance response contracts

Part of #2187.

## Validation
- `vx just preflight`
- `vx cargo nextest run -p dcc-mcp-gateway-admin -p dcc-mcp-gateway --features dcc-mcp-gateway/admin,dcc-mcp-gateway/admin-persist-sqlite --no-fail-fast`
- public documentation scan contains no `_thm` or `rez_local_cache` paths

Creator Skills require no changes because adapter and skill-authoring workflows are unchanged.