### PR TITLE
fix: add exact native menu invocation

### DIFF
--- a/docs/guide/adapter-runtime-contracts.md
+++ b/docs/guide/adapter-runtime-contracts.md
@@ -96,6 +96,13 @@ Preferred agent loop:
    or returns `timeout` with structured details.
 5. `ui_control__snapshot` verifies the final state.
 
+Native application menu bars may use
+`ui_control__act(action="invoke_menu", menu_path=[...])` without a prior
+snapshot when the Host advertises `native_menu_path`. The path is resolved
+inside the exact bound window and fails closed on missing or ambiguous levels.
+The operation invalidates current observations; honor `verification_required`
+and verify the popup or resulting application state with a fresh snapshot.
+
 Use native DCC skills or APIs first. Use `ui_control__*` only when the behavior is
 visible in the application UI but not exposed through a reliable host API.
 Workflow examples and recovery patterns live in

--- a/docs/guide/app-ui-workflows.md
+++ b/docs/guide/app-ui-workflows.md
@@ -77,6 +77,12 @@ The canonical workflow follows this loop:
 Always treat step 6 like a `finally` block — call it on success, failure,
 cancellation, or abandonment.
 
+For native application menu bars, `ui_control__act` also supports
+`action="invoke_menu"` with an explicit top-to-leaf `menu_path` when a
+semantic click or Alt mnemonic cannot prove that a Qt popup opened. This
+negotiated exact-window route invalidates current observations; honor
+`verification_required` and verify with a fresh snapshot.
+
 See [ui-control-workflows.md](ui-control-workflows.md) for the full reference:
 decision rules, evidence attribution, system configuration operations, recovery
 patterns, and verification requirements.

--- a/docs/guide/ui-control-workflows.md
+++ b/docs/guide/ui-control-workflows.md
@@ -69,6 +69,14 @@ Each action is fenced by CUA observation and accessibility-state IDs. Take a
 new snapshot after every mutation. Prefer semantic element tokens; coordinate
 input is a gated fallback for custom-drawn interfaces.
 
+For a native application menu bar, use
+`ui_control__act(action="invoke_menu", menu_path=[...])` when a semantic menu
+click or Alt mnemonic cannot prove that a Qt popup opened. The negotiated
+`native_menu_path` route resolves only the exact bound window and fails closed
+on missing or ambiguous levels. It does not need a prior snapshot, but it
+invalidates any current observation: check `verification_required`, then take
+a fresh snapshot and verify the popup or resulting application state.
+
 Multiple agents can hold independent sessions for different applications.
 Session grants, window capabilities, observations, recording state, and cleanup
 remain isolated. Native input is serialized by the shared Host, while Escape

--- a/python/dcc_mcp_core/adapter_contracts.py
+++ b/python/dcc_mcp_core/adapter_contracts.py
@@ -228,6 +228,7 @@ class UiActionKind:
     SELECT_OPTION = "select_option"
     FOCUS = "focus"
     KEYBOARD_SHORTCUT = "keyboard_shortcut"
+    INVOKE_MENU = "invoke_menu"
     GET_WINDOW_STATE = "get_window_state"
     RESTORE_WINDOW = "restore_window"
     SHOW_WINDOW = "show_window"
@@ -332,6 +333,7 @@ class UiControlPolicy:
             UiActionKind.SELECT_OPTION,
             UiActionKind.FOCUS,
             UiActionKind.KEYBOARD_SHORTCUT,
+            UiActionKind.INVOKE_MENU,
             UiActionKind.RESTORE_WINDOW,
             UiActionKind.SHOW_WINDOW,
             UiActionKind.ACTIVATE_WINDOW,
@@ -368,6 +370,7 @@ class UiActionRequest:
     scroll_y: Optional[int] = None
     path: List[UiPoint] = field(default_factory=list)
     keys: List[str] = field(default_factory=list)
+    menu_path: List[str] = field(default_factory=list)
     snapshot_id: Optional[str] = None
     duration_ms: Optional[int] = None
     metadata: Dict[str, Any] = field(default_factory=dict)

--- a/python/dcc_mcp_core/skills/ui-control/SKILL.md
+++ b/python/dcc_mcp_core/skills/ui-control/SKILL.md
@@ -91,6 +91,14 @@ Never reuse an observation after an action, target change, display change, or
 resume. CUA actions are fenced by both `observation_id` and
 `accessibility_state_id`; stale actions fail closed.
 
+For a native application menu bar, use
+`ui_control__act(action="invoke_menu", menu_path=[...])` when a semantic menu
+click or Alt mnemonic cannot prove that a Qt popup opened. This exact-window
+native path does not require a prior snapshot, fails closed on missing or
+ambiguous levels, and invalidates any current observation. Check
+`verification_required`, then take a fresh snapshot and verify the popup or
+resulting application state before another mutation.
+
 Prefer semantic `control_id` actions. Coordinate clicks, drag paths, raw typing,
 shortcuts, and game navigation are native input and require the raw-input gate.
 Do not use UI Control to enter credentials, solve authentication challenges, or

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_cua_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_cua_backend.py
@@ -210,6 +210,7 @@ def _client_spec(session_id: str, params: Dict[str, Any], policy: UiControlPolic
         "window_handle": window_handle,
         "window_title": window_title,
         "allow_raw_input": allow_raw_input,
+        "allow_menu_invoke": policy.allow_mutating_actions,
         "scope": scope,
     }
 
@@ -217,7 +218,15 @@ def _client_spec(session_id: str, params: Dict[str, Any], policy: UiControlPolic
 def _client_for(session_id: str, params: Dict[str, Any], policy: UiControlPolicy) -> Tuple[Any, Dict[str, Any]]:
     spec = _client_spec(session_id, params, policy)
     identity = tuple(
-        spec[key] for key in ("dcc_type", "process_id", "window_handle", "window_title", "allow_raw_input")
+        spec[key]
+        for key in (
+            "dcc_type",
+            "process_id",
+            "window_handle",
+            "window_title",
+            "allow_raw_input",
+            "allow_menu_invoke",
+        )
     )
     with _CLIENTS_LOCK:
         entry = _CLIENTS.get(session_id)
@@ -235,6 +244,7 @@ def _client_for(session_id: str, params: Dict[str, Any], policy: UiControlPolicy
                 window_handle=spec["window_handle"],
                 window_title=spec["window_title"],
                 allow_raw_input=spec["allow_raw_input"],
+                allow_menu_invoke=spec["allow_menu_invoke"],
             )
             entry = {
                 "client": client,
@@ -664,6 +674,7 @@ def act_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         action=action,
         x=params.get("x"),
         y=params.get("y"),
+        menu_path=list(params.get("menu_path") or []),
     )
     if not policy.allows_request(request):
         return skill_error(f"ui_control action {action!r} disabled by policy", UiErrorCode.POLICY_DISABLED)
@@ -700,6 +711,47 @@ def act_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
             prompt="Take a fresh ui_control__snapshot before any content interaction.",
             session_id=session_id,
             window_state=raw.get("state") or {},
+            audit=_audit_record(action, True, None, session_id, policy, None, message),
+        )
+    if action == UiActionKind.INVOKE_MENU:
+        menu_path = list(params.get("menu_path") or [])
+        try:
+            raw = client.invoke_menu(menu_path)
+        except (UiControlHostError, OSError, ValueError) as exc:
+            entry["snapshot_id"] = None
+            return _host_error(exc)
+        entry["snapshot_id"] = None
+        effect = str(raw.get("effect") or "unverifiable")
+        verification_required = bool(raw.get("verification_required", effect != "confirmed"))
+        observation_required = bool(raw.get("observation_required", True))
+        success = bool(raw.get("success"))
+        if not success:
+            return skill_error(
+                "dcc-cua did not invoke the exact native menu path.",
+                UiErrorCode.INPUT_FAILED,
+                session_id=session_id,
+                menu_path=menu_path,
+                effect=effect,
+                verification_required=True,
+                observation_required=observation_required,
+            )
+        message = (
+            "Invoked and confirmed the exact native menu path."
+            if not verification_required
+            else "Invoked the exact native menu path; delivery requires verification."
+        )
+        return skill_success(
+            message,
+            prompt=(
+                "Take a fresh ui_control__snapshot and verify the requested menu, popup, or application "
+                "state before the next mutation. Native delivery alone is not completion evidence."
+            ),
+            session_id=session_id,
+            menu_path=menu_path,
+            effect=effect,
+            verification_required=verification_required,
+            observation_required=observation_required,
+            target=raw.get("target") or client.target,
             audit=_audit_record(action, True, None, session_id, policy, None, message),
         )
     requested_snapshot_id = str(params.get("snapshot_id") or "")

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_cua_cli_host_client.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_cua_cli_host_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 
 from dcc_mcp_core.cua_cli import CuaCliBridge
@@ -24,30 +25,36 @@ class UiControlHostClient:
         process_id: Optional[int],
         window_handle: Optional[int],
         allow_raw_input: bool,
+        allow_menu_invoke: bool,
         window_title: Optional[str] = None,
         bridge: Optional[CuaCliBridge] = None,
     ) -> None:
         self.session_id = session_id
         self.task_grant_id = task_grant_id
         self._bridge = bridge or CuaCliBridge()
+        capabilities = getattr(getattr(self._bridge, "contract", None), "capabilities", ())
+        self._supports_native_menu_path = "native_menu_path" in capabilities
         self._window_capability: Optional[str] = None
         self._target: Dict[str, Any] = {}
         self._latest_observation_id: Optional[str] = None
         self._latest_accessibility_state_id: Optional[str] = None
         try:
+            grant = {
+                "task_grant_id": task_grant_id,
+                "application_label": dcc_type,
+                "process_id": process_id,
+                "window_handle": window_handle,
+                "window_title": window_title,
+                "allow_raw_input": allow_raw_input,
+                "allow_recording": True,
+            }
+            if self._supports_native_menu_path:
+                grant["allow_menu_invoke"] = allow_menu_invoke
             opened = self._call(
                 "open_session",
                 {
                     "session_id": session_id,
-                    "grant": {
-                        "task_grant_id": task_grant_id,
-                        "application_label": dcc_type,
-                        "process_id": process_id,
-                        "window_handle": window_handle,
-                        "window_title": window_title,
-                        "allow_raw_input": allow_raw_input,
-                        "allow_recording": True,
-                    },
+                    "grant": grant,
                 },
                 "session_opened",
             )
@@ -101,6 +108,26 @@ class UiControlHostClient:
                 {**self._authority(), "operation": host_operation},
                 "window_state_changed",
             )
+        finally:
+            self._invalidate_observation()
+
+    def invoke_menu(self, menu_path: List[str]) -> Dict[str, Any]:
+        """Invoke one exact native menu path without pixel or mnemonic fallback."""
+        if not self._supports_native_menu_path:
+            raise UiControlHostError(
+                "unsupported_action",
+                "The installed dcc-cua does not advertise the native_menu_path capability.",
+            )
+        try:
+            response = self._call(
+                "invoke_menu",
+                {**self._authority(), "request": {"path": menu_path}},
+                "menu_invoked",
+            )
+            result = response.get("result")
+            if not isinstance(result, dict):
+                raise UiControlHostError("protocol_mismatch", "dcc-cua returned no native menu result.")
+            return result
         finally:
             self._invalidate_observation()
 

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_cua_support.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_cua_support.py
@@ -34,6 +34,8 @@ _SESSION_LOCKS: Dict[str, threading.RLock] = {}
 _SESSION_LOCKS_GUARD = threading.Lock()
 _MAX_DRAG_POINTS = 256
 _MAX_KEY_TOKENS = 16
+_MAX_MENU_PATH_SEGMENTS = 16
+_MAX_MENU_PATH_SEGMENT_CHARS = 200
 _MAX_GAME_NAVIGATION_KEYS = 4
 _MAX_TEXT_UTF16_UNITS = 4096
 _GAME_NAVIGATION_NAMED_KEYS = _key_set(
@@ -390,6 +392,7 @@ def _is_native_action(action: str, params: Dict[str, Any]) -> bool:
         UiActionKind.KEYPRESS,
         UiActionKind.GAME_NAVIGATION,
         UiActionKind.KEYBOARD_SHORTCUT,
+        UiActionKind.INVOKE_MENU,
     }
 
 
@@ -454,6 +457,21 @@ def _validate_action_limits(params: Dict[str, Any]) -> Optional[Dict[str, Any]]:
             f"keypress exceeds the {_MAX_KEY_TOKENS}-key safety limit",
             UiErrorCode.INVALID_ACTION,
         )
+
+    if params.get("action") == UiActionKind.INVOKE_MENU:
+        menu_path = params.get("menu_path")
+        if (
+            not isinstance(menu_path, list)
+            or not 1 <= len(menu_path) <= _MAX_MENU_PATH_SEGMENTS
+            or any(
+                not isinstance(segment, str) or not segment.strip() or len(segment) > _MAX_MENU_PATH_SEGMENT_CHARS
+                for segment in menu_path
+            )
+        ):
+            return skill_error(
+                "invoke_menu requires 1..16 non-empty menu_path segments of at most 200 characters",
+                UiErrorCode.INVALID_ACTION,
+            )
 
     text = params.get("text")
     if text is not None:

--- a/python/dcc_mcp_core/skills/ui-control/tools.yaml
+++ b/python/dcc_mcp_core/skills/ui-control/tools.yaml
@@ -253,6 +253,10 @@ tools:
       path: it accepts up to four simultaneous supported canvas keys or `+`
       chords and an optional 0..500 ms hold, while preserving the existing
       raw-text denial.
+      For application menu bars, invoke_menu resolves an explicit native
+      menu_path inside the exact bound window. Prefer it when semantic menu
+      clicks or Alt mnemonics cannot prove that a Qt popup opened; it never
+      guesses pixels and always requires a fresh snapshot for verification.
       For a custom-drawn DCC canvas or face control that has no semantic node,
       use a path from the latest snapshot for one drag; Ctrl, Shift, and Alt in
       keys are held as pointer modifiers. Snapshot again immediately afterward.
@@ -304,6 +308,7 @@ tools:
             - select_option
             - focus
             - keyboard_shortcut
+            - invoke_menu
             - get_window_state
             - restore_window
             - show_window
@@ -314,7 +319,8 @@ tools:
             an exact control_id for non-sensitive Windows text entry. Windows
             keypress cannot synthesize ordinary printable text. game_navigation
             accepts up to four simultaneous supported keys for a non-editable
-            DCC or game canvas; it is not a text-entry action.
+            DCC or game canvas; it is not a text-entry action. invoke_menu uses
+            menu_path and does not require a prior snapshot.
         intent:
           type: string
           enum:
@@ -396,6 +402,18 @@ tools:
           items:
             type: string
             maxLength: 32
+        menu_path:
+          type: array
+          minItems: 1
+          maxItems: 16
+          description: >-
+            Exact top-to-leaf native application menu labels for invoke_menu.
+            Missing or ambiguous levels fail closed. Take a fresh snapshot and
+            verify the popup or resulting application state after invocation.
+          items:
+            type: string
+            minLength: 1
+            maxLength: 200
         duration_ms:
           type: integer
           minimum: 0

--- a/skills/dcc-cua/SKILL.md
+++ b/skills/dcc-cua/SKILL.md
@@ -83,6 +83,11 @@ Do not invent a profile ID. Runtime-advertised capabilities are authoritative.
 8. Stop the session on success, failure, interruption, or abandonment.
 
 An `input sent` acknowledgement is not completion evidence.
+For native application menu bars, prefer the negotiated `native_menu_path`
+route through `ui_control__act(action="invoke_menu", menu_path=[...])` when a
+semantic menu click or Alt mnemonic cannot prove that a popup opened. A menu
+invocation invalidates the current observation; honor `verification_required`
+and verify the popup or resulting application state with a fresh snapshot.
 
 ## DCC-host route
 
@@ -93,6 +98,7 @@ projection:
 dcc-mcp-cli load-skill ui-control --instance-id <instance-id> --output toon
 dcc-mcp-cli ui-control snapshot --instance-id <instance-id> --json '{"session_id":"ui","process_id":1234,"window_handle":5678}'
 dcc-mcp-cli ui-control act --instance-id <instance-id> --json '{"session_id":"ui","control_id":"ok","action":"click","snapshot_id":"<snapshot-id>"}'
+dcc-mcp-cli ui-control act --instance-id <instance-id> --json '{"session_id":"ui","action":"invoke_menu","menu_path":["Window","Arrange","Left"]}'
 dcc-mcp-cli ui-control stop --instance-id <instance-id> --json '{"session_id":"ui"}'
 ```
 

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -140,6 +140,11 @@ the server from its exact target environment. Gateway Admin is check-only.
      `snapshot` → one `act` → `snapshot` loop only when an operation is
      unsupported, no suitable tool exists, or semantic UI Automation cannot
      reach the required control. Re-observe after every action.
+   - For native application menu bars, route an explicit `menu_path` through
+     `ui_control__act(action="invoke_menu")` when semantic click or Alt-mnemonic
+     delivery cannot prove that a Qt popup opened. Require the negotiated
+     `native_menu_path` Host capability, honor `verification_required`, and
+     re-observe the exact window before another mutation.
    - Raw pointer and keyboard input are enabled by default only inside the
      adapter/operator-bound DCC scope. Operators may set
      `DCC_MCP_CUA_ALLOW_RAW_INPUT=false` to disable that runtime ceiling; the

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -259,6 +259,11 @@ only with the matching chunked runner or isolated status/cancel implementation.
   serialization; skill scripts must not instantiate another automation stack.
 - Prefer a `control_id` and semantic UI Automation action. Use raw coordinates
   only when the UI does not expose a stable semantic control.
+- For native application menu bars, use the negotiated `invoke_menu` action
+  with an explicit `menu_path` when a semantic menu click or Alt mnemonic
+  cannot prove that a popup opened. Never guess pixels or report native
+  delivery as completion; take a fresh snapshot and honor
+  `verification_required` before another mutation.
 - For custom-drawn canvases, viewport manipulators, or face controls, use one
   `drag` path from the latest snapshot. `keys` may hold Ctrl, Shift, or Alt for
   pointer-modified drags; snapshot again immediately before deriving another

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -196,7 +196,7 @@ Load the **DCC UI Control** runtime with `dcc-mcp-cli load-skill ui-control` onl
 when structured DCC capabilities cannot reach the required semantic UI:
 
 1. `ui_control__snapshot` with an exact `process_id`, `window_handle`, or `window_title`.
-2. `ui_control__find` and one semantic `ui_control__act` when possible.
+2. `ui_control__find` and one semantic `ui_control__act` when possible. For native menus, use `invoke_menu` with an explicit `menu_path` when semantic delivery cannot prove a Qt popup opened; require `native_menu_path`, honor `verification_required`, and re-observe.
 3. `ui_control__snapshot` after every action before choosing the next action.
 4. `ui_control__stop_computer_use` when the fallback completes, fails, or is abandoned.
 The runtime defaults to `dcc-cua` 0.4.0+; `mock` is test-only, never a production fallback. After loading, local `search --query "ui control snapshot"` returns the loaded `ui_control__*` slugs as callable tool hits.

--- a/tests/test_adapter_contracts.py
+++ b/tests/test_adapter_contracts.py
@@ -129,6 +129,7 @@ def test_ui_action_request_serializes_computer_use_inputs() -> None:
         scroll_y=-500,
         path=[UiPoint(x=10, y=20), UiPoint(x=80, y=90)],
         keys=["CTRL", "A"],
+        menu_path=["Window", "Arrange", "Left"],
         snapshot_id="observation-1",
     )
 
@@ -139,6 +140,7 @@ def test_ui_action_request_serializes_computer_use_inputs() -> None:
     assert payload["scroll_x"] == 0
     assert payload["scroll_y"] == -500
     assert payload["keys"] == ["CTRL", "A"]
+    assert payload["menu_path"] == ["Window", "Arrange", "Left"]
     assert payload["snapshot_id"] == "observation-1"
 
 
@@ -152,6 +154,7 @@ def test_ui_control_policy_blocks_high_risk_actions_by_default() -> None:
     assert policy.allows_action(UiActionKind.GAME_NAVIGATION) is False
     assert policy.allows_action(UiActionKind.GET_WINDOW_STATE) is True
     assert policy.allows_action(UiActionKind.RESTORE_WINDOW) is True
+    assert policy.allows_action(UiActionKind.INVOKE_MENU) is True
     assert policy.require_scoped_window is True
     assert policy.to_dict()["allow_raw_coordinates"] is False
     assert policy.to_dict()["require_scoped_window"] is True

--- a/tests/test_cua_cli_host_client.py
+++ b/tests/test_cua_cli_host_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from conftest import REPO_ROOT
@@ -20,9 +21,10 @@ def _load(path: Path, name: str) -> Any:
 
 
 class FakeBridge:
-    def __init__(self) -> None:
+    def __init__(self, capabilities: tuple[str, ...] = ("native_menu_path",)) -> None:
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self.closed = False
+        self.contract = SimpleNamespace(capabilities=capabilities)
 
     def call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         self.calls.append((method, params))
@@ -80,6 +82,17 @@ class FakeBridge:
                 "type": "window_state_changed",
                 "state": {"minimized": False, "foreground": True},
             }
+        if method == "invoke_menu":
+            return {
+                "type": "menu_invoked",
+                "result": {
+                    "success": True,
+                    "effect": "unverifiable",
+                    "verification_required": True,
+                    "observation_required": True,
+                    "target": {"process_id": 42, "window_handle": 500},
+                },
+            }
         if method == "recording_start":
             return {
                 "type": "recording_started",
@@ -118,6 +131,7 @@ def test_cua_host_adapter_preserves_exact_grant_snapshot_and_action_fences() -> 
         window_handle=500,
         window_title="Autodesk Maya",
         allow_raw_input=True,
+        allow_menu_invoke=True,
         bridge=bridge,
     )
 
@@ -131,6 +145,7 @@ def test_cua_host_adapter_preserves_exact_grant_snapshot_and_action_fences() -> 
         "window_title": "Autodesk Maya",
         "allow_raw_input": True,
         "allow_recording": True,
+        "allow_menu_invoke": True,
     }
     snapshot = client.snapshot(max_depth=5, max_nodes=250)
     button = snapshot["root"]["children"][0]
@@ -174,6 +189,7 @@ def test_restore_window_uses_cua_restore_activate_contract() -> None:
         process_id=42,
         window_handle=500,
         allow_raw_input=False,
+        allow_menu_invoke=True,
         bridge=bridge,
     )
 
@@ -189,6 +205,65 @@ def test_restore_window_uses_cua_restore_activate_contract() -> None:
             "operation": "restore_activate",
         },
     )
+
+
+def test_native_menu_path_uses_explicit_grant_and_invalidates_observation() -> None:
+    client_module = _load(_CLIENT_PATH, "_test_cua_native_menu_path")
+    bridge = FakeBridge()
+    client = client_module.UiControlHostClient(
+        session_id="maya",
+        task_grant_id="grant-1",
+        dcc_type="maya",
+        process_id=42,
+        window_handle=500,
+        allow_raw_input=False,
+        allow_menu_invoke=True,
+        bridge=bridge,
+    )
+    client.snapshot(max_depth=5, max_nodes=250)
+
+    result = client.invoke_menu(["Window", "Arrange", "Left"])
+
+    assert result["verification_required"] is True
+    assert result["observation_required"] is True
+    assert bridge.calls[-1] == (
+        "invoke_menu",
+        {
+            "session_id": "maya",
+            "task_grant_id": "grant-1",
+            "window_capability": "cua-window-1",
+            "request": {"path": ["Window", "Arrange", "Left"]},
+        },
+    )
+    try:
+        client.execute({"action": "click"})
+    except client_module.UiControlHostError as exc:
+        assert exc.code == "stale_observation"
+    else:
+        raise AssertionError("native menu invocation must invalidate the observation")
+
+
+def test_legacy_host_omits_menu_grant_and_fails_capability_check() -> None:
+    client_module = _load(_CLIENT_PATH, "_test_cua_legacy_menu_capability")
+    bridge = FakeBridge(capabilities=())
+    client = client_module.UiControlHostClient(
+        session_id="maya",
+        task_grant_id="grant-1",
+        dcc_type="maya",
+        process_id=42,
+        window_handle=500,
+        allow_raw_input=False,
+        allow_menu_invoke=True,
+        bridge=bridge,
+    )
+
+    assert "allow_menu_invoke" not in bridge.calls[0][1]["grant"]
+    try:
+        client.invoke_menu(["File"])
+    except client_module.UiControlHostError as exc:
+        assert exc.code == "unsupported_action"
+    else:
+        raise AssertionError("native menu invocation must require the negotiated capability")
 
 
 def test_cua_backend_passes_cua_element_token_not_legacy_control_id() -> None:

--- a/tests/test_ui_control_skill.py
+++ b/tests/test_ui_control_skill.py
@@ -216,6 +216,7 @@ def test_ui_control_tool_schema_supports_computer_use_actions() -> None:
         "select_option",
         "focus",
         "keyboard_shortcut",
+        "invoke_menu",
         "get_window_state",
         "restore_window",
         "show_window",
@@ -232,11 +233,14 @@ def test_ui_control_tool_schema_supports_computer_use_actions() -> None:
         "scroll_y",
         "path",
         "keys",
+        "menu_path",
         "snapshot_id",
     }.issubset(schema["properties"])
     assert schema["properties"]["path"]["items"]["required"] == ["x", "y"]
     assert schema["properties"]["path"]["maxItems"] == 256
     assert schema["properties"]["keys"]["maxItems"] == 16
+    assert schema["properties"]["menu_path"]["maxItems"] == 16
+    assert schema["properties"]["menu_path"]["items"]["maxLength"] == 200
     keys_description = schema["properties"]["keys"]["description"]
     assert "pointer actions" in keys_description
     assert "navigation/control/function" in keys_description
@@ -829,6 +833,7 @@ class _FakeHostClient:
         self.kwargs = kwargs
         self.executed: list[dict[str, Any]] = []
         self.window_operations: list[str] = []
+        self.menu_paths: list[list[str]] = []
         self.recordings: list[dict[str, Any]] = []
         self.snapshot_calls = 0
         self.accessibility_snapshot_calls = 0
@@ -964,6 +969,16 @@ class _FakeHostClient:
                 "minimized": False,
                 "foreground": operation == "activate",
             },
+        }
+
+    def invoke_menu(self, menu_path: list[str]) -> dict[str, Any]:
+        self.menu_paths.append(menu_path)
+        return {
+            "success": True,
+            "effect": "unverifiable",
+            "verification_required": True,
+            "observation_required": True,
+            "target": self.target,
         }
 
     def resume(self) -> None:
@@ -1128,6 +1143,8 @@ def test_ui_control_cua_host_semantic_action_is_thin_proxy(monkeypatch: Any) -> 
     assert payload["element_token"] == "dcc-wuia:snapshot:1"
     assert "control_id" not in payload
     assert payload["intent"] == "external_communication"
+    assert _FakeHostClient.instances[0].snapshot_calls == 1
+    assert len(_FakeHostClient.instances) == 1
     source = (_SCRIPTS / "_cua_backend.py").read_text(encoding="utf-8")
     assert "ComputerUseSession" not in source
     assert "subprocess" not in source
@@ -1182,6 +1199,38 @@ def test_ui_control_cua_host_restores_minimized_exact_window_without_snapshot(mo
     assert _FakeHostClient.instances[0].window_operations == ["restore"]
     assert _FakeHostClient.instances[0].executed == []
     assert state["context"]["audit"]["metadata"]["host_enforced"] is True
+
+
+def test_ui_control_cua_host_invokes_exact_native_menu_without_snapshot(monkeypatch: Any) -> None:
+    backend = _load_cua_module()
+    _configure_fake_host(backend, monkeypatch)
+
+    result = backend.act_tool(
+        {
+            "session_id": "native-menu",
+            "action": "invoke_menu",
+            "menu_path": ["Window", "Arrange", "Left"],
+        }
+    )
+
+    assert result["success"] is True
+    assert result["context"]["menu_path"] == ["Window", "Arrange", "Left"]
+    assert result["context"]["verification_required"] is True
+    assert result["context"]["observation_required"] is True
+    assert "not completion evidence" in result["prompt"]
+    assert _FakeHostClient.instances[0].menu_paths == [["Window", "Arrange", "Left"]]
+    assert _FakeHostClient.instances[0].snapshot_calls == 0
+
+
+def test_ui_control_cua_host_rejects_invalid_native_menu_path_before_opening_session(monkeypatch: Any) -> None:
+    backend = _load_cua_module()
+    _configure_fake_host(backend, monkeypatch)
+
+    result = backend.act_tool({"session_id": "native-menu", "action": "invoke_menu", "menu_path": []})
+
+    assert result["success"] is False
+    assert result["error"] == "invalid_action"
+    assert not _FakeHostClient.instances
 
 
 def test_ui_control_cua_host_reports_closed_target_success_and_requires_explicit_rebind(monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary
- expose dcc-cua native menu-path invocation through `ui_control__act`
- negotiate the Host capability while preserving exact grants and observation fences
- retain regression coverage for first-action session reuse and minimized-window restoration
- document mandatory fresh-snapshot verification after native menu delivery

## Validation
- `pytest -q`: 10210 passed, 141 skipped, 3 xfailed
- focused UI/CUA regression suite: 64 passed
- Ruff check and format checks passed
- Rust fmt, check, and clippy validation passed
- affected skills passed `dcc-mcp-cli lint`
- documentation production build passed
- dcc-cua 1.4.0 manifest contract verified with `native_menu_path`

Closes #2207