### PR TITLE
refactor: extract admin health projection

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/health.rs
+++ b/crates/dcc-mcp-gateway-admin/src/health.rs
@@ -1,0 +1,67 @@
+//! Backend-neutral gateway health projections.
+
+use serde_json::{Value, json};
+
+/// Split gateway sentinel rows into the active instance and ordered candidates.
+#[must_use]
+pub fn gateway_health_payload(mut rows: Vec<Value>) -> Value {
+    rows.sort_by(|a, b| {
+        let role_a = a.get("role").and_then(Value::as_str).unwrap_or("");
+        let role_b = b.get("role").and_then(Value::as_str).unwrap_or("");
+        let rank_a = usize::from(role_a != "active");
+        let rank_b = usize::from(role_b != "active");
+        rank_a.cmp(&rank_b).then_with(|| {
+            let timestamp_a = a
+                .get("last_heartbeat_unix")
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            let timestamp_b = b
+                .get("last_heartbeat_unix")
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            timestamp_b.cmp(&timestamp_a)
+        })
+    });
+    let current = rows
+        .iter()
+        .find(|row| row.get("role").and_then(Value::as_str) == Some("active"))
+        .cloned()
+        .or_else(|| rows.first().cloned());
+    let candidates: Vec<Value> = rows
+        .into_iter()
+        .filter(|row| row.get("role").and_then(Value::as_str) != Some("active"))
+        .collect();
+    json!({
+        "current": current,
+        "candidates": candidates,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_active_gateway_and_orders_candidates_by_heartbeat() {
+        let payload = gateway_health_payload(vec![
+            json!({"name": "old", "role": "candidate", "last_heartbeat_unix": 10}),
+            json!({"name": "active", "role": "active", "last_heartbeat_unix": 5}),
+            json!({"name": "new", "role": "candidate", "last_heartbeat_unix": 20}),
+        ]);
+
+        assert_eq!(payload["current"]["name"], "active");
+        assert_eq!(payload["candidates"][0]["name"], "new");
+        assert_eq!(payload["candidates"][1]["name"], "old");
+    }
+
+    #[test]
+    fn falls_back_to_newest_candidate_when_no_active_gateway_exists() {
+        let payload = gateway_health_payload(vec![
+            json!({"name": "old", "role": "candidate", "last_heartbeat_unix": 10}),
+            json!({"name": "new", "role": "candidate", "last_heartbeat_unix": 20}),
+        ]);
+
+        assert_eq!(payload["current"]["name"], "new");
+        assert_eq!(payload["candidates"].as_array().unwrap().len(), 2);
+    }
+}

--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -21,6 +21,7 @@ pub mod domain;
 mod durable_store;
 mod experiments;
 mod governance;
+mod health;
 mod issue_report;
 mod links;
 mod memory;
@@ -69,6 +70,7 @@ pub use experiments::{
 pub use governance::{
     GovernanceCaptureDecision, GovernanceMiddlewareState, governance_payload, governance_stats,
 };
+pub use health::gateway_health_payload;
 pub use issue_report::{IssueReportMode, issue_report_filename, issue_report_json};
 pub use links::AdminLinkBuilder;
 pub use memory::memory_summary;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/health.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/health.rs
@@ -6,6 +6,7 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use dcc_mcp_gateway_admin::gateway_health_payload;
 use serde_json::{Value, json};
 
 use crate::gateway::admin::state::AdminState;
@@ -68,37 +69,7 @@ pub async fn handle_admin_health(State(s): State<AdminState>) -> impl IntoRespon
 }
 
 pub(crate) fn gateway_health_snapshot(sentinels: &[ServiceEntry]) -> Value {
-    let mut rows: Vec<Value> = sentinels.iter().map(gateway_sentinel_json).collect();
-    rows.sort_by(|a, b| {
-        let role_a = a.get("role").and_then(Value::as_str).unwrap_or("");
-        let role_b = b.get("role").and_then(Value::as_str).unwrap_or("");
-        let rank_a = if role_a == "active" { 0 } else { 1 };
-        let rank_b = if role_b == "active" { 0 } else { 1 };
-        rank_a.cmp(&rank_b).then_with(|| {
-            let ta = a
-                .get("last_heartbeat_unix")
-                .and_then(Value::as_u64)
-                .unwrap_or(0);
-            let tb = b
-                .get("last_heartbeat_unix")
-                .and_then(Value::as_u64)
-                .unwrap_or(0);
-            tb.cmp(&ta)
-        })
-    });
-    let current = rows
-        .iter()
-        .find(|row| row.get("role").and_then(Value::as_str) == Some("active"))
-        .cloned()
-        .or_else(|| rows.first().cloned());
-    let candidates: Vec<Value> = rows
-        .into_iter()
-        .filter(|row| row.get("role").and_then(Value::as_str) != Some("active"))
-        .collect();
-    json!({
-        "current": current,
-        "candidates": candidates,
-    })
+    gateway_health_payload(sentinels.iter().map(gateway_sentinel_json).collect())
 }
 
 fn gateway_sentinel_json(entry: &ServiceEntry) -> Value {


### PR DESCRIPTION
## Summary
- move gateway sentinel ordering and active/candidate projection into `dcc-mcp-gateway-admin`
- keep transport `ServiceEntry` conversion in the gateway adapter
- preserve the admin health and reliability response contract

## Validation
- `vx just preflight` (3596 Rust tests plus workspace doctests)
- `vx cargo test -p dcc-mcp-gateway-admin health::tests`
- `vx cargo check -p dcc-mcp-gateway --all-features`
- strict admin Clippy
- public documentation internal-path scan: clean

No creator Skill update is needed because adapter and skill-authoring workflows are unchanged.

Part of #2187.