### PR TITLE
refactor: group admin projection adapters

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/analytics.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/analytics.rs
@@ -7,7 +7,7 @@ use axum::http::HeaderValue;
 use axum::http::{StatusCode, header};
 use axum::response::IntoResponse;
 
-use super::state::{AdminAuditRecord, AdminState};
+use super::super::state::{AdminAuditRecord, AdminState};
 
 pub use dcc_mcp_gateway_admin::AnalyticsQuery;
 use dcc_mcp_gateway_admin::{

--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/governance.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/governance.rs
@@ -7,7 +7,7 @@ use dcc_mcp_gateway_admin::{
 };
 use serde_json::{Value, json};
 
-use super::state::{AdminAuditRecord, AdminState};
+use super::super::state::{AdminAuditRecord, AdminState};
 use crate::gateway::traffic::{TrafficCaptureDecision, TrafficCaptureSnapshot};
 
 /// Build a read-only governance payload for Admin and `/v1/debug/governance`.

--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/handlers.rs
@@ -474,7 +474,7 @@ pub async fn handle_admin_tools(State(s): State<AdminState>) -> impl IntoRespons
 pub async fn handle_admin_skills(State(s): State<AdminState>) -> impl IntoResponse {
     reload_skill_paths_and_refresh_backends(&s, RefreshReason::Periodic).await;
     let records = s.gateway.capability_index.snapshot().records;
-    Json(crate::gateway::admin::skill_health::build_skill_inventory_payload(&s, records).await)
+    Json(super::skill_health::build_skill_inventory_payload(&s, records).await)
 }
 
 fn admin_skill_query_name(params: &AdminSkillDetailQuery) -> Option<&str> {
@@ -1101,7 +1101,7 @@ pub async fn handle_admin_stats(
                 obj.insert("p95_ms".to_string(), json!(stats.latency_ms.p95_ms));
                 obj.insert(
                     "governance".to_string(),
-                    crate::gateway::admin::governance::build_governance_stats(&s),
+                    super::governance::build_governance_stats(&s),
                 );
                 obj.insert(
                     "avg_tokens_per_call".to_string(),
@@ -1138,7 +1138,7 @@ pub async fn handle_admin_stats(
             "payload_token_estimator": TOKEN_ESTIMATOR,
             "payload_token_usage": dcc_mcp_gateway_admin::PayloadTokenUsageStats::empty(0),
             "token_usage": dcc_mcp_gateway_admin::TokenUsageStats::default(),
-            "governance": crate::gateway::admin::governance::build_governance_stats(&s),
+            "governance": super::governance::build_governance_stats(&s),
             });
             debug_response(&headers, &params, StatusCode::OK, root.clone(), Some(root))
         }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/mod.rs
@@ -5,6 +5,18 @@
 //! axum responses.
 
 #[cfg(feature = "admin")]
+pub mod analytics;
+
+#[cfg(feature = "admin")]
+pub mod governance;
+
+#[cfg(feature = "admin")]
+pub(super) mod skill_health;
+
+#[cfg(feature = "admin")]
+pub(super) mod traffic;
+
+#[cfg(feature = "admin")]
 pub mod handlers;
 
 #[cfg(feature = "admin")]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/skill_health.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/skill_health.rs
@@ -81,7 +81,7 @@ pub(super) async fn build_skill_inventory_payload(
     )
 }
 
-pub(super) fn build_skill_paths_payload(state: &AdminState) -> Value {
+pub(in crate::gateway::admin) fn build_skill_paths_payload(state: &AdminState) -> Value {
     let paths = build_skill_path_rows(state);
     let missing = paths
         .iter()

--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/traffic.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/traffic.rs
@@ -6,7 +6,11 @@ use serde_json::Value;
 use super::governance::governance_capture_decision;
 use crate::gateway::traffic::{TrafficCapture, TrafficCaptureSnapshot};
 
-pub(super) fn build_traffic_payload(capture: &TrafficCapture, limit: usize, links: Value) -> Value {
+pub(in crate::gateway::admin) fn build_traffic_payload(
+    capture: &TrafficCapture,
+    limit: usize,
+    links: Value,
+) -> Value {
     let frames = capture
         .recent_frames(limit)
         .into_iter()
@@ -16,7 +20,10 @@ pub(super) fn build_traffic_payload(capture: &TrafficCapture, limit: usize, link
     traffic_payload(frames, &snapshot, links)
 }
 
-pub(super) fn build_traffic_export_body(capture: &TrafficCapture, limit: usize) -> String {
+pub(in crate::gateway::admin) fn build_traffic_export_body(
+    capture: &TrafficCapture,
+    limit: usize,
+) -> String {
     let frames = capture
         .recent_frames(limit)
         .into_iter()

--- a/crates/dcc-mcp-gateway/src/gateway/admin/general.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/general.rs
@@ -49,15 +49,17 @@ pub async fn handle_admin_traffic(
 ) -> impl IntoResponse {
     let links = AdminLinkBuilder::from_request(&headers, &uri);
     let limit = params.limit(200, 1_000);
-    Json(crate::gateway::admin::traffic::build_traffic_payload(
-        &s.gateway.traffic_capture,
-        limit,
-        json!({
-            "admin_traffic_url": links.panel_url("traffic"),
-            "traffic_api_url": links.api_url("/traffic"),
-            "traffic_export_jsonl_url": links.api_url("/traffic/export"),
-        }),
-    ))
+    Json(
+        crate::gateway::admin::application::traffic::build_traffic_payload(
+            &s.gateway.traffic_capture,
+            limit,
+            json!({
+                "admin_traffic_url": links.panel_url("traffic"),
+                "traffic_api_url": links.api_url("/traffic"),
+                "traffic_export_jsonl_url": links.api_url("/traffic/export"),
+            }),
+        ),
+    )
 }
 
 /// `GET /admin/api/traffic/export?limit=1000` — retained live frames as JSONL.
@@ -66,7 +68,7 @@ pub async fn handle_admin_traffic_export(
     Query(params): Query<DebugListQuery>,
 ) -> impl IntoResponse {
     let limit = params.limit(1_000, 10_000);
-    let body = crate::gateway::admin::traffic::build_traffic_export_body(
+    let body = crate::gateway::admin::application::traffic::build_traffic_export_body(
         &s.gateway.traffic_capture,
         limit,
     );

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -76,8 +76,6 @@ pub mod activity;
 #[cfg(feature = "admin")]
 mod agent_trace;
 #[cfg(feature = "admin")]
-pub mod analytics;
-#[cfg(feature = "admin")]
 pub mod artifacts;
 #[cfg(feature = "admin")]
 #[cfg(feature = "admin")]
@@ -88,8 +86,6 @@ mod events;
 pub(crate) mod experiments;
 #[cfg(feature = "admin")]
 mod general;
-#[cfg(feature = "admin")]
-pub mod governance;
 #[cfg(feature = "admin")]
 #[cfg(feature = "admin")]
 mod issue_report;
@@ -105,16 +101,12 @@ mod recordings;
 #[cfg(feature = "admin")]
 pub mod sessions;
 #[cfg(feature = "admin")]
-mod skill_health;
-#[cfg(feature = "admin")]
 mod skill_paths;
 #[cfg(feature = "admin")]
 pub mod skill_reload;
 pub mod sqlite_lane;
 pub mod state;
 pub mod trace;
-#[cfg(feature = "admin")]
-mod traffic;
 #[cfg(feature = "admin")]
 #[cfg(feature = "admin")]
 mod wecom_response;
@@ -152,6 +144,8 @@ mod workflows_tests;
 // ── Backward-compatible re-exports ────────────────────────────────────────
 
 // DB helpers.
+#[cfg(feature = "admin")]
+pub use application::{analytics, governance};
 pub use dcc_mcp_db::{
     default_gateway_admin_sqlite_path as default_admin_db_path,
     resolve_gateway_admin_sqlite_path as resolve_admin_db_path,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/skill_paths.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/skill_paths.rs
@@ -67,7 +67,7 @@ fn push_admin_operator_note(state: &AdminState, msg: String) {
 
 /// `GET /admin/api/skill-paths` — skill search paths (snapshot + SQLite custom).
 pub async fn handle_admin_skill_paths(State(s): State<AdminState>) -> impl IntoResponse {
-    Json(crate::gateway::admin::skill_health::build_skill_paths_payload(&s))
+    Json(crate::gateway::admin::application::skill_health::build_skill_paths_payload(&s))
 }
 
 /// `POST /admin/api/skill-paths` — enqueue a custom path; embedder hook may reload disk catalog.


### PR DESCRIPTION
## Summary

- move analytics, governance, traffic, and skill-health adapters into the admin application layer
- preserve public analytics and governance module paths through direct re-exports
- keep internal traffic and skill-health visibility scoped to the admin boundary

Progresses #2187.

## Validation

- `vx cargo check -p dcc-mcp-gateway --all-features`
- `vx cargo check -p dcc-mcp-gateway --no-default-features`
- `vx cargo test -p dcc-mcp-gateway gateway::admin --all-features` (113 passed)
- `vx cargo clippy -p dcc-mcp-gateway --lib --all-features -- -D warnings`
- `vx just preflight` (3595 passed)
- public documentation internal-path scan: clean

Creator Skills are unchanged because public adapter and skill workflows are unchanged.
