### PR TITLE
refactor: extract admin agent trace projection

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/agent_trace.rs
+++ b/crates/dcc-mcp-gateway-admin/src/agent_trace.rs
@@ -1,0 +1,139 @@
+//! Public-safe agent trace packet projections.
+
+use serde_json::{Value, json};
+
+use crate::TOKEN_ESTIMATOR;
+
+/// Build a compact agent trace packet from a correlated debug bundle.
+///
+/// The caller owns request routing and link construction. This projection
+/// intentionally omits request and response payloads, prompts, scripts, and
+/// scene data from the returned packet.
+#[must_use]
+pub fn agent_trace_packet(lookup_id: &str, bundle: &Value, links: Value) -> Value {
+    let trace = bundle.get("trace").cloned().unwrap_or(Value::Null);
+    let request_id = bundle
+        .get("request_id")
+        .and_then(Value::as_str)
+        .unwrap_or(lookup_id);
+    let ok = trace.get("ok").and_then(Value::as_bool);
+    let span_count = trace
+        .get("spans")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    let postmortem = bundle.get("postmortem").unwrap_or(&Value::Null);
+
+    json!({
+        "schema_version": "dcc-mcp.admin.agent-trace-packet.v1",
+        "lookup_id": lookup_id,
+        "trace_id": bundle.get("trace_id").cloned().unwrap_or(Value::Null),
+        "request_id": request_id,
+        "request_ids": bundle.get("request_ids").cloned().unwrap_or_else(|| json!([])),
+        "status": ok.map(|ok| if ok { "ok" } else { "err" }).unwrap_or("unknown"),
+        "tool": trace
+            .get("tool_slug")
+            .or_else(|| trace.get("method"))
+            .cloned()
+            .unwrap_or(Value::Null),
+        "dcc_type": trace.get("dcc_type").cloned().unwrap_or(Value::Null),
+        "transport": trace.get("transport").cloned().unwrap_or(Value::Null),
+        "total_ms": trace.get("total_ms").cloned().unwrap_or(Value::Null),
+        "span_count": span_count,
+        "payload_tokens": payload_token_packet(&trace),
+        "response_token_accounting": trace
+            .get("token_accounting")
+            .cloned()
+            .unwrap_or(Value::Null),
+        "postmortem": {
+            "previous_call_count": postmortem
+                .get("previous_calls")
+                .and_then(Value::as_array)
+                .map(Vec::len)
+                .unwrap_or(0),
+            "gateway_event_count": postmortem
+                .get("gateway_events")
+                .and_then(Value::as_array)
+                .map(Vec::len)
+                .unwrap_or(0),
+        },
+        "links": links,
+        "privacy_note": "Agent trace packets omit request/response payload previews, prompts, scripts, and scene data. Use debug_bundle_url only for reviewed local diagnostics.",
+    })
+}
+
+fn payload_token_packet(trace: &Value) -> Value {
+    let input_tokens = trace
+        .get("input")
+        .and_then(|payload| payload.get("estimated_tokens"))
+        .and_then(Value::as_u64);
+    let output_tokens = trace
+        .get("output")
+        .and_then(|payload| payload.get("estimated_tokens"))
+        .and_then(Value::as_u64);
+    let total_tokens = match (input_tokens, output_tokens) {
+        (Some(input), Some(output)) => Some(input.saturating_add(output)),
+        (Some(input), None) => Some(input),
+        (None, Some(output)) => Some(output),
+        (None, None) => None,
+    };
+    json!({
+        "token_estimator": TOKEN_ESTIMATOR,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+        "missing_payload_tokens": input_tokens.is_none() && output_tokens.is_none(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn packet_projects_counts_and_omits_payloads() {
+        let bundle = json!({
+            "trace_id": "trace-1",
+            "request_id": "req-1",
+            "request_ids": ["req-1"],
+            "trace": {
+                "ok": false,
+                "tool_slug": "maya__scene_save",
+                "dcc_type": "maya",
+                "transport": "http",
+                "total_ms": 42,
+                "spans": [{"name": "dispatch"}, {"name": "backend"}],
+                "input": {"estimated_tokens": 3, "preview": "private input"},
+                "output": {"estimated_tokens": 5, "preview": "private output"},
+                "token_accounting": {"saved_tokens": 2},
+            },
+            "postmortem": {
+                "previous_calls": [{}, {}],
+                "gateway_events": [{}],
+            },
+        });
+        let links = json!({"trace_url": "/v1/debug/traces/req-1"});
+
+        let packet = agent_trace_packet("req-1", &bundle, links.clone());
+
+        assert_eq!(packet["status"], "err");
+        assert_eq!(packet["span_count"], 2);
+        assert_eq!(packet["payload_tokens"]["total_tokens"], 8);
+        assert_eq!(packet["postmortem"]["previous_call_count"], 2);
+        assert_eq!(packet["postmortem"]["gateway_event_count"], 1);
+        assert_eq!(packet["links"], links);
+        assert!(packet.get("input").is_none());
+        assert!(packet.get("output").is_none());
+        assert!(!packet.to_string().contains("private"));
+    }
+
+    #[test]
+    fn packet_defaults_missing_trace_fields() {
+        let packet = agent_trace_packet("missing", &json!({}), json!({}));
+
+        assert_eq!(packet["request_id"], "missing");
+        assert_eq!(packet["status"], "unknown");
+        assert_eq!(packet["span_count"], 0);
+        assert_eq!(packet["payload_tokens"]["missing_payload_tokens"], true);
+    }
+}

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -2,13 +2,15 @@
 //!
 //! This crate owns admin-facing audit, trace, caller-context, compact projection,
 //! link, issue-report, statistics, analytics, governance, artifact, activity, task-outcome,
-//! debug-bundle, postmortem, and traffic projections independently of gateway routing state.
+//! debug-bundle, postmortem, agent-trace packet, and traffic projections independently of
+//! gateway routing state.
 //! It also owns the Vite/npm build script and generated dashboard payload; the Node.js
 //! toolchain only runs when `embed` is enabled.
 
 #![forbid(unsafe_code)]
 
 mod activity;
+mod agent_trace;
 mod analytics;
 mod artifacts;
 mod audit;
@@ -29,6 +31,7 @@ pub use activity::{
     audit_activity_event, gateway_activity_event, gateway_activity_event_json,
     trace_activity_event,
 };
+pub use agent_trace::agent_trace_packet;
 pub use analytics::{
     AnalyticsQuery, analytics_csv_export, analytics_heatmap_payload, analytics_jsonl_export,
     analytics_overview_payload, analytics_range_duration, analytics_timeseries_payload,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/agent_trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/agent_trace.rs
@@ -4,36 +4,11 @@ use axum::Json;
 use axum::extract::{OriginalUri, Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
+use dcc_mcp_gateway_admin::agent_trace_packet;
 use serde_json::{Value, json};
 
 use super::links::AdminLinkBuilder;
 use super::state::AdminState;
-use crate::gateway::response_codec::TOKEN_ESTIMATOR;
-
-fn payload_token_packet(trace: &Value) -> Value {
-    let input_tokens = trace
-        .get("input")
-        .and_then(|payload| payload.get("estimated_tokens"))
-        .and_then(Value::as_u64);
-    let output_tokens = trace
-        .get("output")
-        .and_then(|payload| payload.get("estimated_tokens"))
-        .and_then(Value::as_u64);
-    let total_tokens = match (input_tokens, output_tokens) {
-        (Some(input), Some(output)) => Some(input.saturating_add(output)),
-        (Some(input), None) => Some(input),
-        (None, Some(output)) => Some(output),
-        (None, None) => None,
-    };
-    json!({
-        "token_estimator": TOKEN_ESTIMATOR,
-        "input_tokens": input_tokens,
-        "output_tokens": output_tokens,
-        "total_tokens": total_tokens,
-        "missing_payload_tokens": input_tokens.is_none() && output_tokens.is_none(),
-    })
-}
-
 /// `GET /v1/debug/agent-traces/{lookup_id}` — compact agent packet by trace id or request id.
 pub async fn handle_v1_debug_agent_trace_packet(
     State(s): State<AdminState>,
@@ -44,53 +19,11 @@ pub async fn handle_v1_debug_agent_trace_packet(
     let links = AdminLinkBuilder::from_request(&headers, &uri);
     match crate::gateway::admin::activity::build_debug_bundle(&s, &lookup_id).await {
         Some(bundle) => {
-            let trace = bundle.get("trace").cloned().unwrap_or(Value::Null);
             let request_id = bundle
                 .get("request_id")
                 .and_then(Value::as_str)
                 .unwrap_or(&lookup_id);
-            let ok = trace.get("ok").and_then(Value::as_bool);
-            let spans = trace
-                .get("spans")
-                .and_then(Value::as_array)
-                .map(Vec::len)
-                .unwrap_or(0);
-            let postmortem = bundle.get("postmortem").cloned().unwrap_or(Value::Null);
-            let packet = json!({
-                "schema_version": "dcc-mcp.admin.agent-trace-packet.v1",
-                "lookup_id": lookup_id,
-                "trace_id": bundle.get("trace_id").cloned().unwrap_or(Value::Null),
-                "request_id": request_id,
-                "request_ids": bundle.get("request_ids").cloned().unwrap_or_else(|| json!([])),
-                "status": ok.map(|ok| if ok { "ok" } else { "err" }).unwrap_or("unknown"),
-                "tool": trace.get("tool_slug")
-                    .or_else(|| trace.get("method"))
-                    .cloned()
-                    .unwrap_or(Value::Null),
-                "dcc_type": trace.get("dcc_type").cloned().unwrap_or(Value::Null),
-                "transport": trace.get("transport").cloned().unwrap_or(Value::Null),
-                "total_ms": trace.get("total_ms").cloned().unwrap_or(Value::Null),
-                "span_count": spans,
-                "payload_tokens": payload_token_packet(&trace),
-                "response_token_accounting": trace
-                    .get("token_accounting")
-                    .cloned()
-                    .unwrap_or(Value::Null),
-                "postmortem": {
-                    "previous_call_count": postmortem
-                        .get("previous_calls")
-                        .and_then(Value::as_array)
-                        .map(Vec::len)
-                        .unwrap_or(0),
-                    "gateway_event_count": postmortem
-                        .get("gateway_events")
-                        .and_then(Value::as_array)
-                        .map(Vec::len)
-                        .unwrap_or(0),
-                },
-                "links": links.request_links(request_id),
-                "privacy_note": "Agent trace packets omit request/response payload previews, prompts, scripts, and scene data. Use debug_bundle_url only for reviewed local diagnostics.",
-            });
+            let packet = agent_trace_packet(&lookup_id, &bundle, links.request_links(request_id));
             (StatusCode::OK, Json(packet)).into_response()
         }
         None => (

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -26,7 +26,7 @@
 //! The runtime UI is a single inline HTML string (`admin/html.rs`). The
 //! `dcc-mcp-gateway-admin` crate owns the trace domain, compact, link,
 //! issue-report, statistics, analytics, governance, artifact, activity, task-outcome,
-//! debug-bundle, postmortem, and traffic projections,
+//! debug-bundle, postmortem, agent-trace packet, and traffic projections,
 //! Vite/npm build boundary, and embedded asset; this module owns the
 //! gateway-specific data-source/HTTP adapters and API handlers.
 //!

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,7 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic domain + optional embedded dashboard asset
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -122,7 +122,7 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic domain + optional embedded dashboard asset
+dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic domain + optional embedded dashboard asset
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
@@ -392,7 +392,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
 
 **Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,7 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic 领域和可选嵌入式 dashboard 资产
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -102,7 +102,7 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic 领域和可选嵌入式 dashboard 资产
+dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic 领域和可选嵌入式 dashboard 资产
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
@@ -293,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, and metadata-only traffic projections, plus the optional embedded dashboard asset.
+- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, and metadata-only traffic projections, plus the optional embedded dashboard asset.
 - **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
@@ -282,7 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move the public-safe agent trace packet projection into `dcc-mcp-gateway-admin`
- keep debug-bundle collection, request links, and HTTP handling in `dcc-mcp-gateway`
- add privacy and missing-field contract tests and document ownership

## Validation
- `vx just preflight` (3579/3579 tests passed; doctests passed)
- gateway admin tests (130 passed)
- strict Clippy for gateway and gateway-admin
- public docs internal-path scan passed
- creator Skills unchanged; adapter and skill-authoring workflows are unaffected

Part of #2187