### PR TITLE
refactor: extract admin debug projection

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/debug.rs
+++ b/crates/dcc-mcp-gateway-admin/src/debug.rs
@@ -1,0 +1,371 @@
+//! Pure debug-bundle and postmortem projections for the admin dashboard.
+
+use std::cmp::Reverse;
+use std::collections::HashSet;
+use std::time::UNIX_EPOCH;
+
+use serde_json::{Value, json};
+
+use crate::{
+    AdminAuditRecord, DispatchTrace, GatewayActivityInput, audit_activity_event,
+    gateway_activity_event_json, trace_activity_event,
+};
+
+const POSTMORTEM_PREVIOUS_CALL_LIMIT: usize = 5;
+const POSTMORTEM_EVENT_LIMIT: usize = 10;
+
+/// Build one correlated debug bundle from already-collected admin records.
+///
+/// The caller owns persistence and event-log access; this function owns only
+/// the backend-neutral correlation and JSON projection contract.
+#[must_use]
+pub fn debug_bundle_payload(
+    lookup_id: &str,
+    audits: Vec<AdminAuditRecord>,
+    all_traces: Vec<DispatchTrace>,
+    gateway_events: Vec<GatewayActivityInput>,
+) -> Option<Value> {
+    let mut matching_traces: Vec<DispatchTrace> = all_traces
+        .iter()
+        .filter(|trace| trace.request_id == lookup_id || trace.trace_id == lookup_id)
+        .cloned()
+        .collect();
+    matching_traces.sort_by_key(|trace| Reverse(trace.started_at));
+
+    let trace_id = matching_traces.first().map(|trace| trace.trace_id.clone());
+    if let Some(trace_id) = trace_id.as_deref() {
+        let extra_traces = all_traces
+            .iter()
+            .filter(|trace| trace.trace_id == trace_id)
+            .filter(|trace| {
+                !matching_traces
+                    .iter()
+                    .any(|existing| existing.request_id == trace.request_id)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        matching_traces.extend(extra_traces);
+    }
+
+    let matching_request_ids: HashSet<String> = matching_traces
+        .iter()
+        .map(|trace| trace.request_id.clone())
+        .collect();
+    let matching_audits: Vec<AdminAuditRecord> = audits
+        .into_iter()
+        .filter(|record| {
+            record.request_id == lookup_id
+                || matching_request_ids.contains(&record.request_id)
+                || trace_id
+                    .as_deref()
+                    .is_some_and(|id| record.trace_id.as_deref() == Some(id))
+        })
+        .collect();
+    if matching_audits.is_empty() && matching_traces.is_empty() {
+        return None;
+    }
+
+    let primary_trace = matching_traces
+        .iter()
+        .find(|trace| trace.request_id == lookup_id)
+        .or_else(|| matching_traces.first())
+        .cloned();
+    let primary_audit = matching_audits
+        .iter()
+        .find(|record| record.request_id == lookup_id)
+        .or_else(|| matching_audits.first())
+        .cloned();
+    let primary_request_id = primary_trace
+        .as_ref()
+        .map(|trace| trace.request_id.clone())
+        .or_else(|| {
+            primary_audit
+                .as_ref()
+                .map(|record| record.request_id.clone())
+        })
+        .unwrap_or_else(|| lookup_id.to_string());
+
+    let mut request_ids: Vec<String> = matching_request_ids.into_iter().collect();
+    if !request_ids.iter().any(|id| id == &primary_request_id) {
+        request_ids.push(primary_request_id.clone());
+    }
+    request_ids.sort();
+
+    let related_events =
+        related_gateway_events(gateway_events, &request_ids, primary_trace.as_ref());
+    let related_activity: Vec<Value> = related_events
+        .iter()
+        .map(gateway_activity_event_json)
+        .chain(
+            matching_audits
+                .iter()
+                .map(audit_activity_event)
+                .filter_map(|event| serde_json::to_value(event).ok()),
+        )
+        .chain(
+            matching_traces
+                .iter()
+                .map(trace_activity_event)
+                .filter_map(|event| serde_json::to_value(event).ok()),
+        )
+        .collect();
+    let postmortem = postmortem_payload(&all_traces, primary_trace.as_ref(), &related_events);
+    let hints = debug_hints(primary_trace.as_ref());
+    let root_cause = primary_audit
+        .as_ref()
+        .and_then(|record| record.error.clone())
+        .or_else(|| {
+            primary_trace
+                .as_ref()
+                .filter(|trace| !trace.ok)
+                .and_then(|_| hints.first().cloned())
+        });
+
+    Some(json!({
+        "lookup_id": lookup_id,
+        "request_id": primary_request_id,
+        "trace_id": trace_id,
+        "request_ids": request_ids,
+        "root_cause": root_cause,
+        "audit": primary_audit.as_ref().map(audit_activity_event),
+        "audits": matching_audits.iter().map(audit_activity_event).collect::<Vec<_>>(),
+        "trace": primary_trace,
+        "traces": matching_traces,
+        "related_activity": related_activity,
+        "postmortem": postmortem,
+        "hints": hints,
+    }))
+}
+
+fn related_gateway_events(
+    gateway_events: Vec<GatewayActivityInput>,
+    request_ids: &[String],
+    trace: Option<&DispatchTrace>,
+) -> Vec<GatewayActivityInput> {
+    gateway_events
+        .into_iter()
+        .filter(|event| gateway_event_matches(event, request_ids, trace))
+        .take(POSTMORTEM_EVENT_LIMIT)
+        .collect()
+}
+
+fn gateway_event_matches(
+    event: &GatewayActivityInput,
+    request_ids: &[String],
+    trace: Option<&DispatchTrace>,
+) -> bool {
+    if let Some(reason) = event.reason.as_deref()
+        && request_ids
+            .iter()
+            .any(|request_id| reason.contains(request_id))
+    {
+        return true;
+    }
+    let Some(trace) = trace else {
+        return false;
+    };
+    if let Some(instance_id) = trace.instance_id.as_deref()
+        && instance_hint_matches(&event.instance_id, instance_id)
+    {
+        return true;
+    }
+    trace
+        .dcc_type
+        .as_deref()
+        .is_some_and(|dcc| event.dcc_type.eq_ignore_ascii_case(dcc))
+        && event.status == "host_died"
+}
+
+fn postmortem_payload(
+    all_traces: &[DispatchTrace],
+    trace: Option<&DispatchTrace>,
+    gateway_events: &[GatewayActivityInput],
+) -> Value {
+    let Some(trace) = trace else {
+        return json!({
+            "previous_calls": [],
+            "gateway_events": gateway_events
+                .iter()
+                .map(gateway_activity_event_json)
+                .collect::<Vec<_>>(),
+        });
+    };
+
+    let previous_calls: Vec<Value> = all_traces
+        .iter()
+        .filter(|candidate| candidate.request_id != trace.request_id)
+        .filter(|candidate| candidate.started_at <= trace.started_at)
+        .filter(|candidate| trace_matches_postmortem_scope(candidate, trace))
+        .take(POSTMORTEM_PREVIOUS_CALL_LIMIT)
+        .cloned()
+        .map(postmortem_trace_row)
+        .collect();
+
+    json!({
+        "target": postmortem_trace_row(trace.clone()),
+        "previous_calls": previous_calls,
+        "gateway_events": gateway_events
+            .iter()
+            .map(gateway_activity_event_json)
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn trace_matches_postmortem_scope(candidate: &DispatchTrace, target: &DispatchTrace) -> bool {
+    if candidate.trace_id == target.trace_id {
+        return true;
+    }
+    if let (Some(a), Some(b)) = (
+        candidate.instance_id.as_deref(),
+        target.instance_id.as_deref(),
+    ) {
+        return instance_hint_matches(a, b);
+    }
+    if let (Some(a), Some(b)) = (
+        candidate.session_id.as_deref(),
+        target.session_id.as_deref(),
+    ) {
+        return a == b;
+    }
+    if let (Some(a), Some(b)) = (candidate.dcc_type.as_deref(), target.dcc_type.as_deref()) {
+        return a.eq_ignore_ascii_case(b);
+    }
+    false
+}
+
+fn postmortem_trace_row(trace: DispatchTrace) -> Value {
+    json!({
+        "request_id": trace.request_id,
+        "trace_id": trace.trace_id,
+        "span_id": trace.span_id,
+        "parent_span_id": trace.parent_span_id,
+        "parent_request_id": trace.parent_request_id,
+        "started_at": rfc3339(trace.started_at),
+        "tool": trace.tool_slug.unwrap_or(trace.method),
+        "dcc_type": trace.dcc_type,
+        "instance_id": trace.instance_id,
+        "session_id": trace.session_id,
+        "transport": trace.transport,
+        "agent_context": trace.agent_context,
+        "ok": trace.ok,
+        "total_ms": trace.total_ms,
+        "input": trace.input,
+        "output": trace.output,
+    })
+}
+
+fn instance_hint_matches(a: &str, b: &str) -> bool {
+    let a = normalise_instance_hint(a);
+    let b = normalise_instance_hint(b);
+    if a.is_empty() || b.is_empty() {
+        return false;
+    }
+    a == b || (a.len() >= 4 && b.starts_with(&a)) || (b.len() >= 4 && a.starts_with(&b))
+}
+
+fn normalise_instance_hint(value: &str) -> String {
+    value
+        .chars()
+        .filter(char::is_ascii_hexdigit)
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn debug_hints(trace: Option<&DispatchTrace>) -> Vec<String> {
+    let Some(trace) = trace else {
+        return vec!["No dispatch trace was retained for this request.".to_string()];
+    };
+    if trace.ok {
+        return vec![
+            "Request completed successfully; inspect spans for slow segments.".to_string(),
+        ];
+    }
+    let mut hints =
+        vec!["Request failed; inspect the last error span and output payload.".to_string()];
+    if trace
+        .spans
+        .iter()
+        .any(|span| span.name.contains("backend") && !span.ok)
+    {
+        hints.push(
+            "A backend span failed; check instance reachability and sidecar/DCC logs.".to_string(),
+        );
+    }
+    hints
+}
+
+fn rfc3339(timestamp: std::time::SystemTime) -> String {
+    timestamp
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|_| {
+            chrono::DateTime::<chrono::Utc>::from(timestamp)
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trace(request_id: &str, trace_id: &str, started_secs: u64) -> DispatchTrace {
+        serde_json::from_value(json!({
+            "request_id": request_id,
+            "trace_id": trace_id,
+            "method": "tools/call",
+            "tool_slug": "maya__scene_save",
+            "instance_id": "abcd-1234",
+            "dcc_type": "maya",
+            "started_at": started_secs * 1_000,
+            "total_ms": 10,
+            "ok": true,
+            "spans": [],
+        }))
+        .expect("trace fixture should deserialize")
+    }
+
+    #[test]
+    fn bundle_correlates_trace_family_and_gateway_events() {
+        let target = trace("req-2", "trace-a", 20);
+        let previous = trace("req-1", "trace-a", 10);
+        let unrelated = trace("req-x", "trace-x", 30);
+        let events = vec![GatewayActivityInput {
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+            status: "host_died".to_string(),
+            reason: None,
+            dcc_type: "maya".to_string(),
+            instance_id: "abcd".to_string(),
+        }];
+
+        let bundle = debug_bundle_payload(
+            "req-2",
+            Vec::new(),
+            vec![target, previous, unrelated],
+            events,
+        )
+        .expect("matching trace should produce a bundle");
+
+        assert_eq!(bundle["request_id"], "req-2");
+        assert_eq!(bundle["request_ids"], json!(["req-1", "req-2"]));
+        assert_eq!(
+            bundle["postmortem"]["previous_calls"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            bundle["postmortem"]["gateway_events"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn missing_records_return_none() {
+        assert!(debug_bundle_payload("missing", Vec::new(), Vec::new(), Vec::new()).is_none());
+    }
+}

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate owns admin-facing audit, trace, caller-context, compact projection,
 //! link, issue-report, statistics, analytics, governance, artifact, activity, task-outcome,
-//! and traffic projections independently of gateway routing state.
+//! debug-bundle, postmortem, and traffic projections independently of gateway routing state.
 //! It also owns the Vite/npm build script and generated dashboard payload; the Node.js
 //! toolchain only runs when `embed` is enabled.
 
@@ -12,6 +12,7 @@ mod activity;
 mod analytics;
 mod artifacts;
 mod audit;
+mod debug;
 /// Admin trace and caller-attribution value types.
 pub mod domain;
 mod governance;
@@ -34,6 +35,7 @@ pub use analytics::{
 };
 pub use artifacts::{ArtifactFilter, artifact_payload, artifact_refs};
 pub use audit::{AdminAuditRecord, AuditLog};
+pub use debug::debug_bundle_payload;
 pub use domain::agent_context::{
     AgentContext, AgentContextTrust, INTERNAL_AUTH_SUBJECT_HEADER, INTERNAL_FORWARDED_FOR_HEADER,
     INTERNAL_SOURCE_IP_HEADER, TRUST_AUTH, TRUST_HEADER, TRUST_SELF_REPORTED, TRUST_SERVER_DERIVED,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/infra/activity.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/infra/activity.rs
@@ -6,16 +6,12 @@
 //! lanes without changing the hot-path writers.
 
 use std::cmp::Reverse;
-use std::collections::{HashMap, HashSet};
-use std::time::UNIX_EPOCH;
+use std::collections::HashMap;
 
 #[cfg(feature = "admin")]
 use dcc_mcp_gateway_admin::task_payload;
-use dcc_mcp_gateway_admin::{
-    GatewayActivityInput, activity_payload, audit_activity_event, gateway_activity_event_json,
-    trace_activity_event,
-};
-use serde_json::{Value, json};
+use dcc_mcp_gateway_admin::{GatewayActivityInput, activity_payload, debug_bundle_payload};
+use serde_json::Value;
 
 pub use dcc_mcp_gateway_admin::{
     ActivityCorrelation, ActivityEvent, TaskArtifact, TaskRelated, TaskSnapshot, TaskValidation,
@@ -27,8 +23,6 @@ use crate::gateway::admin::state::{AdminAuditRecord, AdminState};
 use crate::gateway::admin::trace::DispatchTrace;
 use crate::gateway::event_log::ContendEvent;
 
-const POSTMORTEM_PREVIOUS_CALL_LIMIT: usize = 5;
-const POSTMORTEM_EVENT_LIMIT: usize = 10;
 pub async fn build_activity_payload(state: &AdminState, limit: usize) -> Value {
     let fetch_limit = limit.saturating_mul(2).max(200);
     let audits = collect_audits(state, fetch_limit).await;
@@ -57,111 +51,22 @@ pub(crate) async fn build_tasks_payload(
 
 pub async fn build_debug_bundle(state: &AdminState, lookup_id: &str) -> Option<Value> {
     let audits = collect_audits(state, 1_000).await;
-    let all_traces = collect_traces(state, 1_000).await;
-    let mut matching_traces: Vec<DispatchTrace> = all_traces
+    let mut traces = collect_traces(state, 1_000).await;
+    if !traces
         .iter()
-        .filter(|trace| trace.request_id == lookup_id || trace.trace_id == lookup_id)
-        .cloned()
-        .collect();
-    if matching_traces.is_empty()
+        .any(|trace| trace.request_id == lookup_id || trace.trace_id == lookup_id)
         && let Some(trace) = find_trace(state, lookup_id).await
     {
-        matching_traces.push(trace);
+        traces.push(trace);
     }
-    matching_traces.sort_by_key(|trace| Reverse(trace.started_at));
-    let trace_id = matching_traces.first().map(|trace| trace.trace_id.clone());
-    if let Some(trace_id) = trace_id.as_deref() {
-        let extra_traces: Vec<DispatchTrace> = all_traces
-            .iter()
-            .filter(|trace| trace.trace_id == trace_id)
-            .filter(|trace| {
-                !matching_traces
-                    .iter()
-                    .any(|existing| existing.request_id == trace.request_id)
-            })
-            .cloned()
-            .collect();
-        for trace in extra_traces {
-            matching_traces.push(trace);
-        }
-    }
-    let request_ids: HashSet<String> = matching_traces
+    let gateway_events = state
+        .gateway
+        .event_log
+        .recent_events(500)
         .iter()
-        .map(|trace| trace.request_id.clone())
+        .map(gateway_activity_input)
         .collect();
-    let matching_audits: Vec<AdminAuditRecord> = audits
-        .into_iter()
-        .filter(|record| {
-            record.request_id == lookup_id
-                || request_ids.contains(&record.request_id)
-                || trace_id
-                    .as_deref()
-                    .is_some_and(|id| record.trace_id.as_deref() == Some(id))
-        })
-        .collect();
-    if matching_audits.is_empty() && matching_traces.is_empty() {
-        return None;
-    }
-    let primary_trace = matching_traces
-        .iter()
-        .find(|trace| trace.request_id == lookup_id)
-        .or_else(|| matching_traces.first());
-    let primary_audit = matching_audits
-        .iter()
-        .find(|record| record.request_id == lookup_id)
-        .or_else(|| matching_audits.first());
-    let primary_request_id = primary_trace
-        .map(|trace| trace.request_id.clone())
-        .or_else(|| primary_audit.map(|record| record.request_id.clone()))
-        .unwrap_or_else(|| lookup_id.to_string());
-    let mut request_ids: Vec<String> = request_ids.into_iter().collect();
-    if !request_ids.iter().any(|id| id == &primary_request_id) {
-        request_ids.push(primary_request_id.clone());
-    }
-    request_ids.sort();
-
-    let gateway_events = related_gateway_events(state, &request_ids, primary_trace);
-    let related_activity: Vec<Value> = gateway_events
-        .clone()
-        .into_iter()
-        .map(gateway_event_json)
-        .chain(
-            matching_audits
-                .iter()
-                .map(audit_activity_event)
-                .filter_map(|event| serde_json::to_value(event).ok()),
-        )
-        .chain(
-            matching_traces
-                .iter()
-                .map(trace_activity_event)
-                .filter_map(|event| serde_json::to_value(event).ok()),
-        )
-        .collect();
-    let postmortem = build_postmortem(state, primary_trace, gateway_events).await;
-    let primary_trace_value = primary_trace.cloned();
-    let hints = debug_hints(primary_trace);
-    let root_cause = primary_audit
-        .and_then(|record| record.error.clone())
-        .or_else(|| {
-            primary_trace
-                .filter(|trace| !trace.ok)
-                .and_then(|_| hints.first().cloned())
-        });
-    Some(json!({
-        "lookup_id": lookup_id,
-        "request_id": primary_request_id,
-        "trace_id": trace_id,
-        "request_ids": request_ids,
-        "root_cause": root_cause,
-        "audit": primary_audit.map(audit_activity_event),
-        "audits": matching_audits.iter().map(audit_activity_event).collect::<Vec<_>>(),
-        "trace": primary_trace_value,
-        "traces": matching_traces,
-        "related_activity": related_activity,
-        "postmortem": postmortem,
-        "hints": hints,
-    }))
+    debug_bundle_payload(lookup_id, audits, traces, gateway_events)
 }
 
 pub async fn collect_audits(state: &AdminState, limit: usize) -> Vec<AdminAuditRecord> {
@@ -216,10 +121,6 @@ async fn find_trace(state: &AdminState, request_id: &str) -> Option<DispatchTrac
         .and_then(|lane| lane.reader().get_trace(request_id))
 }
 
-fn gateway_event_json(event: ContendEvent) -> Value {
-    gateway_activity_event_json(&gateway_activity_input(&event))
-}
-
 fn gateway_activity_input(event: &ContendEvent) -> GatewayActivityInput {
     GatewayActivityInput {
         timestamp: event.timestamp.clone(),
@@ -228,168 +129,4 @@ fn gateway_activity_input(event: &ContendEvent) -> GatewayActivityInput {
         dcc_type: event.dcc_type.clone(),
         instance_id: event.instance_id.clone(),
     }
-}
-
-fn related_gateway_events(
-    state: &AdminState,
-    request_ids: &[String],
-    trace: Option<&DispatchTrace>,
-) -> Vec<ContendEvent> {
-    state
-        .gateway
-        .event_log
-        .recent_events(500)
-        .into_iter()
-        .filter(|event| gateway_event_matches(event, request_ids, trace))
-        .take(POSTMORTEM_EVENT_LIMIT)
-        .collect()
-}
-
-fn gateway_event_matches(
-    event: &ContendEvent,
-    request_ids: &[String],
-    trace: Option<&DispatchTrace>,
-) -> bool {
-    if let Some(reason) = event.reason.as_deref()
-        && request_ids
-            .iter()
-            .any(|request_id| reason.contains(request_id))
-    {
-        return true;
-    }
-    let Some(trace) = trace else {
-        return false;
-    };
-    if let Some(instance_id) = trace.instance_id.as_deref()
-        && instance_hint_matches(&event.instance_id, instance_id)
-    {
-        return true;
-    }
-    trace
-        .dcc_type
-        .as_deref()
-        .is_some_and(|dcc| event.dcc_type.eq_ignore_ascii_case(dcc))
-        && event.event.as_label() == "host_died"
-}
-
-async fn build_postmortem(
-    state: &AdminState,
-    trace: Option<&DispatchTrace>,
-    gateway_events: Vec<ContendEvent>,
-) -> Value {
-    let Some(trace) = trace else {
-        return json!({
-            "previous_calls": [],
-            "gateway_events": gateway_events.into_iter().map(gateway_event_json).collect::<Vec<_>>(),
-        });
-    };
-
-    let previous_calls: Vec<Value> = collect_traces(state, 1_000)
-        .await
-        .into_iter()
-        .filter(|candidate| candidate.request_id != trace.request_id)
-        .filter(|candidate| candidate.started_at <= trace.started_at)
-        .filter(|candidate| trace_matches_postmortem_scope(candidate, trace))
-        .take(POSTMORTEM_PREVIOUS_CALL_LIMIT)
-        .map(postmortem_trace_row)
-        .collect();
-
-    json!({
-        "target": postmortem_trace_row(trace.clone()),
-        "previous_calls": previous_calls,
-        "gateway_events": gateway_events.into_iter().map(gateway_event_json).collect::<Vec<_>>(),
-    })
-}
-
-fn trace_matches_postmortem_scope(candidate: &DispatchTrace, target: &DispatchTrace) -> bool {
-    if candidate.trace_id == target.trace_id {
-        return true;
-    }
-    if let (Some(a), Some(b)) = (
-        candidate.instance_id.as_deref(),
-        target.instance_id.as_deref(),
-    ) {
-        return instance_hint_matches(a, b);
-    }
-    if let (Some(a), Some(b)) = (
-        candidate.session_id.as_deref(),
-        target.session_id.as_deref(),
-    ) {
-        return a == b;
-    }
-    if let (Some(a), Some(b)) = (candidate.dcc_type.as_deref(), target.dcc_type.as_deref()) {
-        return a.eq_ignore_ascii_case(b);
-    }
-    false
-}
-
-fn postmortem_trace_row(trace: DispatchTrace) -> Value {
-    json!({
-        "request_id": trace.request_id,
-        "trace_id": trace.trace_id,
-        "span_id": trace.span_id,
-        "parent_span_id": trace.parent_span_id,
-        "parent_request_id": trace.parent_request_id,
-        "started_at": rfc3339(trace.started_at),
-        "tool": trace.tool_slug.unwrap_or(trace.method),
-        "dcc_type": trace.dcc_type,
-        "instance_id": trace.instance_id,
-        "session_id": trace.session_id,
-        "transport": trace.transport,
-        "agent_context": trace.agent_context,
-        "ok": trace.ok,
-        "total_ms": trace.total_ms,
-        "input": trace.input,
-        "output": trace.output,
-    })
-}
-
-fn instance_hint_matches(a: &str, b: &str) -> bool {
-    let a = normalise_instance_hint(a);
-    let b = normalise_instance_hint(b);
-    if a.is_empty() || b.is_empty() {
-        return false;
-    }
-    a == b || (a.len() >= 4 && b.starts_with(&a)) || (b.len() >= 4 && a.starts_with(&b))
-}
-
-fn normalise_instance_hint(value: &str) -> String {
-    value
-        .chars()
-        .filter(|c| c.is_ascii_hexdigit())
-        .flat_map(|c| c.to_lowercase())
-        .collect()
-}
-
-fn debug_hints(trace: Option<&DispatchTrace>) -> Vec<String> {
-    let Some(trace) = trace else {
-        return vec!["No dispatch trace was retained for this request.".to_string()];
-    };
-    if trace.ok {
-        return vec![
-            "Request completed successfully; inspect spans for slow segments.".to_string(),
-        ];
-    }
-    let mut hints =
-        vec!["Request failed; inspect the last error span and output payload.".to_string()];
-    if trace
-        .spans
-        .iter()
-        .any(|span| span.name.contains("backend") && !span.ok)
-    {
-        hints.push(
-            "A backend span failed; check instance reachability and sidecar/DCC logs.".to_string(),
-        );
-    }
-    hints
-}
-
-fn rfc3339(t: std::time::SystemTime) -> String {
-    t.duration_since(UNIX_EPOCH)
-        .ok()
-        .map(|_| {
-            chrono::DateTime::<chrono::Utc>::from(t)
-                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
-        })
-        .unwrap_or_default()
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -25,7 +25,8 @@
 //!
 //! The runtime UI is a single inline HTML string (`admin/html.rs`). The
 //! `dcc-mcp-gateway-admin` crate owns the trace domain, compact, link,
-//! issue-report, statistics, analytics, governance, artifact, activity, task-outcome, and traffic projections,
+//! issue-report, statistics, analytics, governance, artifact, activity, task-outcome,
+//! debug-bundle, postmortem, and traffic projections,
 //! Vite/npm build boundary, and embedded asset; this module owns the
 //! gateway-specific data-source/HTTP adapters and API handlers.
 //!

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,7 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/traffic domain + optional embedded dashboard asset
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -122,7 +122,7 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/traffic domain + optional embedded dashboard asset
+dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic domain + optional embedded dashboard asset
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
@@ -392,7 +392,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
 
 **Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact、activity timeline、task outcome 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,7 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/traffic 领域和可选嵌入式 dashboard 资产
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -102,7 +102,7 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/traffic 领域和可选嵌入式 dashboard 资产
+dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic 领域和可选嵌入式 dashboard 资产
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
@@ -293,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact、activity timeline、task outcome 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, and metadata-only traffic projections, plus the optional embedded dashboard asset.
+- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, and metadata-only traffic projections, plus the optional embedded dashboard asset.
 - **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
@@ -282,7 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move debug-bundle and postmortem correlation into `dcc-mcp-gateway-admin`
- keep gateway persistence, event collection, and HTTP adapters in `dcc-mcp-gateway`
- document the projection ownership boundary

## Validation
- `vx just preflight` (3577/3577 tests passed; doctests passed)
- gateway admin tests (130 passed)
- strict Clippy for gateway and gateway-admin
- public docs internal-path scan passed
- creator Skills unchanged; adapter and skill-authoring workflows are unaffected

Part of #2187