### PR TITLE
chore: update Shogun adapter catalog

### DIFF
--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -468,20 +468,20 @@ entries:
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-touchdesigner/main/install.md"
 
   - name: "dcc-mcp-shogun"
-    description: "Vicon Shogun Post adapter with 66 typed Scene, channel, camera, file, Timeline, editing, production-context, and capability-gated Offline processing tools"
+    description: "Vicon Shogun Post adapter with 67 typed Scene, channel, camera, file, Timeline, editing, production-context, pipeline-context, and capability-gated Offline processing tools"
     dcc: ["shogun"]
     url: "https://github.com/dcc-mcp/dcc-mcp-shogun"
     tags: ["adapter", "shogun", "vicon", "official", "pip", "motion-capture", "timeline", "processing"]
-    version: "0.8.1"
+    version: "0.10.0"
     min_core_version: "0.19.86"
     maintainer: "dcc-mcp"
     install:
       type: pip
       pip_package: "dcc-mcp-shogun"
-      url: "https://files.pythonhosted.org/packages/41/ca/3eba76e8696d3f478f1b2f776abd52640403ea20ac4057b689e57fdde82d/dcc_mcp_shogun-0.8.1-py3-none-any.whl"
-      sha256: "975a2d967a5c9b09cc285b7dd5bd1b8db16cdf3043d75cbae3b7d30d90529b5d"
+      url: "https://files.pythonhosted.org/packages/14/1f/c609d3cab3862722206153b17c9ce2ab27d8ce40a2e41a8c503477c02402/dcc_mcp_shogun-0.10.0-py3-none-any.whl"
+      sha256: "c6c223d86d25902a32fd4cf057feb78de7670c6bacc5c848aeb7a8e82e14392b"
       entry_point: "dcc_mcp_shogun:ShogunMcpServer"
-      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-shogun/main/README.md"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-shogun/main/install.md"
 
   - name: "dcc-mcp-tiled"
     # Automatic install is omitted until a wheel is published.

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -30,7 +30,7 @@ submit a PR updating this matrix before the release PR merges.
 | FreeCAD | [dcc-mcp-freecad](https://github.com/dcc-mcp/dcc-mcp-freecad) | 0.1.2 | >=0.19.91,<1.0.0 | 1.0+ | External FreeCADCmd subprocess | 2026-08 |
 | Cinema 4D | [dcc-mcp-cinema4d](https://github.com/dcc-mcp/dcc-mcp-cinema4d) | 0.1.3 | >=0.19.91,<1.0.0 | R21+ | External headless c4dpy subprocess | 2026-08 |
 | ComfyUI | [dcc-mcp-comfyui](https://github.com/dcc-mcp/dcc-mcp-comfyui) | 0.1.1 | >=0.19.91,<1.0.0 | 0.31+ | 17 typed workflow, catalog, queue, and artifact tools over the local REST bridge | 2026-08 |
-| Shogun | [dcc-mcp-shogun](https://github.com/dcc-mcp/dcc-mcp-shogun) | 0.8.1 | >=0.19.86,<1.0.0 | Vicon Shogun Post | 66 typed Scene, channel, camera, file, Timeline, editing, production-context, and Offline tools; SDK-dependent surfaces remain capability-gated | 2026-08 |
+| Shogun | [dcc-mcp-shogun](https://github.com/dcc-mcp/dcc-mcp-shogun) | 0.10.0 | >=0.19.86,<1.0.0 | Vicon Shogun Post 1.19+ | 67 typed Scene, channel, camera, file, Timeline, editing, production-context, pipeline-context, and Offline tools; SDK-dependent surfaces remain capability-gated | 2026-08 |
 | Mari | [dcc-mcp-mari](https://github.com/dcc-mcp/dcc-mcp-mari) | 0.2.1 | >=0.19.91,<1.0.0 | 5.0+ | Authenticated loopback sidecar + Qt UI timer | 2026-08 |
 | 3ds Max | [dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) | 0.1.40 | >=0.19.45,<1.0.0 | 2025+ | Sidecar + HostPumpController | 2026-08 |
 | Blender | [dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) | 0.1.43 | >=0.19.45,<1.0.0 | 3.6+ | In-process MCP + optional diagnostics sidecar | 2026-08 |

--- a/tests/test_public_adapter_catalog.py
+++ b/tests/test_public_adapter_catalog.py
@@ -18,7 +18,7 @@ def test_recent_adapter_releases_are_current() -> None:
     expected_versions = {
         "dcc-mcp-comfyui": "0.1.1",
         "dcc-mcp-touchdesigner": "0.1.1",
-        "dcc-mcp-shogun": "0.8.1",
+        "dcc-mcp-shogun": "0.10.0",
         "dcc-mcp-tiled": "0.3.0",
         "dcc-mcp-material-maker": "0.3.1",
         "dcc-mcp-wwise": "0.1.2",
@@ -28,7 +28,10 @@ def test_recent_adapter_releases_are_current() -> None:
     assert entries["dcc-mcp-comfyui"]["min_core_version"] == "0.19.91"
     assert "17 typed" in entries["dcc-mcp-comfyui"]["description"]
     assert "19 typed" in entries["dcc-mcp-touchdesigner"]["description"]
-    assert "66 typed" in entries["dcc-mcp-shogun"]["description"]
+    shogun = entries["dcc-mcp-shogun"]
+    assert "67 typed" in shogun["description"]
+    assert shogun["install"]["sha256"] == ("c6c223d86d25902a32fd4cf057feb78de7670c6bacc5c848aeb7a8e82e14392b")
+    assert shogun["install"]["instructions_url"].endswith("/main/install.md")
 
 
 def test_skill_only_packages_are_not_pip_adapters() -> None:


### PR DESCRIPTION
## Summary
- publish Shogun adapter 0.10.0 metadata
- point agent installation guidance to `install.md`
- refresh compatibility and catalog regression coverage

## Validation
- `vx uv run pytest tests/test_public_adapter_catalog.py -q`
- `vx cargo test -p dcc-mcp-catalog`
- verified the published wheel version and SHA-256 against PyPI

Skill guidance is unchanged because this only refreshes published adapter metadata.