### PR TITLE
fix: reject desynchronized tool responses

### DIFF
--- a/crates/dcc-mcp-cli/src/application/client.rs
+++ b/crates/dcc-mcp-cli/src/application/client.rs
@@ -121,6 +121,7 @@ impl DccMcpClient {
     }
 
     pub async fn call(&self, request: CallRequest) -> Result<Value, ClientError> {
+        let request_id = next_request_id();
         let body = json!({
             "tool_slug": &request.tool_slug,
             "arguments": &request.arguments,
@@ -128,16 +129,22 @@ impl DccMcpClient {
         });
         match self
             .gateway
-            .post_json(&self.endpoint.path("/v1/call"), &body)
+            .post_json_correlated(&self.endpoint.path("/v1/call"), &body, &request_id)
             .await
         {
             Ok(value) => Ok(value),
-            Err(error) if is_unknown_rest_tool(&error) => self.call_mcp_tool(request).await,
+            Err(error) if is_unknown_rest_tool(&error) => {
+                self.call_mcp_tool(request, &request_id).await
+            }
             Err(error) => Err(error.into()),
         }
     }
 
-    async fn call_mcp_tool(&self, request: CallRequest) -> Result<Value, ClientError> {
+    async fn call_mcp_tool(
+        &self,
+        request: CallRequest,
+        request_id: &str,
+    ) -> Result<Value, ClientError> {
         let tool_slug = request.tool_slug;
         let mut params = json!({
             "name": &tool_slug,
@@ -152,16 +159,18 @@ impl DccMcpClient {
                 &self.endpoint.mcp_url(),
                 &json!({
                     "jsonrpc": "2.0",
-                    "id": "dcc-mcp-cli-call",
+                    "id": request_id,
                     "method": "tools/call",
                     "params": params,
                 }),
                 &[
                     ("Mcp-Protocol-Version", MCP_PROTOCOL_VERSION),
                     ("Accept", MCP_STREAMABLE_HTTP_ACCEPT),
+                    ("X-Request-ID", request_id),
                 ],
             )
             .await?;
+        validate_jsonrpc_response_id(&response, request_id)?;
         if let Some(error) = response.get("error") {
             return Err(ClientError::Protocol(error.to_string()));
         }
@@ -181,13 +190,15 @@ impl DccMcpClient {
     }
 
     pub async fn call_batch(&self, body: Value) -> Result<Value, ClientError> {
+        let request_id = next_request_id();
         self.gateway
-            .post_json(&self.endpoint.path("/v1/call_batch"), &body)
+            .post_json_correlated(&self.endpoint.path("/v1/call_batch"), &body, &request_id)
             .await
             .map_err(Into::into)
     }
 
     pub async fn direct_call(&self, request: DirectCallRequest) -> Result<Value, ClientError> {
+        let request_id = next_request_id();
         let body = json!({
             "backend_tool": request.backend_tool,
             "arguments": request.arguments,
@@ -198,7 +209,7 @@ impl DccMcpClient {
             request.dcc_type, request.instance_id
         );
         self.gateway
-            .post_json(&self.endpoint.path(&path), &body)
+            .post_json_correlated(&self.endpoint.path(&path), &body, &request_id)
             .await
             .map_err(Into::into)
     }
@@ -450,6 +461,30 @@ fn is_unknown_rest_tool(error: &HttpError) -> bool {
         .is_some_and(|message| message.starts_with("invalid tool slug "))
 }
 
+fn next_request_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("dcc-mcp-cli-{}-{counter}", std::process::id())
+}
+
+fn validate_jsonrpc_response_id(
+    response: &Value,
+    expected_request_id: &str,
+) -> Result<(), ClientError> {
+    let expected = Value::String(expected_request_id.to_string());
+    if response.get("id") == Some(&expected) {
+        return Ok(());
+    }
+    Err(ClientError::Protocol(format!(
+        "transport desync: expected JSON-RPC response id {expected_request_id:?}, got {}",
+        response
+            .get("id")
+            .map_or_else(|| "<missing>".to_string(), Value::to_string),
+    )))
+}
+
 const READINESS_FIELDS: &[&str] = &[
     "process",
     "dcc",
@@ -622,5 +657,17 @@ mod tests {
         assert_eq!(response["query"]["instance_id"], "instance-a");
         assert_eq!(response["query"]["session_id"], "solar-session");
         server.abort();
+    }
+
+    #[test]
+    fn jsonrpc_response_id_must_match_exactly() {
+        validate_jsonrpc_response_id(&json!({"id": "current-call"}), "current-call").unwrap();
+
+        let stale = validate_jsonrpc_response_id(&json!({"id": "previous-call"}), "current-call")
+            .unwrap_err();
+        assert!(stale.to_string().contains("transport desync"));
+
+        let missing = validate_jsonrpc_response_id(&json!({}), "current-call").unwrap_err();
+        assert!(missing.to_string().contains("<missing>"));
     }
 }

--- a/crates/dcc-mcp-cli/src/application/control_plane.rs
+++ b/crates/dcc-mcp-cli/src/application/control_plane.rs
@@ -485,6 +485,7 @@ fn job_poll_error_is_retryable(error: &anyhow::Error) -> bool {
                 | reqwest::StatusCode::SERVICE_UNAVAILABLE
                 | reqwest::StatusCode::GATEWAY_TIMEOUT
         ),
+        Some(HttpError::MissingRequestId { .. } | HttpError::RequestIdMismatch { .. }) => false,
         None => false,
     }
 }
@@ -767,14 +768,26 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
 
-    use axum::extract::{Query, State};
-    use axum::http::StatusCode;
+    use axum::extract::{Query, Request, State};
+    use axum::http::{HeaderValue, StatusCode};
+    use axum::middleware::{self, Next};
     use axum::response::{IntoResponse, Response};
     use axum::routing::{get, post};
     use axum::{Json, Router};
     use tempfile::tempdir;
 
     use super::*;
+
+    async fn echo_request_id(request: Request, next: Next) -> Response {
+        let request_id = request.headers().get("x-request-id").cloned();
+        let mut response = next.run(request).await;
+        if let Some(request_id) = request_id {
+            response
+                .headers_mut()
+                .insert("x-request-id", HeaderValue::from(request_id));
+        }
+        response
+    }
 
     #[tokio::test]
     async fn local_load_skill_routes_through_gateway_to_keep_index_coherent() {
@@ -828,7 +841,8 @@ mod tests {
 
         let app = Router::new()
             .route("/v1/call", post(call))
-            .route("/v1/debug/stats", get(stats));
+            .route("/v1/debug/stats", get(stats))
+            .layer(middleware::from_fn(echo_request_id));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
@@ -926,7 +940,8 @@ mod tests {
         let requests = Arc::new(Mutex::new(Vec::new()));
         let app = Router::new()
             .route("/v1/call", post(call))
-            .with_state(requests.clone());
+            .with_state(requests.clone())
+            .layer(middleware::from_fn(echo_request_id));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
@@ -1032,7 +1047,8 @@ mod tests {
         let requests = Arc::new(Mutex::new(Vec::new()));
         let app = Router::new()
             .route("/v1/call", post(call))
-            .with_state(requests.clone());
+            .with_state(requests.clone())
+            .layer(middleware::from_fn(echo_request_id));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
@@ -1117,7 +1133,8 @@ mod tests {
         let polls = Arc::new(Mutex::new(0));
         let app = Router::new()
             .route("/v1/call", post(call))
-            .with_state(polls.clone());
+            .with_state(polls.clone())
+            .layer(middleware::from_fn(echo_request_id));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
@@ -1186,7 +1203,9 @@ mod tests {
             .into_response()
         }
 
-        let app = Router::new().route("/v1/call", post(call));
+        let app = Router::new()
+            .route("/v1/call", post(call))
+            .layer(middleware::from_fn(echo_request_id));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });

--- a/crates/dcc-mcp-cli/src/infra/http.rs
+++ b/crates/dcc-mcp-cli/src/infra/http.rs
@@ -13,6 +13,12 @@ pub enum HttpError {
         status: reqwest::StatusCode,
         body: String,
     },
+    #[error("transport desync: response is missing X-Request-ID; expected {expected:?}")]
+    MissingRequestId { expected: String },
+    #[error(
+        "transport desync: response X-Request-ID mismatch; expected {expected:?}, got {actual:?}"
+    )]
+    RequestIdMismatch { expected: String, actual: String },
 }
 
 #[derive(Clone)]
@@ -73,6 +79,23 @@ impl HttpGateway {
         Self::json_response(response).await
     }
 
+    pub async fn post_json_correlated(
+        &self,
+        url: &str,
+        body: &Value,
+        request_id: &str,
+    ) -> Result<Value, HttpError> {
+        let response = self
+            .client
+            .post(url)
+            .header(header::ACCEPT, "application/json")
+            .header("X-Request-ID", request_id)
+            .json(body)
+            .send()
+            .await?;
+        Self::json_response_correlated(response, request_id).await
+    }
+
     pub async fn post_json_with_headers(
         &self,
         url: &str,
@@ -102,6 +125,30 @@ impl HttpGateway {
         let body = response.text().await.unwrap_or_default();
         Err(HttpError::Status { status, body })
     }
+
+    async fn json_response_correlated(
+        response: reqwest::Response,
+        expected_request_id: &str,
+    ) -> Result<Value, HttpError> {
+        let actual_request_id = response
+            .headers()
+            .get("X-Request-ID")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned)
+            .ok_or_else(|| HttpError::MissingRequestId {
+                expected: expected_request_id.to_string(),
+            })?;
+        if actual_request_id != expected_request_id {
+            return Err(HttpError::RequestIdMismatch {
+                expected: expected_request_id.to_string(),
+                actual: actual_request_id,
+            });
+        }
+        if !response.status().is_success() {
+            return Self::json_response(response).await;
+        }
+        response.json::<Value>().await.map_err(Into::into)
+    }
 }
 
 #[cfg(test)]
@@ -110,7 +157,7 @@ mod tests {
 
     use axum::Router;
     use axum::extract::Json;
-    use axum::http::{HeaderMap, header};
+    use axum::http::{HeaderMap, StatusCode, header};
     use axum::routing::get;
     use serde_json::json;
     use tokio::sync::oneshot;
@@ -137,7 +184,41 @@ mod tests {
     }
 
     async fn spawn_accept_fixture() -> AcceptFixture {
-        let app = Router::new().route("/accept", get(accept_echo).post(accept_echo));
+        async fn correlated_echo(headers: HeaderMap) -> (HeaderMap, Json<Value>) {
+            let mut response_headers = HeaderMap::new();
+            if let Some(request_id) = headers.get("x-request-id") {
+                response_headers.insert("x-request-id", request_id.clone());
+            }
+            (response_headers, Json(json!({"ok": true})))
+        }
+
+        async fn stale_correlation() -> (HeaderMap, Json<Value>) {
+            let mut response_headers = HeaderMap::new();
+            response_headers.insert("x-request-id", "previous-call".parse().unwrap());
+            (response_headers, Json(json!({"ok": true})))
+        }
+
+        async fn correlated_error(headers: HeaderMap) -> (StatusCode, HeaderMap, Json<Value>) {
+            let mut response_headers = HeaderMap::new();
+            if let Some(request_id) = headers.get("x-request-id") {
+                response_headers.insert("x-request-id", request_id.clone());
+            }
+            (
+                StatusCode::BAD_REQUEST,
+                response_headers,
+                Json(json!({"error": "invalid request"})),
+            )
+        }
+
+        let app = Router::new()
+            .route("/accept", get(accept_echo).post(accept_echo))
+            .route("/correlated", axum::routing::post(correlated_echo))
+            .route(
+                "/correlated-missing",
+                axum::routing::post(|| async { Json(json!({"ok": true})) }),
+            )
+            .route("/correlated-stale", axum::routing::post(stale_correlation))
+            .route("/correlated-error", axum::routing::post(correlated_error));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
@@ -204,5 +285,68 @@ mod tests {
             .unwrap();
 
         assert_eq!(response["accept"], "application/json, text/event-stream");
+    }
+
+    #[tokio::test]
+    async fn post_json_correlated_accepts_an_exact_echo() {
+        let fixture = spawn_accept_fixture().await;
+        let gateway = HttpGateway::default();
+        let url = fixture.url.replace("/accept", "/correlated");
+
+        let response = gateway
+            .post_json_correlated(&url, &json!({}), "current-call")
+            .await
+            .unwrap();
+
+        assert_eq!(response["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn post_json_correlated_rejects_a_missing_echo() {
+        let fixture = spawn_accept_fixture().await;
+        let gateway = HttpGateway::default();
+        let url = fixture.url.replace("/accept", "/correlated-missing");
+
+        let error = gateway
+            .post_json_correlated(&url, &json!({}), "current-call")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, HttpError::MissingRequestId { .. }));
+    }
+
+    #[tokio::test]
+    async fn post_json_correlated_rejects_a_stale_echo() {
+        let fixture = spawn_accept_fixture().await;
+        let gateway = HttpGateway::default();
+        let url = fixture.url.replace("/accept", "/correlated-stale");
+
+        let error = gateway
+            .post_json_correlated(&url, &json!({}), "current-call")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, HttpError::RequestIdMismatch { .. }));
+        assert!(error.to_string().contains("transport desync"));
+    }
+
+    #[tokio::test]
+    async fn post_json_correlated_validates_an_error_before_returning_its_status() {
+        let fixture = spawn_accept_fixture().await;
+        let gateway = HttpGateway::default();
+        let url = fixture.url.replace("/accept", "/correlated-error");
+
+        let error = gateway
+            .post_json_correlated(&url, &json!({}), "current-call")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            HttpError::Status {
+                status: StatusCode::BAD_REQUEST,
+                ..
+            }
+        ));
     }
 }

--- a/crates/dcc-mcp-cli/tests/support/mod.rs
+++ b/crates/dcc-mcp-cli/tests/support/mod.rs
@@ -5,8 +5,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use axum::Router;
-use axum::extract::{Json, Path, Query, State};
+use axum::extract::{Json, Path, Query, Request, State};
 use axum::http::{HeaderMap, StatusCode, header};
+use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use serde_json::{Value, json};
@@ -87,6 +88,15 @@ pub(crate) fn json_or_compact_fixture_response(
         )
             .into_response()
     }
+}
+
+async fn echo_request_id(request: Request, next: Next) -> Response {
+    let request_id = request.headers().get("x-request-id").cloned();
+    let mut response = next.run(request).await;
+    if let Some(request_id) = request_id {
+        response.headers_mut().insert("x-request-id", request_id);
+    }
+    response
 }
 
 pub(crate) fn spawn_gateway_fixture() -> GatewayFixture {
@@ -587,7 +597,8 @@ pub(crate) fn spawn_gateway_fixture() -> GatewayFixture {
                     })),
                 )
             }),
-        );
+        )
+        .layer(middleware::from_fn(echo_request_id));
 
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -138,3 +138,5 @@ mod marketplace_tests;
 mod raw_proxy_lease_tests;
 #[cfg(all(test, feature = "admin"))]
 mod tests;
+#[cfg(all(test, feature = "admin"))]
+mod ui_control_dispatch_tests;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -24,7 +24,7 @@ pub(in crate::gateway::admin) mod admin_tests {
     use crate::gateway::state::GatewayState;
     use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 
-    fn make_gateway_state() -> GatewayState {
+    pub(in crate::gateway::admin) fn make_gateway_state() -> GatewayState {
         let dir = tempfile::tempdir().unwrap();
         let registry = Arc::new(FileRegistry::new(dir.path()).unwrap());
         let (yield_tx, _) = watch::channel(false);
@@ -343,8 +343,8 @@ filters:
         (port, tx)
     }
 
-    async fn spawn_sidecar_dispatch_backend() -> (u16, oneshot::Sender<()>, Arc<Mutex<Vec<Value>>>)
-    {
+    pub(in crate::gateway::admin) async fn spawn_sidecar_dispatch_backend()
+    -> (u16, oneshot::Sender<()>, Arc<Mutex<Vec<Value>>>) {
         let calls = Arc::new(Mutex::new(Vec::new()));
         let calls_for_route = calls.clone();
         let app = Router::new()
@@ -363,67 +363,6 @@ filters:
                                 "content": [{
                                     "type": "text",
                                     "text": "{\"success\":true,\"created\":\"random_sphere_1\"}"
-                                }],
-                                "isError": false
-                            }
-                        }))
-                    }
-                }),
-            );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let (tx, rx) = oneshot::channel::<()>();
-        tokio::spawn(async move {
-            let _ = axum::serve(listener, app)
-                .with_graceful_shutdown(async {
-                    let _ = rx.await;
-                })
-                .await;
-        });
-        (port, tx, calls)
-    }
-
-    async fn spawn_discovery_dispatch_backend(
-        hits: Value,
-    ) -> (u16, oneshot::Sender<()>, Arc<Mutex<Vec<Value>>>) {
-        let calls = Arc::new(Mutex::new(Vec::new()));
-        let calls_for_rest = calls.clone();
-        let calls_for_route = calls.clone();
-        let app = Router::new()
-            .route(
-                "/v1/search",
-                axum::routing::post(move || {
-                    let hits = hits.clone();
-                    async move { axum::Json(json!({ "hits": hits })) }
-                }),
-            )
-            .route(
-                "/v1/call",
-                axum::routing::post(move |axum::Json(req): axum::Json<Value>| {
-                    let calls = calls_for_rest.clone();
-                    async move {
-                        calls.lock().push(req);
-                        axum::Json(json!({
-                            "isError": false,
-                            "output": {"success": true, "snapshot_id": "snapshot-1"}
-                        }))
-                    }
-                }),
-            )
-            .route(
-                "/mcp",
-                axum::routing::post(move |axum::Json(req): axum::Json<Value>| {
-                    let calls = calls_for_route.clone();
-                    async move {
-                        calls.lock().push(req.clone());
-                        let id = req.get("id").cloned().unwrap_or(json!("test"));
-                        axum::Json(json!({
-                            "jsonrpc": "2.0",
-                            "id": id,
-                            "result": {
-                                "content": [{
-                                    "type": "text",
-                                    "text": "{\"success\":true,\"snapshot_id\":\"snapshot-1\"}"
                                 }],
                                 "isError": false
                             }
@@ -929,67 +868,6 @@ filters:
                 .expect_err("an expired lease should behave as unleased");
         let error: Value = serde_json::from_str(&error).unwrap();
         assert_eq!(error["reason"], "no_active_lease");
-    }
-
-    #[tokio::test]
-    async fn test_gateway_call_routes_ui_control_to_sidecar_discovery_endpoint() {
-        let gs = make_gateway_state();
-        let (discovery_port, stop_discovery, discovery_calls) =
-            spawn_discovery_dispatch_backend(json!([{
-                "skill": "core",
-                "action": "ui_control__snapshot",
-                "summary": "Capture a bounded UI Control snapshot",
-                "loaded": true,
-                "has_schema": true
-            }]))
-            .await;
-        let (sidecar_port, stop_sidecar, sidecar_calls) = spawn_sidecar_dispatch_backend().await;
-        let mut entry = make_service_entry("3dsmax", "127.0.0.1", sidecar_port, None);
-        entry.metadata.insert(
-            crate::gateway::http_registration::MCP_URL_METADATA_KEY.to_string(),
-            format!("http://127.0.0.1:{sidecar_port}/mcp"),
-        );
-        entry.metadata.insert(
-            crate::gateway::http_registration::DISCOVERY_MCP_URL_METADATA_KEY.to_string(),
-            format!("http://127.0.0.1:{discovery_port}/mcp"),
-        );
-        entry.metadata.insert(
-            crate::gateway::http_registration::ROLE_METADATA_KEY.to_string(),
-            crate::gateway::http_registration::ROLE_PER_DCC_SIDECAR.to_string(),
-        );
-        let instance_id = entry.instance_id;
-        {
-            let registry = &gs.registry;
-            registry.register(entry).unwrap();
-        }
-
-        crate::gateway::capability_service::refresh_all_live_backends(
-            &gs,
-            crate::gateway::capability::RefreshReason::Periodic,
-        )
-        .await;
-        let slug =
-            crate::gateway::capability::tool_slug("3dsmax", &instance_id, "ui_control__snapshot");
-
-        let result = crate::gateway::capability_service::call_service(
-            &gs,
-            &slug,
-            json!({}),
-            None,
-            None,
-            None,
-        )
-        .await
-        .expect("ui-control calls should use the in-process discovery endpoint");
-        let _ = stop_discovery.send(());
-        let _ = stop_sidecar.send(());
-
-        assert_eq!(result["isError"], false);
-        assert_eq!(discovery_calls.lock().len(), 1);
-        assert!(
-            sidecar_calls.lock().is_empty(),
-            "ui-control calls must not be sent to the sidecar action dispatcher"
-        );
     }
 
     #[tokio::test]
@@ -1758,7 +1636,7 @@ filters:
     }
 
     // ── /api/workers (Phase 4) ────────────────────────────────────────────
-    fn make_service_entry(
+    pub(in crate::gateway::admin) fn make_service_entry(
         dcc_type: &str,
         host: &str,
         port: u16,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/ui_control_dispatch_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/ui_control_dispatch_tests.rs
@@ -1,0 +1,120 @@
+use std::sync::Arc;
+
+use axum::Router;
+use parking_lot::Mutex;
+use serde_json::{Value, json};
+use tokio::sync::oneshot;
+
+use super::tests::admin_tests::{
+    make_gateway_state, make_service_entry, spawn_sidecar_dispatch_backend,
+};
+
+async fn spawn_discovery_dispatch_backend(
+    hits: Value,
+) -> (u16, oneshot::Sender<()>, Arc<Mutex<Vec<Value>>>) {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let calls_for_rest = calls.clone();
+    let app = Router::new()
+        .route(
+            "/v1/search",
+            axum::routing::post(move || {
+                let hits = hits.clone();
+                async move { axum::Json(json!({ "hits": hits })) }
+            }),
+        )
+        .route(
+            "/v1/call",
+            axum::routing::post(
+                move |headers: axum::http::HeaderMap, axum::Json(req): axum::Json<Value>| {
+                    let calls = calls_for_rest.clone();
+                    async move {
+                        let request_id = headers
+                            .get("x-request-id")
+                            .and_then(|value| value.to_str().ok())
+                            .filter(|value| !value.is_empty())
+                            .expect("gateway REST calls must carry an X-Request-ID header")
+                            .to_string();
+                        calls.lock().push(json!({
+                            "request_id": request_id.clone(),
+                            "body": req,
+                        }));
+                        axum::Json(json!({
+                            "request_id": request_id,
+                            "isError": false,
+                            "output": {"success": true, "snapshot_id": "snapshot-1"}
+                        }))
+                    }
+                },
+            ),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (tx, rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = rx.await;
+            })
+            .await;
+    });
+    (port, tx, calls)
+}
+
+#[tokio::test]
+async fn gateway_call_routes_ui_control_to_sidecar_discovery_endpoint() {
+    let gs = make_gateway_state();
+    let (discovery_port, stop_discovery, discovery_calls) =
+        spawn_discovery_dispatch_backend(json!([{
+            "skill": "core",
+            "action": "ui_control__snapshot",
+            "summary": "Capture a bounded UI Control snapshot",
+            "loaded": true,
+            "has_schema": true
+        }]))
+        .await;
+    let (sidecar_port, stop_sidecar, sidecar_calls) = spawn_sidecar_dispatch_backend().await;
+    let mut entry = make_service_entry("3dsmax", "127.0.0.1", sidecar_port, None);
+    entry.metadata.insert(
+        crate::gateway::http_registration::MCP_URL_METADATA_KEY.to_string(),
+        format!("http://127.0.0.1:{sidecar_port}/mcp"),
+    );
+    entry.metadata.insert(
+        crate::gateway::http_registration::DISCOVERY_MCP_URL_METADATA_KEY.to_string(),
+        format!("http://127.0.0.1:{discovery_port}/mcp"),
+    );
+    entry.metadata.insert(
+        crate::gateway::http_registration::ROLE_METADATA_KEY.to_string(),
+        crate::gateway::http_registration::ROLE_PER_DCC_SIDECAR.to_string(),
+    );
+    let instance_id = entry.instance_id;
+    gs.registry.register(entry).unwrap();
+
+    crate::gateway::capability_service::refresh_all_live_backends(
+        &gs,
+        crate::gateway::capability::RefreshReason::Periodic,
+    )
+    .await;
+    let slug =
+        crate::gateway::capability::tool_slug("3dsmax", &instance_id, "ui_control__snapshot");
+
+    let result =
+        crate::gateway::capability_service::call_service(&gs, &slug, json!({}), None, None, None)
+            .await
+            .expect("ui-control calls should use the in-process discovery endpoint");
+    let _ = stop_discovery.send(());
+    let _ = stop_sidecar.send(());
+
+    assert_eq!(result["isError"], false);
+    let discovery_calls = discovery_calls.lock();
+    assert_eq!(discovery_calls.len(), 1);
+    assert!(
+        discovery_calls[0]["request_id"]
+            .as_str()
+            .is_some_and(|id| !id.is_empty()),
+        "gateway REST calls must carry a non-empty request_id"
+    );
+    assert!(
+        sidecar_calls.lock().is_empty(),
+        "ui-control calls must not be sent to the sidecar action dispatcher"
+    );
+}

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests/helpers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests/helpers.rs
@@ -224,19 +224,25 @@ pub(crate) async fn spawn_canonical_workflow_backend() -> (
         )
         .route(
             "/v1/call",
-            axum::routing::post(|axum::Json(body): axum::Json<Value>| async move {
-                axum::Json(json!({
-                    "content": [{
-                        "type": "text",
-                        "text": format!(
-                            "called {} with {}",
-                            body.get("tool_slug").and_then(Value::as_str).unwrap_or(""),
-                            body.get("arguments").cloned().unwrap_or_else(|| json!({}))
-                        )
-                    }],
-                    "isError": false
-                }))
-            }),
+            axum::routing::post(
+                |headers: axum::http::HeaderMap, axum::Json(body): axum::Json<Value>| async move {
+                    let request_id = headers
+                        .get("x-request-id")
+                        .and_then(|value| value.to_str().ok());
+                    axum::Json(json!({
+                        "content": [{
+                            "type": "text",
+                            "text": format!(
+                                "called {} with {}",
+                                body.get("tool_slug").and_then(Value::as_str).unwrap_or(""),
+                                body.get("arguments").cloned().unwrap_or_else(|| json!({}))
+                            )
+                        }],
+                        "isError": false,
+                        "request_id": request_id
+                    }))
+                },
+            ),
         )
         .route(
             "/mcp",

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests/tool_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests/tool_tests.rs
@@ -1359,13 +1359,19 @@ async fn load_skill_preserves_existing_index_when_v1_search_fails() {
         )
         .route(
             "/v1/call",
-            axum::routing::post(|axum::Json(body): axum::Json<Value>| async move {
-                axum::Json(json!({
-                    "success": true,
-                    "called": body.get("tool_slug").cloned().unwrap_or(Value::Null),
-                    "arguments": body.get("arguments").cloned().unwrap_or_else(|| json!({})),
-                }))
-            }),
+            axum::routing::post(
+                |headers: axum::http::HeaderMap, axum::Json(body): axum::Json<Value>| async move {
+                    let request_id = headers
+                        .get("x-request-id")
+                        .and_then(|value| value.to_str().ok());
+                    axum::Json(json!({
+                        "success": true,
+                        "request_id": request_id,
+                        "called": body.get("tool_slug").cloned().unwrap_or(Value::Null),
+                        "arguments": body.get("arguments").cloned().unwrap_or_else(|| json!({})),
+                    }))
+                },
+            ),
         );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/error.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/error.rs
@@ -25,6 +25,11 @@ pub(crate) enum BackendCallError {
         mcp_url: String,
         reason: String,
     },
+    ResponseIdMismatch {
+        mcp_url: String,
+        expected: String,
+        actual: String,
+    },
     Backend {
         mcp_url: String,
         code: i64,
@@ -58,6 +63,15 @@ impl fmt::Display for BackendCallError {
             Self::InvalidJson { mcp_url, reason } => {
                 write!(f, "{mcp_url}: invalid JSON-RPC response: {reason}")
             }
+            Self::ResponseIdMismatch {
+                mcp_url,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "{mcp_url}: transport desync: expected response id {expected}, got {}",
+                actual,
+            ),
             Self::Backend {
                 mcp_url,
                 code,
@@ -98,6 +112,7 @@ impl BackendCallError {
             Self::Http { status, .. } => http_status_prometheus_kind(status),
             Self::ReadBody { .. } => "read_body",
             Self::InvalidJson { .. } => "invalid_json",
+            Self::ResponseIdMismatch { .. } => "response_id_mismatch",
             Self::Backend { .. } => "jsonrpc_backend",
             Self::EmptyResult { .. } => "empty_result",
         }
@@ -112,6 +127,9 @@ pub(crate) fn rest_error_prometheus_kind(err: &str) -> &'static str {
     }
     if err.contains("transport error") {
         return "transport";
+    }
+    if err.contains("transport desync") {
+        return "response_id_mismatch";
     }
     if let Some(idx) = err.find(": HTTP ") {
         let tail = &err[idx + 7..];

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/http.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/http.rs
@@ -67,7 +67,7 @@ pub(super) async fn rest_post(
     body: Value,
     timeout: Duration,
 ) -> Result<Value, String> {
-    rest_post_with_trace_context(client, url, body, timeout, None).await
+    rest_post_with_trace_context(client, url, body, timeout, None, None).await
 }
 
 /// Issue a `POST` with optional W3C Trace Context propagation headers.
@@ -76,6 +76,7 @@ pub(super) async fn rest_post_with_trace_context(
     url: &str,
     body: Value,
     timeout: Duration,
+    request_id: Option<&str>,
     trace_context: Option<&TraceContext>,
 ) -> Result<Value, String> {
     let mut request = client
@@ -84,8 +85,12 @@ pub(super) async fn rest_post_with_trace_context(
         .header("content-type", "application/json")
         .header("accept", "application/json, text/event-stream")
         .body(body.to_string());
+    let expected_request_id =
+        request_id.or_else(|| trace_context.map(|ctx| ctx.request_id.as_str()));
+    if let Some(request_id) = expected_request_id {
+        request = request.header("x-request-id", request_id);
+    }
     if let Some(ctx) = trace_context {
-        request = request.header("x-request-id", ctx.request_id.as_str());
         if let Some(parent_request_id) = ctx.parent_request_id.as_deref() {
             request = request.header("x-dcc-mcp-parent-request-id", parent_request_id);
         }
@@ -102,15 +107,34 @@ pub(super) async fn rest_post_with_trace_context(
         .await
         .map_err(|e| format!("{url}: transport error: {e}"))?;
 
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("{url}: invalid JSON response: {e}"))?;
+    if expected_request_id.is_none() && !status.is_success() {
         return Err(format!("{url}: HTTP {status}: {body}"));
     }
-
-    resp.json::<Value>()
-        .await
-        .map_err(|e| format!("{url}: invalid JSON response: {e}"))
+    let response: Value =
+        serde_json::from_str(&body).map_err(|e| format!("{url}: invalid JSON response: {e}"))?;
+    if let Some(expected) = expected_request_id {
+        let actual = response.get("request_id").and_then(Value::as_str);
+        if actual != Some(expected) {
+            return Err(format!(
+                "{url}: transport desync: expected response request_id {expected:?}, got {}",
+                actual.map_or_else(
+                    || response
+                        .get("request_id")
+                        .map_or_else(|| "<missing>".to_string(), Value::to_string),
+                    |value| format!("{value:?}"),
+                ),
+            ));
+        }
+    }
+    if !status.is_success() {
+        return Err(format!("{url}: HTTP {status}: {body}"));
+    }
+    Ok(response)
 }
 
 pub(super) async fn post_jsonrpc(
@@ -137,6 +161,7 @@ pub(super) async fn post_jsonrpc_with_trace_context(
     trace_context: Option<&TraceContext>,
 ) -> Result<Value, BackendCallError> {
     let circuit_key = rest_base_from_mcp_url(mcp_url);
+    let expected_id = req_body.get("id").cloned().unwrap_or(Value::Null);
     if let Err(reason) = resilience.circuits().check_open(&circuit_key) {
         let err = BackendCallError::Transport {
             mcp_url: mcp_url.to_string(),
@@ -155,8 +180,10 @@ pub(super) async fn post_jsonrpc_with_trace_context(
     if let Some(session_id) = session_id {
         request = request.header("Mcp-Session-Id", session_id);
     }
+    if let Some(request_id) = expected_id.as_str() {
+        request = request.header("x-request-id", request_id);
+    }
     if let Some(ctx) = trace_context {
-        request = request.header("x-request-id", ctx.request_id.as_str());
         if let Some(parent_request_id) = ctx.parent_request_id.as_deref() {
             request = request.header("x-dcc-mcp-parent-request-id", parent_request_id);
         }
@@ -211,7 +238,7 @@ pub(super) async fn post_jsonrpc_with_trace_context(
         }
     };
 
-    let out = parse_jsonrpc_result(mcp_url, &text);
+    let out = parse_jsonrpc_result(mcp_url, &text, &expected_id);
     match &out {
         Ok(_) => resilience.circuits().on_success(&circuit_key),
         Err(e) => {
@@ -226,11 +253,25 @@ pub(super) async fn post_jsonrpc_with_trace_context(
     out
 }
 
-pub(super) fn parse_jsonrpc_result(mcp_url: &str, text: &str) -> Result<Value, BackendCallError> {
+pub(super) fn parse_jsonrpc_result(
+    mcp_url: &str,
+    text: &str,
+    expected_id: &Value,
+) -> Result<Value, BackendCallError> {
     let parsed: Value = serde_json::from_str(text).map_err(|e| BackendCallError::InvalidJson {
         mcp_url: mcp_url.to_string(),
         reason: e.to_string(),
     })?;
+
+    if parsed.get("id") != Some(expected_id) {
+        return Err(BackendCallError::ResponseIdMismatch {
+            mcp_url: mcp_url.to_string(),
+            expected: expected_id.to_string(),
+            actual: parsed
+                .get("id")
+                .map_or_else(|| "<missing>".to_string(), Value::to_string),
+        });
+    }
 
     if let Some(err) = parsed.get("error") {
         let code = err.get("code").and_then(Value::as_i64).unwrap_or(-1);

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
@@ -728,8 +728,8 @@ pub struct ForwardToolsCallRequest<'a> {
     pub tool_name: &'a str,
     pub arguments: Option<Value>,
     pub meta: Option<Value>,
-    /// Accepted for API compatibility but not forwarded; the REST surface does
-    /// not use JSON-RPC request ids.
+    /// Correlation id forwarded as `X-Request-ID` and required in the backend
+    /// response body as `request_id`.
     pub request_id: Option<String>,
     pub trace_context: Option<&'a TraceContext>,
     pub traffic_capture: Option<&'a crate::gateway::traffic::TrafficCapture>,
@@ -747,7 +747,7 @@ pub async fn forward_tools_call(
         tool_name,
         arguments,
         meta,
-        request_id: _request_id,
+        request_id,
         trace_context,
         traffic_capture,
         timeout,
@@ -789,7 +789,19 @@ pub async fn forward_tools_call(
         }
         return Err(msg);
     }
-    match rest_post_with_trace_context(client, &url, body, timeout, trace_context).await {
+    let expected_request_id = request_id
+        .as_deref()
+        .or_else(|| trace_context.map(|ctx| ctx.request_id.as_str()));
+    match rest_post_with_trace_context(
+        client,
+        &url,
+        body,
+        timeout,
+        expected_request_id,
+        trace_context,
+    )
+    .await
+    {
         Ok(v) => {
             resilience.circuits().on_success(key);
             if let Some(capture) = traffic_capture {

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/tests.rs
@@ -471,6 +471,39 @@ async fn post_jsonrpc_omits_session_header_when_none() {
     let _ = stop.send(());
 }
 
+#[tokio::test]
+async fn post_jsonrpc_rejects_a_stale_response_id() {
+    let app = axum::Router::new().route(
+        "/mcp",
+        axum::routing::post(|| async {
+            axum::Json(json!({
+                "jsonrpc": "2.0",
+                "id": "previous-call",
+                "result": {"ok": true}
+            }))
+        }),
+    );
+    let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+    let error = post_jsonrpc(
+        &reqwest::Client::new(),
+        &crate::gateway::resilience::GatewayResilienceState::default(),
+        &mcp_url,
+        json!({"jsonrpc":"2.0","id":"current-call","method":"ping"}),
+        None,
+        Duration::from_secs(2),
+    )
+    .await
+    .expect_err("a response from the previous call must fail closed");
+
+    assert!(
+        matches!(error, BackendCallError::ResponseIdMismatch { .. }),
+        "unexpected error: {error:?}",
+    );
+    assert!(error.to_string().contains("transport desync"));
+    let _ = stop.send(());
+}
+
 #[test]
 fn parses_success_result() {
     let body = r#"{"jsonrpc":"2.0","id":"gw-1","result":{"tools":[]}}"#;
@@ -827,7 +860,7 @@ async fn forward_tools_call_propagates_trace_context_headers() {
                     header("traceparent"),
                     header("tracestate"),
                 ));
-                axum::Json(json!({"success": true}))
+                axum::Json(json!({"success": true, "request_id": "req-forward"}))
             }
         }),
     );
@@ -867,6 +900,88 @@ async fn forward_tools_call_propagates_trace_context_headers() {
         "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
     );
     assert_eq!(seen[0].3, "vendor=value");
+    let _ = stop.send(());
+}
+
+#[tokio::test]
+async fn forward_tools_call_rejects_a_stale_response_request_id() {
+    let app = axum::Router::new().route(
+        "/v1/call",
+        axum::routing::post(|| async {
+            axum::Json(json!({
+                "success": true,
+                "request_id": "previous-call"
+            }))
+        }),
+    );
+    let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+    let error = forward_tools_call(
+        &reqwest::Client::new(),
+        &crate::gateway::resilience::GatewayResilienceState::default(),
+        &mcp_url,
+        ForwardToolsCallRequest {
+            tool_name: "maya.render",
+            arguments: Some(json!({})),
+            meta: None,
+            request_id: Some("current-call".into()),
+            trace_context: None,
+            traffic_capture: None,
+            timeout: Duration::from_secs(2),
+        },
+    )
+    .await
+    .expect_err("a stale backend REST response must fail closed");
+
+    assert!(
+        error.contains("transport desync"),
+        "unexpected error: {error}"
+    );
+    assert!(error.contains("current-call"));
+    assert!(error.contains("previous-call"));
+    let _ = stop.send(());
+}
+
+#[tokio::test]
+async fn forward_tools_call_rejects_a_stale_error_response_request_id() {
+    let app = axum::Router::new().route(
+        "/v1/call",
+        axum::routing::post(|| async {
+            (
+                axum::http::StatusCode::BAD_REQUEST,
+                axum::Json(json!({
+                    "success": false,
+                    "request_id": "previous-call",
+                    "error": {"kind": "invalid-arguments", "message": "bad input"}
+                })),
+            )
+        }),
+    );
+    let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+    let error = forward_tools_call(
+        &reqwest::Client::new(),
+        &crate::gateway::resilience::GatewayResilienceState::default(),
+        &mcp_url,
+        ForwardToolsCallRequest {
+            tool_name: "maya.render",
+            arguments: Some(json!({})),
+            meta: None,
+            request_id: Some("current-call".into()),
+            trace_context: None,
+            traffic_capture: None,
+            timeout: Duration::from_secs(2),
+        },
+    )
+    .await
+    .expect_err("a stale backend REST error must fail closed before status handling");
+
+    assert!(
+        error.contains("transport desync"),
+        "unexpected error: {error}"
+    );
+    assert!(error.contains("current-call"));
+    assert!(error.contains("previous-call"));
     let _ = stop.send(());
 }
 
@@ -933,7 +1048,7 @@ async fn call_backend_with_observability_propagates_trace_and_captures_traffic()
         BackendJsonRpcCallRequest {
             method: "tools/call",
             params: Some(json!({"name": "maya_primitives__create_sphere", "arguments": {}})),
-            request_id: None,
+            request_id: Some("req-jsonrpc".into()),
             require_ready: true,
             trace_context: Some(&trace_context),
             traffic_capture: Some(&capture),

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -711,6 +711,9 @@ pub async fn call_service(
         entry_mcp_url(entry)
     };
     let entry = entry.clone();
+    let request_id = trace_context
+        .map(|context| context.request_id.clone())
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
 
     let call_result = if is_backend_job_tool(&record.backend_tool)
         || (entry_uses_sidecar_dispatch(&entry) && !use_discovery_dispatch)
@@ -730,7 +733,7 @@ pub async fn call_service(
             BackendJsonRpcCallRequest {
                 method: "tools/call",
                 params: Some(params),
-                request_id: None,
+                request_id: Some(request_id.clone()),
                 require_ready: !is_backend_job_tool(&record.backend_tool),
                 trace_context,
                 traffic_capture: Some(&gs.traffic_capture),
@@ -747,7 +750,7 @@ pub async fn call_service(
                 tool_name: &record.callable_id,
                 arguments: Some(arguments),
                 meta: meta_with_agent_context(meta, agent_context),
-                request_id: None,
+                request_id: Some(request_id),
                 trace_context,
                 traffic_capture: Some(&gs.traffic_capture),
                 timeout: gs.backend_timeout,

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl_tests.rs
@@ -169,9 +169,13 @@ async fn rich_image_gateway_state() -> (
         )
         .route(
             "/v1/call",
-            axum::routing::post(|| async {
+            axum::routing::post(|headers: axum::http::HeaderMap| async move {
+                let request_id = headers
+                    .get("x-request-id")
+                    .and_then(|value| value.to_str().ok());
                 axum::Json(json!({
                     "success": true,
+                    "request_id": request_id,
                     "output": {
                         "success": true,
                         "context": {

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_batch_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_batch_tests.rs
@@ -49,16 +49,23 @@ async fn spawn_echo_backend() -> (u16, tokio::sync::oneshot::Sender<()>) {
         )
         .route(
             "/v1/call",
-            axum::routing::post(move |axum::Json(body): axum::Json<Value>| async move {
-                let slug = body.get("tool_slug").and_then(Value::as_str).unwrap_or("");
-                axum::Json(json!({
-                    "content": [{
-                        "type": "text",
-                        "text": format!("called {slug} successfully")
-                    }],
-                    "isError": false
-                }))
-            }),
+            axum::routing::post(
+                move |headers: axum::http::HeaderMap,
+                      axum::Json(body): axum::Json<Value>| async move {
+                    let slug = body.get("tool_slug").and_then(Value::as_str).unwrap_or("");
+                    let request_id = headers
+                        .get("x-request-id")
+                        .and_then(|value| value.to_str().ok());
+                    axum::Json(json!({
+                        "content": [{
+                            "type": "text",
+                            "text": format!("called {slug} successfully")
+                        }],
+                        "isError": false,
+                        "request_id": request_id
+                    }))
+                },
+            ),
         );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_safety_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_safety_tests.rs
@@ -8,9 +8,15 @@ async fn seed_call_backend(
 ) -> (String, tokio::sync::oneshot::Sender<()>) {
     let app = axum::Router::new().route(
         "/v1/call",
-        axum::routing::post(move || {
-            let payload = payload.clone();
-            async move { Json(payload) }
+        axum::routing::post(move |headers: axum::http::HeaderMap| {
+            let mut payload = payload.clone();
+            async move {
+                payload["request_id"] = headers
+                    .get("x-request-id")
+                    .and_then(|value| value.to_str().ok())
+                    .map_or(Value::Null, |value| json!(value));
+                Json(payload)
+            }
         }),
     );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/dcc-mcp-gateway/src/gateway/resilience.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/resilience.rs
@@ -283,7 +283,7 @@ impl Default for GatewayResilienceState {
 /// Classify `rest_get` / `rest_post` string errors for **read** retries.
 #[must_use]
 pub fn is_retryable_rest_error(err: &str) -> bool {
-    if err.contains("transport error") {
+    if err.contains("transport error") || err.contains("transport desync") {
         return true;
     }
     // `rest_get` errors look like `"{url}: HTTP {status}: ..."`
@@ -310,7 +310,8 @@ pub(crate) fn is_circuit_worthy_jsonrpc_error(err: &BackendCallError) -> bool {
         BackendCallError::Transport { .. }
         | BackendCallError::ReadBody { .. }
         | BackendCallError::Unreachable { .. }
-        | BackendCallError::Booting { .. } => true,
+        | BackendCallError::Booting { .. }
+        | BackendCallError::ResponseIdMismatch { .. } => true,
         BackendCallError::Http { status, .. } => status
             .split_whitespace()
             .next()

--- a/crates/dcc-mcp-host-rpc/src/commandport.rs
+++ b/crates/dcc-mcp-host-rpc/src/commandport.rs
@@ -283,17 +283,25 @@ impl HostRpcClient for CommandPortClient {
             Ok(_) => {
                 let line = buf.trim_end_matches(['\r', '\n']);
                 if line.is_empty() {
-                    // Maya commandPort returns an empty line when the
-                    // Python expression evaluated to `None`. Map to
-                    // `null` rather than failing — agents see a
-                    // structured "no result" envelope.
-                    return Ok(Value::Null);
+                    return Err(HostRpcError::transport(format!(
+                        "commandport transport desync for {action}: expected response request_id {request_id:?}, got <missing>",
+                    )));
                 }
-                serde_json::from_str::<Value>(line).map_err(|e| {
+                let response = serde_json::from_str::<Value>(line).map_err(|e| {
                     HostRpcError::transport(format!(
                         "commandport returned non-JSON line ({e}); raw: {line:?}",
                     ))
-                })
+                })?;
+                let expected_id = Value::String(request_id.to_string());
+                if response.get("request_id") != Some(&expected_id) {
+                    return Err(HostRpcError::transport(format!(
+                        "commandport transport desync for {action}: expected response request_id {request_id:?}, got {}",
+                        response
+                            .get("request_id")
+                            .map_or_else(|| "<missing>".to_string(), Value::to_string),
+                    )));
+                }
+                Ok(response)
             }
             Err(e) => Err(io_error_to_host_rpc(
                 e,
@@ -549,7 +557,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn connect_call_close_roundtrip() {
         let (port, request_rx) = spawn_fake_command_port(
-            r#"{"success":true,"object_name":"pSphere1"}"#.to_string(),
+            r#"{"success":true,"request_id":"req-test-1","object_name":"pSphere1"}"#.to_string(),
             true,
         )
         .await;
@@ -592,6 +600,92 @@ mod tests {
 
         client.close().await;
         assert!(!client.is_alive(), "client should NOT be alive after close");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stale_response_id_is_rejected_before_the_payload_is_delivered() {
+        let (port, _request_rx) = spawn_fake_command_port(
+            r#"{"success":true,"request_id":"previous-call","object_name":"pSphere1"}"#.to_string(),
+            true,
+        )
+        .await;
+
+        let mut client = CommandPortClient::new();
+        client
+            .connect(
+                &format!("commandport://127.0.0.1:{port}"),
+                Duration::from_secs(2),
+            )
+            .await
+            .expect("connect");
+
+        let error = client
+            .call(
+                "maya_primitives__create_sphere",
+                serde_json::json!({"radius": 1.0}),
+                "current-call",
+            )
+            .await
+            .expect_err("a stale commandPort response must fail closed");
+
+        match error {
+            HostRpcError::TransportError { message } => {
+                assert!(message.contains("transport desync"), "{message}");
+                assert!(message.contains("current-call"), "{message}");
+                assert!(message.contains("previous-call"), "{message}");
+            }
+            other => panic!("expected TransportError, got {other:?}"),
+        }
+        client.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn slow_then_fast_off_by_one_responses_never_cross_request_boundaries() {
+        let (port, _requests) = spawn_fake_command_port_multi(
+            vec![
+                "None".to_string(),
+                r#"{"success":true,"request_id":"previous-call","value":"stale"}"#.to_string(),
+                r#"{"success":true,"request_id":"slow-call","value":"slow-result"}"#.to_string(),
+            ],
+            true,
+        )
+        .await;
+
+        let mut client = CommandPortClient::new();
+        client
+            .connect(
+                &format!("commandport://127.0.0.1:{port}"),
+                Duration::from_secs(2),
+            )
+            .await
+            .expect("connect");
+
+        let slow_error = client
+            .call(
+                "maya_scripting__execute_python",
+                serde_json::json!({"code": "slow()"}),
+                "slow-call",
+            )
+            .await
+            .expect_err("the stale response before a slow result must be rejected");
+        let fast_error = client
+            .call(
+                "maya_scene__get_session_info",
+                serde_json::json!({}),
+                "fast-call",
+            )
+            .await
+            .expect_err("the slow result must not be delivered to the following fast call");
+
+        for error in [slow_error, fast_error] {
+            match error {
+                HostRpcError::TransportError { message } => {
+                    assert!(message.contains("transport desync"), "{message}");
+                }
+                other => panic!("expected TransportError, got {other:?}"),
+            }
+        }
+        client.close().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -639,9 +733,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn empty_response_line_maps_to_null() {
-        // Maya returns an empty line when the Python expression
-        // evaluated to None — common for fire-and-forget setters.
+    async fn empty_response_line_is_a_transport_desync() {
         let (port, _request_rx) = spawn_fake_command_port(String::new(), true).await;
 
         let mut client = CommandPortClient::new();
@@ -652,18 +744,21 @@ mod tests {
             )
             .await
             .expect("connect");
-        let response = client
+        let error = client
             .call(
                 "maya_scene__set_unit",
                 serde_json::json!({"unit": "cm"}),
                 "req-null",
             )
             .await
-            .expect("empty response is valid (None → Null)");
-        assert!(
-            response.is_null(),
-            "empty response line must deserialize to Value::Null, got {response:?}",
-        );
+            .expect_err("an uncorrelated empty response must fail closed");
+        match error {
+            HostRpcError::TransportError { message } => {
+                assert!(message.contains("transport desync"), "{message}");
+                assert!(message.contains("req-null"), "{message}");
+            }
+            other => panic!("expected TransportError, got {other:?}"),
+        }
         client.close().await;
     }
 

--- a/crates/dcc-mcp-host-rpc/src/qtserver.rs
+++ b/crates/dcc-mcp-host-rpc/src/qtserver.rs
@@ -253,7 +253,7 @@ impl HostRpcClient for QtServerClient {
                         "qtserver returned non-JSON line ({e}); raw: {line:?}",
                     ))
                 })?;
-                interpret_envelope(envelope, action)
+                interpret_envelope(envelope, action, request_id)
             }
             Err(e) => Err(io_error_to_host_rpc(
                 e,
@@ -324,7 +324,20 @@ fn io_error_to_host_rpc(
 ///   violation. The Qt dispatcher must produce one of the two
 ///   well-formed shapes per request; a malformed reply is a wire
 ///   contract violation, not a user-visible error.
-fn interpret_envelope(envelope: Value, action: &str) -> Result<Value, HostRpcError> {
+fn interpret_envelope(
+    envelope: Value,
+    action: &str,
+    request_id: &str,
+) -> Result<Value, HostRpcError> {
+    let expected_id = Value::String(request_id.to_string());
+    if envelope.get("id") != Some(&expected_id) {
+        return Err(HostRpcError::transport(format!(
+            "qtserver transport desync for {action}: expected response id {request_id:?}, got {}",
+            envelope
+                .get("id")
+                .map_or_else(|| "<missing>".to_string(), Value::to_string),
+        )));
+    }
     if let Some(result) = envelope.get("result").cloned() {
         return Ok(result);
     }
@@ -563,7 +576,7 @@ mod tests {
     #[test]
     fn interpret_envelope_extracts_result() {
         let env = json!({"id": "req-1", "result": {"value": 42}});
-        let value = interpret_envelope(env, "any").unwrap();
+        let value = interpret_envelope(env, "any", "req-1").unwrap();
         assert_eq!(value, json!({"value": 42}));
     }
 
@@ -581,7 +594,8 @@ mod tests {
         });
         let env = json!({"id": "req-domain-error", "result": domain_result.clone()});
 
-        let value = interpret_envelope(env, "maya_scene__create_sphere").unwrap();
+        let value =
+            interpret_envelope(env, "maya_scene__create_sphere", "req-domain-error").unwrap();
 
         assert_eq!(value, domain_result);
     }
@@ -592,7 +606,7 @@ mod tests {
             "id": "req-2",
             "error": {"code": "handler-exception", "message": "BoomError: blew up"},
         });
-        let err = interpret_envelope(env, "maya_scene__crash").unwrap_err();
+        let err = interpret_envelope(env, "maya_scene__crash", "req-2").unwrap_err();
         match err {
             HostRpcError::TransportError { message } => {
                 assert!(message.contains("handler-exception"), "{message}");
@@ -606,8 +620,22 @@ mod tests {
     #[test]
     fn interpret_envelope_rejects_malformed_envelope() {
         let env = json!({"id": "req-3"}); // no result, no error
-        let err = interpret_envelope(env, "any").unwrap_err();
+        let err = interpret_envelope(env, "any", "req-3").unwrap_err();
         assert!(matches!(err, HostRpcError::TransportError { .. }));
+    }
+
+    #[test]
+    fn interpret_envelope_rejects_a_stale_response_id() {
+        let env = json!({"id": "previous-call", "result": {"value": 42}});
+        let err = interpret_envelope(env, "maya_scene__create_sphere", "current-call").unwrap_err();
+        match err {
+            HostRpcError::TransportError { message } => {
+                assert!(message.contains("transport desync"), "{message}");
+                assert!(message.contains("current-call"), "{message}");
+                assert!(message.contains("previous-call"), "{message}");
+            }
+            other => panic!("expected TransportError, got {other:?}"),
+        }
     }
 
     // ── connect / call roundtrip against a fake Qt server ────────────────

--- a/crates/dcc-mcp-host-rpc/src/websocket.rs
+++ b/crates/dcc-mcp-host-rpc/src/websocket.rs
@@ -248,11 +248,13 @@ fn interpret_envelope(
     action: &str,
     request_id: &str,
 ) -> Result<Value, HostRpcError> {
-    if let Some(id) = envelope.get("id")
-        && id != request_id
-    {
+    let expected_id = Value::String(request_id.to_string());
+    if envelope.get("id") != Some(&expected_id) {
         return Err(HostRpcError::transport(format!(
-            "websocket response id mismatch for {action}: expected {request_id:?}, got {id}",
+            "websocket transport desync for {action}: expected response id {request_id:?}, got {}",
+            envelope
+                .get("id")
+                .map_or_else(|| "<missing>".to_string(), Value::to_string),
         )));
     }
     if let Some(result) = envelope.get("result").cloned() {
@@ -341,6 +343,24 @@ mod tests {
                 assert_eq!(envelope["error"]["message"], "Photoshop failed");
             }
             other => panic!("expected BackendError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn websocket_response_without_id_is_a_transport_desync() {
+        let error = interpret_envelope(
+            json!({"jsonrpc": "2.0", "result": {"success": true}}),
+            "photoshop_layers__list",
+            "req-current",
+        )
+        .unwrap_err();
+
+        match error {
+            HostRpcError::TransportError { message } => {
+                assert!(message.contains("transport desync"), "{message}");
+                assert!(message.contains("req-current"), "{message}");
+            }
+            other => panic!("expected TransportError, got {other:?}"),
         }
     }
 

--- a/crates/dcc-mcp-sidecar/src/sidecar_tests.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_tests.rs
@@ -863,7 +863,9 @@ async fn commandport_sidecar_dispatches_tools_call_to_fake_server() {
             let _ = reader.read_line(&mut call_line).await;
             let _ = call_line_tx.send(call_line);
             let _ = write_half
-                .write_all(br#"{"success":true,"object_name":"pSphere1"}"#)
+                .write_all(
+                    br#"{"success":true,"request_id":"sidecar-call-1","object_name":"pSphere1"}"#,
+                )
                 .await;
             let _ = write_half.write_all(b"\n").await;
             let _ = write_half.flush().await;

--- a/crates/dcc-mcp-skill-rest/src/router.rs
+++ b/crates/dcc-mcp-skill-rest/src/router.rs
@@ -10,8 +10,9 @@ use std::sync::Arc;
 
 use axum::{
     Json, Router,
-    extract::{Path, Query, State},
-    http::{HeaderMap, StatusCode},
+    extract::{Path, Query, Request, State},
+    http::{HeaderMap, HeaderValue, StatusCode},
+    middleware::{self, Next},
     response::{
         Html, IntoResponse, Response,
         sse::{Event, KeepAlive, Sse},
@@ -100,9 +101,30 @@ pub fn build_skill_rest_router(config: SkillRestConfig) -> Router {
         .route("/v1/jobs/{id}/events", get(handle_job_events))
         .route("/v1/jobs/{id}", delete(handle_job_cancel))
         .with_state(config)
+        .layer(middleware::from_fn(correlate_response))
 }
 
 // ── Auth wrapper ─────────────────────────────────────────────────────
+
+async fn correlate_response(mut request: Request, next: Next) -> Response {
+    let request_id = request
+        .headers()
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let header_value: HeaderValue = request_id
+        .parse()
+        .expect("request ids must be valid HTTP header values");
+    request
+        .headers_mut()
+        .insert("x-request-id", header_value.clone());
+
+    let mut response = next.run(request).await;
+    response.headers_mut().insert("x-request-id", header_value);
+    response
+}
 
 fn principal_or_error(
     cfg: &SkillRestConfig,

--- a/crates/dcc-mcp-skill-rest/src/tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/tests.rs
@@ -415,8 +415,32 @@ async fn bearer_auth_gate_accepts_valid_token_and_echoes_request_id() {
         .add_header("x-request-id", "req-42")
         .await;
     resp.assert_status_ok();
+    assert_eq!(
+        resp.header("x-request-id").to_str().unwrap_or_default(),
+        "req-42"
+    );
     let body: Value = resp.json();
     assert_eq!(body["request_id"], "req-42");
+}
+
+#[tokio::test]
+async fn request_id_is_generated_once_and_echoed_in_error_header_and_body() {
+    let (svc, _, _) = fixture_loaded_spheres();
+    let gate = Arc::new(BearerTokenGate::new(vec!["s3cret".into()]).unwrap());
+    let cfg = SkillRestConfig::new(svc).with_auth(gate);
+    let server = TestServer::new(build_skill_rest_router(cfg));
+
+    let resp = server.get("/v1/skills").await;
+
+    assert_eq!(resp.status_code().as_u16(), 401);
+    let echoed = resp
+        .header("x-request-id")
+        .to_str()
+        .expect("generated request id must be a response header")
+        .to_owned();
+    assert!(!echoed.is_empty());
+    let body: Value = resp.json();
+    assert_eq!(body["request_id"], echoed);
 }
 
 /// OpenAPI document lists every documented route and parses as JSON.

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -64,6 +64,14 @@ body = {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {
 # use the adapter's typed status/cancellation contract.
 ```
 
+**Execution response correlation:** Every tool call carries a unique request
+id. JSON-RPC responses must echo `id`, sidecar payload responses must echo
+top-level `request_id`, and gateway REST responses must echo `X-Request-ID`.
+The gateway and CLI reject missing or mismatched echoes as `transport desync`;
+they must never deliver that payload as the current call's result. Adapter
+transport tests must include a slow call followed by fast calls on one session
+and assert that no response crosses request boundaries.
+
 **`ToolRegistry.register()` — keyword args only, no positional:**
 ```python
 registry.register(name="my_tool", description="...", dcc="maya")

--- a/python/dcc_mcp_core/sidecar.py
+++ b/python/dcc_mcp_core/sidecar.py
@@ -115,17 +115,22 @@ class SidecarActionDispatcher:
 
     def dispatch_payload(self, payload: Mapping[str, Any]) -> dict[str, Any]:
         """Validate and execute a sidecar dispatch payload."""
+        incoming_request_id = (
+            payload.get("request_id")
+            if isinstance(payload, Mapping) and isinstance(payload.get("request_id"), str)
+            else None
+        )
         validated = self._validate_payload(payload)
         if _is_error_envelope(validated):
-            return validated
+            return self._with_request_id(validated, incoming_request_id)
 
         server = self._get_server(validated)
         if _is_error_envelope(server):
-            return server
+            return self._with_request_id(server, validated.request_id)
 
         resolved = self._resolve_source(validated, server)
         if _is_error_envelope(resolved):
-            return resolved
+            return self._with_request_id(resolved, validated.request_id)
 
         request = SidecarDispatchRequest(
             dcc_name=self.dcc_name,
@@ -377,8 +382,8 @@ class SidecarActionDispatcher:
     def _normalize_result(self, result: Any, request: SidecarDispatchRequest) -> dict[str, Any]:
         safe_result = _json_safe(result)
         if isinstance(safe_result, dict) and isinstance(safe_result.get("success"), bool):
-            return safe_result
-        return {
+            return self._with_request_id(safe_result, request.request_id)
+        response = {
             "success": True,
             "message": "Sidecar action dispatched",
             "context": {
@@ -389,6 +394,16 @@ class SidecarActionDispatcher:
                 "result": safe_result,
             },
         }
+        if request.request_id is not None:
+            response["request_id"] = request.request_id
+        return response
+
+    @staticmethod
+    def _with_request_id(result: Mapping[str, Any], request_id: str | None) -> dict[str, Any]:
+        response = dict(result)
+        if request_id is not None and "request_id" not in response:
+            response["request_id"] = request_id
+        return response
 
     def _error(self, code: str, message: str, **context: Any) -> dict[str, Any]:
         clean_context = {
@@ -404,6 +419,9 @@ class SidecarActionDispatcher:
             "message": message,
             "error": code,
         }
+        request_id = context.get("request_id")
+        if isinstance(request_id, str) and request_id:
+            result["request_id"] = request_id
         if clean_context:
             result["context"] = _json_safe(clean_context)
         return result

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -194,6 +194,7 @@ the server from its exact target environment. Gateway Admin is check-only.
    - The sidecar MCP listener is dispatch-only. A py37-lite factory can expose local skill metadata, but it cannot advertise or activate declarative skills through the gateway. Require a native py37 wheel for that path, or provide a separate discovery MCP URL; never report lite `load_skill` success without an executable catalog.
    - Wrap the outer adapter import/start block with `capture_bootstrap_errors(...)`; it is stdlib-only, records pre-MCP failures, and re-raises for the DCC's native error UI. `DccServerBase` already captures Python error logs and uncaught exceptions into the shared log plus `output://` / `events://`. Forward host-native console callbacks with `server.report_host_error(...)`; do not replace global stdout/stderr or add an adapter-local error store.
    - For DCC-Link IPC upgrades, deploy readers that accept current version 1 and legacy version 0 before switching writers to the default versioned frame. Use `DccLinkFrame(..., version=0)` only during that compatibility window, preserve an incoming frame's version in its reply, and treat `unsupported DCC-Link protocol version` as an explicit peer-upgrade failure rather than retrying body decoding.
+   - Preserve one caller-generated request id across every execution hop. JSON-RPC responses must echo `id`; commandPort-style sidecar responses must echo top-level `request_id`; gateway REST responses must echo `X-Request-ID`. Never replace an explicit response id with the current request id, because that can disguise a stale response. Treat a missing or mismatched echo as `transport desync`, fail closed, and regression-test a slow call followed by fast calls on the same connection.
    - Registry producers must write `ServiceEntry.schema_version` using `SERVICE_ENTRY_SCHEMA_VERSION`; rows with no field are legacy version 0. Consumers may read legacy/current rows but must reject a higher schema version without quarantining, deleting, or rewriting `services.json`. Treat that error as an explicit peer-upgrade requirement, not as corrupt JSON.
 10. Pass `instance_id` to sidecar launch helpers only when it is a real UUID for the DCC service. During early startup, omit it or pass `None`; `build_sidecar_command()` rejects cosmetic values such as `"unknown"` with `success=false` and `reason="invalid_instance_id"` so adapters do not spawn a child that can only fail with a CLI argument error.
     After `DccServerBase.start()`, use `server.instance_id` when adapter UI or
@@ -248,6 +249,10 @@ return bake_frames()
 - Declare `execution: async`, `affinity: main`, and
   `job_strategy: chunked`. The bridge rejects a declared chunked tool that
   returns a monolithic value.
+- Any operation that can exceed the caller's synchronous timeout must return a
+  job envelope. Declare `execution: async` or a positive `timeout_hint_secs`;
+  Core promotes either declaration through `JobManager` instead of allowing a
+  timed-out synchronous call to leave a stale transport response queued.
 - Yield one bounded host-API callable per step. A returned string becomes the
   progress message.
 - `submit_chunked_runner()` advances at most one step per host pump tick, so

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -234,6 +234,10 @@ For one indivisible DCC-native call, keep `job_strategy: monolithic`. Prefer
 `execution: async` so the initial transport returns a core job id, then poll
 the instance-routable `jobs_get_status`. A transport timeout is not completion
 or cancellation: rediscover the instance and query the job before retrying.
+Do not publish a potentially long tool as `execution: sync` with no timeout
+metadata. A positive `timeout_hint_secs` also makes Core return a job envelope;
+use it when duration is known but the tool otherwise retains synchronous
+semantics inside the worker.
 The creator scaffold deliberately emits `monolithic` for async tools; change it
 only with the matching chunked runner or isolated status/cancel implementation.
 

--- a/tests/test_dispatcher_migration_conformance.py
+++ b/tests/test_dispatcher_migration_conformance.py
@@ -214,6 +214,7 @@ def test_3dsmax_like_sidecar_uses_core_script_runner_envelope(tmp_path: Path) ->
     assert result == {
         "success": True,
         "message": "Sidecar action dispatched",
+        "request_id": "req-max",
         "context": {
             "dcc_name": "3dsmax",
             "action": "max__create_box",

--- a/tests/test_sidecar_action_dispatcher.py
+++ b/tests/test_sidecar_action_dispatcher.py
@@ -83,6 +83,7 @@ def test_maya_style_executor_resolves_registered_action_source(tmp_path: Path) -
         "success": True,
         "message": "created cube",
         "context": {"object_name": "pCube1"},
+        "request_id": "req-1",
     }
     assert calls == [
         {
@@ -122,6 +123,7 @@ def test_3dsmax_style_executor_wraps_plain_script_result(tmp_path: Path) -> None
     assert result == {
         "success": True,
         "message": "Sidecar action dispatched",
+        "request_id": "req-2",
         "context": {
             "dcc_name": "3dsmax",
             "action": "max__create_box",
@@ -131,6 +133,29 @@ def test_3dsmax_style_executor_wraps_plain_script_result(tmp_path: Path) -> None
         },
     }
     assert calls == [(str(script), {"length": 10})]
+
+
+def test_sidecar_dispatcher_preserves_a_mismatched_executor_request_id(tmp_path: Path) -> None:
+    script = tmp_path / "stale.py"
+    script.write_text("def main(): return None\n", encoding="utf-8")
+    dispatcher = SidecarActionDispatcher(
+        "maya",
+        server_provider=lambda: object(),
+        executor=lambda _request: {
+            "success": True,
+            "request_id": "previous-call",
+        },
+    )
+
+    result = dispatcher.dispatch_payload(
+        {
+            "action": "maya__stale",
+            "source_file": str(script),
+            "request_id": "current-call",
+        },
+    )
+
+    assert result["request_id"] == "previous-call"
 
 
 @pytest.mark.parametrize(
@@ -155,6 +180,16 @@ def test_malformed_payloads_return_payload_malformed(payload: Any, reason: str |
     assert result["error"] == ERROR_PAYLOAD_MALFORMED
     if reason is not None:
         assert result["context"]["reason"] == reason
+
+
+def test_malformed_sidecar_response_echoes_a_valid_caller_request_id() -> None:
+    dispatcher = SidecarActionDispatcher("maya", server_provider=lambda: object())
+
+    result = dispatcher.dispatch_payload({"request_id": "req-malformed"})
+
+    assert result["success"] is False
+    assert result["error"] == ERROR_PAYLOAD_MALFORMED
+    assert result["request_id"] == "req-malformed"
 
 
 def test_server_provider_none_returns_server_not_running(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- propagate exact request ids through CLI, gateway, Skill REST, sidecars, and host RPC transports
- reject missing or mismatched ids on successful and error responses
- document and validate async or timeout-hinted promotion to job envelopes

## Validation
- vx just clippy
- vx just fmt-check
- vx cargo test -p dcc-mcp-gateway
- vx cargo test -p dcc-mcp-cli
- vx cargo test -p dcc-mcp-host-rpc
- vx cargo test -p dcc-mcp-skill-rest
- targeted Python sidecar and dispatcher conformance tests
- vx just lint-skills

Skill guidance updated: yes.

## Remaining acceptance
- replay the greater-than-30-second slow-then-fast sequence in Maya issue 490
- replay the same sequence in 3ds Max issue 151

Refs #2256