### PR TITLE
refactor: extract admin recording projection

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -23,6 +23,7 @@ mod issue_report;
 mod links;
 mod memory;
 mod projection;
+mod recordings;
 mod skill_paths;
 mod stats;
 mod tasks;
@@ -67,6 +68,9 @@ pub use memory::memory_summary;
 pub use projection::{
     compact_debug_bundle_payload, compact_trace_context_payload, compact_trace_detail_payload,
     compact_trace_list_payload,
+};
+pub use recordings::{
+    recording_default_postcondition, recording_semantic_query, recording_ui_session,
 };
 pub use skill_paths::{skill_path_hash, skill_path_row};
 pub use stats::{

--- a/crates/dcc-mcp-gateway-admin/src/recordings.rs
+++ b/crates/dcc-mcp-gateway-admin/src/recordings.rs
@@ -1,0 +1,99 @@
+//! Pure recording projections used by the admin recording compiler.
+
+use serde_json::{Map, Value};
+
+/// Resolve the logical UI session used to pair semantic find and act events.
+#[must_use]
+pub fn recording_ui_session(arguments: &Value) -> String {
+    arguments
+        .get("session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("default")
+        .to_owned()
+}
+
+/// Retain only backend-neutral semantic locator fields from a UI find event.
+#[must_use]
+pub fn recording_semantic_query(arguments: &Value) -> Value {
+    let mut query = Map::new();
+    for key in ["query", "role", "label", "object_name"] {
+        if let Some(value) = arguments.get(key) {
+            query.insert(key.to_owned(), value.clone());
+        }
+    }
+    Value::Object(query)
+}
+
+/// Build the default replay postcondition for a semantic UI action.
+#[must_use]
+pub fn recording_default_postcondition(query: &Value) -> Value {
+    let mut condition = Map::from_iter([(
+        "kind".to_owned(),
+        Value::String("control_exists".to_owned()),
+    )]);
+    if let Some(fields) = query.as_object() {
+        condition.extend(fields.clone());
+    }
+    Value::Object(condition)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn semantic_projection_preserves_supported_locator_fields() {
+        let arguments = json!({
+            "session_id": "maya-main",
+            "query": "Render Settings",
+            "role": "dialog",
+            "label": "Render Settings",
+            "object_name": "renderSettingsWindow",
+            "coordinates": [120, 240],
+        });
+
+        let query = recording_semantic_query(&arguments);
+
+        assert_eq!(recording_ui_session(&arguments), "maya-main");
+        assert_eq!(
+            query,
+            json!({
+                "query": "Render Settings",
+                "role": "dialog",
+                "label": "Render Settings",
+                "object_name": "renderSettingsWindow",
+            })
+        );
+        assert_eq!(
+            recording_default_postcondition(&query),
+            json!({
+                "kind": "control_exists",
+                "query": "Render Settings",
+                "role": "dialog",
+                "label": "Render Settings",
+                "object_name": "renderSettingsWindow",
+            })
+        );
+    }
+
+    #[test]
+    fn semantic_projection_is_backend_neutral_and_defaults_the_session() {
+        let arguments = json!({
+            "query": "Layers panel",
+            "role": "panel",
+            "dcc_type": "photoshop",
+        });
+
+        assert_eq!(recording_ui_session(&arguments), "default");
+        assert_eq!(
+            recording_semantic_query(&arguments),
+            json!({"query": "Layers panel", "role": "panel"})
+        );
+        assert_eq!(
+            recording_default_postcondition(&Value::Null),
+            json!({"kind": "control_exists"})
+        );
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/recordings.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/recordings.rs
@@ -6,6 +6,9 @@ use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
+use dcc_mcp_gateway_admin::{
+    recording_default_postcondition, recording_semantic_query, recording_ui_session,
+};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
@@ -225,8 +228,8 @@ pub async fn handle_recording_compile(
             continue;
         }
         if captured_tool == "ui_control__find" {
-            let session = logical_ui_session(&captured.arguments);
-            ui_queries.insert(session, semantic_query(&captured.arguments));
+            let session = recording_ui_session(&captured.arguments);
+            ui_queries.insert(session, recording_semantic_query(&captured.arguments));
             continue;
         }
         if captured_tool == "ui_control__wait_for" {
@@ -250,14 +253,14 @@ pub async fn handle_recording_compile(
             {
                 return compile_error("raw_ui_action_requires_visual_guard", &captured.tool_slug);
             }
-            let session = logical_ui_session(&captured.arguments);
+            let session = recording_ui_session(&captured.arguments);
             let Some(query) = ui_queries.get(&session).cloned() else {
                 return compile_error(
                     "semantic_query_missing",
                     "ui_control__act must follow a successful ui_control__find in the same session",
                 );
             };
-            let postcondition = default_postcondition(&query);
+            let postcondition = recording_default_postcondition(&query);
             events.push(RecordedEvent::UiSemanticAction {
                 sequence: captured.sequence,
                 query,
@@ -392,35 +395,6 @@ pub async fn handle_recording_replay_validate(
         Json(json!({"validated": validated, "replay_authorized": false})),
     )
         .into_response()
-}
-
-fn logical_ui_session(arguments: &Value) -> String {
-    arguments
-        .get("session_id")
-        .and_then(Value::as_str)
-        .unwrap_or("default")
-        .to_owned()
-}
-
-fn semantic_query(arguments: &Value) -> Value {
-    let mut query = serde_json::Map::new();
-    for key in ["query", "role", "label", "object_name"] {
-        if let Some(value) = arguments.get(key) {
-            query.insert(key.to_owned(), value.clone());
-        }
-    }
-    Value::Object(query)
-}
-
-fn default_postcondition(query: &Value) -> Value {
-    let mut condition = serde_json::Map::from_iter([(
-        "kind".to_owned(),
-        Value::String("control_exists".to_owned()),
-    )]);
-    if let Some(fields) = query.as_object() {
-        condition.extend(fields.clone());
-    }
-    Value::Object(condition)
 }
 
 pub(super) fn caller_session(headers: &HeaderMap) -> Option<String> {


### PR DESCRIPTION
## Summary

- move pure recording UI session, semantic query, and postcondition projections into dcc-mcp-gateway-admin
- keep HTTP, capability resolution, recording storage, and workflow compilation in the gateway
- preserve existing recording compile behavior

## Validation

- x just preflight (3586 tests plus doctests)
- focused gateway-admin and gateway recording tests
- strict Clippy for affected crates
- public documentation path scan found no _thm or ez_local_cache references
- creator Skills unchanged because adapter and skill-authoring workflows are unchanged

Part of #2187