### PR TITLE
refactor: extract admin experiment projection

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/experiments.rs
+++ b/crates/dcc-mcp-gateway-admin/src/experiments.rs
@@ -1,0 +1,155 @@
+//! Pure experiment projections for the admin API.
+
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value, json};
+
+/// Project persisted experiment summaries into the list response.
+#[must_use]
+pub fn project_experiment_list(experiments: Vec<Value>) -> Value {
+    json!({"total": experiments.len(), "experiments": experiments})
+}
+
+/// Project persisted experiment events into the detail response.
+///
+/// Returns `None` when the event stream does not contain an
+/// `experiment.created` event.
+#[must_use]
+pub fn project_experiment_detail(events: Vec<Value>) -> Option<Value> {
+    let experiment = events
+        .iter()
+        .find(|event| event["event_type"] == "experiment.created")
+        .cloned()?;
+
+    let mut runs = BTreeMap::<String, Value>::new();
+    let mut judge_results = Vec::new();
+    for event in &events {
+        match event["event_type"].as_str().unwrap_or_default() {
+            value if value.starts_with("experiment.run.") => {
+                if let Some(run_id) = event["run_id"].as_str() {
+                    runs.insert(run_id.to_owned(), event.clone());
+                }
+            }
+            "experiment.judge.result" => judge_results.push(event.clone()),
+            _ => {}
+        }
+    }
+    let runs = runs.into_values().collect::<Vec<_>>();
+
+    Some(json!({
+        "experiment": experiment,
+        "runs": runs,
+        "session_dag": session_dag(&runs),
+        "judge_results": judge_results,
+        "metrics": summary_metrics(&runs, &judge_results),
+        "events": events,
+    }))
+}
+
+fn session_dag(runs: &[Value]) -> Value {
+    let nodes = runs
+        .iter()
+        .map(|run| {
+            json!({
+                "run_id": run["run_id"],
+                "session_id": run["session_id"],
+                "parent_run_id": run["parent_run_id"],
+                "parent_session_id": run["parent_session_id"],
+                "status": run["status"],
+            })
+        })
+        .collect::<Vec<_>>();
+    let edges = runs
+        .iter()
+        .filter_map(|run| {
+            let from = run["parent_run_id"]
+                .as_str()
+                .or_else(|| run["parent_session_id"].as_str())?;
+            Some(json!({
+                "from": from,
+                "to": run["run_id"].as_str().unwrap_or_default(),
+            }))
+        })
+        .collect::<Vec<_>>();
+    json!({"nodes": nodes, "edges": edges})
+}
+
+fn summary_metrics(runs: &[Value], judges: &[Value]) -> Value {
+    let mut run_counts = Map::new();
+    let mut judge_counts = Map::new();
+    for run in runs {
+        increment(&mut run_counts, run["status"].as_str().unwrap_or("unknown"));
+    }
+    for judge in judges {
+        increment(
+            &mut judge_counts,
+            judge["status"].as_str().unwrap_or("unknown"),
+        );
+    }
+    run_counts.insert("total".into(), json!(runs.len()));
+    judge_counts.insert("total".into(), json!(judges.len()));
+    json!({"runs": run_counts, "judges": judge_counts})
+}
+
+fn increment(counts: &mut Map<String, Value>, key: &str) {
+    let next = counts.get(key).and_then(Value::as_u64).unwrap_or(0) + 1;
+    counts.insert(key.to_owned(), json!(next));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_projection_reports_total() {
+        let payload = project_experiment_list(vec![json!({"experiment_id": "exp-1"})]);
+        assert_eq!(payload["total"], 1);
+        assert_eq!(payload["experiments"][0]["experiment_id"], "exp-1");
+    }
+
+    #[test]
+    fn detail_projection_keeps_latest_run_and_builds_dag_and_metrics() {
+        let events = vec![
+            json!({"event_type": "experiment.created", "experiment_id": "exp-1"}),
+            json!({
+                "event_type": "experiment.run.running",
+                "run_id": "run-1",
+                "session_id": "maya-session",
+                "status": "running"
+            }),
+            json!({
+                "event_type": "experiment.run.passed",
+                "run_id": "run-1",
+                "session_id": "maya-session",
+                "parent_session_id": "photoshop-session",
+                "status": "passed"
+            }),
+            json!({
+                "event_type": "experiment.judge.result",
+                "run_id": "run-1",
+                "status": "passed"
+            }),
+        ];
+
+        let payload = project_experiment_detail(events).unwrap();
+        assert_eq!(payload["runs"].as_array().unwrap().len(), 1);
+        assert_eq!(payload["runs"][0]["status"], "passed");
+        assert_eq!(
+            payload["session_dag"]["edges"][0]["from"],
+            "photoshop-session"
+        );
+        assert_eq!(payload["metrics"]["runs"]["passed"], 1);
+        assert_eq!(payload["metrics"]["judges"]["passed"], 1);
+    }
+
+    #[test]
+    fn detail_projection_requires_creation_event() {
+        assert!(
+            project_experiment_detail(vec![json!({
+                "event_type": "experiment.run.passed",
+                "run_id": "run-1"
+            })])
+            .is_none()
+        );
+    }
+}

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate owns admin-facing audit, trace, caller-context, compact projection,
 //! link, issue-report, statistics, analytics, governance, artifact, activity, task-outcome,
-//! debug-bundle, postmortem, agent-trace packet, memory-summary, skill-path, and traffic projections
+//! debug-bundle, postmortem, agent-trace packet, memory-summary, experiment, skill-path, and traffic projections
 //! independently of gateway routing state.
 //! It also owns the Vite/npm build script and generated dashboard payload; the Node.js
 //! toolchain only runs when `embed` is enabled.
@@ -17,6 +17,7 @@ mod audit;
 mod debug;
 /// Admin trace and caller-attribution value types.
 pub mod domain;
+mod experiments;
 mod governance;
 mod issue_report;
 mod links;
@@ -52,6 +53,7 @@ pub use domain::trace::{
     TokenTelemetry, TraceContext, TraceContextHeader, TracePayload, TraceSpan, estimate_tokens,
     parse_traceparent,
 };
+pub use experiments::{project_experiment_detail, project_experiment_list};
 pub use governance::{
     GovernanceCaptureDecision, GovernanceMiddlewareState, governance_payload, governance_stats,
 };

--- a/crates/dcc-mcp-gateway/src/gateway/admin/experiments.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/experiments.rs
@@ -1,14 +1,14 @@
 //! Reproducible experiment projections backed by the existing session timeline.
 
-use std::collections::BTreeMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
+use dcc_mcp_gateway_admin::{project_experiment_detail, project_experiment_list};
 use serde::Deserialize;
-use serde_json::{Map, Value, json};
+use serde_json::{Value, json};
 
 use super::recordings::caller_session;
 use super::state::AdminState;
@@ -272,7 +272,7 @@ pub(crate) fn experiment_list_payload(
         return Err(ExperimentReadError::SqliteUnavailable);
     };
     let experiments = lane.reader().list_experiments(limit.clamp(1, 1_000));
-    Ok(json!({"total": experiments.len(), "experiments": experiments}))
+    Ok(project_experiment_list(experiments))
 }
 
 pub(crate) fn experiment_detail_payload(
@@ -288,39 +288,7 @@ pub(crate) fn experiment_detail_payload(
     let events = lane
         .reader()
         .list_experiment_events(experiment_id, MAX_EVENTS);
-    let Some(experiment) = events
-        .iter()
-        .find(|event| event["event_type"] == "experiment.created")
-        .cloned()
-    else {
-        return Err(ExperimentReadError::NotFound);
-    };
-
-    let mut runs = BTreeMap::<String, Value>::new();
-    let mut judge_results = Vec::new();
-    for event in &events {
-        match event["event_type"].as_str().unwrap_or_default() {
-            value if value.starts_with("experiment.run.") => {
-                if let Some(run_id) = event["run_id"].as_str() {
-                    runs.insert(run_id.to_owned(), event.clone());
-                }
-            }
-            "experiment.judge.result" => judge_results.push(event.clone()),
-            _ => {}
-        }
-    }
-    let runs = runs.into_values().collect::<Vec<_>>();
-    let session_dag = session_dag(&runs);
-    let metrics = summary_metrics(&runs, &judge_results);
-
-    Ok(json!({
-        "experiment": experiment,
-        "runs": runs,
-        "session_dag": session_dag,
-        "judge_results": judge_results,
-        "metrics": metrics,
-        "events": events,
-    }))
+    project_experiment_detail(events).ok_or(ExperimentReadError::NotFound)
 }
 
 fn validate_create(body: &CreateExperimentBody) -> Result<(), &'static str> {
@@ -346,56 +314,6 @@ fn validate_create(body: &CreateExperimentBody) -> Result<(), &'static str> {
         return Err("invalid or oversized experiment definition");
     }
     Ok(())
-}
-
-fn session_dag(runs: &[Value]) -> Value {
-    let nodes = runs
-        .iter()
-        .map(|run| {
-            json!({
-                "run_id": run["run_id"],
-                "session_id": run["session_id"],
-                "parent_run_id": run["parent_run_id"],
-                "parent_session_id": run["parent_session_id"],
-                "status": run["status"],
-            })
-        })
-        .collect::<Vec<_>>();
-    let edges = runs
-        .iter()
-        .filter_map(|run| {
-            let from = run["parent_run_id"]
-                .as_str()
-                .or_else(|| run["parent_session_id"].as_str())?;
-            Some(json!({
-                "from": from,
-                "to": run["run_id"].as_str().unwrap_or_default(),
-            }))
-        })
-        .collect::<Vec<_>>();
-    json!({"nodes": nodes, "edges": edges})
-}
-
-fn summary_metrics(runs: &[Value], judges: &[Value]) -> Value {
-    let mut run_counts = Map::new();
-    let mut judge_counts = Map::new();
-    for run in runs {
-        increment(&mut run_counts, run["status"].as_str().unwrap_or("unknown"));
-    }
-    for judge in judges {
-        increment(
-            &mut judge_counts,
-            judge["status"].as_str().unwrap_or("unknown"),
-        );
-    }
-    run_counts.insert("total".into(), json!(runs.len()));
-    judge_counts.insert("total".into(), json!(judges.len()));
-    json!({"runs": run_counts, "judges": judge_counts})
-}
-
-fn increment(counts: &mut Map<String, Value>, key: &str) {
-    let next = counts.get(key).and_then(Value::as_u64).unwrap_or(0) + 1;
-    counts.insert(key.to_owned(), json!(next));
 }
 
 fn valid_id(value: &str) -> bool {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -26,7 +26,7 @@
 //! The runtime UI is a single inline HTML string (`admin/html.rs`). The
 //! `dcc-mcp-gateway-admin` crate owns the trace domain, compact, link,
 //! issue-report, statistics, analytics, governance, artifact, activity, task-outcome,
-//! debug-bundle, postmortem, agent-trace packet, memory-summary, skill-path, and traffic projections,
+//! debug-bundle, postmortem, agent-trace packet, memory-summary, experiment, skill-path, and traffic projections,
 //! Vite/npm build boundary, and embedded asset; this module owns the
 //! gateway-specific data-source/HTTP adapters and API handlers.
 //!

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # Built-in Admin Dashboard
 
-The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, privacy-safe skill-path, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
+The gateway ships an embedded `/admin` web dashboard (issue #772). At runtime it is a single HTML payload served from the binary; contributors edit the Vite/React source in `admin-ui/`, and `dcc-mcp-gateway-admin` owns the audit/trace/caller domain, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, experiment, privacy-safe skill-path, and metadata-only traffic projections, plus the optional frontend build and embedded asset. The gateway crate retains only data-source and HTTP adapters for those contracts. Builds that do not enable the gateway `admin` feature never execute the Node/Vite build boundary.
 
 ## Activation and Defaults
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -69,7 +69,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search # Reusable capability search/query/ranking engine
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic domain + optional embedded dashboard asset
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/experiment/skill-path/traffic domain + optional embedded dashboard asset
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-sidecar       # Per-DCC sidecar + gateway daemon guardian runtime
@@ -122,7 +122,7 @@ dcc-mcp-gateway-core ← pure gateway domain/search/ranking types
        ↓
 dcc-mcp-gateway-search ← reusable search/query/ranking engine
        ↓
-dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic domain + optional embedded dashboard asset
+dcc-mcp-gateway-admin ← admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/experiment/skill-path/traffic domain + optional embedded dashboard asset
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
 
@@ -392,7 +392,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — concurrent application wrapper over core index state; coordinates live per-DCC refreshes and evicts stale instances.
 - `search`, `describe`, `load_skill`, `call` — fixed gateway MCP workflow tools over the dynamic capability index; `/v1/*` routes are the pure HTTP twin.
 - Gateway REST facade — `POST /v1/search`, `/v1/describe`, `/v1/call`, `/v1/call_batch`, plus diagnostics/resources/prompts aggregation.
-- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, privacy-safe skill-path, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
+- Admin/dashboard support — read-only `/admin/api/*` inspection for instances, tools, calls, traces, stats, workers, logs, and health. Audit, trace, caller-context, token-telemetry, bounded audit/trace-log, compact agent-facing projection, link projection, issue-report privacy, pure statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, experiment, privacy-safe skill-path, and metadata-only traffic contracts are owned by `dcc-mcp-gateway-admin`; gateway-specific persistence and HTTP adapters remain in the gateway crate.
 
 **Dependencies**: `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, `dcc-mcp-wire`, `dcc-mcp-transport`, `dcc-mcp-skill-rest`, `reqwest`, `tokio`.
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,6 +1,6 @@
 # 内置 Admin 仪表盘
 
-网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet、memory summary、隐私安全的 skill-path 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
+网关内置一个嵌入式 `/admin` Web 仪表盘（issue #772）。运行时仍由二进制提供单个 HTML 资产；贡献者在 `admin-ui/` 中维护 Vite/React 源码，`dcc-mcp-gateway-admin` 持有 audit/trace/caller 领域契约、面向 agent 的 compact projection、链接 projection、issue-report 隐私契约、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet、memory summary、experiment、隐私安全的 skill-path 与 metadata-only traffic projection，并负责可选的前端构建与嵌入资产；gateway crate 只保留数据源和 HTTP adapter。未启用网关 `admin` feature 的构建不会执行 Node/Vite 构建边界。
 
 ## 启用方式与默认值
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -54,7 +54,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway-search # 能力搜索/排序引擎
-├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic 领域和可选嵌入式 dashboard 资产
+├── dcc-mcp-gateway-admin # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/experiment/skill-path/traffic 领域和可选嵌入式 dashboard 资产
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -102,7 +102,7 @@ dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
 dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
        ↓
-dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic 领域和可选嵌入式 dashboard 资产
+dcc-mcp-gateway-admin ← Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/experiment/skill-path/traffic 领域和可选嵌入式 dashboard 资产
        ↓
 dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-gateway-admin, dcc-mcp-wire, dcc-mcp-transport
        ↓
@@ -293,7 +293,7 @@ dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 - `CapabilityIndex` + refresh tasks — 从活跃 per-DCC 实例构建 capability records，并剔除 stale 实例
 - `search`、`describe` — 固定的只读 gateway MCP 发现工具，覆盖动态 capability index；`/v1/call` 与 `/v1/call_batch` 是执行面
 - Gateway REST facade — `POST /v1/search`、`/v1/describe`、`/v1/call` 以及 diagnostics/resources/prompts 聚合
-- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet、memory summary、隐私安全的 skill-path 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
+- Admin/dashboard — `/admin/api/*` 只读检查 instances、tools、calls、traces、stats、workers、logs、health。Audit、trace、caller context、token telemetry、有界 audit/trace log、面向 agent 的 compact projection、链接 projection、issue-report 隐私、纯统计、audit analytics、governance、artifact、activity timeline、task outcome、debug bundle、postmortem、agent-trace packet、memory summary、experiment、隐私安全的 skill-path 与 metadata-only traffic 契约由 `dcc-mcp-gateway-admin` 持有；gateway crate 保留持久化、HTTP adapter 和兼容导入路径。
 
 ### dcc-mcp-http-types
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,7 @@ crates/
 ├── dcc-mcp-skill-rest/   # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/ # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/experiment/skill-path/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types

--- a/llms.txt
+++ b/llms.txt
@@ -262,7 +262,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-skill-rest`** — per-DCC `/v1/*` REST skill API. Owns the `utoipa` OpenAPI generator.
 - **`dcc-mcp-gateway-core`** — pure gateway domain types and algorithms (`CapabilityRecord`, search query/page/hit types, slug helpers, ranking scorers) with no HTTP or async runtime dependency.
 - **`dcc-mcp-gateway-search`** — canonical Rust `SearchRecord`/`Scorer` contracts used by skill catalogs, per-DCC REST, and gateway search, including shared fuzzy/exact matching, rank policy, and pagination.
-- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, privacy-safe skill-path, and metadata-only traffic projections, plus the optional embedded dashboard asset.
+- **`dcc-mcp-gateway-admin`** — admin audit/trace/caller-context/token-telemetry domain, bounded audit/trace logs, compact agent-facing, link, issue-report, statistics, audit-analytics, governance, artifact, activity-timeline, task-outcome, debug-bundle, postmortem, agent-trace packet, memory-summary, experiment, privacy-safe skill-path, and metadata-only traffic projections, plus the optional embedded dashboard asset.
 - **`dcc-mcp-gateway`** — multi-DCC gateway app/infrastructure: registry probing, REST facade, and dynamic-capability MCP wrappers. It depends inward on `dcc-mcp-gateway-core`, `dcc-mcp-gateway-search`, `dcc-mcp-gateway-admin`, and `dcc-mcp-wire`.
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
@@ -282,7 +282,7 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway-search/ # Reusable capability search/ranking engine
-├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/skill-path/traffic domain + embedded dashboard boundary
+├── dcc-mcp-gateway-admin/  # Admin audit/trace/caller/projection/report/stats/analytics/governance/artifact/activity/task/debug/agent-trace/memory/experiment/skill-path/traffic domain + embedded dashboard boundary
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-gateway-ensure/ # Shared gateway health check, launch lock, spawn, process utilities
 ├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig


### PR DESCRIPTION
## Summary
- move pure experiment list/detail, session-DAG, and metrics projections into `dcc-mcp-gateway-admin`
- keep SQLite persistence, validation, authorization, and HTTP handlers in `dcc-mcp-gateway`
- document the clarified admin ownership boundary

## Validation
- `vx just preflight` (3582 tests passed, plus doctests)
- focused gateway-admin projection tests and gateway experiment API E2E
- strict Clippy for both affected crates
- public documentation scan contains no `_thm` or `rez_local_cache`
- creator Skills unchanged because adapter and skill-authoring workflows are unchanged

Part of #2187