### PR TITLE
refactor: extract admin session projections

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -26,6 +26,7 @@ mod links;
 mod memory;
 mod projection;
 mod recordings;
+mod sessions;
 mod skill_health;
 mod skill_paths;
 mod sqlite_lane;
@@ -78,6 +79,7 @@ pub use projection::{
 pub use recordings::{
     recording_default_postcondition, recording_semantic_query, recording_ui_session,
 };
+pub use sessions::{session_detail_payload, sessions_payload};
 pub use skill_health::{
     SkillCapabilityInput, SkillSearchFollowupInput, SkillSearchHitInput, SkillSearchInput,
     skill_inventory_payload,

--- a/crates/dcc-mcp-gateway-admin/src/sessions.rs
+++ b/crates/dcc-mcp-gateway-admin/src/sessions.rs
@@ -1,0 +1,117 @@
+//! Backend-neutral session list and detail projections.
+
+use std::collections::{BTreeMap, HashSet};
+
+use serde_json::{Value, json};
+
+/// Build the stable session-list response from persistence rows.
+#[must_use]
+pub fn sessions_payload(rows: Vec<Value>) -> Value {
+    let mut by_dcc = BTreeMap::<String, usize>::new();
+    let mut active = 0usize;
+    let mut ended = 0usize;
+    let mut crashed = 0usize;
+    let mut disconnected = 0usize;
+
+    for row in &rows {
+        let dcc = row
+            .get("dcc_type")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        *by_dcc.entry(dcc.to_string()).or_default() += 1;
+
+        match row
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+        {
+            "active" => active += 1,
+            "ended" => ended += 1,
+            "crashed" | "gpu_crashed" => crashed += 1,
+            "disconnected" => disconnected += 1,
+            _ => {}
+        }
+    }
+
+    json!({
+        "total": rows.len(),
+        "sessions": rows,
+        "summary": {
+            "active": active,
+            "ended": ended,
+            "crashed": crashed,
+            "disconnected": disconnected,
+            "by_dcc": by_dcc,
+        },
+    })
+}
+
+/// Build the stable session-detail response from persistence rows.
+#[must_use]
+pub fn session_detail_payload(session: Value, tool_calls: Vec<Value>, events: Vec<Value>) -> Value {
+    let trace_ids: Vec<&str> = tool_calls
+        .iter()
+        .filter_map(|call| call.get("trace_id").and_then(Value::as_str))
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .take(20)
+        .collect();
+    let total_calls = tool_calls.len();
+    let successful_calls = tool_calls
+        .iter()
+        .filter(|call| call.get("success").and_then(Value::as_i64) == Some(1))
+        .count();
+
+    json!({
+        "session": session,
+        "tool_calls": tool_calls,
+        "events": events,
+        "traces": trace_ids,
+        "summary": {
+            "total_tool_calls": total_calls,
+            "successful_tool_calls": successful_calls,
+            "failed_tool_calls": total_calls.saturating_sub(successful_calls),
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_projection_groups_status_and_dcc_without_backend_types() {
+        let payload = sessions_payload(vec![
+            json!({"session_id": "a", "dcc_type": "maya", "status": "active"}),
+            json!({"session_id": "b", "dcc_type": "maya", "status": "gpu_crashed"}),
+            json!({"session_id": "c", "dcc_type": "photoshop", "status": "disconnected"}),
+            json!({"session_id": "d", "status": "ended"}),
+        ]);
+
+        assert_eq!(payload["total"], 4);
+        assert_eq!(payload["summary"]["active"], 1);
+        assert_eq!(payload["summary"]["ended"], 1);
+        assert_eq!(payload["summary"]["crashed"], 1);
+        assert_eq!(payload["summary"]["disconnected"], 1);
+        assert_eq!(payload["summary"]["by_dcc"]["maya"], 2);
+        assert_eq!(payload["summary"]["by_dcc"]["unknown"], 1);
+    }
+
+    #[test]
+    fn detail_projection_deduplicates_traces_and_counts_outcomes() {
+        let payload = session_detail_payload(
+            json!({"session_id": "session-a"}),
+            vec![
+                json!({"trace_id": "trace-a", "success": 1}),
+                json!({"trace_id": "trace-a", "success": 0}),
+                json!({"trace_id": "trace-b"}),
+            ],
+            vec![json!({"event_type": "ended"})],
+        );
+
+        assert_eq!(payload["summary"]["total_tool_calls"], 3);
+        assert_eq!(payload["summary"]["successful_tool_calls"], 1);
+        assert_eq!(payload["summary"]["failed_tool_calls"], 2);
+        assert_eq!(payload["traces"].as_array().unwrap().len(), 2);
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/sessions.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/sessions.rs
@@ -7,76 +7,15 @@
 //! (`SessionRow` / `SessionKpi` / `SessionsPayload`) mirror the frontend types
 //! in `admin-ui/src/admin-types.ts`.
 
-use std::collections::{BTreeMap, HashMap};
-
 use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use serde::{Deserialize, Serialize};
+use dcc_mcp_gateway_admin::{session_detail_payload, sessions_payload};
+use serde::Deserialize;
 use serde_json::json;
 
 use super::state::AdminState;
-
-// ── Stable response contract types (PIP-2752 frontend contract) ─────────────
-
-/// Correlation ids for one session row — mirrors `SessionRow.correlation` in
-/// `admin-ui/src/admin-types.ts`.
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct SessionCorrelation {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub trace_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workflow_id: Option<String>,
-}
-
-/// One row in the sessions table — mirrors `SessionRow` in
-/// `admin-ui/src/admin-types.ts`.
-#[derive(Debug, Clone, Serialize)]
-pub struct SessionRow {
-    pub session_id: String,
-    pub parent_session_id: Option<String>,
-    /// One of `active`, `ended`, `crashed`, `interrupted`, `timed_out`, `cancelled`, `unknown`.
-    pub status: String,
-    pub dcc_type: Option<String>,
-    pub instance_id: Option<String>,
-    pub agent_id: Option<String>,
-    pub agent_name: Option<String>,
-    pub agent_model: Option<String>,
-    pub started_at: String,
-    pub ended_at: Option<String>,
-    pub duration_ms: Option<u64>,
-    pub turn_count: u64,
-    pub tool_call_count: u64,
-    pub end_reason: Option<String>,
-    pub version: Option<String>,
-    pub actor_id: Option<String>,
-    pub actor_name: Option<String>,
-    pub correlation: SessionCorrelation,
-}
-
-/// Aggregate KPI summary — mirrors `SessionKpi` in `admin-ui/src/admin-types.ts`.
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct SessionKpi {
-    pub total: u64,
-    pub active: u64,
-    pub ended: u64,
-    pub crashed: u64,
-    pub by_dcc: BTreeMap<String, u64>,
-}
-
-/// Response body for `GET /admin/api/sessions` — mirrors `SessionsPayload` in
-/// `admin-ui/src/admin-types.ts`.
-#[derive(Debug, Clone, Serialize)]
-pub struct SessionsPayload {
-    pub sessions: Vec<SessionRow>,
-    pub kpi: SessionKpi,
-    pub total: usize,
-}
-
-// ── SQLite-backed handlers (PIP-2751) ───────────────────────────────────────
 
 #[derive(Debug, Default, Deserialize)]
 pub struct SessionsQuery {
@@ -106,44 +45,7 @@ pub async fn handle_admin_sessions(
         })
         .unwrap_or_default();
 
-    let mut by_dcc: HashMap<String, usize> = HashMap::new();
-    let mut active_count = 0usize;
-    let mut ended_count = 0usize;
-    let mut crashed_count = 0usize;
-    let mut disconnected_count = 0usize;
-
-    for row in &rows {
-        let dcc = row
-            .get("dcc_type")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
-        *by_dcc.entry(dcc.to_string()).or_default() += 1;
-
-        let status = row
-            .get("status")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
-        match status {
-            "active" => active_count += 1,
-            "ended" => ended_count += 1,
-            "crashed" | "gpu_crashed" => crashed_count += 1,
-            "disconnected" => disconnected_count += 1,
-            _ => {}
-        }
-    }
-
-    Json(json!({
-        "total": rows.len(),
-        "sessions": rows,
-        "summary": {
-            "active": active_count,
-            "ended": ended_count,
-            "crashed": crashed_count,
-            "disconnected": disconnected_count,
-            "by_dcc": by_dcc,
-        },
-    }))
-    .into_response()
+    Json(sessions_payload(rows)).into_response()
 }
 
 /// `GET /admin/api/sessions/{session_id}` — detail for one session.
@@ -183,33 +85,5 @@ pub async fn handle_admin_session_detail(
     let tool_calls = reader.list_tool_calls(&session_id, 500);
     let events = reader.list_session_events(&session_id, 200);
 
-    // Extract trace_ids from tool calls for trace drill-down
-    let trace_ids: Vec<&str> = tool_calls
-        .iter()
-        .filter_map(|tc| tc.get("trace_id").and_then(|v| v.as_str()))
-        .collect::<std::collections::HashSet<_>>()
-        .into_iter()
-        .take(20)
-        .collect();
-
-    // Compute tool-call stats
-    let total_calls = tool_calls.len();
-    let successful_calls = tool_calls
-        .iter()
-        .filter(|tc| tc.get("success").and_then(|v| v.as_i64()) == Some(1))
-        .count();
-    let failed_calls = total_calls.saturating_sub(successful_calls);
-
-    Json(json!({
-        "session": session,
-        "tool_calls": tool_calls,
-        "events": events,
-        "traces": trace_ids,
-        "summary": {
-            "total_tool_calls": total_calls,
-            "successful_tool_calls": successful_calls,
-            "failed_tool_calls": failed_calls,
-        },
-    }))
-    .into_response()
+    Json(session_detail_payload(session, tool_calls, events)).into_response()
 }


### PR DESCRIPTION
## Summary
- move session list KPI and detail response projections into `dcc-mcp-gateway-admin`
- keep SQLite reads and HTTP status handling in the gateway adapter
- preserve session status grouping, trace deduplication, and tool-call outcome counts

## Validation
- `vx just preflight` (3594 Rust tests plus workspace doctests)
- `vx cargo test -p dcc-mcp-gateway-admin sessions::tests`
- `vx cargo check -p dcc-mcp-gateway --all-features`
- `vx cargo clippy -p dcc-mcp-gateway-admin --all-targets --all-features -- -D warnings`
- public documentation internal-path scan: clean

No creator Skill update is needed because adapter and skill-authoring workflows are unchanged.

Part of #2187.