### PR TITLE
refactor: extract admin experiment validation

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/experiments.rs
+++ b/crates/dcc-mcp-gateway-admin/src/experiments.rs
@@ -1,8 +1,121 @@
-//! Pure experiment projections for the admin API.
+//! Pure experiment contracts and projections for the admin API.
 
 use std::collections::BTreeMap;
 
 use serde_json::{Map, Value, json};
+
+const MAX_METADATA_BYTES: usize = 16 * 1024;
+
+/// Validate a persisted experiment identifier.
+#[must_use]
+pub fn valid_experiment_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
+}
+
+/// Validate the bounded fields accepted when an experiment is created.
+pub fn validate_experiment_definition(
+    name: &str,
+    scenario_id: &str,
+    description: &str,
+    workflow_id: Option<&str>,
+    recording_id: Option<&str>,
+    tags: &[String],
+    metadata: &Value,
+) -> Result<(), &'static str> {
+    if name.trim().is_empty()
+        || name.len() > 256
+        || !valid_experiment_id(scenario_id)
+        || description.len() > 2_048
+        || workflow_id.is_some_and(|value| !valid_experiment_id(value))
+        || recording_id.is_some_and(|value| !valid_experiment_id(value))
+        || tags.len() > 32
+        || tags
+            .iter()
+            .any(|value| value.is_empty() || value.len() > 64)
+        || !bounded_json(metadata)
+    {
+        return Err("invalid or oversized experiment definition");
+    }
+    Ok(())
+}
+
+/// Validate the bounded fields accepted for an experiment run event.
+pub fn validate_experiment_run(
+    run_id: &str,
+    status: &str,
+    parent_run_id: Option<&str>,
+    parent_session_id: Option<&str>,
+    parameters: &Value,
+    metrics: &Value,
+    evidence: &[String],
+) -> Result<(), &'static str> {
+    if !valid_experiment_id(run_id)
+        || !matches!(
+            status,
+            "pending" | "running" | "passed" | "failed" | "error" | "cancelled"
+        )
+        || parent_run_id.is_some_and(|value| !valid_experiment_id(value))
+        || parent_session_id.is_some_and(|value| !valid_experiment_id(value))
+        || !bounded_json(parameters)
+        || !bounded_json(metrics)
+        || !valid_evidence(evidence)
+    {
+        return Err("invalid or oversized experiment run payload");
+    }
+    Ok(())
+}
+
+/// Fields required to validate one judge-result event.
+#[derive(Debug, Clone, Copy)]
+pub struct ExperimentJudgeValidation<'a> {
+    pub run_id: &'a str,
+    pub evaluator_id: &'a str,
+    pub evaluator_version: &'a str,
+    pub rubric_hash: &'a str,
+    pub status: &'a str,
+    pub scores: &'a Value,
+    pub summary: &'a str,
+    pub cost: Option<f64>,
+    pub evidence: &'a [String],
+}
+
+/// Validate the bounded fields accepted for an experiment judge result.
+pub fn validate_experiment_judge(input: ExperimentJudgeValidation<'_>) -> Result<(), &'static str> {
+    if !valid_experiment_id(input.run_id)
+        || !valid_experiment_id(input.evaluator_id)
+        || input.evaluator_version.is_empty()
+        || input.evaluator_version.len() > 64
+        || input.rubric_hash.is_empty()
+        || input.rubric_hash.len() > 256
+        || !matches!(input.status, "passed" | "failed" | "error")
+        || input.summary.len() > 2_048
+        || !bounded_json(input.scores)
+        || !valid_evidence(input.evidence)
+        || input
+            .cost
+            .is_some_and(|value| !value.is_finite() || value < 0.0)
+    {
+        return Err("invalid or oversized judge result payload");
+    }
+    Ok(())
+}
+
+fn bounded_json(value: &Value) -> bool {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len() <= MAX_METADATA_BYTES)
+        .unwrap_or(false)
+}
+
+fn valid_evidence(values: &[String]) -> bool {
+    values.len() <= 32
+        && values
+            .iter()
+            .all(|value| !value.is_empty() && value.len() <= 2_048)
+}
 
 /// Project persisted experiment summaries into the list response.
 #[must_use]
@@ -150,6 +263,65 @@ mod tests {
                 "run_id": "run-1"
             })])
             .is_none()
+        );
+    }
+
+    #[test]
+    fn validation_accepts_backend_neutral_experiment_contracts() {
+        assert!(
+            validate_experiment_definition(
+                "Cross-DCC validation",
+                "scene-v1",
+                "",
+                Some("workflow-1"),
+                None,
+                &["maya".to_string(), "photoshop".to_string()],
+                &json!({"seed": 7}),
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_experiment_run(
+                "run-1",
+                "passed",
+                None,
+                Some("session-1"),
+                &json!({"dcc": "custom"}),
+                &json!({"score": 0.9}),
+                &["artefact://sha256/example".to_string()],
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn validation_rejects_unsafe_or_oversized_values() {
+        assert!(!valid_experiment_id("bad/id"));
+        assert!(
+            validate_experiment_run(
+                "run-1",
+                "unknown",
+                None,
+                None,
+                &Value::Null,
+                &Value::Null,
+                &[],
+            )
+            .is_err()
+        );
+        assert!(
+            validate_experiment_judge(ExperimentJudgeValidation {
+                run_id: "run-1",
+                evaluator_id: "quality",
+                evaluator_version: "1",
+                rubric_hash: "sha256:abc",
+                status: "passed",
+                scores: &json!({}),
+                summary: "ok",
+                cost: Some(f64::NAN),
+                evidence: &[],
+            })
+            .is_err()
         );
     }
 }

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -53,7 +53,11 @@ pub use domain::trace::{
     TokenTelemetry, TraceContext, TraceContextHeader, TracePayload, TraceSpan, estimate_tokens,
     parse_traceparent,
 };
-pub use experiments::{project_experiment_detail, project_experiment_list};
+pub use experiments::{
+    ExperimentJudgeValidation, project_experiment_detail, project_experiment_list,
+    valid_experiment_id, validate_experiment_definition, validate_experiment_judge,
+    validate_experiment_run,
+};
 pub use governance::{
     GovernanceCaptureDecision, GovernanceMiddlewareState, governance_payload, governance_stats,
 };

--- a/crates/dcc-mcp-gateway/src/gateway/admin/experiments.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/experiments.rs
@@ -1,4 +1,4 @@
-//! Reproducible experiment projections backed by the existing session timeline.
+//! Reproducible experiment HTTP and persistence adapters.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -6,14 +6,17 @@ use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
-use dcc_mcp_gateway_admin::{project_experiment_detail, project_experiment_list};
+use dcc_mcp_gateway_admin::{
+    ExperimentJudgeValidation, project_experiment_detail, project_experiment_list,
+    valid_experiment_id, validate_experiment_definition, validate_experiment_judge,
+    validate_experiment_run,
+};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
 use super::recordings::caller_session;
 use super::state::AdminState;
 
-const MAX_METADATA_BYTES: usize = 16 * 1024;
 const MAX_EVENTS: usize = 1_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -113,7 +116,15 @@ pub async fn handle_experiment_create(
     let Some(session_id) = caller_session(&headers) else {
         return session_required();
     };
-    if let Err(message) = validate_create(&body) {
+    if let Err(message) = validate_experiment_definition(
+        &body.name,
+        &body.scenario_id,
+        &body.description,
+        body.workflow_id.as_deref(),
+        body.recording_id.as_deref(),
+        &body.tags,
+        &body.metadata,
+    ) {
         return invalid_request(message);
     }
     let Some(lane) = &state.admin_sqlite_lane else {
@@ -147,30 +158,22 @@ pub async fn handle_experiment_run(
     let Some(session_id) = caller_session(&headers) else {
         return session_required();
     };
-    if !valid_id(&experiment_id) {
+    if !valid_experiment_id(&experiment_id) {
         return invalid_request("experiment_id must be a bounded identifier");
     }
     let run_id = body
         .run_id
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-    if !valid_id(&run_id)
-        || !matches!(
-            body.status.as_str(),
-            "pending" | "running" | "passed" | "failed" | "error" | "cancelled"
-        )
-        || body
-            .parent_run_id
-            .as_deref()
-            .is_some_and(|value| !valid_id(value))
-        || body
-            .parent_session_id
-            .as_deref()
-            .is_some_and(|value| !valid_id(value))
-        || !bounded_json(&body.parameters)
-        || !bounded_json(&body.metrics)
-        || !valid_evidence(&body.evidence)
-    {
-        return invalid_request("invalid or oversized experiment run payload");
+    if let Err(message) = validate_experiment_run(
+        &run_id,
+        &body.status,
+        body.parent_run_id.as_deref(),
+        body.parent_session_id.as_deref(),
+        &body.parameters,
+        &body.metrics,
+        &body.evidence,
+    ) {
+        return invalid_request(message);
     }
     let Some(lane) = &state.admin_sqlite_lane else {
         return sqlite_unavailable();
@@ -203,22 +206,21 @@ pub async fn handle_experiment_judge_result(
     let Some(session_id) = caller_session(&headers) else {
         return session_required();
     };
-    if !valid_id(&experiment_id)
-        || !valid_id(&body.run_id)
-        || !valid_id(&body.evaluator_id)
-        || body.evaluator_version.is_empty()
-        || body.evaluator_version.len() > 64
-        || body.rubric_hash.is_empty()
-        || body.rubric_hash.len() > 256
-        || !matches!(body.status.as_str(), "passed" | "failed" | "error")
-        || body.summary.len() > 2_048
-        || !bounded_json(&body.scores)
-        || !valid_evidence(&body.evidence)
-        || body
-            .cost
-            .is_some_and(|value| !value.is_finite() || value < 0.0)
-    {
+    if !valid_experiment_id(&experiment_id) {
         return invalid_request("invalid or oversized judge result payload");
+    }
+    if let Err(message) = validate_experiment_judge(ExperimentJudgeValidation {
+        run_id: &body.run_id,
+        evaluator_id: &body.evaluator_id,
+        evaluator_version: &body.evaluator_version,
+        rubric_hash: &body.rubric_hash,
+        status: &body.status,
+        scores: &body.scores,
+        summary: &body.summary,
+        cost: body.cost,
+        evidence: &body.evidence,
+    }) {
+        return invalid_request(message);
     }
     let Some(lane) = &state.admin_sqlite_lane else {
         return sqlite_unavailable();
@@ -279,7 +281,7 @@ pub(crate) fn experiment_detail_payload(
     state: &AdminState,
     experiment_id: &str,
 ) -> Result<Value, ExperimentReadError> {
-    if !valid_id(experiment_id) {
+    if !valid_experiment_id(experiment_id) {
         return Err(ExperimentReadError::InvalidId);
     }
     let Some(lane) = &state.admin_sqlite_lane else {
@@ -289,52 +291,6 @@ pub(crate) fn experiment_detail_payload(
         .reader()
         .list_experiment_events(experiment_id, MAX_EVENTS);
     project_experiment_detail(events).ok_or(ExperimentReadError::NotFound)
-}
-
-fn validate_create(body: &CreateExperimentBody) -> Result<(), &'static str> {
-    if body.name.trim().is_empty()
-        || body.name.len() > 256
-        || !valid_id(&body.scenario_id)
-        || body.description.len() > 2_048
-        || body
-            .workflow_id
-            .as_deref()
-            .is_some_and(|value| !valid_id(value))
-        || body
-            .recording_id
-            .as_deref()
-            .is_some_and(|value| !valid_id(value))
-        || body.tags.len() > 32
-        || body
-            .tags
-            .iter()
-            .any(|value| value.is_empty() || value.len() > 64)
-        || !bounded_json(&body.metadata)
-    {
-        return Err("invalid or oversized experiment definition");
-    }
-    Ok(())
-}
-
-fn valid_id(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= 256
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
-}
-
-fn bounded_json(value: &Value) -> bool {
-    serde_json::to_vec(value)
-        .map(|bytes| bytes.len() <= MAX_METADATA_BYTES)
-        .unwrap_or(false)
-}
-
-fn valid_evidence(values: &[String]) -> bool {
-    values.len() <= 32
-        && values
-            .iter()
-            .all(|value| !value.is_empty() && value.len() <= 2_048)
 }
 
 fn now_ms() -> u64 {


### PR DESCRIPTION
## Summary

- move pure experiment definition, run, and judge validation into dcc-mcp-gateway-admin
- keep HTTP, authentication, UUID, and persistence adapters in the gateway
- preserve existing validation messages and HTTP status contracts

## Validation

- x just preflight (3584 tests plus doctests)
- focused gateway-admin tests and gateway experiment API test
- strict Clippy for affected crates
- public documentation path scan found no _thm or ez_local_cache references
- creator Skills unchanged because adapter and skill-authoring workflows are unchanged

Part of #2187