### PR TITLE
fix: preserve legacy marketplace ledgers

### DIFF
--- a/crates/dcc-mcp-marketplace/src/service_tests.rs
+++ b/crates/dcc-mcp-marketplace/src/service_tests.rs
@@ -23,6 +23,73 @@ fn installed_package(name: &str, dcc: &str) -> InstalledMarketplacePackage {
 }
 
 #[test]
+fn legacy_installed_state_without_target_infers_dcc_target() {
+    let temp = tempfile::tempdir().unwrap();
+    let service = MarketplaceService::new(temp.path().to_path_buf());
+    let state_path = temp.path().join("installed.json");
+    std::fs::write(
+        &state_path,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "packages": [{
+                "name": "legacy-tools",
+                "dcc": "Maya",
+                "version": "0.20.4",
+                "path": temp.path().join("maya").join("legacy-tools"),
+                "source_name": "official",
+                "source_url": "https://example.invalid/marketplace.json",
+                "install_type": "git",
+                "install_url": null,
+                "install_ref": null,
+                "installed_at_ms": 1
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let installed = service.list_installed(None).unwrap();
+    assert_eq!(installed.count, 1);
+    assert_eq!(
+        installed.packages[0].target,
+        CatalogTarget {
+            kind: CatalogTargetKind::Dcc,
+            id: "maya".into(),
+        }
+    );
+
+    service
+        .upsert_installed(installed_package("blender-tools", "blender"))
+        .unwrap();
+    let persisted: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(state_path).unwrap()).unwrap();
+    assert!(
+        persisted["packages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|package| package.get("target").is_some())
+    );
+}
+
+#[test]
+fn installed_package_without_target_or_legacy_dcc_is_rejected() {
+    let mut package = serde_json::to_value(installed_package("broken-tools", "maya")).unwrap();
+    let package = package.as_object_mut().unwrap();
+    package.remove("target");
+    package.insert("dcc".into(), serde_json::Value::String("  ".into()));
+
+    let error = serde_json::from_value::<InstalledMarketplacePackage>(serde_json::Value::Object(
+        package.clone(),
+    ))
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("missing field `target` and legacy `dcc` is empty")
+    );
+}
+
+#[test]
 fn resolve_installed_dcc_infers_the_only_matching_host() {
     let temp = tempfile::tempdir().unwrap();
     let service = MarketplaceService::new(temp.path().to_path_buf());

--- a/crates/dcc-mcp-marketplace/src/types.rs
+++ b/crates/dcc-mcp-marketplace/src/types.rs
@@ -115,6 +115,7 @@ pub enum MarketplaceActivation {
 // ── installed state ──────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(try_from = "InstalledMarketplacePackageWire")]
 pub struct InstalledMarketplacePackage {
     pub name: String,
     pub dcc: String,
@@ -136,6 +137,65 @@ pub struct InstalledMarketplacePackage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_commit: Option<String>,
     pub installed_at_ms: u128,
+}
+
+/// Persistence DTO that keeps DCC-only ledgers written before `target` compatible.
+#[derive(Debug, Clone, Deserialize)]
+struct InstalledMarketplacePackageWire {
+    name: String,
+    dcc: String,
+    #[serde(default)]
+    target: Option<CatalogTarget>,
+    #[serde(default)]
+    components: Vec<CatalogComponent>,
+    #[serde(default)]
+    package_format: Option<CatalogPackageFormat>,
+    version: Option<String>,
+    path: String,
+    source_name: String,
+    source_url: String,
+    install_type: String,
+    install_url: Option<String>,
+    install_ref: Option<String>,
+    #[serde(default)]
+    resolved_commit: Option<String>,
+    installed_at_ms: u128,
+}
+
+impl TryFrom<InstalledMarketplacePackageWire> for InstalledMarketplacePackage {
+    type Error = String;
+
+    fn try_from(value: InstalledMarketplacePackageWire) -> Result<Self, Self::Error> {
+        let target = match value.target {
+            Some(target) => target,
+            None => {
+                let legacy_dcc = value.dcc.trim();
+                if legacy_dcc.is_empty() {
+                    return Err("missing field `target` and legacy `dcc` is empty".into());
+                }
+                CatalogTarget {
+                    kind: CatalogTargetKind::Dcc,
+                    id: legacy_dcc.to_ascii_lowercase(),
+                }
+            }
+        };
+        Ok(Self {
+            name: value.name,
+            dcc: value.dcc,
+            target,
+            components: value.components,
+            package_format: value.package_format,
+            version: value.version,
+            path: value.path,
+            source_name: value.source_name,
+            source_url: value.source_url,
+            install_type: value.install_type,
+            install_url: value.install_url,
+            install_ref: value.install_ref,
+            resolved_commit: value.resolved_commit,
+            installed_at_ms: value.installed_at_ms,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- infer DCC targets for legacy marketplace ledger entries that predate `target`
- keep malformed targetless records fail-closed
- normalize legacy entries on the next ledger write

## Validation
- `vx just preflight`
- `vx just lint`
- `vx cargo test -p dcc-mcp-marketplace` (58 passed)
- full Python pytest: 10,214 passed; one unrelated existing Rez search fixture fails locally for `motion-2d`

Skill guidance: no update needed; this changes internal marketplace persistence compatibility, not adapter or skill-authoring contracts.

Closes #2205