### PR TITLE
refactor: extract admin traffic projection

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -1,8 +1,8 @@
 //! Domain and embedded frontend boundary for the DCC-MCP gateway admin dashboard.
 //!
 //! This crate owns admin-facing audit, trace, caller-context, compact projection,
-//! link, issue-report, statistics, analytics, and governance contracts independently of gateway
-//! routing state.
+//! link, issue-report, statistics, analytics, governance, and traffic projections independently of
+//! gateway routing state.
 //! It also owns the Vite/npm build script and generated dashboard payload; the Node.js
 //! toolchain only runs when `embed` is enabled.
 
@@ -18,6 +18,7 @@ mod links;
 mod projection;
 mod stats;
 mod trace_log;
+mod traffic;
 
 pub use analytics::{
     AnalyticsQuery, analytics_csv_export, analytics_heatmap_payload, analytics_jsonl_export,
@@ -50,6 +51,7 @@ pub use stats::{
     compute_stats_filtered,
 };
 pub use trace_log::TraceLog;
+pub use traffic::{TrafficProjectionSnapshot, traffic_jsonl_export, traffic_payload};
 
 /// The Vite-built React admin dashboard HTML page.
 #[cfg(feature = "embed")]

--- a/crates/dcc-mcp-gateway-admin/src/traffic.rs
+++ b/crates/dcc-mcp-gateway-admin/src/traffic.rs
@@ -1,0 +1,244 @@
+//! Metadata-only traffic projections for the admin dashboard.
+
+use std::collections::BTreeSet;
+
+use serde_json::{Value, json};
+
+use crate::GovernanceCaptureDecision;
+
+const SCHEMA_VERSION: &str = "dcc-mcp.admin.traffic.v1";
+
+/// Backend-neutral traffic capture state consumed by admin projections.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrafficProjectionSnapshot {
+    pub enabled: bool,
+    pub sink_count: usize,
+    pub subscriber_enabled: bool,
+    pub live_sink_enabled: bool,
+    pub admin_live_capacity: Option<usize>,
+    pub recent_decisions: Vec<GovernanceCaptureDecision>,
+}
+
+/// Build the metadata-only traffic payload returned by the admin API.
+#[must_use]
+pub fn traffic_payload(
+    frames: Vec<Value>,
+    snapshot: &TrafficProjectionSnapshot,
+    links: Value,
+) -> Value {
+    let frames: Vec<Value> = frames.into_iter().map(sanitize_frame).collect();
+    let capture_status = capture_status(snapshot, frames.len());
+
+    json!({
+        "schema_version": SCHEMA_VERSION,
+        "total": frames.len(),
+        "frames": frames,
+        "capture_status": capture_status,
+        "links": links,
+    })
+}
+
+/// Encode metadata-only traffic frames as newline-delimited JSON.
+#[must_use]
+pub fn traffic_jsonl_export(frames: Vec<Value>) -> String {
+    let mut body = String::new();
+    for frame in frames.into_iter().map(sanitize_frame) {
+        if let Ok(line) = serde_json::to_string(&frame) {
+            body.push_str(&line);
+            body.push('\n');
+        }
+    }
+    body
+}
+
+fn sanitize_frame(mut frame: Value) -> Value {
+    if let Some(attributes) = frame
+        .as_object_mut()
+        .and_then(|map| map.get_mut("attributes"))
+    {
+        sanitize_attributes(attributes);
+    }
+    frame
+}
+
+fn sanitize_attributes(attributes: &mut Value) {
+    let Some(map) = attributes.as_object_mut() else {
+        return;
+    };
+
+    if let Some(body) = map.get_mut("body").and_then(Value::as_object_mut) {
+        body.remove("data");
+        body.insert("payload_omitted".to_string(), Value::Bool(true));
+        body.insert(
+            "omission_reason".to_string(),
+            Value::String("admin-traffic-metadata-only".to_string()),
+        );
+    }
+}
+
+fn capture_status(snapshot: &TrafficProjectionSnapshot, retained_frames: usize) -> Value {
+    let captured_decision_count = decision_count(&snapshot.recent_decisions, "captured");
+    let skipped_decision_count = decision_count(&snapshot.recent_decisions, "skipped");
+    let skip_reasons = skip_reasons(&snapshot.recent_decisions);
+    let redacted_paths = redacted_paths(&snapshot.recent_decisions);
+    let state = capture_state(
+        snapshot.enabled,
+        snapshot.live_sink_enabled,
+        retained_frames,
+        skipped_decision_count,
+    );
+
+    json!({
+        "state": state,
+        "message": capture_message(state),
+        "capture_enabled": snapshot.enabled,
+        "live_sink_enabled": snapshot.live_sink_enabled,
+        "sink_count": snapshot.sink_count,
+        "subscriber_enabled": snapshot.subscriber_enabled,
+        "retained_frames": retained_frames,
+        "recent_decision_count": snapshot.recent_decisions.len(),
+        "captured_decision_count": captured_decision_count,
+        "skipped_decision_count": skipped_decision_count,
+        "skip_reasons": skip_reasons,
+        "redacted_path_count": redacted_paths.len(),
+        "redacted_paths": redacted_paths,
+        "safe_to_share": true,
+        "payload_policy": "metadata-only",
+        "retention": {
+            "admin_live_configured": snapshot.live_sink_enabled,
+            "ring_buffer_capacity": snapshot.admin_live_capacity,
+        },
+    })
+}
+
+fn capture_state(
+    capture_enabled: bool,
+    live_sink_enabled: bool,
+    retained_frames: usize,
+    skipped_decision_count: usize,
+) -> &'static str {
+    if retained_frames > 0 {
+        "captured"
+    } else if !capture_enabled {
+        "capture_disabled"
+    } else if !live_sink_enabled {
+        "capture_unavailable"
+    } else if skipped_decision_count > 0 {
+        "capture_filtered"
+    } else {
+        "no_traffic"
+    }
+}
+
+fn capture_message(state: &str) -> &'static str {
+    match state {
+        "captured" => "Sanitized traffic metadata is retained in the admin live ring.",
+        "capture_disabled" => {
+            "Traffic capture is disabled; the panel is showing zero retained frames by configuration."
+        }
+        "capture_unavailable" => {
+            "Traffic capture is enabled, but no admin_live sink is configured for this panel."
+        }
+        "capture_filtered" => {
+            "Recent gateway traffic was skipped by capture filters or redaction policy before live retention."
+        }
+        _ => {
+            "Admin live capture is ready, but no matching traffic has been observed in the retained range."
+        }
+    }
+}
+
+fn decision_count(decisions: &[GovernanceCaptureDecision], outcome: &str) -> usize {
+    decisions
+        .iter()
+        .filter(|decision| decision.outcome == outcome)
+        .count()
+}
+
+fn skip_reasons(decisions: &[GovernanceCaptureDecision]) -> Vec<String> {
+    decisions
+        .iter()
+        .filter_map(|decision| decision.reason.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn redacted_paths(decisions: &[GovernanceCaptureDecision]) -> Vec<String> {
+    decisions
+        .iter()
+        .flat_map(|decision| decision.redacted_paths.iter().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::UNIX_EPOCH;
+
+    use super::*;
+
+    fn decision(outcome: &str) -> GovernanceCaptureDecision {
+        GovernanceCaptureDecision {
+            timestamp: UNIX_EPOCH,
+            request_id: Some("request-1".to_string()),
+            trace_id: None,
+            session_id: None,
+            transport: "mcp".to_string(),
+            mcp_method: Some("tools/call".to_string()),
+            outcome: outcome.to_string(),
+            reason: (outcome == "skipped").then(|| "method-filter".to_string()),
+            redacted_paths: vec!["$.arguments.token".to_string()],
+        }
+    }
+
+    fn snapshot() -> TrafficProjectionSnapshot {
+        TrafficProjectionSnapshot {
+            enabled: true,
+            sink_count: 1,
+            subscriber_enabled: false,
+            live_sink_enabled: true,
+            admin_live_capacity: Some(32),
+            recent_decisions: vec![decision("captured")],
+        }
+    }
+
+    #[test]
+    fn payload_removes_body_data_and_reports_capture_state() {
+        let payload = traffic_payload(
+            vec![json!({
+                "attributes": {"body": {"data": "secret", "size": 6}},
+                "event": "traffic"
+            })],
+            &snapshot(),
+            json!({"self": "/admin/api/traffic"}),
+        );
+
+        assert_eq!(payload["capture_status"]["state"], "captured");
+        assert_eq!(payload["capture_status"]["safe_to_share"], true);
+        assert_eq!(
+            payload["frames"][0]["attributes"]["body"]["data"],
+            Value::Null
+        );
+        assert_eq!(
+            payload["frames"][0]["attributes"]["body"]["payload_omitted"],
+            true
+        );
+    }
+
+    #[test]
+    fn filtered_capture_and_jsonl_export_share_sanitization() {
+        let mut snapshot = snapshot();
+        snapshot.recent_decisions = vec![decision("skipped")];
+        let payload = traffic_payload(vec![], &snapshot, Value::Null);
+        assert_eq!(payload["capture_status"]["state"], "capture_filtered");
+
+        let export = traffic_jsonl_export(vec![json!({
+            "attributes": {"body": {"data": {"token": "secret"}}}
+        })]);
+        assert!(!export.contains("secret"));
+        assert!(export.contains("admin-traffic-metadata-only"));
+        assert_eq!(export.lines().count(), 1);
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/governance.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/governance.rs
@@ -93,7 +93,9 @@ fn governance_capture_decisions(
         .collect()
 }
 
-fn governance_capture_decision(decision: &TrafficCaptureDecision) -> GovernanceCaptureDecision {
+pub(super) fn governance_capture_decision(
+    decision: &TrafficCaptureDecision,
+) -> GovernanceCaptureDecision {
     GovernanceCaptureDecision {
         timestamp: decision.timestamp,
         request_id: decision.request_id.clone(),

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -25,9 +25,9 @@
 //!
 //! The runtime UI is a single inline HTML string (`admin/html.rs`). The
 //! `dcc-mcp-gateway-admin` crate owns the trace domain, compact, link,
-//! issue-report, statistics, analytics, and governance projections, Vite/npm
-//! build boundary, and embedded asset; this module owns the gateway-specific
-//! data-source/HTTP adapters and API handlers.
+//! issue-report, statistics, analytics, governance, and traffic projections,
+//! Vite/npm build boundary, and embedded asset; this module owns the
+//! gateway-specific data-source/HTTP adapters and API handlers.
 //!
 //! # Module layout (PIP-687 split)
 //!

--- a/crates/dcc-mcp-gateway/src/gateway/admin/traffic.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/traffic.rs
@@ -1,178 +1,45 @@
-//! Admin traffic projection.
-//!
-//! The capture layer may retain high-sensitivity payloads for explicit private
-//! replay sinks. The admin API presents a metadata-only projection so operators
-//! can understand capture state without leaking tool arguments.
+//! Gateway adapters for metadata-only admin traffic projections.
 
-use std::collections::BTreeSet;
+use dcc_mcp_gateway_admin::{TrafficProjectionSnapshot, traffic_jsonl_export, traffic_payload};
+use serde_json::Value;
 
-use dcc_mcp_actions::events::EventEnvelope;
-use serde_json::{Value, json};
-
-use crate::gateway::traffic::{TrafficCapture, TrafficCaptureDecision, TrafficCaptureSnapshot};
-
-const SCHEMA_VERSION: &str = "dcc-mcp.admin.traffic.v1";
+use super::governance::governance_capture_decision;
+use crate::gateway::traffic::{TrafficCapture, TrafficCaptureSnapshot};
 
 pub(super) fn build_traffic_payload(capture: &TrafficCapture, limit: usize, links: Value) -> Value {
-    let frames: Vec<Value> = capture
+    let frames = capture
         .recent_frames(limit)
         .into_iter()
-        .map(sanitized_frame_value)
+        .map(|frame| frame.to_value())
         .collect();
-    let snapshot = capture.governance_snapshot();
-    let capture_status = capture_status(&snapshot, frames.len());
-
-    json!({
-        "schema_version": SCHEMA_VERSION,
-        "total": frames.len(),
-        "frames": frames,
-        "capture_status": capture_status,
-        "links": links,
-    })
+    let snapshot = traffic_projection_snapshot(&capture.governance_snapshot());
+    traffic_payload(frames, &snapshot, links)
 }
 
 pub(super) fn build_traffic_export_body(capture: &TrafficCapture, limit: usize) -> String {
-    let mut body = String::new();
-    for frame in capture.recent_frames(limit) {
-        if let Ok(line) = serde_json::to_string(&sanitized_frame_value(frame)) {
-            body.push_str(&line);
-            body.push('\n');
-        }
-    }
-    body
+    let frames = capture
+        .recent_frames(limit)
+        .into_iter()
+        .map(|frame| frame.to_value())
+        .collect();
+    traffic_jsonl_export(frames)
 }
 
-fn sanitized_frame_value(frame: EventEnvelope) -> Value {
-    let mut value = frame.to_value();
-    if let Some(attributes) = value
-        .as_object_mut()
-        .and_then(|map| map.get_mut("attributes"))
-    {
-        sanitize_attributes(attributes);
-    }
-    value
-}
-
-fn sanitize_attributes(attributes: &mut Value) {
-    let Some(map) = attributes.as_object_mut() else {
-        return;
-    };
-
-    if let Some(body) = map.get_mut("body").and_then(Value::as_object_mut) {
-        body.remove("data");
-        body.insert("payload_omitted".to_string(), Value::Bool(true));
-        body.insert(
-            "omission_reason".to_string(),
-            Value::String("admin-traffic-metadata-only".to_string()),
-        );
-    }
-}
-
-fn capture_status(snapshot: &TrafficCaptureSnapshot, retained_frames: usize) -> Value {
-    let live_sink_enabled = snapshot
+fn traffic_projection_snapshot(snapshot: &TrafficCaptureSnapshot) -> TrafficProjectionSnapshot {
+    let admin_live = snapshot
         .sinks
         .iter()
-        .any(|sink| sink.kind.eq_ignore_ascii_case("admin_live"));
-    let captured_decision_count = decision_count(&snapshot.recent_decisions, "captured");
-    let skipped_decision_count = decision_count(&snapshot.recent_decisions, "skipped");
-    let skip_reasons = skip_reasons(&snapshot.recent_decisions);
-    let redacted_paths = redacted_paths(&snapshot.recent_decisions);
-    let state = capture_state(
-        snapshot.enabled,
-        live_sink_enabled,
-        retained_frames,
-        skipped_decision_count,
-    );
-
-    json!({
-        "state": state,
-        "message": capture_message(state),
-        "capture_enabled": snapshot.enabled,
-        "live_sink_enabled": live_sink_enabled,
-        "sink_count": snapshot.sink_count,
-        "subscriber_enabled": snapshot.subscriber_enabled,
-        "retained_frames": retained_frames,
-        "recent_decision_count": snapshot.recent_decisions.len(),
-        "captured_decision_count": captured_decision_count,
-        "skipped_decision_count": skipped_decision_count,
-        "skip_reasons": skip_reasons,
-        "redacted_path_count": redacted_paths.len(),
-        "redacted_paths": redacted_paths,
-        "safe_to_share": true,
-        "payload_policy": "metadata-only",
-        "retention": {
-            "admin_live_configured": live_sink_enabled,
-            "ring_buffer_capacity": admin_live_capacity(snapshot),
-        },
-    })
-}
-
-fn capture_state(
-    capture_enabled: bool,
-    live_sink_enabled: bool,
-    retained_frames: usize,
-    skipped_decision_count: usize,
-) -> &'static str {
-    if retained_frames > 0 {
-        "captured"
-    } else if !capture_enabled {
-        "capture_disabled"
-    } else if !live_sink_enabled {
-        "capture_unavailable"
-    } else if skipped_decision_count > 0 {
-        "capture_filtered"
-    } else {
-        "no_traffic"
+        .find(|sink| sink.kind.eq_ignore_ascii_case("admin_live"));
+    TrafficProjectionSnapshot {
+        enabled: snapshot.enabled,
+        sink_count: snapshot.sink_count,
+        subscriber_enabled: snapshot.subscriber_enabled,
+        live_sink_enabled: admin_live.is_some(),
+        admin_live_capacity: admin_live.and_then(|sink| sink.ring_buffer_capacity),
+        recent_decisions: snapshot
+            .recent_decisions
+            .iter()
+            .map(governance_capture_decision)
+            .collect(),
     }
-}
-
-fn capture_message(state: &str) -> &'static str {
-    match state {
-        "captured" => "Sanitized traffic metadata is retained in the admin live ring.",
-        "capture_disabled" => {
-            "Traffic capture is disabled; the panel is showing zero retained frames by configuration."
-        }
-        "capture_unavailable" => {
-            "Traffic capture is enabled, but no admin_live sink is configured for this panel."
-        }
-        "capture_filtered" => {
-            "Recent gateway traffic was skipped by capture filters or redaction policy before live retention."
-        }
-        _ => {
-            "Admin live capture is ready, but no matching traffic has been observed in the retained range."
-        }
-    }
-}
-
-fn decision_count(decisions: &[TrafficCaptureDecision], outcome: &str) -> usize {
-    decisions
-        .iter()
-        .filter(|decision| decision.outcome == outcome)
-        .count()
-}
-
-fn skip_reasons(decisions: &[TrafficCaptureDecision]) -> Vec<String> {
-    decisions
-        .iter()
-        .filter_map(|decision| decision.reason.clone())
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect()
-}
-
-fn redacted_paths(decisions: &[TrafficCaptureDecision]) -> Vec<String> {
-    decisions
-        .iter()
-        .flat_map(|decision| decision.redacted_paths.iter().cloned())
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect()
-}
-
-fn admin_live_capacity(snapshot: &TrafficCaptureSnapshot) -> Option<usize> {
-    snapshot
-        .sinks
-        .iter()
-        .find(|sink| sink.kind.eq_ignore_ascii_case("admin_live"))
-        .and_then(|sink| sink.ring_buffer_capacity)
 }

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, and governance projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,7 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance domain + optional embedded dashboard asset
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/traffic domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -122,7 +122,7 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance domain + optional embedded dashboard asset
+dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/traffic domain + optional embedded dashboard asset
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
@@ -392,7 +392,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, and governance contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
 
 **Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics 与 governance projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,7 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance 领域和可选嵌入式 dashboard 资产
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/traffic 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -102,7 +102,7 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance 领域和可选嵌入式 dashboard 资产
+dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/traffic 领域和可选嵌入式 dashboard 资产
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
@@ -293,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics 与 governance 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, and governance projections, plus the optional embedded dashboard asset.
+- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, and metadata-only traffic projections, plus the optional embedded dashboard asset.
 - **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
@@ -282,7 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move metadata-only traffic sanitization, status projection, and JSONL export into `dcc-mcp-gateway-admin`
- keep capture ring reads and gateway snapshot adapters in `dcc-mcp-gateway`
- preserve existing admin traffic payload and export contracts

Part of #2187.

## Validation
- `vx just preflight`
- admin traffic domain tests: 50 passed
- gateway admin traffic endpoint tests: 5 passed
- public documentation scan contains no `_thm` or `rez_local_cache` paths

Creator Skills require no changes because adapter and skill-authoring workflows are unchanged.