### PR TITLE
refactor: extract admin update resolution

### DIFF
--- a/crates/dcc-mcp-gateway-admin/src/lib.rs
+++ b/crates/dcc-mcp-gateway-admin/src/lib.rs
@@ -36,6 +36,7 @@ mod stats;
 mod tasks;
 mod trace_log;
 mod traffic;
+mod update;
 mod wecom;
 mod workers;
 
@@ -104,6 +105,9 @@ pub use stats::{
 pub use tasks::{TaskArtifact, TaskRelated, TaskSnapshot, TaskValidation, task_payload};
 pub use trace_log::TraceLog;
 pub use traffic::{TrafficProjectionSnapshot, traffic_jsonl_export, traffic_payload};
+pub use update::{
+    AdminInstanceUpdateVersion, admin_instance_update_version, instance_server_binary_version,
+};
 pub use wecom::{
     WECOM_WEBHOOK_URL_HINT, strict_wecom_webhook_url_looks_valid, summarize_wecom_response,
 };

--- a/crates/dcc-mcp-gateway-admin/src/update.rs
+++ b/crates/dcc-mcp-gateway-admin/src/update.rs
@@ -1,7 +1,10 @@
+//! Instance update version resolution for admin endpoints.
+
 use dcc_mcp_transport::discovery::types::{SERVER_BINARY_VERSION_METADATA_KEY, ServiceEntry};
 use serde_json::Value;
 
-pub(super) enum AdminInstanceUpdateVersion {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdminInstanceUpdateVersion {
     Known {
         current: String,
         display: Option<String>,
@@ -10,7 +13,8 @@ pub(super) enum AdminInstanceUpdateVersion {
     MissingCurrentVersion,
 }
 
-pub(super) fn admin_instance_update_version(
+#[must_use]
+pub fn admin_instance_update_version(
     instance: &ServiceEntry,
     binary_name: &str,
     requested_current_version: Option<&str>,
@@ -37,9 +41,8 @@ pub(super) fn admin_instance_update_version(
     AdminInstanceUpdateVersion::MissingCurrentVersion
 }
 
-pub(super) fn instance_server_binary_version(
-    instance: &ServiceEntry,
-) -> Option<(String, &'static str)> {
+#[must_use]
+pub fn instance_server_binary_version(instance: &ServiceEntry) -> Option<(String, &'static str)> {
     const SERVER_VERSION_KEYS: [&str; 3] = [
         SERVER_BINARY_VERSION_METADATA_KEY,
         "server_binary_version",
@@ -57,7 +60,6 @@ pub(super) fn instance_server_binary_version(
             return Some((version.to_string(), "instance_metadata"));
         }
     }
-
     for key in SERVER_VERSION_KEYS {
         if let Some(version) = instance
             .extras
@@ -69,7 +71,6 @@ pub(super) fn instance_server_binary_version(
             return Some((version.to_string(), "instance_extras"));
         }
     }
-
     None
 }
 
@@ -78,35 +79,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn update_version_uses_server_binary_metadata() {
+    fn registry_server_version_is_used_but_dcc_versions_are_not() {
         let mut instance = ServiceEntry::new("maya", "127.0.0.1", 18813);
         instance.version = Some("2024.0".to_string());
         instance.adapter_version = Some("0.3.0".to_string());
+        assert_eq!(
+            admin_instance_update_version(&instance, "dcc-mcp-server", None),
+            AdminInstanceUpdateVersion::MissingCurrentVersion
+        );
         instance.metadata.insert(
             SERVER_BINARY_VERSION_METADATA_KEY.to_string(),
             "0.18.0".to_string(),
         );
-
-        let AdminInstanceUpdateVersion::Known {
-            current, source, ..
-        } = admin_instance_update_version(&instance, "dcc-mcp-server", None)
-        else {
-            panic!("expected metadata-backed server version");
-        };
-
-        assert_eq!(current, "0.18.0");
-        assert_eq!(source, "instance_metadata");
+        assert_eq!(
+            admin_instance_update_version(&instance, "dcc-mcp-server", None),
+            AdminInstanceUpdateVersion::Known {
+                current: "0.18.0".to_string(),
+                display: Some("0.18.0".to_string()),
+                source: "instance_metadata",
+            }
+        );
     }
 
     #[test]
-    fn update_version_does_not_use_dcc_or_adapter_version() {
-        let mut instance = ServiceEntry::new("maya", "127.0.0.1", 18813);
-        instance.version = Some("2024.0".to_string());
-        instance.adapter_version = Some("0.3.0".to_string());
-
-        assert!(matches!(
-            admin_instance_update_version(&instance, "dcc-mcp-server", None),
-            AdminInstanceUpdateVersion::MissingCurrentVersion
-        ));
+    fn explicit_request_wins_over_registry_metadata() {
+        let mut instance = ServiceEntry::new("blender", "127.0.0.1", 18814);
+        instance.metadata.insert(
+            SERVER_BINARY_VERSION_METADATA_KEY.to_string(),
+            "0.18.0".to_string(),
+        );
+        assert_eq!(
+            admin_instance_update_version(&instance, "dcc-mcp-server", Some(" 0.20.8 ")),
+            AdminInstanceUpdateVersion::Known {
+                current: "0.20.8".to_string(),
+                display: Some("0.20.8".to_string()),
+                source: "request",
+            }
+        );
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/handlers.rs
@@ -21,12 +21,12 @@ use crate::gateway::admin::links::AdminLinkBuilder;
 use crate::gateway::admin::skill_reload::reload_skill_paths_and_refresh_backends;
 use crate::gateway::admin::state::{AdminAuditRecord, AdminState};
 use crate::gateway::admin::trace::{AgentContext, DispatchTrace};
-use crate::gateway::admin::update::{AdminInstanceUpdateVersion, admin_instance_update_version};
 use crate::gateway::capability::RefreshReason;
 use crate::gateway::capability_service::refresh_all_live_backends;
 use crate::gateway::response_codec::TOKEN_ESTIMATOR;
 use dcc_mcp_db::env::ENV_DCC_MCP_LOG_DIR;
 use dcc_mcp_db::read_gateway_log_dir_rows_recent;
+use dcc_mcp_gateway_admin::{AdminInstanceUpdateVersion, admin_instance_update_version};
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 
 const ADMIN_FILE_LOG_READ_TIMEOUT: Duration = Duration::from_millis(750);

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -124,7 +124,6 @@ pub mod trace;
 #[cfg(feature = "admin")]
 mod traffic;
 #[cfg(feature = "admin")]
-mod update;
 #[cfg(feature = "admin")]
 mod wecom_response;
 #[cfg(feature = "admin")]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/workers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/workers.rs
@@ -12,7 +12,9 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use dcc_mcp_gateway_admin::{WorkerHealth, WorkerSnapshot, workers_payload};
+use dcc_mcp_gateway_admin::{
+    WorkerHealth, WorkerSnapshot, instance_server_binary_version, workers_payload,
+};
 use serde_json::Value;
 
 use crate::gateway::http_registration::{MCP_URL_METADATA_KEY, entry_mcp_url};
@@ -61,7 +63,7 @@ fn instance_type(e: &ServiceEntry) -> String {
             || e.adapter_version.is_some()
         {
             "gui".to_string()
-        } else if super::update::instance_server_binary_version(e).is_some() {
+        } else if instance_server_binary_version(e).is_some() {
             "standalone".to_string()
         } else {
             "unknown".to_string()
@@ -131,8 +133,7 @@ fn entry_to_worker(
         gateway_recovery_driver(e, gateway_runtime_mode.as_deref(), gateway_guardian_enabled);
     let registration_refresh_mode = metadata_text(e, REGISTRATION_REFRESH_MODE_METADATA_KEY)
         .unwrap_or_else(|| REGISTRATION_REFRESH_MODE_FILE_REGISTRY_HEARTBEAT.to_string());
-    let server_version =
-        super::update::instance_server_binary_version(e).map(|(version, _)| version);
+    let server_version = instance_server_binary_version(e).map(|(version, _)| version);
 
     WorkerSnapshot {
         instance_id: e.instance_id.to_string(),


### PR DESCRIPTION
Part of #2187.

## Summary
- move instance update version resolution into `dcc-mcp-gateway-admin`
- remove the gateway-owned update module
- reuse the same admin resolver from update handlers and worker projections

## Validation
- `vx just preflight` (3595/3595 tests plus doctests)
- targeted admin resolver tests (2/2)
- instance update endpoint regressions (8/8)
- public documentation path scan is clean

Creator Skills do not need updates because public adapter and skill-authoring workflows are unchanged.