### PR TITLE
refactor: extract admin skill path projection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ version = "0.20.8"
 dependencies = [
  "axum",
  "chrono",
+ "dcc-mcp-test-utils",
  "dunce",
  "parking_lot",
  "proptest",

--- a/crates/dcc-mcp-gateway-admin/Cargo.toml
+++ b/crates/dcc-mcp-gateway-admin/Cargo.toml
@@ -29,4 +29,5 @@ embed = []
 dunce = "1.0"
 
 [dev-dependencies]
+dcc-mcp-test-utils.workspace = true
 proptest = "1.5"

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate owns admin-facing audit, trace, caller-context, compact projection,
 //! link, issue-report, statistics, analytics, governance, artifact, activity, task-outcome,
-//! debug-bundle, postmortem, agent-trace packet, memory-summary, and traffic projections
+//! debug-bundle, postmortem, agent-trace packet, memory-summary, skill-path, and traffic projections
 //! independently of gateway routing state.
 //! It also owns the Vite/npm build script and generated dashboard payload; the Node.js
 //! toolchain only runs when `embed` is enabled.
@@ -22,6 +22,7 @@ mod issue_report;
 mod links;
 mod memory;
 mod projection;
+mod skill_paths;
 mod stats;
 mod tasks;
 mod trace_log;
@@ -61,6 +62,7 @@ pub use projection::{
     compact_debug_bundle_payload, compact_trace_context_payload, compact_trace_detail_payload,
     compact_trace_list_payload,
 };
+pub use skill_paths::{skill_path_hash, skill_path_row};
 pub use stats::{
     AttributionFacet, GatewayStats, LatencyStats, PayloadTokenUsageStats, StatsFilter, StatsRange,
     StatsStatus, TokenBreakdownEntry, TokenUsageStats, TopEntry, TraceStatsAggregator,

--- a/crates/dcc-mcp-gateway-admin/src/skill_paths.rs
+++ b/crates/dcc-mcp-gateway-admin/src/skill_paths.rs
@@ -1,0 +1,187 @@
+//! Privacy-safe skill-path projections for the admin dashboard.
+
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+
+use serde_json::{Value, json};
+
+/// Project a raw skill path into a privacy-safe admin row.
+#[must_use]
+pub fn skill_path_row(path: &str, source: &str, id: Option<i64>, ordinal: usize) -> Value {
+    let hash = skill_path_hash(path);
+    let status = skill_path_status(path);
+    let source_label = friendly_source_label(source);
+    let tail = safe_path_tail(path);
+    let display_path = if tail.is_empty() {
+        format!("{source_label} #{}", id.unwrap_or(ordinal as i64))
+    } else {
+        format!("{source_label} · {tail}")
+    };
+    let mut row = json!({
+        "path": display_path,
+        "display_path": display_path,
+        "source_label": source_label,
+        "path_tail": tail,
+        "path_alias": format!("skill-path:{hash}"),
+        "path_hash": hash,
+        "path_redacted": true,
+        "source": source,
+        "status": status,
+        "exists": status == "present",
+        "package": Value::Null,
+        "version": Value::Null,
+    });
+    if let Some(id) = id
+        && let Some(obj) = row.as_object_mut()
+    {
+        obj.insert("id".to_string(), json!(id));
+    }
+    row
+}
+
+/// Return the stable, normalized identifier used to deduplicate skill paths.
+#[must_use]
+pub fn skill_path_hash(path: &str) -> String {
+    let mut hasher = StableHasher::new();
+    path.replace('\\', "/")
+        .to_ascii_lowercase()
+        .hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn friendly_source_label(source: &str) -> String {
+    if source.trim().is_empty() {
+        return "Skill path".to_string();
+    }
+    let normalized: String = source
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { ' ' })
+        .collect();
+    let key = normalized.split_whitespace().next().unwrap_or("");
+    match key {
+        "bundled" => "Bundled".to_string(),
+        "admin" | "admincustom" => "Admin custom".to_string(),
+        "env" | "envvar" => "Env var".to_string(),
+        "explicit" | "explicitarg" => "Explicit arg".to_string(),
+        "local" | "localdev" => "Local dev".to_string(),
+        "platform" => "Platform".to_string(),
+        "user" => "User".to_string(),
+        "team" => "Team".to_string(),
+        "repo" => "Repo".to_string(),
+        "system" => "System".to_string(),
+        _ => {
+            let safe = safe_source_label(source);
+            let mut chars = safe.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => "Skill path".to_string(),
+            }
+        }
+    }
+}
+
+fn safe_path_tail(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    let username = std::env::var("USERNAME")
+        .or_else(|_| std::env::var("USER"))
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let components: Vec<&str> = normalized
+        .split('/')
+        .filter(|c| !c.is_empty() && *c != "." && *c != "..")
+        .filter(|c| !(c.len() == 2 && c.ends_with(':')))
+        .collect();
+    let take = components.len().min(2);
+    components[components.len() - take..]
+        .iter()
+        .map(|c| {
+            if !username.is_empty() && c.to_ascii_lowercase() == username {
+                "~".to_string()
+            } else {
+                (*c).to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn safe_source_label(source: &str) -> String {
+    let trimmed = source.trim();
+    if trimmed.is_empty() {
+        return "skill_path".to_string();
+    }
+    trimmed
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | ':' | '.') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .take(64)
+        .collect()
+}
+
+fn skill_path_status(path: &str) -> &'static str {
+    if path.trim().is_empty() {
+        return "missing";
+    }
+    if Path::new(path).exists() {
+        "present"
+    } else {
+        "missing"
+    }
+}
+
+struct StableHasher(u64);
+
+impl StableHasher {
+    fn new() -> Self {
+        Self(0xcbf29ce484222325)
+    }
+}
+
+impl Hasher for StableHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.0 ^= u64::from(*byte);
+            self.0 = self.0.wrapping_mul(0x100000001b3);
+        }
+    }
+
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rows_are_redacted_and_labelled() {
+        let row = skill_path_row("G:/studio/pipeline/skills", "bundled", None, 1);
+        assert_eq!(row["path_redacted"], json!(true));
+        assert_eq!(row["source_label"], json!("Bundled"));
+        assert_eq!(row["path_tail"], json!("pipeline/skills"));
+        assert!(!row["display_path"].as_str().unwrap().contains("G:/studio"));
+    }
+
+    #[test]
+    fn rows_redact_username_components() {
+        let _guard = dcc_mcp_test_utils::EnvVarGuard::set("USERNAME", Some("alice"));
+        let row = skill_path_row("C:/Users/alice/skills", "user", None, 1);
+        assert_eq!(row["path_tail"], json!("~/skills"));
+    }
+
+    #[test]
+    fn hashes_normalize_case_and_separators() {
+        assert_eq!(
+            skill_path_hash("C:\\Studio\\Skills"),
+            skill_path_hash("c:/studio/skills")
+        );
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -26,7 +26,7 @@
 //! The runtime UI is a single inline HTML string (`admin/html.rs`). The
 //! `dcc-mcp-gateway-admin` crate owns the trace domain, compact, link,
 //! issue-report, statistics, analytics, governance, artifact, activity, task-outcome,
-//! debug-bundle, postmortem, agent-trace packet, memory-summary, and traffic projections,
+//! debug-bundle, postmortem, agent-trace packet, memory-summary, skill-path, and traffic projections,
 //! Vite/npm build boundary, and embedded asset; this module owns the
 //! gateway-specific data-source/HTTP adapters and API handlers.
 //!

--- a/crates/dcc-mcp-gateway/src/gateway/admin/skill_health.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/skill_health.rs
@@ -5,11 +5,10 @@
 //! answer skill-level questions without exposing raw local skill paths.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::hash::{Hash, Hasher};
-use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use dcc_mcp_gateway_admin::{skill_path_hash, skill_path_row};
 use serde::Serialize;
 use serde_json::{Value, json};
 
@@ -462,15 +461,15 @@ fn build_skill_path_rows(state: &AdminState) -> Vec<Value> {
         .skill_paths_snapshot
         .iter()
         .enumerate()
-        .map(|(idx, e)| safe_skill_path_row(&e.path, &e.source, None, idx + 1))
+        .map(|(idx, e)| skill_path_row(&e.path, &e.source, None, idx + 1))
         .collect();
     if let Some(ref lane) = state.admin_sqlite_lane {
         let r = lane.reader();
         for (id, path) in r.list_custom_skill_paths() {
             if !rows.iter().any(|v| {
-                v.get("path_hash").and_then(Value::as_str) == Some(path_hash(&path).as_str())
+                v.get("path_hash").and_then(Value::as_str) == Some(skill_path_hash(&path).as_str())
             }) {
-                rows.push(safe_skill_path_row(
+                rows.push(skill_path_row(
                     &path,
                     "admin_custom",
                     Some(id),
@@ -482,169 +481,8 @@ fn build_skill_path_rows(state: &AdminState) -> Vec<Value> {
     rows
 }
 
-fn safe_skill_path_row(path: &str, source: &str, id: Option<i64>, ordinal: usize) -> Value {
-    let hash = path_hash(path);
-    let status = skill_path_status(path);
-    let source_label = friendly_source_label(source);
-    let tail = safe_path_tail(path);
-    // Prefer a non-sensitive folder tail (e.g. "studio/skills") so operators
-    // can tell same-source rows apart; fall back to the ordinal id only when no
-    // meaningful tail is available. The full local path is never exposed.
-    let display_path = if tail.is_empty() {
-        format!("{source_label} #{}", id.unwrap_or(ordinal as i64))
-    } else {
-        format!("{source_label} · {tail}")
-    };
-    let mut row = json!({
-        "path": display_path,
-        "display_path": display_path,
-        "source_label": source_label,
-        "path_tail": tail,
-        "path_alias": format!("skill-path:{hash}"),
-        "path_hash": hash,
-        "path_redacted": true,
-        "source": source,
-        "status": status,
-        "exists": status == "present",
-        "package": Value::Null,
-        "version": Value::Null,
-    });
-    if let Some(id) = id
-        && let Some(obj) = row.as_object_mut()
-    {
-        obj.insert("id".to_string(), json!(id));
-    }
-    row
-}
-
-/// Map a raw path-source token (e.g. `bundled`, `admin_custom`,
-/// `env:DCC_MCP_SKILL_PATHS`) to a friendly, human-readable label for the
-/// admin UI. Unknown sources are title-cased from their safe form.
-fn friendly_source_label(source: &str) -> String {
-    if source.trim().is_empty() {
-        return "Skill path".to_string();
-    }
-    let normalized: String = source
-        .trim()
-        .to_ascii_lowercase()
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { ' ' })
-        .collect();
-    let key = normalized.split_whitespace().next().unwrap_or("");
-    match key {
-        "bundled" => "Bundled".to_string(),
-        "admin" | "admincustom" => "Admin custom".to_string(),
-        "env" | "envvar" => "Env var".to_string(),
-        "explicit" | "explicitarg" => "Explicit arg".to_string(),
-        "local" | "localdev" => "Local dev".to_string(),
-        "platform" => "Platform".to_string(),
-        "user" => "User".to_string(),
-        "team" => "Team".to_string(),
-        "repo" => "Repo".to_string(),
-        "system" => "System".to_string(),
-        _ => {
-            let safe = safe_source_label(source);
-            let mut chars = safe.chars();
-            match chars.next() {
-                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-                None => "Skill path".to_string(),
-            }
-        }
-    }
-}
-
-/// Return the final one or two path components, which are safe to show because
-/// they describe the skill *folder* rather than the user's filesystem layout.
-/// Any component matching the current OS username is replaced with `~` so a
-/// `C:\Users\<name>\...` style root cannot leak the operator's identity.
-fn safe_path_tail(path: &str) -> String {
-    let normalized = path.replace('\\', "/");
-    let username = std::env::var("USERNAME")
-        .or_else(|_| std::env::var("USER"))
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    let components: Vec<&str> = normalized
-        .split('/')
-        .filter(|c| !c.is_empty() && *c != "." && *c != "..")
-        // Drop drive letters like "C:" so the tail stays folder-focused.
-        .filter(|c| !(c.len() == 2 && c.ends_with(':')))
-        .collect();
-    let take = components.len().min(2);
-    components[components.len() - take..]
-        .iter()
-        .map(|c| {
-            if !username.is_empty() && c.to_ascii_lowercase() == username {
-                "~".to_string()
-            } else {
-                (*c).to_string()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
-}
-
 fn skill_path_count(state: &AdminState) -> usize {
     build_skill_path_rows(state).len()
-}
-
-fn safe_source_label(source: &str) -> String {
-    let trimmed = source.trim();
-    if trimmed.is_empty() {
-        return "skill_path".to_string();
-    }
-    trimmed
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | ':' | '.') {
-                ch
-            } else {
-                '_'
-            }
-        })
-        .take(64)
-        .collect()
-}
-
-fn skill_path_status(path: &str) -> &'static str {
-    if path.trim().is_empty() {
-        return "missing";
-    }
-    if Path::new(path).exists() {
-        "present"
-    } else {
-        "missing"
-    }
-}
-
-fn path_hash(path: &str) -> String {
-    let mut hasher = StableHasher::new();
-    normalise_path_for_hash(path).hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
-}
-
-fn normalise_path_for_hash(path: &str) -> String {
-    path.replace('\\', "/").to_ascii_lowercase()
-}
-
-struct StableHasher(u64);
-
-impl StableHasher {
-    fn new() -> Self {
-        Self(0xcbf29ce484222325)
-    }
-}
-
-impl Hasher for StableHasher {
-    fn write(&mut self, bytes: &[u8]) {
-        for byte in bytes {
-            self.0 ^= u64::from(*byte);
-            self.0 = self.0.wrapping_mul(0x100000001b3);
-        }
-    }
-
-    fn finish(&self) -> u64 {
-        self.0
-    }
 }
 
 fn max_ms(current: Option<u64>, candidate: Option<u64>) -> Option<u64> {
@@ -687,54 +525,8 @@ fn instance_short(id: &uuid::Uuid) -> String {
 }
 
 #[cfg(test)]
-mod skill_path_display_tests {
+mod skill_health_tests {
     use super::*;
-
-    #[test]
-    fn friendly_labels_map_known_sources() {
-        assert_eq!(friendly_source_label("bundled"), "Bundled");
-        assert_eq!(friendly_source_label("admin_custom"), "Admin custom");
-        assert_eq!(friendly_source_label("env:DCC_MCP_SKILL_PATHS"), "Env var");
-        assert_eq!(friendly_source_label("LocalDev"), "Local dev");
-        assert_eq!(friendly_source_label("ExplicitArg"), "Explicit arg");
-        assert_eq!(friendly_source_label("platform"), "Platform");
-    }
-
-    #[test]
-    fn friendly_labels_title_case_unknown_sources() {
-        assert_eq!(friendly_source_label("studio-shared"), "Studio-shared");
-        assert_eq!(friendly_source_label(""), "Skill path");
-    }
-
-    #[test]
-    fn path_tail_keeps_last_two_components_and_drops_drive() {
-        assert_eq!(
-            safe_path_tail("G:/studio/pipeline/skills"),
-            "pipeline/skills"
-        );
-        assert_eq!(safe_path_tail("C:\\repo\\skills"), "repo/skills");
-        assert_eq!(safe_path_tail("skills"), "skills");
-        assert_eq!(safe_path_tail(""), "");
-    }
-
-    #[test]
-    fn path_tail_redacts_os_username_component() {
-        let _g = dcc_mcp_test_utils::EnvVarGuard::set("USERNAME", Some("alice"));
-        // A home-rooted path must not leak the operator's username.
-        assert_eq!(safe_path_tail("C:/Users/alice/skills"), "~/skills");
-    }
-
-    #[test]
-    fn skill_path_row_is_redacted_and_labelled() {
-        let row = safe_skill_path_row("G:/studio/pipeline/skills", "bundled", None, 1);
-        assert_eq!(row["path_redacted"], serde_json::json!(true));
-        assert_eq!(row["source_label"], serde_json::json!("Bundled"));
-        assert_eq!(row["path_tail"], serde_json::json!("pipeline/skills"));
-        // The display string must never contain the original absolute path.
-        let display = row["display_path"].as_str().unwrap();
-        assert!(!display.contains("G:/studio"));
-        assert!(display.starts_with("Bundled"));
-    }
 
     #[test]
     fn historical_instance_prefix_preserves_full_backend_tool() {

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, privacy-safe skill-path, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,7 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic domain + optional embedded dashboard asset
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -122,7 +122,7 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic domain + optional embedded dashboard asset
+dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic domain + optional embedded dashboard asset
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
@@ -392,7 +392,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, privacy-safe skill-path, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
 
 **Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet、memory summary 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet、memory summary、隐私安全的 skill-path 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,7 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic 领域和可选嵌入式 dashboard 资产
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -102,7 +102,7 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic 领域和可选嵌入式 dashboard 资产
+dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic 领域和可选嵌入式 dashboard 资产
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
@@ -293,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet、memory summary 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet、memory summary、隐私安全的 skill-path 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, and metadata-only traffic projections, plus the optional embedded dashboard asset.
+- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, privacy-safe skill-path, and metadata-only traffic projections, plus the optional embedded dashboard asset.
 - **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
@@ -282,7 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move privacy-safe skill-path projection and stable hashes into `dcc-mcp-gateway-admin`
- keep gateway state, SQLite collection, deduplication, and HTTP handlers in `dcc-mcp-gateway`
- document the clarified admin ownership boundary

## Validation
- `vx just preflight` (3579 tests passed, plus doctests)
- targeted gateway-admin and gateway skill-health tests
- strict Clippy for both affected crates
- public documentation scan contains no `_thm` or `rez_local_cache`
- creator Skills unchanged because adapter and skill-authoring workflows are unchanged

Part of #2187