### PR TITLE
refactor: extract admin activity projection

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/activity.rs
+++ b/crates/dcc-mcp-gateway-admin/src/activity.rs
@@ -1,0 +1,267 @@
+//! Pure activity timeline projections for the admin dashboard.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use serde_json::{Value, json};
+
+use crate::{AdminAuditRecord, DispatchTrace, TokenTelemetry};
+
+/// Correlation fields shared by audit, trace, and gateway activity rows.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ActivityCorrelation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_span_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dcc_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actor_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actor_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_platform: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_request_id: Option<String>,
+}
+
+/// One backend-neutral row in the unified activity timeline.
+#[derive(Debug, Clone, Serialize)]
+pub struct ActivityEvent {
+    pub event_id: String,
+    pub timestamp: String,
+    pub kind: String,
+    pub severity: String,
+    pub status: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_accounting: Option<TokenTelemetry>,
+    pub correlation: ActivityCorrelation,
+}
+
+/// Gateway-owned event data accepted by the admin timeline projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayActivityInput {
+    pub timestamp: String,
+    pub status: String,
+    pub reason: Option<String>,
+    pub dcc_type: String,
+    pub instance_id: String,
+}
+
+/// Build the unified activity payload from already-collected domain rows.
+#[must_use]
+pub fn activity_payload(
+    audits: &[AdminAuditRecord],
+    traces: &[DispatchTrace],
+    gateway_events: &[GatewayActivityInput],
+    limit: usize,
+) -> Value {
+    let mut events = audits
+        .iter()
+        .map(audit_activity_event)
+        .chain(traces.iter().map(trace_activity_event))
+        .chain(gateway_events.iter().map(gateway_activity_event))
+        .collect::<Vec<_>>();
+    events.sort_by(|left, right| right.timestamp.cmp(&left.timestamp));
+    events.truncate(limit);
+    json!({ "total": events.len(), "events": events })
+}
+
+/// Project an audit record into one activity row.
+#[must_use]
+pub fn audit_activity_event(record: &AdminAuditRecord) -> ActivityEvent {
+    ActivityEvent {
+        event_id: format!("audit:{}", record.request_id),
+        timestamp: rfc3339(record.timestamp),
+        kind: "tool_call".to_string(),
+        severity: if record.success { "info" } else { "error" }.to_string(),
+        status: if record.success { "ok" } else { "err" }.to_string(),
+        message: format!(
+            "{} {}",
+            record.method.as_deref().unwrap_or("call"),
+            record.action
+        ),
+        tool: Some(record.action.clone()),
+        duration_ms: record.duration_ms,
+        token_accounting: record.token_accounting.clone(),
+        correlation: ActivityCorrelation {
+            trace_id: record.trace_id.clone(),
+            span_id: record.span_id.clone(),
+            parent_span_id: record.parent_span_id.clone(),
+            request_id: Some(record.request_id.clone()),
+            session_id: record.session_id.clone(),
+            instance_id: record.instance_id.clone(),
+            dcc_type: record.dcc_type.clone(),
+            workflow_id: None,
+            job_id: None,
+            agent_id: record.agent_id.clone(),
+            actor_id: record.actor_id.clone(),
+            actor_name: record.actor_name.clone(),
+            client_platform: record.client_platform.clone(),
+            source_ip: record.source_ip.clone(),
+            parent_request_id: record.parent_request_id.clone(),
+        },
+    }
+}
+
+/// Project a dispatch trace into one activity row.
+#[must_use]
+pub fn trace_activity_event(trace: &DispatchTrace) -> ActivityEvent {
+    let tool = trace
+        .tool_slug
+        .clone()
+        .unwrap_or_else(|| trace.method.clone());
+    ActivityEvent {
+        event_id: format!("trace:{}", trace.request_id),
+        timestamp: rfc3339(trace.started_at),
+        kind: "dispatch_trace".to_string(),
+        severity: if trace.ok { "debug" } else { "error" }.to_string(),
+        status: if trace.ok { "ok" } else { "err" }.to_string(),
+        message: format!("{} completed in {}ms", tool, trace.total_ms),
+        tool: Some(tool),
+        duration_ms: Some(trace.total_ms),
+        token_accounting: trace.token_accounting.clone(),
+        correlation: trace_correlation(trace),
+    }
+}
+
+/// Project a gateway event DTO into one activity row.
+#[must_use]
+pub fn gateway_activity_event(event: &GatewayActivityInput) -> ActivityEvent {
+    ActivityEvent {
+        event_id: format!(
+            "gateway:{}:{}:{}",
+            event.timestamp, event.dcc_type, event.instance_id
+        ),
+        timestamp: event.timestamp.clone(),
+        kind: "gateway_event".to_string(),
+        severity: "info".to_string(),
+        status: event.status.clone(),
+        message: event.reason.clone().unwrap_or_else(|| {
+            format!(
+                "{} dcc_type={} instance={}",
+                event.status, event.dcc_type, event.instance_id
+            )
+        }),
+        tool: None,
+        duration_ms: None,
+        token_accounting: None,
+        correlation: ActivityCorrelation {
+            instance_id: Some(event.instance_id.clone()),
+            dcc_type: Some(event.dcc_type.clone()),
+            ..ActivityCorrelation::default()
+        },
+    }
+}
+
+/// Serialize a gateway event row for debug-bundle composition.
+#[must_use]
+pub fn gateway_activity_event_json(event: &GatewayActivityInput) -> Value {
+    serde_json::to_value(gateway_activity_event(event)).unwrap_or_else(|_| json!({}))
+}
+
+fn trace_correlation(trace: &DispatchTrace) -> ActivityCorrelation {
+    ActivityCorrelation {
+        trace_id: Some(trace.trace_id.clone()),
+        span_id: trace.span_id.clone(),
+        parent_span_id: trace.parent_span_id.clone(),
+        request_id: Some(trace.request_id.clone()),
+        session_id: trace.session_id.clone(),
+        instance_id: trace.instance_id.clone(),
+        dcc_type: trace.dcc_type.clone(),
+        workflow_id: None,
+        job_id: None,
+        agent_id: trace
+            .agent_context
+            .as_ref()
+            .and_then(|context| context.agent_id.clone()),
+        actor_id: trace
+            .agent_context
+            .as_ref()
+            .and_then(|context| context.actor_id.clone()),
+        actor_name: trace
+            .agent_context
+            .as_ref()
+            .and_then(|context| context.actor_name.clone()),
+        client_platform: trace
+            .agent_context
+            .as_ref()
+            .and_then(|context| context.client_platform.clone()),
+        source_ip: trace
+            .agent_context
+            .as_ref()
+            .and_then(|context| context.source_ip.clone()),
+        parent_request_id: trace
+            .agent_context
+            .as_ref()
+            .and_then(|context| context.parent_request_id.clone()),
+    }
+}
+
+fn rfc3339(timestamp: SystemTime) -> String {
+    timestamp
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|_| {
+            chrono::DateTime::<chrono::Utc>::from(timestamp)
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gateway_event(timestamp: &str, instance_id: &str) -> GatewayActivityInput {
+        GatewayActivityInput {
+            timestamp: timestamp.to_string(),
+            status: "host_died".to_string(),
+            reason: None,
+            dcc_type: "maya".to_string(),
+            instance_id: instance_id.to_string(),
+        }
+    }
+
+    #[test]
+    fn gateway_projection_preserves_operator_context_without_gateway_types() {
+        let event = gateway_activity_event(&gateway_event("2026-08-23T01:02:03Z", "abc123"));
+        assert_eq!(event.kind, "gateway_event");
+        assert_eq!(event.status, "host_died");
+        assert_eq!(event.correlation.dcc_type.as_deref(), Some("maya"));
+        assert!(event.message.contains("instance=abc123"));
+    }
+
+    #[test]
+    fn activity_payload_orders_newest_first_and_applies_limit() {
+        let events = vec![
+            gateway_event("2026-08-23T01:00:00Z", "older"),
+            gateway_event("2026-08-23T02:00:00Z", "newer"),
+        ];
+        let payload = activity_payload(&[], &[], &events, 1);
+        assert_eq!(payload["total"], 1);
+        assert_eq!(payload["events"][0]["correlation"]["instance_id"], "newer");
+    }
+}

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -1,13 +1,14 @@
 //! Domain and embedded frontend boundary for the DCC-MCP gateway admin dashboard.
 //!
 //! This crate owns admin-facing audit, trace, caller-context, compact projection,
-//! link, issue-report, statistics, analytics, governance, artifact, and traffic projections
-//! independently of gateway routing state.
+//! link, issue-report, statistics, analytics, governance, artifact, activity, and traffic
+//! projections independently of gateway routing state.
 //! It also owns the Vite/npm build script and generated dashboard payload; the Node.js
 //! toolchain only runs when `embed` is enabled.
 
 #![forbid(unsafe_code)]
 
+mod activity;
 mod analytics;
 mod artifacts;
 mod audit;
@@ -21,6 +22,11 @@ mod stats;
 mod trace_log;
 mod traffic;
 
+pub use activity::{
+    ActivityCorrelation, ActivityEvent, GatewayActivityInput, activity_payload,
+    audit_activity_event, gateway_activity_event, gateway_activity_event_json,
+    trace_activity_event,
+};
 pub use analytics::{
     AnalyticsQuery, analytics_csv_export, analytics_heatmap_payload, analytics_jsonl_export,
     analytics_overview_payload, analytics_range_duration, analytics_timeseries_payload,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/infra/activity.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/infra/activity.rs
@@ -9,8 +9,14 @@ use std::cmp::Reverse;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::time::UNIX_EPOCH;
 
+use dcc_mcp_gateway_admin::{
+    GatewayActivityInput, activity_payload, audit_activity_event, gateway_activity_event_json,
+    trace_activity_event,
+};
 use serde::Serialize;
 use serde_json::{Value, json};
+
+pub use dcc_mcp_gateway_admin::{ActivityCorrelation, ActivityEvent};
 
 #[cfg(feature = "admin")]
 use crate::gateway::admin::links::AdminLinkBuilder;
@@ -24,57 +30,6 @@ const POSTMORTEM_EVENT_LIMIT: usize = 10;
 const MAX_TASK_RELATED_IDS: usize = 32;
 const MAX_TASK_ARTEFACTS: usize = 8;
 const MAX_TASK_VALIDATIONS: usize = 8;
-
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct ActivityCorrelation {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub trace_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub span_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub parent_span_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub instance_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub dcc_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workflow_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub job_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub agent_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub actor_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub actor_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_platform: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_ip: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub parent_request_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct ActivityEvent {
-    pub event_id: String,
-    pub timestamp: String,
-    pub kind: String,
-    pub severity: String,
-    pub status: String,
-    pub message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration_ms: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub token_accounting: Option<crate::gateway::admin::trace::TokenTelemetry>,
-    pub correlation: ActivityCorrelation,
-}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct TaskSnapshot {
@@ -162,8 +117,17 @@ struct TaskBuilder {
 }
 
 pub async fn build_activity_payload(state: &AdminState, limit: usize) -> Value {
-    let events = collect_activity_events(state, limit).await;
-    json!({ "total": events.len(), "events": events })
+    let fetch_limit = limit.saturating_mul(2).max(200);
+    let audits = collect_audits(state, fetch_limit).await;
+    let traces = collect_traces(state, fetch_limit).await;
+    let gateway_events = state
+        .gateway
+        .event_log
+        .recent_events(limit.min(500))
+        .iter()
+        .map(gateway_activity_input)
+        .collect::<Vec<_>>();
+    activity_payload(&audits, &traces, &gateway_events, limit)
 }
 
 #[cfg(feature = "admin")]
@@ -252,13 +216,13 @@ pub async fn build_debug_bundle(state: &AdminState, lookup_id: &str) -> Option<V
         .chain(
             matching_audits
                 .iter()
-                .map(audit_event)
+                .map(audit_activity_event)
                 .filter_map(|event| serde_json::to_value(event).ok()),
         )
         .chain(
             matching_traces
                 .iter()
-                .map(trace_event)
+                .map(trace_activity_event)
                 .filter_map(|event| serde_json::to_value(event).ok()),
         )
         .collect();
@@ -278,30 +242,14 @@ pub async fn build_debug_bundle(state: &AdminState, lookup_id: &str) -> Option<V
         "trace_id": trace_id,
         "request_ids": request_ids,
         "root_cause": root_cause,
-        "audit": primary_audit.map(audit_event),
-        "audits": matching_audits.iter().map(audit_event).collect::<Vec<_>>(),
+        "audit": primary_audit.map(audit_activity_event),
+        "audits": matching_audits.iter().map(audit_activity_event).collect::<Vec<_>>(),
         "trace": primary_trace_value,
         "traces": matching_traces,
         "related_activity": related_activity,
         "postmortem": postmortem,
         "hints": hints,
     }))
-}
-
-async fn collect_activity_events(state: &AdminState, limit: usize) -> Vec<ActivityEvent> {
-    let mut events = Vec::new();
-    for record in collect_audits(state, limit.saturating_mul(2).max(200)).await {
-        events.push(audit_event(&record));
-    }
-    for trace in collect_traces(state, limit.saturating_mul(2).max(200)).await {
-        events.push(trace_event(&trace));
-    }
-    for event in state.gateway.event_log.recent_events(limit.min(500)) {
-        events.push(gateway_event(&event));
-    }
-    events.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-    events.truncate(limit);
-    events
 }
 
 pub async fn collect_audits(state: &AdminState, limit: usize) -> Vec<AdminAuditRecord> {
@@ -889,102 +837,18 @@ async fn find_trace(state: &AdminState, request_id: &str) -> Option<DispatchTrac
         .and_then(|lane| lane.reader().get_trace(request_id))
 }
 
-fn audit_event(record: &AdminAuditRecord) -> ActivityEvent {
-    ActivityEvent {
-        event_id: format!("audit:{}", record.request_id),
-        timestamp: rfc3339(record.timestamp),
-        kind: "tool_call".to_string(),
-        severity: if record.success { "info" } else { "error" }.to_string(),
-        status: if record.success { "ok" } else { "err" }.to_string(),
-        message: format!(
-            "{} {}",
-            record.method.as_deref().unwrap_or("call"),
-            record.action
-        ),
-        tool: Some(record.action.clone()),
-        duration_ms: record.duration_ms,
-        token_accounting: record.token_accounting.clone(),
-        correlation: ActivityCorrelation {
-            trace_id: record.trace_id.clone(),
-            span_id: record.span_id.clone(),
-            parent_span_id: record.parent_span_id.clone(),
-            request_id: Some(record.request_id.clone()),
-            session_id: record.session_id.clone(),
-            instance_id: record.instance_id.clone(),
-            dcc_type: record.dcc_type.clone(),
-            workflow_id: None,
-            job_id: None,
-            agent_id: record.agent_id.clone(),
-            actor_id: record.actor_id.clone(),
-            actor_name: record.actor_name.clone(),
-            client_platform: record.client_platform.clone(),
-            source_ip: record.source_ip.clone(),
-            parent_request_id: record.parent_request_id.clone(),
-        },
-    }
-}
-
-fn trace_event(trace: &DispatchTrace) -> ActivityEvent {
-    let tool = trace
-        .tool_slug
-        .clone()
-        .unwrap_or_else(|| trace.method.clone());
-    ActivityEvent {
-        event_id: format!("trace:{}", trace.request_id),
-        timestamp: rfc3339(trace.started_at),
-        kind: "dispatch_trace".to_string(),
-        severity: if trace.ok { "debug" } else { "error" }.to_string(),
-        status: if trace.ok { "ok" } else { "err" }.to_string(),
-        message: format!("{} completed in {}ms", tool, trace.total_ms),
-        tool: Some(tool),
-        duration_ms: Some(trace.total_ms),
-        token_accounting: trace.token_accounting.clone(),
-        correlation: trace_correlation(trace),
-    }
-}
-
-fn gateway_event(event: &ContendEvent) -> ActivityEvent {
-    let label = event.event.as_label();
-    ActivityEvent {
-        event_id: format!(
-            "gateway:{}:{}:{}",
-            event.timestamp, event.dcc_type, event.instance_id
-        ),
-        timestamp: event.timestamp.clone(),
-        kind: "gateway_event".to_string(),
-        severity: "info".to_string(),
-        status: label.to_string(),
-        message: event.reason.clone().unwrap_or_else(|| {
-            format!(
-                "{label} dcc_type={} instance={}",
-                event.dcc_type, event.instance_id
-            )
-        }),
-        tool: None,
-        duration_ms: None,
-        token_accounting: None,
-        correlation: ActivityCorrelation {
-            trace_id: None,
-            span_id: None,
-            parent_span_id: None,
-            request_id: None,
-            session_id: None,
-            instance_id: Some(event.instance_id.clone()),
-            dcc_type: Some(event.dcc_type.clone()),
-            workflow_id: None,
-            job_id: None,
-            agent_id: None,
-            actor_id: None,
-            actor_name: None,
-            client_platform: None,
-            source_ip: None,
-            parent_request_id: None,
-        },
-    }
-}
-
 fn gateway_event_json(event: ContendEvent) -> Value {
-    serde_json::to_value(gateway_event(&event)).unwrap_or_else(|_| json!({}))
+    gateway_activity_event_json(&gateway_activity_input(&event))
+}
+
+fn gateway_activity_input(event: &ContendEvent) -> GatewayActivityInput {
+    GatewayActivityInput {
+        timestamp: event.timestamp.clone(),
+        status: event.event.as_label().to_string(),
+        reason: event.reason.clone(),
+        dcc_type: event.dcc_type.clone(),
+        instance_id: event.instance_id.clone(),
+    }
 }
 
 fn related_gateway_events(
@@ -1116,44 +980,6 @@ fn normalise_instance_hint(value: &str) -> String {
         .filter(|c| c.is_ascii_hexdigit())
         .flat_map(|c| c.to_lowercase())
         .collect()
-}
-
-fn trace_correlation(trace: &DispatchTrace) -> ActivityCorrelation {
-    ActivityCorrelation {
-        trace_id: Some(trace.trace_id.clone()),
-        span_id: trace.span_id.clone(),
-        parent_span_id: trace.parent_span_id.clone(),
-        request_id: Some(trace.request_id.clone()),
-        session_id: trace.session_id.clone(),
-        instance_id: trace.instance_id.clone(),
-        dcc_type: trace.dcc_type.clone(),
-        workflow_id: None,
-        job_id: None,
-        agent_id: trace
-            .agent_context
-            .as_ref()
-            .and_then(|ctx| ctx.agent_id.clone()),
-        actor_id: trace
-            .agent_context
-            .as_ref()
-            .and_then(|ctx| ctx.actor_id.clone()),
-        actor_name: trace
-            .agent_context
-            .as_ref()
-            .and_then(|ctx| ctx.actor_name.clone()),
-        client_platform: trace
-            .agent_context
-            .as_ref()
-            .and_then(|ctx| ctx.client_platform.clone()),
-        source_ip: trace
-            .agent_context
-            .as_ref()
-            .and_then(|ctx| ctx.source_ip.clone()),
-        parent_request_id: trace
-            .agent_context
-            .as_ref()
-            .and_then(|ctx| ctx.parent_request_id.clone()),
-    }
 }
 
 fn debug_hints(trace: Option<&DispatchTrace>) -> Vec<String> {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -25,7 +25,7 @@
 //!
 //! The runtime UI is a single inline HTML string (`admin/html.rs`). The
 //! `dcc-mcp-gateway-admin` crate owns the trace domain, compact, link,
-//! issue-report, statistics, analytics, governance, artifact, and traffic projections,
+//! issue-report, statistics, analytics, governance, artifact, activity, and traffic projections,
 //! Vite/npm build boundary, and embedded asset; this module owns the
 //! gateway-specific data-source/HTTP adapters and API handlers.
 //!

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,7 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic domain + optional embedded dashboard asset
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/traffic domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -122,7 +122,7 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic domain + optional embedded dashboard asset
+dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/traffic domain + optional embedded dashboard asset
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
@@ -392,7 +392,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, activity-timeline, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
 
 **Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact、activity timeline 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,7 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic 领域和可选嵌入式 dashboard 资产
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/traffic 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -102,7 +102,7 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic 领域和可选嵌入式 dashboard 资产
+dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/traffic 领域和可选嵌入式 dashboard 资产
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
@@ -293,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact、activity timeline 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, and metadata-only traffic projections, plus the optional embedded dashboard asset.
+- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, and metadata-only traffic projections, plus the optional embedded dashboard asset.
 - **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
@@ -282,7 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move audit, trace, and gateway-event activity timeline projection into `dcc-mcp-gateway-admin`
- map gateway contention events into a backend-neutral admin DTO at the adapter boundary
- preserve existing activity and debug-bundle response contracts

## Validation
- `vx just preflight` (3573 tests passed)
- activity and debug-bundle endpoint regression tests
- public docs contain no `_thm` or `rez_local_cache` paths
- creator Skills unchanged because adapter and skill-authoring workflows are unaffected

Part of #2187