### PR TITLE
refactor: extract admin memory projection

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! This crate owns admin-facing audit, trace, caller-context, compact projection,
 //! link, issue-report, statistics, analytics, governance, artifact, activity, task-outcome,
-//! debug-bundle, postmortem, agent-trace packet, and traffic projections independently of
-//! gateway routing state.
+//! debug-bundle, postmortem, agent-trace packet, memory-summary, and traffic projections
+//! independently of gateway routing state.
 //! It also owns the Vite/npm build script and generated dashboard payload; the Node.js
 //! toolchain only runs when `embed` is enabled.
 
@@ -20,6 +20,7 @@ pub mod domain;
 mod governance;
 mod issue_report;
 mod links;
+mod memory;
 mod projection;
 mod stats;
 mod tasks;
@@ -55,6 +56,7 @@ pub use governance::{
 };
 pub use issue_report::{IssueReportMode, issue_report_filename, issue_report_json};
 pub use links::AdminLinkBuilder;
+pub use memory::memory_summary;
 pub use projection::{
     compact_debug_bundle_payload, compact_trace_context_payload, compact_trace_detail_payload,
     compact_trace_list_payload,

--- a/crates/dcc-mcp-gateway-admin/src/memory.rs
+++ b/crates/dcc-mcp-gateway-admin/src/memory.rs
@@ -1,0 +1,92 @@
+//! Pure agent-memory summary projections for the admin dashboard.
+
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+/// Summarize already-loaded memory rows without owning persistence or queries.
+#[must_use]
+pub fn memory_summary(rows: &[Value]) -> Value {
+    let mut by_dcc = BTreeMap::<String, usize>::new();
+    let mut positive = 0usize;
+    let mut negative = 0usize;
+    let mut ok_count = 0u64;
+    let mut fail_count = 0u64;
+
+    for row in rows {
+        let dcc = row
+            .get("dcc_name")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        *by_dcc.entry(dcc).or_default() += 1;
+        let score = row.get("score").and_then(Value::as_f64).unwrap_or(0.0);
+        if score > 0.0 {
+            positive += 1;
+        } else if score < 0.0 {
+            negative += 1;
+        }
+        let (ok, fail) = outcome_counts(row.get("payload").unwrap_or(&Value::Null));
+        ok_count += ok;
+        fail_count += fail;
+    }
+    let hit_rate_pct = if ok_count + fail_count > 0 {
+        Some((ok_count as f64 / (ok_count + fail_count) as f64) * 100.0)
+    } else {
+        None
+    };
+    json!({
+        "total": rows.len(),
+        "by_dcc": by_dcc,
+        "positive": positive,
+        "negative": negative,
+        "ok_count": ok_count,
+        "fail_count": fail_count,
+        "hit_rate_pct": hit_rate_pct,
+    })
+}
+
+fn outcome_counts(payload: &Value) -> (u64, u64) {
+    let ok = payload.get("ok_count").and_then(Value::as_u64);
+    let fail = payload.get("fail_count").and_then(Value::as_u64);
+    if ok.is_some() || fail.is_some() {
+        return (ok.unwrap_or(0), fail.unwrap_or(0));
+    }
+    match payload.get("ok").and_then(Value::as_bool) {
+        Some(true) => (1, 0),
+        Some(false) => (0, 1),
+        None => (0, 0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summary_groups_dcc_scores_and_outcomes() {
+        let rows = vec![
+            json!({"dcc_name": "maya", "score": 1.0, "payload": {"ok": true}}),
+            json!({"dcc_name": "maya", "score": -0.5, "payload": {"ok_count": 2, "fail_count": 1}}),
+            json!({"dcc_name": "houdini", "score": 0.0, "payload": {"ok": false}}),
+        ];
+
+        let summary = memory_summary(&rows);
+
+        assert_eq!(summary["total"], 3);
+        assert_eq!(summary["by_dcc"], json!({"houdini": 1, "maya": 2}));
+        assert_eq!(summary["positive"], 1);
+        assert_eq!(summary["negative"], 1);
+        assert_eq!(summary["ok_count"], 3);
+        assert_eq!(summary["fail_count"], 2);
+        assert_eq!(summary["hit_rate_pct"], 60.0);
+    }
+
+    #[test]
+    fn empty_summary_has_no_hit_rate() {
+        let summary = memory_summary(&[]);
+
+        assert_eq!(summary["total"], 0);
+        assert!(summary["hit_rate_pct"].is_null());
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/memory.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/memory.rs
@@ -1,10 +1,10 @@
-use std::collections::BTreeMap;
 use std::time::Duration;
 
 use axum::Json;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use dcc_mcp_gateway_admin::memory_summary;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
@@ -38,7 +38,7 @@ pub async fn handle_admin_memory(
         return Json(json!({
             "enabled": false,
             "memory": [],
-            "summary": build_memory_summary(&[]),
+            "summary": memory_summary(&[]),
             "error": "admin sqlite lane disabled",
         }))
         .into_response();
@@ -58,7 +58,7 @@ pub async fn handle_admin_memory(
     Json(json!({
         "enabled": true,
         "memory": rows,
-        "summary": build_memory_summary(&rows),
+        "summary": memory_summary(&rows),
     }))
     .into_response()
 }
@@ -115,59 +115,6 @@ async fn wait_until_agent_memory_id_removed(
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
     tracing::warn!(memory_id = id, "agent memory id not removed after 2 s poll");
-}
-
-fn build_memory_summary(rows: &[Value]) -> Value {
-    let mut by_dcc = BTreeMap::<String, usize>::new();
-    let mut positive = 0usize;
-    let mut negative = 0usize;
-    let mut ok_count = 0u64;
-    let mut fail_count = 0u64;
-
-    for row in rows {
-        let dcc = row
-            .get("dcc_name")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown")
-            .to_string();
-        *by_dcc.entry(dcc).or_default() += 1;
-        let score = row.get("score").and_then(Value::as_f64).unwrap_or(0.0);
-        if score > 0.0 {
-            positive += 1;
-        } else if score < 0.0 {
-            negative += 1;
-        }
-        let (ok, fail) = outcome_counts(row.get("payload").unwrap_or(&Value::Null));
-        ok_count += ok;
-        fail_count += fail;
-    }
-    let hit_rate_pct = if ok_count + fail_count > 0 {
-        Some((ok_count as f64 / (ok_count + fail_count) as f64) * 100.0)
-    } else {
-        None
-    };
-    json!({
-        "total": rows.len(),
-        "by_dcc": by_dcc,
-        "positive": positive,
-        "negative": negative,
-        "ok_count": ok_count,
-        "fail_count": fail_count,
-        "hit_rate_pct": hit_rate_pct,
-    })
-}
-
-fn outcome_counts(payload: &Value) -> (u64, u64) {
-    let ok = payload.get("ok_count").and_then(Value::as_u64);
-    let fail = payload.get("fail_count").and_then(Value::as_u64);
-    if ok.is_some() || fail.is_some() {
-        return (ok.unwrap_or(0), fail.unwrap_or(0));
-    }
-    match payload.get("ok").and_then(Value::as_bool) {
-        Some(true) => (1, 0),
-        Some(false) => (0, 1),
-        None => (0, 0),
-    }
 }
 
 fn clean(value: Option<String>) -> Option<String> {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -26,7 +26,7 @@
 //! The runtime UI is a single inline HTML string (`admin/html.rs`). The
 //! `dcc-mcp-gateway-admin` crate owns the trace domain, compact, link,
 //! issue-report, statistics, analytics, governance, artifact, activity, task-outcome,
-//! debug-bundle, postmortem, agent-trace packet, and traffic projections,
+//! debug-bundle, postmortem, agent-trace packet, memory-summary, and traffic projections,
 //! Vite/npm build boundary, and embedded asset; this module owns the
 //! gateway-specific data-source/HTTP adapters and API handlers.
 //!

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,7 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic domain + optional embedded dashboard asset
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -122,7 +122,7 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic domain + optional embedded dashboard asset
+dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic domain + optional embedded dashboard asset
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
@@ -392,7 +392,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
 
 **Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet、memory summary 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,7 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic 领域和可选嵌入式 dashboard 资产
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -102,7 +102,7 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic 领域和可选嵌入式 dashboard 资产
+dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic 领域和可选嵌入式 dashboard 资产
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
@@ -293,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet、memory summary 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, and metadata-only traffic projections, plus the optional embedded dashboard asset.
+- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, and metadata-only traffic projections, plus the optional embedded dashboard asset.
 - **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
@@ -282,7 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move memory summary aggregation into `dcc-mcp-gateway-admin`
- keep SQLite queries, forget operations, and HTTP adapters in the gateway crate
- document the updated admin projection ownership

## Validation
- `vx just preflight` (3581 tests passed; doctests passed)
- targeted admin memory endpoint test
- strict Clippy for gateway-admin and gateway
- public path scan found no `_thm` or `rez_local_cache` references
- Creator Skills unchanged because adapter and skill-authoring workflows are unchanged

Part of #2187