### PR TITLE
refactor: move admin stats adapter to infra

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/handlers.rs
@@ -1073,7 +1073,7 @@ pub async fn handle_admin_stats(
     headers: HeaderMap,
     axum::extract::Query(params): axum::extract::Query<DebugListQuery>,
 ) -> impl IntoResponse {
-    use crate::gateway::admin::stats::StatsRange;
+    use crate::gateway::admin::StatsRange;
 
     let range_str = params.range();
     let range = StatsRange::from_str(range_str);
@@ -1136,8 +1136,8 @@ pub async fn handle_admin_stats(
             "avg_total_tokens_per_call": 0.0,
             "avg_tokens_per_call": 0.0,
             "payload_token_estimator": TOKEN_ESTIMATOR,
-            "payload_token_usage": crate::gateway::admin::stats::PayloadTokenUsageStats::empty(0),
-            "token_usage": crate::gateway::admin::stats::TokenUsageStats::default(),
+            "payload_token_usage": dcc_mcp_gateway_admin::PayloadTokenUsageStats::empty(0),
+            "token_usage": dcc_mcp_gateway_admin::TokenUsageStats::default(),
             "governance": crate::gateway::admin::governance::build_governance_stats(&s),
             });
             debug_response(&headers, &params, StatusCode::OK, root.clone(), Some(root))

--- a/crates/dcc-mcp-gateway/src/gateway/admin/infra/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/infra/mod.rs
@@ -4,12 +4,16 @@
 
 pub mod activity;
 pub(crate) mod audit_sink;
+pub mod stats;
 
 #[cfg(feature = "admin")]
 pub(crate) mod integrations;
 
 pub use activity::*;
 pub use audit_sink::AdminAuditSink;
+pub use stats::{
+    GatewayStats, LatencyStats, StatsAggregator, StatsFilter, StatsRange, StatsStatus, TopEntry,
+};
 
 #[cfg(feature = "admin")]
 pub use integrations::*;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/infra/stats.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/infra/stats.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use dcc_mcp_gateway_admin::{DispatchTrace, TraceLog, compute_stats_filtered};
 
-use super::sqlite_lane::AdminSqliteReader;
+use super::super::sqlite_lane::AdminSqliteReader;
 
 pub use dcc_mcp_gateway_admin::{
     AttributionFacet, GatewayStats, LatencyStats, PayloadTokenUsageStats, StatsFilter, StatsRange,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -112,7 +112,6 @@ mod skill_paths;
 pub mod skill_reload;
 pub mod sqlite_lane;
 pub mod state;
-pub mod stats;
 pub mod trace;
 #[cfg(feature = "admin")]
 mod traffic;
@@ -157,13 +156,13 @@ pub use dcc_mcp_db::{
     default_gateway_admin_sqlite_path as default_admin_db_path,
     resolve_gateway_admin_sqlite_path as resolve_admin_db_path,
 };
-pub use infra::audit_sink::AdminAuditSink;
+pub use infra::stats;
+pub use infra::{
+    AdminAuditSink, GatewayStats, LatencyStats, StatsAggregator, StatsFilter, StatsRange,
+    StatsStatus, TopEntry,
+};
 pub use sqlite_lane::{AdminSqliteLane, AdminSqliteReader, read_custom_skill_paths_for_startup};
 pub use state::{AdminAuditRecord, AdminState, AuditLog, DurableAuditStore};
-pub use stats::{
-    GatewayStats, LatencyStats, StatsAggregator, StatsFilter, StatsRange, StatsStatus, TopEntry,
-};
-
 pub use trace::{DispatchTrace, TraceContext, TraceLog, TracePayload, TraceSpan};
 
 #[cfg(feature = "admin")]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 use crate::gateway::state::GatewayState;
 
-use super::stats::StatsAggregator;
+use super::infra::StatsAggregator;
 use super::trace::TraceLog;
 
 pub use dcc_mcp_gateway_admin::{AdminAuditRecord, AuditLog, DurableAuditStore};


### PR DESCRIPTION
## Summary
- move the SQLite and in-memory stats data-source adapter into the admin infrastructure layer
- preserve the existing public admin stats module and root exports through direct module re-export
- route internal consumers through canonical owners

Part of #2187.

## Validation
- vx just preflight (3595 tests passed plus doctests)
- all-features and no-default-features gateway checks
- strict gateway Clippy
- 7 stats and trace endpoint tests
- known marketplace mock HTTP flake passed on exact rerun and full preflight rerun
- public documentation path scan for internal Rez cache markers: clean

Creator Skills are unchanged because public adapter and skill workflows are unchanged.