### PR TITLE
refactor: extract admin artifact projection

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/artifacts.rs
+++ b/crates/dcc-mcp-gateway-admin/src/artifacts.rs
@@ -1,0 +1,233 @@
+//! Artifact extraction and verification projections for the admin dashboard.
+
+use serde_json::{Value, json};
+
+/// Optional filters applied to the admin artifact projection.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ArtifactFilter {
+    pub dcc_type: Option<String>,
+    pub status: Option<String>,
+}
+
+/// Extract file references from a tool output and attach its DCC type.
+#[must_use]
+pub fn artifact_refs(output: &Value, dcc_type: Option<&str>) -> Vec<Value> {
+    let mut refs = Vec::new();
+    collect_file_refs(output, &mut refs, true, false);
+    refs.into_iter()
+        .map(|artifact| with_dcc_type(artifact, dcc_type))
+        .collect()
+}
+
+/// Build the filtered artifact verification payload returned by the admin API.
+#[must_use]
+pub fn artifact_payload(artifacts: Vec<Value>, filter: &ArtifactFilter, limit: usize) -> Value {
+    let mut artifacts = deduplicate_artifacts(artifacts);
+    let mut verified_count = 0usize;
+    let mut unverified_count = 0usize;
+    let mut failed_count = 0usize;
+
+    for artifact in &mut artifacts {
+        let verification = artifact_verification(artifact);
+        match verification
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unverified")
+        {
+            "verified" => verified_count += 1,
+            "failed" => failed_count += 1,
+            _ => unverified_count += 1,
+        }
+        if let Some(object) = artifact.as_object_mut() {
+            object.insert("verification".to_string(), verification);
+        }
+    }
+
+    if let Some(dcc_filter) = &filter.dcc_type {
+        artifacts.retain(|artifact| {
+            artifact
+                .get("dcc_type")
+                .and_then(Value::as_str)
+                .is_some_and(|dcc| dcc.eq_ignore_ascii_case(dcc_filter))
+        });
+    }
+    if let Some(status_filter) = &filter.status {
+        artifacts.retain(|artifact| {
+            artifact
+                .pointer("/verification/status")
+                .and_then(Value::as_str)
+                .is_some_and(|status| status.eq_ignore_ascii_case(status_filter))
+        });
+    }
+    artifacts.truncate(limit.clamp(1, 500));
+
+    let total = artifacts.len();
+    if total == 0 && verified_count == 0 && unverified_count == 0 {
+        return json!({
+            "total": 0,
+            "artifacts": [],
+            "summary": {
+                "verified": 0,
+                "unverified": 0,
+                "failed": 0,
+            },
+            "message": "No artifacts found. Artifacts are derived from tool-call output payloads containing file references.",
+        });
+    }
+
+    json!({
+        "total": total,
+        "artifacts": artifacts,
+        "summary": {
+            "verified": verified_count,
+            "unverified": unverified_count,
+            "failed": failed_count,
+        },
+    })
+}
+
+fn collect_file_refs(value: &Value, refs: &mut Vec<Value>, root: bool, file_collection: bool) {
+    match value {
+        Value::Object(object) => {
+            if (root || file_collection) && value.get("uri").and_then(Value::as_str).is_some() {
+                push_file_ref(value, refs);
+                return;
+            }
+            for (key, child) in object {
+                collect_file_refs(
+                    child,
+                    refs,
+                    false,
+                    matches!(key.as_str(), "files" | "artifacts" | "file_refs"),
+                );
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_file_refs(item, refs, false, file_collection);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_file_ref(value: &Value, refs: &mut Vec<Value>) {
+    if !refs
+        .iter()
+        .any(|existing| same_artifact_identity(existing, value))
+    {
+        refs.push(value.clone());
+    }
+}
+
+fn deduplicate_artifacts(artifacts: Vec<Value>) -> Vec<Value> {
+    let mut unique = Vec::new();
+    for artifact in artifacts {
+        if !unique
+            .iter()
+            .any(|existing| same_artifact_identity(existing, &artifact))
+        {
+            unique.push(artifact);
+        }
+    }
+    unique
+}
+
+fn same_artifact_identity(left: &Value, right: &Value) -> bool {
+    ["uri", "session_id", "correlation_id"]
+        .into_iter()
+        .all(|key| left.get(key) == right.get(key))
+}
+
+fn with_dcc_type(mut artifact: Value, dcc_type: Option<&str>) -> Value {
+    if let (Some(object), Some(dcc_type)) = (artifact.as_object_mut(), dcc_type) {
+        object.insert("dcc_type".to_string(), json!(dcc_type));
+    }
+    artifact
+}
+
+fn artifact_verification(artifact: &Value) -> Value {
+    if artifact.get("error").is_some() {
+        return json!({
+            "status": "failed",
+            "checked_at": chrono::Utc::now().to_rfc3339(),
+            "reason": artifact.get("error").and_then(Value::as_str).unwrap_or("unknown error"),
+        });
+    }
+
+    if artifact.get("sha256").is_some() || artifact.get("digest").is_some() {
+        return json!({
+            "status": "verified",
+            "checked_at": chrono::Utc::now().to_rfc3339(),
+            "method": "sha256_metadata",
+        });
+    }
+
+    json!({
+        "status": "unverified",
+        "checked_at": chrono::Utc::now().to_rfc3339(),
+        "reason": "no integrity metadata available",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nested_artifacts_are_deduplicated_by_capture_identity() {
+        let value = json!({
+            "result": {"artifacts": [{
+                "uri": "artefact://sha256/abc",
+                "display_name": "snapshot.png",
+                "digest": "sha256:abc",
+                "session_id": "session-a",
+                "correlation_id": "snapshot-a"
+            }]},
+            "duplicate": {"artifacts": [{
+                "uri": "artefact://sha256/abc",
+                "session_id": "session-a",
+                "correlation_id": "snapshot-a"
+            }]},
+            "new_capture": {"artifacts": [{
+                "uri": "artefact://sha256/abc",
+                "session_id": "session-b",
+                "correlation_id": "snapshot-b"
+            }]}
+        });
+
+        let artifacts = artifact_refs(&value, Some("unity"));
+        assert_eq!(artifacts.len(), 2);
+        assert_eq!(artifacts[0]["display_name"], "snapshot.png");
+        assert_eq!(artifacts[0]["dcc_type"], "unity");
+    }
+
+    #[test]
+    fn payload_enriches_filters_and_summarizes_verification() {
+        let payload = artifact_payload(
+            vec![
+                json!({"uri": "file:///verified", "dcc_type": "maya", "digest": "sha256:1"}),
+                json!({"uri": "file:///failed", "dcc_type": "maya", "error": "missing"}),
+                json!({"uri": "file:///plain", "dcc_type": "blender"}),
+            ],
+            &ArtifactFilter {
+                dcc_type: Some("maya".to_string()),
+                status: Some("verified".to_string()),
+            },
+            100,
+        );
+
+        assert_eq!(payload["total"], 1);
+        assert_eq!(payload["artifacts"][0]["uri"], "file:///verified");
+        assert_eq!(payload["summary"]["verified"], 1);
+        assert_eq!(payload["summary"]["failed"], 1);
+        assert_eq!(payload["summary"]["unverified"], 1);
+    }
+
+    #[test]
+    fn empty_payload_keeps_operator_message() {
+        let payload = artifact_payload(vec![], &ArtifactFilter::default(), 100);
+        assert_eq!(payload["total"], 0);
+        assert!(payload["message"].as_str().is_some());
+    }
+}

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -1,14 +1,15 @@
 //! Domain and embedded frontend boundary for the DCC-MCP gateway admin dashboard.
 //!
 //! This crate owns admin-facing audit, trace, caller-context, compact projection,
-//! link, issue-report, statistics, analytics, governance, and traffic projections independently of
-//! gateway routing state.
+//! link, issue-report, statistics, analytics, governance, artifact, and traffic projections
+//! independently of gateway routing state.
 //! It also owns the Vite/npm build script and generated dashboard payload; the Node.js
 //! toolchain only runs when `embed` is enabled.
 
 #![forbid(unsafe_code)]
 
 mod analytics;
+mod artifacts;
 mod audit;
 /// Admin trace and caller-attribution value types.
 pub mod domain;
@@ -24,6 +25,7 @@ pub use analytics::{
     AnalyticsQuery, analytics_csv_export, analytics_heatmap_payload, analytics_jsonl_export,
     analytics_overview_payload, analytics_range_duration, analytics_timeseries_payload,
 };
+pub use artifacts::{ArtifactFilter, artifact_payload, artifact_refs};
 pub use audit::{AdminAuditRecord, AuditLog};
 pub use domain::agent_context::{
     AgentContext, AgentContextTrust, INTERNAL_AUTH_SUBJECT_HEADER, INTERNAL_FORWARDED_FOR_HEADER,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/artifacts.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/artifacts.rs
@@ -1,13 +1,14 @@
 //! Artifact verification API handler.
 //!
 //! Provides `GET /admin/api/artifacts` — aggregates artifact data from
-//! trace/audit logs and the dcc-mcp-artefact store.
+//! trace/audit logs and delegates the pure projection to the admin domain.
 
 use axum::Json;
 use axum::extract::{Query, State};
 use axum::response::IntoResponse;
+use dcc_mcp_gateway_admin::{ArtifactFilter, artifact_payload, artifact_refs};
 use serde::Deserialize;
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use dcc_mcp_db::env::ENV_DCC_MCP_LOG_DIR;
 use dcc_mcp_db::read_gateway_log_dir_rows_recent;
@@ -35,50 +36,31 @@ pub async fn handle_admin_artifacts(
     Query(params): Query<ArtifactsQuery>,
 ) -> impl IntoResponse {
     let limit = params.limit.unwrap_or(100).clamp(1, 500);
-
-    // Collect artifacts from audit records and traces.
-    // An artifact is identified when a trace/audit entry has output payloads
-    // that contain file references (URI, MIME, size).
     let mut artifacts: Vec<Value> = Vec::new();
 
-    // 1. From trace log ring buffer
     if let Some(trace_log) = &s.trace_log {
         for trace in trace_log.recent(limit) {
             if let Some(output) = &trace.output
                 && let Ok(parsed) = serde_json::from_str::<Value>(&output.content)
             {
-                let file_refs = extract_file_refs(&parsed);
-                for fr in file_refs {
-                    artifacts.push(with_dcc_type(fr, trace.dcc_type.as_deref()));
-                }
+                artifacts.extend(artifact_refs(&parsed, trace.dcc_type.as_deref()));
             }
         }
     }
 
-    // 2. From SQLite (traces table)
     if let Some(ref lane) = s.admin_sqlite_lane {
         let reader = lane.reader();
-        let traces = reader.list_traces_since(None, limit);
-        for trace in traces {
+        for trace in reader.list_traces_since(None, limit) {
             if let Some(output) = &trace.output
                 && let Ok(parsed) = serde_json::from_str::<Value>(&output.content)
             {
-                let file_refs = extract_file_refs(&parsed);
-                for fr in file_refs {
-                    let fr = with_dcc_type(fr, trace.dcc_type.as_deref());
-                    if !artifacts
-                        .iter()
-                        .any(|existing| same_artifact_identity(existing, &fr))
-                    {
-                        artifacts.push(fr);
-                    }
-                }
+                artifacts.extend(artifact_refs(&parsed, trace.dcc_type.as_deref()));
             }
         }
     }
 
-    // 3. From UI Control's existing redacted file audit stream. Direct
-    // instance calls do not necessarily traverse the gateway trace middleware.
+    // Direct UI Control calls do not necessarily traverse gateway tracing, so
+    // retain the existing redacted file-audit source at the infrastructure edge.
     let log_dir = std::env::var(ENV_DCC_MCP_LOG_DIR)
         .unwrap_or_else(|_| dcc_mcp_db::default_gateway_log_dir());
     if let Ok(rows) =
@@ -86,234 +68,17 @@ pub async fn handle_admin_artifacts(
     {
         for row in rows {
             let dcc_type = row.get("dcc_type").and_then(Value::as_str);
-            for fr in extract_file_refs(&row) {
-                let fr = with_dcc_type(fr, dcc_type);
-                if !artifacts
-                    .iter()
-                    .any(|existing| same_artifact_identity(existing, &fr))
-                {
-                    artifacts.push(fr);
-                }
-            }
+            artifacts.extend(artifact_refs(&row, dcc_type));
         }
     }
 
-    // 4. Enrich with verification status from artefact store (best-effort)
-    let mut verified_count = 0usize;
-    let mut unverified_count = 0usize;
-    let mut failed_count = 0usize;
-
-    for artifact in &mut artifacts {
-        let verification = check_artifact_verification(artifact);
-        let status = verification
-            .get("status")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unverified");
-        match status {
-            "verified" => verified_count += 1,
-            "failed" => failed_count += 1,
-            _ => unverified_count += 1,
-        }
-        if let Some(obj) = artifact.as_object_mut() {
-            obj.insert("verification".to_string(), verification);
-        }
-    }
-
-    // Apply filters
-    if let Some(ref dcc_filter) = params.dcc_type {
-        artifacts.retain(|a| {
-            a.get("dcc_type")
-                .and_then(|v| v.as_str())
-                .is_some_and(|d| d.eq_ignore_ascii_case(dcc_filter))
-        });
-    }
-    if let Some(ref status_filter) = params.status {
-        artifacts.retain(|a| {
-            a.get("verification")
-                .and_then(|v| v.get("status"))
-                .and_then(|v| v.as_str())
-                .is_some_and(|s| s.eq_ignore_ascii_case(status_filter))
-        });
-    }
-
-    artifacts.truncate(limit);
-
-    let total = artifacts.len();
-    if total == 0 && verified_count == 0 && unverified_count == 0 {
-        // If no artifacts were found from traces, include a placeholder with
-        // gateway health data so the frontend panel is not empty.
-        return Json(json!({
-            "total": 0,
-            "artifacts": [],
-            "summary": {
-                "verified": 0,
-                "unverified": 0,
-                "failed": 0,
-            },
-            "message": "No artifacts found. Artifacts are derived from tool-call output payloads containing file references.",
-        }))
-        .into_response();
-    }
-
-    Json(json!({
-        "total": total,
-        "artifacts": artifacts,
-        "summary": {
-            "verified": verified_count,
-            "unverified": unverified_count,
-            "failed": failed_count,
+    Json(artifact_payload(
+        artifacts,
+        &ArtifactFilter {
+            dcc_type: params.dcc_type,
+            status: params.status,
         },
-    }))
+        limit,
+    ))
     .into_response()
-}
-
-/// Extract file references from a tool-call output payload.
-///
-/// Recognises wrapped or direct JSON payloads containing `files`, `artifacts`,
-/// `file_refs`, or a single file-like object with a `uri` field.
-fn extract_file_refs(output: &Value) -> Vec<Value> {
-    let mut refs = Vec::new();
-    collect_file_refs(output, &mut refs, true, false);
-    refs
-}
-
-fn collect_file_refs(value: &Value, refs: &mut Vec<Value>, root: bool, file_collection: bool) {
-    match value {
-        Value::Object(object) => {
-            if (root || file_collection) && value.get("uri").and_then(Value::as_str).is_some() {
-                push_file_ref(value, refs);
-                return;
-            }
-            for (key, child) in object {
-                collect_file_refs(
-                    child,
-                    refs,
-                    false,
-                    matches!(key.as_str(), "files" | "artifacts" | "file_refs"),
-                );
-            }
-        }
-        Value::Array(items) => {
-            for item in items {
-                collect_file_refs(item, refs, false, file_collection);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn push_file_ref(value: &Value, refs: &mut Vec<Value>) {
-    if !refs
-        .iter()
-        .any(|existing| same_artifact_identity(existing, value))
-    {
-        refs.push(value.clone());
-    }
-}
-
-fn same_artifact_identity(left: &Value, right: &Value) -> bool {
-    ["uri", "session_id", "correlation_id"]
-        .into_iter()
-        .all(|key| left.get(key) == right.get(key))
-}
-
-fn with_dcc_type(mut artifact: Value, dcc_type: Option<&str>) -> Value {
-    if let (Some(object), Some(dcc_type)) = (artifact.as_object_mut(), dcc_type) {
-        object.insert("dcc_type".to_string(), json!(dcc_type));
-    }
-    artifact
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn extracts_nested_artifacts_once_for_admin_tracing() {
-        let value = json!({
-            "result": {
-                "structuredContent": {
-                    "context": {
-                        "artifacts": [{
-                            "uri": "artefact://sha256/abc",
-                            "display_name": "ui-control-snapshot-session-snapshot.png",
-                            "digest": "sha256:abc",
-                            "session_id": "session-a",
-                            "correlation_id": "snapshot-a"
-                        }]
-                    }
-                }
-            },
-            "duplicate": {"artifacts": [{
-                "uri": "artefact://sha256/abc",
-                "session_id": "session-a",
-                "correlation_id": "snapshot-a"
-            }]},
-            "same_pixels_new_capture": {"artifacts": [{
-                "uri": "artefact://sha256/abc",
-                "session_id": "session-b",
-                "correlation_id": "snapshot-b"
-            }]}
-        });
-
-        let artifacts = extract_file_refs(&value);
-
-        assert_eq!(artifacts.len(), 2);
-        assert_eq!(
-            artifacts[0]["display_name"],
-            "ui-control-snapshot-session-snapshot.png"
-        );
-        assert_eq!(
-            with_dcc_type(artifacts[0].clone(), Some("unity"))["dcc_type"],
-            "unity"
-        );
-    }
-
-    #[test]
-    fn extracts_ui_control_artifact_from_file_audit_row() {
-        let row = json!({
-            "dcc_type": "unity",
-            "artifacts": [{
-                "uri": "artefact://sha256/abc",
-                "display_name": "ui-control-snapshot-session-snapshot.png",
-                "session_id": "session-a",
-                "correlation_id": "snapshot-a"
-            }]
-        });
-
-        let artifact = with_dcc_type(extract_file_refs(&row).remove(0), row["dcc_type"].as_str());
-        assert_eq!(artifact["dcc_type"], "unity");
-    }
-}
-
-/// Check verification status of an artifact.
-///
-/// Currently a best-effort check: if the artifact has a `sha256` field,
-/// we mark it as "verified"; if it has an `error` field, "failed";
-/// otherwise "unverified".
-///
-/// Future: integrate with `dcc-mcp-artefact::ArtefactStore` to check
-/// on-disk file existence and SHA-256 integrity.
-fn check_artifact_verification(artifact: &Value) -> Value {
-    if artifact.get("error").is_some() {
-        return json!({
-            "status": "failed",
-            "checked_at": chrono::Utc::now().to_rfc3339(),
-            "reason": artifact.get("error").and_then(|v| v.as_str()).unwrap_or("unknown error"),
-        });
-    }
-
-    if artifact.get("sha256").is_some() || artifact.get("digest").is_some() {
-        return json!({
-            "status": "verified",
-            "checked_at": chrono::Utc::now().to_rfc3339(),
-            "method": "sha256_metadata",
-        });
-    }
-
-    json!({
-        "status": "unverified",
-        "checked_at": chrono::Utc::now().to_rfc3339(),
-        "reason": "no integrity metadata available",
-    })
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/basic_endpoint_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/basic_endpoint_tests.rs
@@ -292,6 +292,7 @@ mod endpoint_contracts {
             "/api/logs",
             "/api/stats",
             "/api/governance",
+            "/api/artifacts",
             "/api/traces",
             "/api/workflows",
         ] {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -25,7 +25,7 @@
 //!
 //! The runtime UI is a single inline HTML string (`admin/html.rs`). The
 //! `dcc-mcp-gateway-admin` crate owns the trace domain, compact, link,
-//! issue-report, statistics, analytics, governance, and traffic projections,
+//! issue-report, statistics, analytics, governance, artifact, and traffic projections,
 //! Vite/npm build boundary, and embedded asset; this module owns the
 //! gateway-specific data-source/HTTP adapters and API handlers.
 //!

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,7 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/traffic domain + optional embedded dashboard asset
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -122,7 +122,7 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/traffic domain + optional embedded dashboard asset
+dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic domain + optional embedded dashboard asset
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
@@ -392,7 +392,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
 
 **Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,7 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/traffic 领域和可选嵌入式 dashboard 资产
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -102,7 +102,7 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/traffic 领域和可选嵌入式 dashboard 资产
+dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic 领域和可选嵌入式 dashboard 资产
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
@@ -293,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, and metadata-only traffic projections, plus the optional embedded dashboard asset.
+- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, and metadata-only traffic projections, plus the optional embedded dashboard asset.
 - **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
@@ -282,7 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move artifact extraction, deduplication, verification, and filtering into `dcc-mcp-gateway-admin`
- keep trace, SQLite, log access, and HTTP routing in the gateway adapter
- document the artifact projection ownership boundary

## Validation
- `vx just preflight` (3571 tests passed)
- admin endpoint contract test
- public docs contain no `_thm` or `rez_local_cache` paths
- creator Skills unchanged because adapter and skill-authoring workflows are unaffected

Part of #2187