### PR TITLE
fix: forward adapter feedback through gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,9 @@ Admin UI at [http://127.0.0.1:9765/admin](http://127.0.0.1:9765/admin) after the
 gateway is available.
 
 When a call fails, preserve its `request_id`, run `doctor` or a failure-filtered
-`stats` query, and discover `dcc_feedback__report` through the normal
-`search -> describe -> call` flow. Gateway-routed failures also expose a
+`stats` query, and use gateway-owned `dcc-mcp-cli feedback`. A live adapter's
+`dcc_feedback__report` is only a thin Core forwarder to the same endpoint.
+Gateway-routed failures also expose a
 public-safe `/v1/debug/issue-reports/<request_id>` payload for a reviewed bug
 report; raw bundles must never be uploaded automatically.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -185,8 +185,9 @@ dcc-mcp-cli update check --binary dcc-mcp-server --current-version <server_versi
    `dcc-mcp-server` 更新。`dcc-mcp-cli update apply` 只用于更新 CLI 二进制本身。
 
 调用失败时保留 `request_id`，根据故障类型运行 `doctor` 或带
-`--status failure --session-id <id>` 的 `stats`，再通过正常的
-`search -> describe -> call` 流程调用 `dcc_feedback__report`。gateway 路径还提供
+`--status failure --session-id <id>` 的 `stats`，再使用 gateway 级
+`dcc-mcp-cli feedback`；在线 adapter 的 `dcc_feedback__report` 仅作为转发到
+同一 endpoint 的 Core 薄兼容层。gateway 路径还提供
 public-safe `/v1/debug/issue-reports/<request_id>` 作为经审查的 Bug 报告材料；
 禁止自动上传 raw bundle。
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/feedback.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/feedback.rs
@@ -2,7 +2,7 @@
 
 use axum::Json;
 use axum::extract::State;
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use dcc_mcp_models::FeedbackReport;
 use serde_json::{Value, json};
@@ -15,14 +15,15 @@ const GATEWAY_EVENTS_URI: &str = "resources://gateway/events";
 /// `POST /v1/feedback` — record feedback without requiring a live DCC instance.
 pub async fn handle_v1_feedback(
     State(gateway): State<GatewayState>,
+    headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
     let report = match serde_json::from_value::<FeedbackReport>(body) {
         Ok(report) => report,
-        Err(error) => return invalid_feedback(error.to_string()),
+        Err(error) => return correlate_response(invalid_feedback(error.to_string()), &headers),
     };
     if let Err(error) = report.validate() {
-        return invalid_feedback(error.to_string());
+        return correlate_response(invalid_feedback(error.to_string()), &headers);
     }
 
     let feedback_id = uuid::Uuid::new_v4().to_string();
@@ -52,17 +53,29 @@ pub async fn handle_v1_feedback(
         "gateway feedback recorded"
     );
 
-    (
-        StatusCode::CREATED,
-        Json(json!({
-            "ok": true,
-            "success": true,
-            "feedback_id": feedback_id,
-            "recorded_at": recorded_at,
-            "event_resource_uri": GATEWAY_EVENTS_URI,
-        })),
+    correlate_response(
+        (
+            StatusCode::CREATED,
+            Json(json!({
+                "ok": true,
+                "success": true,
+                "feedback_id": feedback_id,
+                "recorded_at": recorded_at,
+                "event_resource_uri": GATEWAY_EVENTS_URI,
+            })),
+        )
+            .into_response(),
+        &headers,
     )
-        .into_response()
+}
+
+fn correlate_response(mut response: Response, request_headers: &HeaderMap) -> Response {
+    if let Some(request_id) = request_headers.get("x-request-id") {
+        response
+            .headers_mut()
+            .insert("x-request-id", request_id.clone());
+    }
+    response
 }
 
 #[cfg(test)]
@@ -97,11 +110,19 @@ mod tests {
                     .method("POST")
                     .uri("/v1/feedback")
                     .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .header("x-request-id", "feedback-request-42")
                     .body(Body::from(serde_json::to_vec(&request_body).unwrap()))
                     .unwrap(),
             )
             .await
             .unwrap();
+        assert_eq!(
+            response
+                .headers()
+                .get("x-request-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("feedback-request-42")
+        );
         let (status, body) = response_json(response).await;
 
         assert_eq!(status, StatusCode::CREATED);
@@ -132,19 +153,27 @@ mod tests {
     #[tokio::test]
     async fn gateway_feedback_rejects_empty_required_text() {
         let gateway = test_gateway_state("1.2.3");
-        let (status, body) = response_json(
-            handle_v1_feedback(
-                State(gateway),
-                Json(json!({
-                    "tool_name": "maya_scene__save",
-                    "intent": "Save the scene",
-                    "blocker": " ",
-                    "severity": "suggestion"
-                })),
-            )
-            .await,
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-request-id", "invalid-feedback-42".parse().unwrap());
+        let response = handle_v1_feedback(
+            State(gateway),
+            headers,
+            Json(json!({
+                "tool_name": "maya_scene__save",
+                "intent": "Save the scene",
+                "blocker": " ",
+                "severity": "suggestion"
+            })),
         )
         .await;
+        assert_eq!(
+            response
+                .headers()
+                .get("x-request-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("invalid-feedback-42")
+        );
+        let (status, body) = response_json(response).await;
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(body["error"]["kind"], "invalid-feedback");

--- a/crates/dcc-mcp-gateway/src/gateway/rest_openapi_feedback.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/rest_openapi_feedback.rs
@@ -13,10 +13,23 @@ pub(super) fn path_operation() -> Value {
     let responses = operation["post"]["responses"]
         .as_object_mut()
         .expect("POST operation responses must be an object");
-    let response = responses
+    let mut response = responses
         .remove("200")
         .expect("POST operation must define a success response");
+    response["headers"] = json!({
+        "X-Request-ID": {
+            "description": "Exact echo of the optional request correlation header.",
+            "schema": {"type": "string"}
+        }
+    });
     responses.insert("201".to_string(), response);
+    operation["post"]["parameters"] = json!([{
+        "name": "X-Request-ID",
+        "in": "header",
+        "required": false,
+        "description": "Optional transport correlation id echoed on success and validation errors.",
+        "schema": {"type": "string"}
+    }]);
     operation
 }
 
@@ -76,6 +89,19 @@ mod tests {
         assert_eq!(
             operation["requestBody"]["content"]["application/json"]["schema"]["$ref"],
             "#/components/schemas/GatewayFeedbackReport"
+        );
+        assert!(
+            operation["parameters"]
+                .as_array()
+                .is_some_and(|parameters| {
+                    parameters
+                        .iter()
+                        .any(|parameter| parameter["name"] == "X-Request-ID")
+                })
+        );
+        assert_eq!(
+            operation["responses"]["201"]["headers"]["X-Request-ID"]["schema"]["type"],
+            "string"
         );
         let report = &doc["components"]["schemas"]["GatewayFeedbackReport"];
         assert!(report["properties"].get("instance_id").is_some());

--- a/crates/dcc-mcp-sidecar/src/sidecar.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar.rs
@@ -360,8 +360,16 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
     let mut gateway_control: Option<crate::sidecar_gateway::SidecarGatewayControl> = None;
 
     let mut host_rpc_reconnect_handle: Option<tokio::task::JoinHandle<()>> = None;
+    let gateway_host = args.gateway_host.as_deref().unwrap_or(&args.host);
+    let feedback = crate::sidecar_mcp::SidecarFeedbackForwarder::for_gateway(
+        key.dcc_type.clone(),
+        key.instance_id.to_string(),
+        gateway_host,
+        args.gateway_port,
+    );
     let state =
-        crate::sidecar_mcp::SidecarMcpState::new(host_rpc_client, env!("CARGO_PKG_VERSION"));
+        crate::sidecar_mcp::SidecarMcpState::new(host_rpc_client, env!("CARGO_PKG_VERSION"))
+            .with_feedback(feedback);
     let reconnect_state = state.clone();
     let mcp_handle = match crate::sidecar_mcp::spawn_listener(state, "127.0.0.1", 0).await {
         Ok(handle) => {

--- a/crates/dcc-mcp-sidecar/src/sidecar_mcp.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_mcp.rs
@@ -14,7 +14,7 @@
 //! | Method            | Behaviour |
 //! |-------------------|-----------|
 //! | `initialize`      | Returns a capability envelope advertising `tools: { listChanged: false }` only. |
-//! | `tools/call`      | Dispatches via the in-process [`HostRpcClient`]; returns the result envelope verbatim. |
+//! | `tools/call`      | Forwards `dcc_feedback__report` to the gateway; dispatches every other tool via the in-process [`HostRpcClient`]. |
 //! | `ping`            | Echo `{}` — needed by some hosts' health probes. |
 //! | `notifications/*` | Accepted and discarded (per JSON-RPC, no response when `id` is absent). |
 //! | everything else   | `-32601` "method not found". |
@@ -42,10 +42,13 @@ pub use dcc_mcp_jsonrpc::MCP_PROTOCOL_VERSION;
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, watch};
 
+mod feedback;
 mod handlers;
 #[cfg(test)]
 mod tests;
 mod trace;
+
+pub(crate) use feedback::SidecarFeedbackForwarder;
 
 use handlers::{
     handle_health, handle_healthz, handle_mcp_post, handle_v1_healthz, handle_v1_readyz,
@@ -66,6 +69,7 @@ pub const SIDECAR_SERVER_NAME: &str = "dcc-mcp-sidecar";
 pub struct SidecarMcpState {
     pub(crate) host_rpc: Arc<Mutex<Box<dyn HostRpcClient>>>,
     pub(crate) server_version: String,
+    pub(crate) feedback: Option<SidecarFeedbackForwarder>,
 }
 
 impl SidecarMcpState {
@@ -78,7 +82,14 @@ impl SidecarMcpState {
         Self {
             host_rpc: Arc::new(Mutex::new(host_rpc)),
             server_version: server_version.into(),
+            feedback: None,
         }
+    }
+
+    /// Configure the gateway-owned feedback compatibility forwarder.
+    pub(crate) fn with_feedback(mut self, feedback: SidecarFeedbackForwarder) -> Self {
+        self.feedback = Some(feedback);
+        self
     }
 
     /// Tear down the inner client; useful for test fixtures that

--- a/crates/dcc-mcp-sidecar/src/sidecar_mcp/feedback.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_mcp/feedback.rs
@@ -1,0 +1,243 @@
+//! Gateway feedback forwarding for the sidecar dispatch surface.
+
+use std::time::Duration;
+
+use reqwest::StatusCode;
+use serde_json::{Map, Value, json};
+
+pub(super) const FEEDBACK_TOOL_NAME: &str = "dcc_feedback__report";
+const GATEWAY_EVENTS_URI: &str = "resources://gateway/events";
+const FEEDBACK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Gateway client that binds reports to one sidecar-owned DCC instance.
+#[derive(Clone)]
+pub(crate) struct SidecarFeedbackForwarder {
+    dcc_type: String,
+    instance_id: String,
+    endpoint: Option<String>,
+    client: Option<reqwest::Client>,
+}
+
+impl SidecarFeedbackForwarder {
+    pub(crate) fn new(
+        dcc_type: impl Into<String>,
+        instance_id: impl Into<String>,
+        endpoint: Option<String>,
+    ) -> Self {
+        Self {
+            dcc_type: dcc_type.into(),
+            instance_id: instance_id.into(),
+            endpoint,
+            client: reqwest::Client::builder()
+                .timeout(FEEDBACK_TIMEOUT)
+                .build()
+                .ok(),
+        }
+    }
+
+    pub(crate) fn for_gateway(
+        dcc_type: impl Into<String>,
+        instance_id: impl Into<String>,
+        gateway_host: &str,
+        gateway_port: u16,
+    ) -> Self {
+        Self::new(
+            dcc_type,
+            instance_id,
+            gateway_feedback_endpoint(gateway_host, gateway_port),
+        )
+    }
+
+    pub(crate) async fn forward(&self, arguments: Value) -> Value {
+        let Some(arguments) = arguments.as_object() else {
+            return feedback_error(
+                "Feedback params must be an object.",
+                "invalid_input",
+                Map::new(),
+            );
+        };
+        let (Some(endpoint), Some(client)) = (self.endpoint.as_deref(), self.client.as_ref())
+        else {
+            return unavailable_error();
+        };
+
+        let mut report = Map::new();
+        for name in [
+            "tool_name",
+            "intent",
+            "attempt",
+            "blocker",
+            "severity",
+            "request_id",
+            "job_id",
+        ] {
+            if let Some(value) = arguments.get(name)
+                && !value.is_null()
+            {
+                report.insert(name.to_string(), value.clone());
+            }
+        }
+        report.insert("dcc_type".to_string(), Value::String(self.dcc_type.clone()));
+        report.insert(
+            "instance_id".to_string(),
+            Value::String(self.instance_id.clone()),
+        );
+
+        let transport_request_id = uuid::Uuid::new_v4().to_string();
+        let response = match client
+            .post(endpoint)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .header("X-Request-ID", &transport_request_id)
+            .json(&Value::Object(report))
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::warn!(error = %error, "sidecar gateway feedback forwarding failed");
+                return unavailable_error();
+            }
+        };
+
+        let echoed_request_id = response
+            .headers()
+            .get("X-Request-ID")
+            .and_then(|value| value.to_str().ok());
+        if echoed_request_id != Some(transport_request_id.as_str()) {
+            return feedback_error(
+                "Gateway feedback response did not match the request.",
+                "transport_desync",
+                Map::new(),
+            );
+        }
+
+        let status = response.status();
+        let payload = response.json::<Value>().await.ok();
+        if !status.is_success() {
+            let mut context = Map::new();
+            context.insert(
+                "status_code".to_string(),
+                Value::Number(status.as_u16().into()),
+            );
+            return feedback_error(
+                gateway_error_message(payload.as_ref()),
+                "gateway_feedback_rejected",
+                context,
+            );
+        }
+        if status != StatusCode::CREATED {
+            return invalid_receipt(status);
+        }
+
+        let Some(payload) = payload.as_ref().and_then(Value::as_object) else {
+            return invalid_receipt(status);
+        };
+        let feedback_id = payload.get("feedback_id").and_then(Value::as_str);
+        let recorded_at = payload.get("recorded_at").and_then(Value::as_str);
+        let event_resource_uri = payload.get("event_resource_uri").and_then(Value::as_str);
+        let feedback_id_is_valid =
+            feedback_id.is_some_and(|value| uuid::Uuid::parse_str(value).is_ok());
+        if payload.get("ok").and_then(Value::as_bool) != Some(true)
+            || payload.get("success").and_then(Value::as_bool) != Some(true)
+            || !feedback_id_is_valid
+            || recorded_at.is_none_or(str::is_empty)
+            || event_resource_uri != Some(GATEWAY_EVENTS_URI)
+        {
+            return invalid_receipt(status);
+        }
+
+        json!({
+            "success": true,
+            "message": "Feedback recorded at the gateway.",
+            "context": {
+                "feedback_id": feedback_id,
+                "recorded_at": recorded_at,
+                "event_resource_uri": event_resource_uri,
+            }
+        })
+    }
+}
+
+fn gateway_feedback_endpoint(host: &str, port: u16) -> Option<String> {
+    let host = host.trim();
+    if port == 0
+        || host.is_empty()
+        || ["://", "/", "?", "#", "@"]
+            .iter()
+            .any(|marker| host.contains(marker))
+    {
+        return None;
+    }
+    let host = match host {
+        "0.0.0.0" => "127.0.0.1".to_string(),
+        "::" | "[::]" => "[::1]".to_string(),
+        value if value.contains(':') && !value.starts_with('[') => format!("[{value}]"),
+        value => value.to_string(),
+    };
+    let endpoint = format!("http://{host}:{port}/v1/feedback");
+    reqwest::Url::parse(&endpoint).ok().map(|_| endpoint)
+}
+
+fn gateway_error_message(payload: Option<&Value>) -> &str {
+    payload
+        .and_then(|value| value.pointer("/error/message"))
+        .and_then(Value::as_str)
+        .or_else(|| {
+            payload
+                .and_then(|value| value.get("message"))
+                .and_then(Value::as_str)
+        })
+        .unwrap_or("Gateway rejected the feedback report.")
+}
+
+fn unavailable_error() -> Value {
+    feedback_error(
+        "Gateway feedback endpoint is unavailable.",
+        "gateway_feedback_unavailable",
+        Map::new(),
+    )
+}
+
+fn invalid_receipt(status: StatusCode) -> Value {
+    let mut context = Map::new();
+    context.insert(
+        "status_code".to_string(),
+        Value::Number(status.as_u16().into()),
+    );
+    feedback_error(
+        "Gateway returned an invalid feedback receipt.",
+        "gateway_feedback_invalid_receipt",
+        context,
+    )
+}
+
+fn feedback_error(message: &str, error: &str, context: Map<String, Value>) -> Value {
+    let mut result = Map::from_iter([
+        ("success".to_string(), Value::Bool(false)),
+        ("message".to_string(), Value::String(message.to_string())),
+        ("error".to_string(), Value::String(error.to_string())),
+    ]);
+    if !context.is_empty() {
+        result.insert("context".to_string(), Value::Object(context));
+    }
+    Value::Object(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gateway_endpoint_normalizes_wildcard_and_ipv6_hosts() {
+        assert_eq!(
+            gateway_feedback_endpoint("0.0.0.0", 9765).as_deref(),
+            Some("http://127.0.0.1:9765/v1/feedback")
+        );
+        assert_eq!(
+            gateway_feedback_endpoint("::1", 9765).as_deref(),
+            Some("http://[::1]:9765/v1/feedback")
+        );
+        assert_eq!(gateway_feedback_endpoint("127.0.0.1", 0), None);
+        assert_eq!(gateway_feedback_endpoint("http://gateway", 9765), None);
+    }
+}

--- a/crates/dcc-mcp-sidecar/src/sidecar_mcp/handlers.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_mcp/handlers.rs
@@ -6,6 +6,7 @@ use dcc_mcp_jsonrpc::negotiate_protocol_version;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+use super::feedback::FEEDBACK_TOOL_NAME;
 use super::trace::trace_context_from_headers;
 use super::{SIDECAR_SERVER_NAME, SidecarMcpState};
 
@@ -177,6 +178,21 @@ async fn handle_tools_call(
         Value::String(s) => s.clone(),
         other => other.to_string(),
     };
+
+    if params.name == FEEDBACK_TOOL_NAME {
+        let payload = match state.feedback.as_ref() {
+            Some(feedback) => feedback.forward(params.arguments).await,
+            None => json!({
+                "success": false,
+                "message": "Gateway feedback endpoint is unavailable.",
+                "error": "gateway_feedback_unavailable",
+            }),
+        };
+        return json!({
+            "jsonrpc": "2.0", "id": id,
+            "result": payload
+        });
+    }
 
     let result = {
         let guard = state.host_rpc.lock().await;

--- a/crates/dcc-mcp-sidecar/src/sidecar_mcp/tests.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_mcp/tests.rs
@@ -1,8 +1,15 @@
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
 use dcc_mcp_host_rpc::{HostRpcClient, StubHostRpcClient, UnavailableHostRpcClient};
 use serde_json::{Value, json};
+use tokio::sync::oneshot;
 
 use super::*;
 
@@ -31,6 +38,116 @@ async fn post_mcp(url: &str, body: Value) -> reqwest::Response {
         .send()
         .await
         .expect("POST /mcp")
+}
+
+#[derive(Clone)]
+enum FeedbackGatewayMode {
+    Echo,
+    Stale,
+    InvalidReceipt,
+    Rejected,
+}
+
+#[derive(Clone)]
+struct FeedbackGatewayState {
+    received: Arc<StdMutex<Vec<Value>>>,
+    mode: FeedbackGatewayMode,
+}
+
+struct FeedbackGatewayFixture {
+    endpoint: String,
+    received: Arc<StdMutex<Vec<Value>>>,
+    shutdown: Option<oneshot::Sender<()>>,
+}
+
+impl Drop for FeedbackGatewayFixture {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+    }
+}
+
+async fn feedback_gateway_handler(
+    State(state): State<FeedbackGatewayState>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    state.received.lock().expect("feedback capture").push(body);
+    let request_id = match state.mode {
+        FeedbackGatewayMode::Echo
+        | FeedbackGatewayMode::InvalidReceipt
+        | FeedbackGatewayMode::Rejected => headers
+            .get("x-request-id")
+            .cloned()
+            .expect("forwarder must send X-Request-ID"),
+        FeedbackGatewayMode::Stale => HeaderValue::from_static("previous-request"),
+    };
+    let (status, ok, success, feedback_id, error) = match state.mode {
+        FeedbackGatewayMode::InvalidReceipt => (
+            StatusCode::CREATED,
+            false,
+            true,
+            "not-a-feedback-uuid",
+            Value::Null,
+        ),
+        FeedbackGatewayMode::Rejected => (
+            StatusCode::BAD_REQUEST,
+            false,
+            false,
+            "",
+            json!({"kind": "invalid-feedback", "message": "intent must not be empty"}),
+        ),
+        FeedbackGatewayMode::Echo | FeedbackGatewayMode::Stale => (
+            StatusCode::CREATED,
+            true,
+            true,
+            "11111111-1111-4111-8111-111111111111",
+            Value::Null,
+        ),
+    };
+    let mut response = (
+        status,
+        Json(json!({
+            "ok": ok,
+            "success": success,
+            "feedback_id": feedback_id,
+            "recorded_at": "2026-08-24T00:00:00.000Z",
+            "event_resource_uri": "resources://gateway/events",
+            "error": error,
+        })),
+    )
+        .into_response();
+    response.headers_mut().insert("x-request-id", request_id);
+    response
+}
+
+async fn spawn_feedback_gateway(mode: FeedbackGatewayMode) -> FeedbackGatewayFixture {
+    let received = Arc::new(StdMutex::new(Vec::new()));
+    let app = Router::new()
+        .route("/v1/feedback", post(feedback_gateway_handler))
+        .with_state(FeedbackGatewayState {
+            received: received.clone(),
+            mode,
+        });
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind feedback fixture");
+    let address = listener.local_addr().expect("feedback fixture address");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("serve feedback fixture");
+    });
+    FeedbackGatewayFixture {
+        endpoint: format!("http://{address}/v1/feedback"),
+        received,
+        shutdown: Some(shutdown_tx),
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -235,6 +352,216 @@ async fn tools_call_routes_through_host_rpc_client() {
         "data.message should propagate the transport error: {body}"
     );
 
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn feedback_tool_forwards_through_gateway_without_host_rpc() {
+    for (dcc_type, instance_id) in [
+        ("maya", "aaaaaaaa-0000-0000-0000-000000000001"),
+        ("3dsmax", "bbbbbbbb-0000-0000-0000-000000000002"),
+    ] {
+        let gateway = spawn_feedback_gateway(FeedbackGatewayMode::Echo).await;
+        let state = SidecarMcpState::new(Box::new(StubHostRpcClient::new()), "test").with_feedback(
+            SidecarFeedbackForwarder::new(dcc_type, instance_id, Some(gateway.endpoint.clone())),
+        );
+        let handle = spawn_listener(state, "127.0.0.1", 0).await.expect("spawn");
+
+        let body: Value = post_mcp(
+            &handle.mcp_url,
+            json!({
+                "jsonrpc": "2.0", "id": format!("feedback-{dcc_type}"),
+                "method": "tools/call",
+                "params": {
+                    "name": "dcc_feedback__report",
+                    "arguments": {
+                        "tool_name": "scene.save",
+                        "intent": "Save the scene",
+                        "attempt": "Called the advertised tool",
+                        "blocker": "The host dispatcher rejected the action",
+                        "severity": "blocked",
+                        "dcc_type": "caller-must-not-control-this",
+                        "instance_id": "caller-must-not-control-this",
+                        "request_id": "failed-request-42",
+                        "job_id": "failed-job-42"
+                    }
+                }
+            }),
+        )
+        .await
+        .json()
+        .await
+        .expect("parse feedback response");
+
+        assert_eq!(body["result"]["success"], true, "{body}");
+        assert_eq!(
+            body["result"]["context"]["feedback_id"],
+            "11111111-1111-4111-8111-111111111111"
+        );
+        assert_eq!(
+            body["result"]["context"]["event_resource_uri"],
+            "resources://gateway/events"
+        );
+        let reports = gateway.received.lock().expect("feedback capture");
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0]["dcc_type"], dcc_type);
+        assert_eq!(reports[0]["instance_id"], instance_id);
+        assert_eq!(reports[0]["request_id"], "failed-request-42");
+        assert_eq!(reports[0]["job_id"], "failed-job-42");
+        drop(reports);
+        handle.shutdown().await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn feedback_tool_fails_closed_when_gateway_is_not_configured() {
+    let state = SidecarMcpState::new(Box::new(StubHostRpcClient::new()), "test").with_feedback(
+        SidecarFeedbackForwarder::new("maya", "aaaaaaaa-0000-0000-0000-000000000001", None),
+    );
+    let handle = spawn_listener(state, "127.0.0.1", 0).await.expect("spawn");
+
+    let body: Value = post_mcp(
+        &handle.mcp_url,
+        json!({
+            "jsonrpc": "2.0", "id": "feedback-disabled",
+            "method": "tools/call",
+            "params": {
+                "name": "dcc_feedback__report",
+                "arguments": {
+                    "tool_name": "scene.save",
+                    "intent": "Save the scene",
+                    "blocker": "Gateway is disabled",
+                    "severity": "blocked"
+                }
+            }
+        }),
+    )
+    .await
+    .json()
+    .await
+    .expect("parse feedback response");
+
+    assert_eq!(body["result"]["success"], false, "{body}");
+    assert_eq!(
+        body["result"]["error"], "gateway_feedback_unavailable",
+        "the feedback tool must not fall through to the host RPC stub: {body}"
+    );
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn feedback_tool_rejects_a_stale_gateway_response() {
+    let gateway = spawn_feedback_gateway(FeedbackGatewayMode::Stale).await;
+    let state = SidecarMcpState::new(Box::new(StubHostRpcClient::new()), "test").with_feedback(
+        SidecarFeedbackForwarder::new(
+            "3dsmax",
+            "bbbbbbbb-0000-0000-0000-000000000002",
+            Some(gateway.endpoint.clone()),
+        ),
+    );
+    let handle = spawn_listener(state, "127.0.0.1", 0).await.expect("spawn");
+
+    let body: Value = post_mcp(
+        &handle.mcp_url,
+        json!({
+            "jsonrpc": "2.0", "id": "feedback-stale",
+            "method": "tools/call",
+            "params": {
+                "name": "dcc_feedback__report",
+                "arguments": {
+                    "tool_name": "scene.save",
+                    "intent": "Save the scene",
+                    "blocker": "The response belongs to another request",
+                    "severity": "blocked"
+                }
+            }
+        }),
+    )
+    .await
+    .json()
+    .await
+    .expect("parse feedback response");
+
+    assert_eq!(body["result"]["success"], false, "{body}");
+    assert_eq!(body["result"]["error"], "transport_desync");
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn feedback_tool_rejects_an_invalid_gateway_receipt() {
+    let gateway = spawn_feedback_gateway(FeedbackGatewayMode::InvalidReceipt).await;
+    let state = SidecarMcpState::new(Box::new(StubHostRpcClient::new()), "test").with_feedback(
+        SidecarFeedbackForwarder::new(
+            "maya",
+            "aaaaaaaa-0000-0000-0000-000000000001",
+            Some(gateway.endpoint.clone()),
+        ),
+    );
+    let handle = spawn_listener(state, "127.0.0.1", 0).await.expect("spawn");
+
+    let body: Value = post_mcp(
+        &handle.mcp_url,
+        json!({
+            "jsonrpc": "2.0", "id": "feedback-invalid-receipt",
+            "method": "tools/call",
+            "params": {
+                "name": "dcc_feedback__report",
+                "arguments": {
+                    "tool_name": "scene.save",
+                    "intent": "Save the scene",
+                    "blocker": "The receipt violated the gateway contract",
+                    "severity": "blocked"
+                }
+            }
+        }),
+    )
+    .await
+    .json()
+    .await
+    .expect("parse feedback response");
+
+    assert_eq!(body["result"]["success"], false, "{body}");
+    assert_eq!(body["result"]["error"], "gateway_feedback_invalid_receipt");
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn feedback_tool_surfaces_a_correlated_gateway_rejection() {
+    let gateway = spawn_feedback_gateway(FeedbackGatewayMode::Rejected).await;
+    let state = SidecarMcpState::new(Box::new(StubHostRpcClient::new()), "test").with_feedback(
+        SidecarFeedbackForwarder::new(
+            "maya",
+            "aaaaaaaa-0000-0000-0000-000000000001",
+            Some(gateway.endpoint.clone()),
+        ),
+    );
+    let handle = spawn_listener(state, "127.0.0.1", 0).await.expect("spawn");
+
+    let body: Value = post_mcp(
+        &handle.mcp_url,
+        json!({
+            "jsonrpc": "2.0", "id": "feedback-rejected",
+            "method": "tools/call",
+            "params": {
+                "name": "dcc_feedback__report",
+                "arguments": {
+                    "tool_name": "scene.save",
+                    "intent": "",
+                    "blocker": "The report is invalid",
+                    "severity": "blocked"
+                }
+            }
+        }),
+    )
+    .await
+    .json()
+    .await
+    .expect("parse feedback response");
+
+    assert_eq!(body["result"]["success"], false, "{body}");
+    assert_eq!(body["result"]["error"], "gateway_feedback_rejected");
+    assert_eq!(body["result"]["message"], "intent must not be empty");
+    assert_eq!(body["result"]["context"]["status_code"], 400);
     handle.shutdown().await;
 }
 

--- a/docs/api/feedback.md
+++ b/docs/api/feedback.md
@@ -2,19 +2,27 @@
 
 Agent feedback and rationale utilities for DCC-MCP servers (issues #433, #434).
 
-Three complementary features: **Rationale capture** — agents include `_meta.dcc.rationale` in `tools/call` requests to explain why they are invoking a tool. **Gateway feedback** — `POST /v1/feedback` and `dcc-mcp-cli feedback` remain available with zero live DCC instances. **Compatibility tool** — `dcc_feedback__report` remains available on live adapters.
+Three complementary features: **Rationale capture** — agents include `_meta.dcc.rationale` in `tools/call` requests to explain why they are invoking a tool. **Gateway feedback** — `POST /v1/feedback` and `dcc-mcp-cli feedback` remain available with zero live DCC instances. **Compatibility forwarder** — `dcc_feedback__report` remains available on live adapters and forwards through the same gateway contract.
 
 **Exported symbols:** `clear_feedback`, `extract_rationale`, `get_feedback_entries`, `make_rationale_meta`, `register_feedback_tool`
 
 ## register_feedback_tool
 
 ```python
-register_feedback_tool(server, *, dcc_name="dcc") -> None
+register_feedback_tool(
+    server,
+    *,
+    dcc_name="dcc",
+    gateway_endpoint=None,
+    gateway_host=None,
+    gateway_port=None,
+    instance_id_provider=None,
+) -> None
 ```
 
 Register the `dcc_feedback__report` MCP tool on `server`. Call **before** `server.start()`.
 
-The tool accepts: `tool_name`, `intent`, `blocker`, `severity` (`"blocked"` | `"workaround_found"` | `"suggestion"`), optional `attempt`.
+The tool accepts `tool_name`, `intent`, `blocker`, `severity` (`"blocked"` | `"workaround_found"` | `"suggestion"`), optional `attempt`, and optional failed-call `request_id` / `job_id`. The shared Core handler attaches the adapter `dcc_type` and current `instance_id`, posts to gateway `/v1/feedback`, validates the exact `X-Request-ID` response correlation, and returns the gateway receipt. It fails closed when the gateway is disabled, unavailable, rejects the report, or returns a stale/malformed receipt. There is no instance-local success fallback.
 
 ## Agent failure-reporting workflow
 
@@ -47,9 +55,10 @@ upload it automatically. Route Skill defects to the owning Skill, adapter or
 host-runtime defects to the adapter repository, and shared CLI/gateway/protocol
 defects to `dcc-mcp-core`; create an external issue only with user authorization.
 
-The compatibility `dcc_feedback__report` tool is instance-owned and therefore
-cannot be used after that instance exits. Prefer the gateway CLI/REST path for
-crash-class feedback.
+The compatibility `dcc_feedback__report` entry point disappears with its live
+adapter, but while live it is only a thin forwarder to the gateway authority.
+Prefer the gateway CLI/REST path for crash-class feedback and reference the dead
+instance plus its last request/job ids directly.
 
 ## extract_rationale
 

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -240,11 +240,14 @@ component for adapters that also register IPC diagnostics. The compatibility def
 omit the argument and exposes an explicit test reset seam.
 
 `DccServerBase` also owns `feedback_store`, `script_execution_context`, and
-`checkpoint_store`. Pass those components to `register_feedback_tool(...,
-store=...)`, `execute_with_context(..., context=...)`, and checkpoint helpers'
-existing `store=` parameter. Module-level convenience calls use explicit
-compatibility holders with `reset_default_*_for_tests()` seams; adapters must
-not add their own mutable namespace, feedback, or checkpoint globals.
+`checkpoint_store`. The base registration wires `dcc_feedback__report` to the
+configured gateway `/v1/feedback` endpoint, late-binds the current instance id,
+and mirrors only gateway-accepted receipts into `feedback_store`; adapters must
+not override this shared forwarder or add host-specific feedback actions.
+Pass the other components to `execute_with_context(..., context=...)` and
+checkpoint helpers' existing `store=` parameter. Module-level convenience calls
+use explicit compatibility holders with `reset_default_*_for_tests()` seams;
+adapters must not add their own mutable namespace, feedback, or checkpoint globals.
 
 **Return `ToolResultEnvelope` from Python tool handlers (#2183) — never hand-roll the dict:**
 ```python

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -347,9 +347,11 @@ registration helpers so two DCC servers in one process never share recorder,
 capturer, dispatcher, or instance-context caches.
 
 The base server also exposes instance-owned `feedback_store`,
-`script_execution_context`, and `checkpoint_store`. Pass these through the
-corresponding core helper parameters when an adapter registers feedback,
-persistent script execution, or checkpoint tools.
+`script_execution_context`, and `checkpoint_store`. Its shared feedback
+registration forwards `dcc_feedback__report` to gateway `/v1/feedback` and only
+mirrors accepted receipts; adapters must not replace it with host-specific
+handlers. Pass the other components through the corresponding Core helper
+parameters for persistent script execution or checkpoint tools.
 
 ## Development Setup
 

--- a/docs/zh/api/feedback.md
+++ b/docs/zh/api/feedback.md
@@ -2,13 +2,13 @@
 
 > **[English](../../api/feedback.md)**
 
-代理反馈与决策理由机制。Gateway 提供 `POST /v1/feedback` 与 `dcc-mcp-cli feedback`，即使没有在线 DCC 也可提交；`dcc_feedback__report` 继续作为在线实例兼容工具。另可提取和构建 `tools/call` 请求中的 `_meta.dcc.rationale` 决策理由。
+代理反馈与决策理由机制。Gateway 提供 `POST /v1/feedback` 与 `dcc-mcp-cli feedback`，即使没有在线 DCC 也可提交；在线实例的 `dcc_feedback__report` 仅作为共享 Core 实现的 gateway 转发入口。另可提取和构建 `tools/call` 请求中的 `_meta.dcc.rationale` 决策理由。
 
 **导出符号：** `register_feedback_tool`, `extract_rationale`, `make_rationale_meta`, `get_feedback_entries`, `clear_feedback`
 
 ## 主要函数
 
-- `register_feedback_tool(server, *, dcc_name="dcc")` — 注册 `dcc_feedback__report` MCP 工具，**在 `server.start()` 之前调用**
+- `register_feedback_tool(server, *, dcc_name="dcc", gateway_endpoint=None, gateway_host=None, gateway_port=None, instance_id_provider=None)` — 注册 `dcc_feedback__report` MCP 工具，**在 `server.start()` 之前调用**；Core 会附加当前 DCC/instance，转发到 gateway，严格校验 `X-Request-ID` 与回执，并在 gateway 不可用或回执失配时 fail-closed，不会本地伪成功
 - `extract_rationale(params) -> str | None` — 从 `tools/call` 参数中提取 `_meta.dcc.rationale`
 - `make_rationale_meta(rationale) -> dict` — 构建包含 rationale 的 `_meta` 片段
 - `get_feedback_entries(*, tool_name=None, severity=None, limit=50) -> list[dict]` — 获取最近的反馈条目（最新在前）
@@ -34,7 +34,7 @@ dcc-mcp-cli feedback \
 ```
 
 Gateway 会把有界的 `feedback_reported` 记录写入
-`resources://gateway/events` 并返回 `feedback_id`；它不依赖在线 DCC，也不会创建外部 issue。只提交经过脱敏的值，绝不能包含凭据、可复用令牌或原始敏感载荷。实例退出后不要再依赖实例级 `dcc_feedback__report`。gateway 路径失败时，
+`resources://gateway/events` 并返回 `feedback_id`；它不依赖在线 DCC，也不会创建外部 issue。只提交经过脱敏的值，绝不能包含凭据、可复用令牌或原始敏感载荷。实例退出后直接使用 gateway CLI/REST，并携带已退出 instance 及最后的 request/job id；不要再依赖已消失的实例工具。gateway 路径失败时，
 保留 CLI 返回的 `request_id`，获取 public-safe
 `/v1/debug/issue-reports/<request_id>`；`?mode=raw` 必须本地人工审查，禁止自动上传。
 Skill 缺陷归属对应 Skill，adapter/host runtime 缺陷归属 adapter 仓库，

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25,7 +25,8 @@ the task is embedding core, implementing an adapter, or extending the runtime.
 
 On failure, the `dcc-mcp` workflow preserves `request_id`, uses `doctor` or a
 failure-filtered `stats` query for bounded diagnosis, records structured
-feedback through the CLI-discovered `dcc_feedback__report`, and uses public-safe
+feedback through gateway-owned `dcc-mcp-cli feedback` (with live-adapter
+`dcc_feedback__report` only a thin Core forwarder), and uses public-safe
 `/v1/debug/issue-reports/<request_id>` for reviewed bug reports. Raw evidence
 and external issue creation require human review and user authorization.
 

--- a/llms.txt
+++ b/llms.txt
@@ -131,7 +131,7 @@ legacy unsigned staging, and does not replace a running server.
 | Checkpoint/resume long-running tool executions (issue #436) | `save_checkpoint(job_id, state)` / `get_checkpoint(job_id)` / `checkpoint_every(n, job_id, state_fn)` — persist progress at intervals so interrupted jobs resume from last checkpoint |
 | Project-level state persistence (#576) | `DccProject.open(scene_path)` creates/loads `.dcc-mcp/project.json`; mutate via `add_asset`, `activate_skill`, `activate_tool_group`, `add_checkpoint_id`, `update_metadata`; call `register_project_tools(server, ...)` to expose `project_save`, `project_load`, `project_resume`, and `project_status`; use `resume_session()` to recover scene/assets/skills/checkpoints across DCC restarts |
 | Agent-facing docs:// MCP resources (issue #435) | `register_docs_server(server)` — serves `docs://output-format/*` and `docs://skill-authoring/*` resources; agents fetch only specs they need |
-| Agent feedback / rationale (issues #433, #434) | `register_feedback_tool(server)` / `extract_rationale(params)` / `make_rationale_meta(text)` — `dcc_feedback__report` tool + `_meta.dcc.rationale` extraction |
+| Agent feedback / rationale (issues #433, #434, #2257) | `dcc-mcp-cli feedback` / `POST /v1/feedback` remain available without live DCCs; `register_feedback_tool(server)` exposes `dcc_feedback__report` as a shared thin gateway forwarder; `extract_rationale(params)` / `make_rationale_meta(text)` handle `_meta.dcc.rationale` |
 | Runtime DCC namespace introspection (issue #426) | `register_introspect_tools(server)` — `dcc_introspect__list_module`, `dcc_introspect__signature`, `dcc_introspect__search`, `dcc_introspect__eval` |
 | Optional skill metadata extension tools (issue #1229) | `register_metadata_driven_tools(server, skills=..., dcc_name="maya")` — registers optional metadata-driven tools such as recipes and skill reference docs, returning a report with `registered` / `failed` / `skipped` extension outcomes |
 | Skill/domain recipes (issues #428, #616) | `register_recipes_tools(server, skills=...)` — `recipes__list/search/get/validate/apply` tools for Markdown anchors and structured YAML recipe packs |
@@ -652,7 +652,7 @@ Rust `dcc_mcp_models::DccMcpError` enum.
 
 ### Agent Feedback & Rationale (`dcc_mcp_core.feedback`)
 
-- `register_feedback_tool(server, *, dcc_name="dcc")` — register `dcc_feedback__report` MCP tool; call **before** `server.start()`
+- `register_feedback_tool(server, *, dcc_name="dcc", gateway_endpoint=None, gateway_host=None, gateway_port=None, instance_id_provider=None)` — register `dcc_feedback__report` as a fail-closed thin forwarder to gateway `/v1/feedback`; call **before** `server.start()`
 - `extract_rationale(params) -> str | None` — extract `_meta.dcc.rationale` from a `tools/call` params dict
 - `make_rationale_meta(rationale) -> dict` — build the `_meta` fragment for a `tools/call` request with a rationale
 - `get_feedback_entries(*, tool_name=None, severity=None, limit=50) -> list[dict]` — return recent feedback entries (newest first)

--- a/python/dcc_mcp_core/_registration.py
+++ b/python/dcc_mcp_core/_registration.py
@@ -190,21 +190,28 @@ class IntrospectToolsPhase(RegistrationPhase):
 
 
 class FeedbackToolPhase(RegistrationPhase):
-    """Register the ``dcc_feedback__report`` MCP tool."""
+    """Register the shared ``dcc_feedback__report`` gateway forwarder."""
 
     name = "feedback_tool"
 
     def run(self, context: RegistrationContext) -> None:
-        if _run_adapter_extension(context, "_register_feedback_tool"):
-            return
         try:
             from dcc_mcp_core.feedback import register_feedback_tool
         except ImportError:
             return
+        server = context.server
+        config = getattr(server, "_config", None)
+        gateway_port = int(getattr(config, "gateway_port", 0) or 0)
+
+        def instance_id_provider() -> str | None:
+            return server.instance_id
+
         register_feedback_tool(
-            context.server._server,
-            dcc_name=context.server._dcc_name,
-            store=context.server.feedback_store,
+            server._server,
+            dcc_name=server._dcc_name,
+            store=server.feedback_store,
+            gateway_port=gateway_port,
+            instance_id_provider=instance_id_provider,
         )
 
 

--- a/python/dcc_mcp_core/_server/skill_discovery.py
+++ b/python/dcc_mcp_core/_server/skill_discovery.py
@@ -170,6 +170,7 @@ class SkillDiscoveryController:
         """Register standard built-in skills (diagnostics, introspect, etc)."""
         owner = self._owner
         try:
+            gateway_port = int(getattr(owner._config, "gateway_port", 0) or 0)
             register_all_builtin_skills(
                 owner._server,
                 dcc_name=options.dcc_name,
@@ -180,6 +181,8 @@ class SkillDiscoveryController:
                 reload_skills=owner.reload_skill_paths,
                 diagnostic_state=owner.diagnostic_state,
                 feedback_store=owner.feedback_store,
+                gateway_port=gateway_port,
+                instance_id_provider=lambda: owner.instance_id,
             )
         except Exception as exc:
             logger.warning("[%s] built-in skill registration failed: %s", options.dcc_name, exc)

--- a/python/dcc_mcp_core/feedback.py
+++ b/python/dcc_mcp_core/feedback.py
@@ -53,9 +53,15 @@ Example — feedback tool call::
 from __future__ import annotations
 
 import logging
+import os
 import threading
 import time
 from typing import Any
+from typing import Callable
+from urllib.error import HTTPError
+from urllib.error import URLError
+from urllib.request import Request
+from urllib.request import urlopen
 import uuid
 
 from dcc_mcp_core import json_dumps
@@ -63,11 +69,17 @@ from dcc_mcp_core import json_loads
 from dcc_mcp_core._tool_registration import ToolSpec
 from dcc_mcp_core._tool_registration import register_tools
 from dcc_mcp_core.constants import CATEGORY_FEEDBACK
+from dcc_mcp_core.constants import ENV_GATEWAY_HOST
+from dcc_mcp_core.constants import ENV_GATEWAY_PORT
 from dcc_mcp_core.result_envelope import ToolResultEnvelope
 
 logger = logging.getLogger(__name__)
 
 _MAX_FEEDBACK_ENTRIES = 500
+_DEFAULT_GATEWAY_HOST = "127.0.0.1"
+_DEFAULT_GATEWAY_PORT = 9765
+_GATEWAY_FEEDBACK_TIMEOUT_SECS = 5.0
+_GATEWAY_EVENTS_URI = "resources://gateway/events"
 
 
 class FeedbackStore:
@@ -277,6 +289,14 @@ _FEEDBACK_SCHEMA: dict[str, Any] = {
             "enum": ["blocked", "workaround_found", "suggestion"],
             "description": "blocked | workaround_found | suggestion",
         },
+        "request_id": {
+            "type": "string",
+            "description": "Request id of the failed call, when known.",
+        },
+        "job_id": {
+            "type": "string",
+            "description": "Job id of the failed asynchronous operation, when known.",
+        },
     },
     "required": ["tool_name", "intent", "blocker", "severity"],
     "additionalProperties": False,
@@ -289,8 +309,195 @@ _FEEDBACK_TOOL_DESCRIPTION = (
     "can improve the skill. "
     "How to use: set tool_name to the tool that failed, intent to your goal, "
     "attempt to what you tried, blocker to where you got stuck, severity to "
-    "'blocked' / 'workaround_found' / 'suggestion'."
+    "'blocked' / 'workaround_found' / 'suggestion'. The shared Core handler "
+    "forwards the report to the gateway; request_id and job_id may correlate "
+    "the failed operation."
 )
+
+
+def _build_gateway_feedback_endpoint(
+    *,
+    gateway_host: str | None = None,
+    gateway_port: int | None = None,
+) -> str | None:
+    """Build the configured gateway feedback URL, or ``None`` when disabled."""
+    host = gateway_host
+    if host is None:
+        host = os.environ.get(ENV_GATEWAY_HOST, _DEFAULT_GATEWAY_HOST)
+    host = str(host).strip()
+
+    port = gateway_port
+    if port is None:
+        raw_port = os.environ.get(ENV_GATEWAY_PORT, str(_DEFAULT_GATEWAY_PORT)).strip()
+        try:
+            port = int(raw_port)
+        except ValueError:
+            return None
+    if not host or not 0 < int(port) <= 65535:
+        return None
+    if any(marker in host for marker in ("://", "/", "?", "#", "@")):
+        return None
+    if host == "0.0.0.0":
+        host = "127.0.0.1"
+    elif host in {"::", "[::]"}:
+        host = "[::1]"
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"http://{host}:{int(port)}/v1/feedback"
+
+
+def _feedback_error(message: str, error: str, **context: Any) -> str:
+    return ToolResultEnvelope.fail(message, error=error, **context).to_json()
+
+
+def _decode_gateway_response(raw: bytes) -> dict[str, Any] | None:
+    try:
+        payload = json_loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _gateway_error_message(payload: dict[str, Any] | None) -> str:
+    if not payload:
+        return "Gateway rejected the feedback report."
+    error = payload.get("error")
+    if isinstance(error, dict) and isinstance(error.get("message"), str):
+        return error["message"]
+    if isinstance(payload.get("message"), str):
+        return payload["message"]
+    return "Gateway rejected the feedback report."
+
+
+def _handle_gateway_feedback_report(
+    params: str | dict[str, Any],
+    *,
+    dcc_name: str,
+    gateway_endpoint: str | None,
+    instance_id_provider: Callable[[], str | None] | None = None,
+    store: FeedbackStore | None = None,
+) -> str:
+    """Forward one compatibility-tool report to the gateway authority."""
+    try:
+        args = json_loads(params) if isinstance(params, str) else params
+    except (TypeError, ValueError) as exc:
+        return _feedback_error(f"Invalid params: {exc}", "invalid_input")
+    if not isinstance(args, dict):
+        return _feedback_error("Feedback params must be an object.", "invalid_input")
+    if not gateway_endpoint:
+        return _feedback_error(
+            "Gateway feedback is disabled or not configured.",
+            "gateway_feedback_unavailable",
+        )
+
+    report = {
+        name: args[name]
+        for name in ("tool_name", "intent", "attempt", "blocker", "severity", "request_id", "job_id")
+        if name in args and args[name] is not None
+    }
+    report["dcc_type"] = dcc_name
+    if instance_id_provider is not None:
+        try:
+            instance_id = instance_id_provider()
+        except Exception as exc:
+            logger.warning("Could not resolve feedback instance id: %s", exc)
+            return _feedback_error(
+                "The adapter instance id is unavailable.",
+                "feedback_instance_unavailable",
+            )
+        if not instance_id:
+            return _feedback_error(
+                "The adapter instance id is unavailable.",
+                "feedback_instance_unavailable",
+            )
+        report["instance_id"] = str(instance_id)
+
+    transport_request_id = str(uuid.uuid4())
+    try:
+        request = Request(
+            gateway_endpoint,
+            data=json_dumps(report).encode("utf-8"),
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "X-Request-ID": transport_request_id,
+            },
+            method="POST",
+        )
+        with urlopen(request, timeout=_GATEWAY_FEEDBACK_TIMEOUT_SECS) as response:
+            status = int(getattr(response, "status", 0) or 0)
+            echoed_request_id = response.headers.get("X-Request-ID")
+            payload = _decode_gateway_response(response.read())
+    except HTTPError as exc:
+        echoed_request_id = exc.headers.get("X-Request-ID") if exc.headers is not None else None
+        if echoed_request_id != transport_request_id:
+            return _feedback_error(
+                "Gateway feedback response did not match the request.",
+                "transport_desync",
+            )
+        payload = _decode_gateway_response(exc.read())
+        return _feedback_error(
+            _gateway_error_message(payload),
+            "gateway_feedback_rejected",
+            status_code=int(exc.code),
+        )
+    except (URLError, OSError, TimeoutError, ValueError) as exc:
+        logger.warning("Gateway feedback forwarding failed: %s", exc)
+        return _feedback_error(
+            "Gateway feedback endpoint is unavailable.",
+            "gateway_feedback_unavailable",
+        )
+
+    if echoed_request_id != transport_request_id:
+        return _feedback_error(
+            "Gateway feedback response did not match the request.",
+            "transport_desync",
+        )
+    if status != 201 or payload is None or payload.get("ok") is not True or payload.get("success") is not True:
+        return _feedback_error(
+            _gateway_error_message(payload),
+            "gateway_feedback_invalid_receipt",
+            status_code=status,
+        )
+
+    feedback_id = payload.get("feedback_id")
+    event_resource_uri = payload.get("event_resource_uri")
+    recorded_at = payload.get("recorded_at")
+    try:
+        parsed_feedback_id = uuid.UUID(feedback_id) if isinstance(feedback_id, str) else None
+    except (ValueError, AttributeError):
+        parsed_feedback_id = None
+    if (
+        parsed_feedback_id is None
+        or event_resource_uri != _GATEWAY_EVENTS_URI
+        or not isinstance(recorded_at, str)
+        or not recorded_at
+    ):
+        return _feedback_error(
+            "Gateway returned an invalid feedback receipt.",
+            "gateway_feedback_invalid_receipt",
+        )
+
+    _store_feedback(
+        {
+            "id": feedback_id,
+            "timestamp": time.time(),
+            **report,
+        },
+        store=store,
+    )
+    logger.info(
+        "dcc_feedback__report forwarded: id=%s tool=%s severity=%s",
+        feedback_id,
+        report.get("tool_name", ""),
+        report.get("severity", ""),
+    )
+    return ToolResultEnvelope.ok(
+        "Feedback recorded at the gateway.",
+        feedback_id=feedback_id,
+        recorded_at=recorded_at,
+        event_resource_uri=event_resource_uri,
+    ).to_json()
 
 
 def _handle_feedback_report(params: str, *, store: FeedbackStore | None = None) -> str:
@@ -327,6 +534,10 @@ def register_feedback_tool(
     *,
     dcc_name: str = "dcc",
     store: FeedbackStore | None = None,
+    gateway_endpoint: str | None = None,
+    gateway_host: str | None = None,
+    gateway_port: int | None = None,
+    instance_id_provider: Callable[[], str | None] | None = None,
 ) -> None:
     """Register the ``dcc_feedback__report`` MCP tool on *server*.
 
@@ -342,7 +553,16 @@ def register_feedback_tool(
     dcc_name:
         DCC name string used in the tool's ``dcc`` metadata field.
     store:
-        Instance-owned store captured by the registered handler.
+        Optional compatibility mirror updated only after gateway acceptance.
+    gateway_endpoint:
+        Explicit gateway ``/v1/feedback`` URL. When omitted, it is built from
+        ``gateway_host`` / ``gateway_port`` or their environment defaults.
+    gateway_host:
+        Optional configured gateway host used when no endpoint is supplied.
+    gateway_port:
+        Optional configured gateway port; ``0`` disables the forwarder.
+    instance_id_provider:
+        Optional late-bound provider for the live adapter instance id.
 
     Example
     -------
@@ -359,10 +579,20 @@ def register_feedback_tool(
         handle = server.start()
 
     """
+    resolved_endpoint = gateway_endpoint or _build_gateway_feedback_endpoint(
+        gateway_host=gateway_host,
+        gateway_port=gateway_port,
+    )
 
     def _mcp_handler(params: Any) -> Any:
         params_str = json_dumps(params) if not isinstance(params, str) else params
-        result_str = _handle_feedback_report(params_str, store=store)
+        result_str = _handle_gateway_feedback_report(
+            params_str,
+            dcc_name=dcc_name,
+            gateway_endpoint=resolved_endpoint,
+            instance_id_provider=instance_id_provider,
+            store=store,
+        )
         try:
             return json_loads(result_str)
         except (TypeError, ValueError):

--- a/python/dcc_mcp_core/skills/builtin.py
+++ b/python/dcc_mcp_core/skills/builtin.py
@@ -36,6 +36,9 @@ def register_all_builtin_skills(
     skills: list[Any] | None = None,
     diagnostic_state: DiagnosticRuntimeState | None = None,
     feedback_store: FeedbackStore | None = None,
+    gateway_endpoint: str | None = None,
+    gateway_port: int | None = None,
+    instance_id_provider: Callable[[], str | None] | None = None,
 ) -> None:
     """Register all standard built-in tools on *server*.
 
@@ -77,7 +80,14 @@ def register_all_builtin_skills(
     register_introspect_tools(server, dcc_name=dcc_name)
 
     # 3. Agent feedback
-    register_feedback_tool(server, dcc_name=dcc_name, store=feedback_store)
+    register_feedback_tool(
+        server,
+        dcc_name=dcc_name,
+        store=feedback_store,
+        gateway_endpoint=gateway_endpoint,
+        gateway_port=gateway_port,
+        instance_id_provider=instance_id_provider,
+    )
 
     # 4. Recipes (skills default to empty at base init; adapters re-register
     #    with the scanned skill set later — registration is idempotent).

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -322,9 +322,10 @@ contract failures to `dcc-mcp-core`. Tool schema/script/workflow defects belong
 to the owning Skill and `dcc-mcp-skills-creator`. Record runtime feedback with
 the gateway-owned `dcc-mcp-cli feedback` command so the report remains possible
 after an adapter or DCC process exits; include the last known instance,
-request, and job ids. Treat instance-level `dcc_feedback__report` as a
-live-adapter compatibility path. Open an external issue only with user
-authorization.
+request, and job ids. Instance-level `dcc_feedback__report` is a live-adapter
+compatibility entry point, but Core must register it as the shared thin gateway
+forwarder; never add an adapter-specific feedback action or local-success
+fallback. Open an external issue only with user authorization.
 
 ## Example: New Nuke Adapter
 

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -344,7 +344,9 @@ skill without the task owner's requested scope.
 For a failed task, first use the `dcc-mcp` recovery flow: retain the
 `request_id`, run `doctor` for runtime/readiness faults, query
 `stats --status failure --session-id <session-id>`, and record structured
-feedback through the CLI-discovered `dcc_feedback__report` tool. The public-safe
+feedback through the gateway-owned `dcc-mcp-cli feedback` command. A live
+adapter's `dcc_feedback__report` is only a shared Core forwarder to that same
+gateway contract. The public-safe
 `/v1/debug/issue-reports/<request_id>` payload is suitable for a reviewed issue;
 never publish `?mode=raw` automatically.
 

--- a/skills/dcc-mcp/SKILL.md
+++ b/skills/dcc-mcp/SKILL.md
@@ -445,7 +445,7 @@ dcc-mcp-cli feedback --tool-name maya_geometry__create_sphere --intent "Create a
   --request-id <request-id>
 ```
 
-Use `doctor` for profile, registry, daemon, binary, and readiness failures. For a tool failure, refresh `describe`, compare the schema/annotations with the attempt, inspect failure-only stats, and call the gateway-owned `feedback` command. Its severity is `blocked`, `workaround_found`, or `suggestion`; it remains available after the target instance exits, records a bounded entry in `resources://gateway/events`, and does not create an external issue. Use instance-level `dcc_feedback__report` only as a live-adapter compatibility path.
+Use `doctor` for profile, registry, daemon, binary, and readiness failures. For a tool failure, refresh `describe`, compare the schema/annotations with the attempt, inspect failure-only stats, and call the gateway-owned `feedback` command. Its severity is `blocked`, `workaround_found`, or `suggestion`; it remains available after the target instance exits, records a bounded entry in `resources://gateway/events`, and does not create an external issue. Instance-level `dcc_feedback__report` is only a live-adapter compatibility entry point and Core forwards it to the same gateway contract; it has no local-success fallback.
 
 For a gateway-routed failure, use the CLI-returned `request_id` to read `/v1/debug/agent-traces/<request_id>` and public-safe `/v1/debug/issue-reports/<request_id>`. The latter supplies a bounded summary and suggested GitHub title/body. Never publish `?mode=raw` without human review; create an external issue only with user authorization.
 

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -59,12 +59,18 @@ def test_register_all_builtin_skills_runs_every_step(monkeypatch):
 
     diagnostic_state = DiagnosticRuntimeState("maya")
     feedback_store = FeedbackStore()
+
+    def instance_id_provider():
+        return "maya-instance-1"
+
     builtin.register_all_builtin_skills(
         _make_server(),
         dcc_name="maya",
         reload_skills=lambda: 0,
         diagnostic_state=diagnostic_state,
         feedback_store=feedback_store,
+        gateway_endpoint="http://127.0.0.1:19765/v1/feedback",
+        instance_id_provider=instance_id_provider,
     )
 
     # Every step, including the two that previously got skipped after the
@@ -75,6 +81,8 @@ def test_register_all_builtin_skills_runs_every_step(monkeypatch):
     assert recipes_kwargs["skills"] == []
     assert diagnostics_kwargs["diagnostic_state"] is diagnostic_state
     assert feedback_kwargs["store"] is feedback_store
+    assert feedback_kwargs["gateway_endpoint"] == "http://127.0.0.1:19765/v1/feedback"
+    assert feedback_kwargs["instance_id_provider"] is instance_id_provider
 
 
 def test_register_all_builtin_skills_forwards_skills(monkeypatch):

--- a/tests/test_dcc_adapter_base.py
+++ b/tests/test_dcc_adapter_base.py
@@ -565,12 +565,14 @@ class TestDccServerBase:
         monkeypatch.setattr("dcc_mcp_core._server.skill_discovery.register_all_builtin_skills", mock_register)
         monkeypatch.setattr("dcc_mcp_core.server_base.create_adapter_server", MagicMock())
 
-        opts = DccServerOptions.from_env("maya", tmp_path, port=0, gateway_port=0)
+        opts = DccServerOptions.from_env("maya", tmp_path, port=0, gateway_port=19765)
         _ = DccServerBase(opts)
 
         assert len(calls) == 1
         assert "dcc_name" in calls[0][1]
         assert calls[0][1]["dcc_name"] == "maya"
+        assert calls[0][1]["gateway_port"] == 19765
+        assert calls[0][1]["instance_id_provider"]() is None
 
     def test_start_enables_gateway_election_through_runtime_controller(self, tmp_path, monkeypatch):
         server = self._make_server(tmp_path)

--- a/tests/test_feedback_and_rationale.py
+++ b/tests/test_feedback_and_rationale.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 from unittest.mock import MagicMock
+import urllib.error
 
 import pytest
 
@@ -198,6 +199,20 @@ def test_feedback_invalid_params():
 # ── register_feedback_tool ────────────────────────────────────────────────
 
 
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("0.0.0.0", "http://127.0.0.1:19765/v1/feedback"),
+        ("::", "http://[::1]:19765/v1/feedback"),
+        ("::1", "http://[::1]:19765/v1/feedback"),
+    ],
+)
+def test_gateway_feedback_endpoint_uses_a_connectable_loopback(host, expected):
+    from dcc_mcp_core.feedback import _build_gateway_feedback_endpoint
+
+    assert _build_gateway_feedback_endpoint(gateway_host=host, gateway_port=19765) == expected
+
+
 def test_register_feedback_tool_registers_name():
     from dcc_mcp_core.feedback import register_feedback_tool
 
@@ -216,18 +231,111 @@ def test_register_feedback_tool_registers_name():
     assert name_arg == "dcc_feedback__report"
 
 
-def test_registered_feedback_handler_uses_injected_store():
+class _GatewayResponse:
+    def __init__(self, payload, *, request_id):
+        self.status = 201
+        self.headers = {"X-Request-ID": request_id}
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+@pytest.mark.parametrize("dcc_name", ["maya", "3dsmax", "houdini"])
+def test_registered_feedback_handler_forwards_through_one_gateway_implementation(monkeypatch, dcc_name):
+    import dcc_mcp_core.feedback as feedback_module
     from dcc_mcp_core.feedback import FeedbackStore
     from dcc_mcp_core.feedback import get_feedback_entries
     from dcc_mcp_core.feedback import register_feedback_tool
 
+    requests = []
+
+    def _urlopen(request, *, timeout):
+        requests.append((request, timeout))
+        headers = {name.lower(): value for name, value in request.header_items()}
+        return _GatewayResponse(
+            {
+                "ok": True,
+                "success": True,
+                "feedback_id": "11111111-1111-4111-8111-111111111111",
+                "recorded_at": "2026-08-24T00:00:00.000Z",
+                "event_resource_uri": "resources://gateway/events",
+            },
+            request_id=headers["x-request-id"],
+        )
+
+    monkeypatch.setattr(feedback_module, "urlopen", _urlopen)
     store = FeedbackStore()
     server = MagicMock()
     server.registry = MagicMock()
-    register_feedback_tool(server, dcc_name="photoshop", store=store)
+    register_feedback_tool(
+        server,
+        dcc_name=dcc_name,
+        store=store,
+        gateway_endpoint="http://127.0.0.1:19765/v1/feedback",
+        instance_id_provider=lambda: f"{dcc_name}-instance-1",
+    )
     handler = server.register_handler.call_args.args[1]
 
-    handler(
+    result = handler(
+        {
+            "tool_name": f"{dcc_name}_scene__save",
+            "intent": "Save the scene",
+            "blocker": "The save action returned no artifact",
+            "severity": "blocked",
+            "request_id": "failed-request-42",
+            "job_id": "failed-job-42",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["context"]["feedback_id"] == "11111111-1111-4111-8111-111111111111"
+    assert result["context"]["event_resource_uri"] == "resources://gateway/events"
+    assert len(requests) == 1
+    request, timeout = requests[0]
+    assert request.full_url == "http://127.0.0.1:19765/v1/feedback"
+    assert timeout == 5.0
+    body = json.loads(request.data.decode("utf-8"))
+    assert body == {
+        "tool_name": f"{dcc_name}_scene__save",
+        "intent": "Save the scene",
+        "blocker": "The save action returned no artifact",
+        "severity": "blocked",
+        "request_id": "failed-request-42",
+        "job_id": "failed-job-42",
+        "dcc_type": dcc_name,
+        "instance_id": f"{dcc_name}-instance-1",
+    }
+    assert get_feedback_entries(store=store)[0]["id"] == "11111111-1111-4111-8111-111111111111"
+
+
+def test_registered_feedback_handler_fails_closed_when_gateway_is_unavailable(monkeypatch):
+    import dcc_mcp_core.feedback as feedback_module
+    from dcc_mcp_core.feedback import FeedbackStore
+    from dcc_mcp_core.feedback import get_feedback_entries
+    from dcc_mcp_core.feedback import register_feedback_tool
+
+    def _urlopen(*_args, **_kwargs):
+        raise urllib.error.URLError("gateway offline")
+
+    monkeypatch.setattr(feedback_module, "urlopen", _urlopen)
+    store = FeedbackStore()
+    server = MagicMock()
+    server.registry = MagicMock()
+    register_feedback_tool(
+        server,
+        dcc_name="photoshop",
+        store=store,
+        gateway_endpoint="http://127.0.0.1:19765/v1/feedback",
+    )
+
+    result = server.register_handler.call_args.args[1](
         {
             "tool_name": "photoshop_layers__merge",
             "intent": "Merge layers",
@@ -236,7 +344,193 @@ def test_registered_feedback_handler_uses_injected_store():
         }
     )
 
-    assert get_feedback_entries(store=store)[0]["tool_name"] == "photoshop_layers__merge"
+    assert result["success"] is False
+    assert result["error"] == "gateway_feedback_unavailable"
+    assert get_feedback_entries(store=store) == []
+
+
+def test_registered_feedback_handler_rejects_desynchronized_gateway_receipt(monkeypatch):
+    import dcc_mcp_core.feedback as feedback_module
+    from dcc_mcp_core.feedback import register_feedback_tool
+
+    monkeypatch.setattr(
+        feedback_module,
+        "urlopen",
+        lambda *_args, **_kwargs: _GatewayResponse(
+            {
+                "ok": True,
+                "success": True,
+                "feedback_id": "11111111-1111-4111-8111-111111111111",
+                "recorded_at": "2026-08-24T00:00:00.000Z",
+                "event_resource_uri": "resources://gateway/events",
+            },
+            request_id="stale-request-id",
+        ),
+    )
+    server = MagicMock()
+    server.registry = MagicMock()
+    register_feedback_tool(
+        server,
+        dcc_name="zbrush",
+        gateway_endpoint="http://127.0.0.1:19765/v1/feedback",
+    )
+
+    result = server.register_handler.call_args.args[1](
+        {
+            "tool_name": "zbrush_document__save",
+            "intent": "Save the document",
+            "blocker": "The response belonged to an earlier call",
+            "severity": "blocked",
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "transport_desync"
+
+
+def test_registered_feedback_handler_rejects_invalid_gateway_receipt(monkeypatch):
+    import dcc_mcp_core.feedback as feedback_module
+    from dcc_mcp_core.feedback import register_feedback_tool
+
+    def _urlopen(request, **_kwargs):
+        headers = {name.lower(): value for name, value in request.header_items()}
+        return _GatewayResponse(
+            {
+                "ok": False,
+                "success": True,
+                "feedback_id": "not-a-feedback-uuid",
+                "recorded_at": "2026-08-24T00:00:00.000Z",
+                "event_resource_uri": "resources://gateway/events",
+            },
+            request_id=headers["x-request-id"],
+        )
+
+    monkeypatch.setattr(feedback_module, "urlopen", _urlopen)
+    server = MagicMock()
+    server.registry = MagicMock()
+    register_feedback_tool(
+        server,
+        dcc_name="maya",
+        gateway_endpoint="http://127.0.0.1:19765/v1/feedback",
+    )
+
+    result = server.register_handler.call_args.args[1](
+        {
+            "tool_name": "maya_scene__save",
+            "intent": "Save the scene",
+            "blocker": "The gateway returned an invalid receipt",
+            "severity": "blocked",
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "gateway_feedback_invalid_receipt"
+
+
+def test_registered_feedback_handler_surfaces_correlated_gateway_rejection(monkeypatch):
+    import io
+
+    import dcc_mcp_core.feedback as feedback_module
+    from dcc_mcp_core.feedback import register_feedback_tool
+
+    def _urlopen(request, **_kwargs):
+        headers = {name.lower(): value for name, value in request.header_items()}
+        raise urllib.error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            {"X-Request-ID": headers["x-request-id"]},
+            io.BytesIO(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "success": False,
+                        "error": {
+                            "kind": "invalid-feedback",
+                            "message": "intent must not be empty",
+                        },
+                    }
+                ).encode("utf-8")
+            ),
+        )
+
+    monkeypatch.setattr(feedback_module, "urlopen", _urlopen)
+    server = MagicMock()
+    server.registry = MagicMock()
+    register_feedback_tool(
+        server,
+        dcc_name="maya",
+        gateway_endpoint="http://127.0.0.1:19765/v1/feedback",
+    )
+
+    result = server.register_handler.call_args.args[1](
+        {
+            "tool_name": "maya_scene__save",
+            "intent": "",
+            "blocker": "The report is invalid",
+            "severity": "blocked",
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "gateway_feedback_rejected"
+    assert result["message"] == "intent must not be empty"
+    assert result["context"]["status_code"] == 400
+
+
+def test_registered_feedback_handler_fails_closed_for_malformed_gateway_endpoint():
+    from dcc_mcp_core.feedback import register_feedback_tool
+
+    server = MagicMock()
+    server.registry = MagicMock()
+    register_feedback_tool(
+        server,
+        dcc_name="custom-host",
+        gateway_endpoint="not a valid gateway URL",
+    )
+
+    result = server.register_handler.call_args.args[1](
+        {
+            "tool_name": "custom_scene__save",
+            "intent": "Save the scene",
+            "blocker": "No receipt was returned",
+            "severity": "blocked",
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "gateway_feedback_unavailable"
+
+
+def test_registered_feedback_handler_requires_bound_instance_when_provider_is_configured(monkeypatch):
+    import dcc_mcp_core.feedback as feedback_module
+    from dcc_mcp_core.feedback import register_feedback_tool
+
+    monkeypatch.setattr(
+        feedback_module,
+        "urlopen",
+        lambda *_args, **_kwargs: pytest.fail("unbound feedback must not reach the gateway"),
+    )
+    server = MagicMock()
+    server.registry = MagicMock()
+    register_feedback_tool(
+        server,
+        dcc_name="maya",
+        gateway_endpoint="http://127.0.0.1:19765/v1/feedback",
+        instance_id_provider=lambda: None,
+    )
+
+    result = server.register_handler.call_args.args[1](
+        {
+            "tool_name": "maya_scene__save",
+            "intent": "Save the scene",
+            "blocker": "The adapter instance is not bound",
+            "severity": "blocked",
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "feedback_instance_unavailable"
 
 
 def test_register_feedback_tool_no_registry():

--- a/tests/test_registration_pipeline.py
+++ b/tests/test_registration_pipeline.py
@@ -151,6 +151,8 @@ def test_host_hook_override_is_dispatched() -> None:
     phases = get_standard_phases()
 
     for phase in phases:
+        if phase.name == "feedback_tool":
+            continue
         phase.run(context)
 
     assert server.calls == [
@@ -158,13 +160,43 @@ def test_host_hook_override_is_dispatched() -> None:
         "strict",
         "metadata",
         "introspect",
-        "feedback",
         "qt",
         "manifest",
         "project",
         "resources",
         "ready",
     ]
+
+
+def test_feedback_phase_uses_shared_core_forwarder_instead_of_adapter_override(monkeypatch) -> None:
+    """Feedback registration must not dispatch host-specific legacy actions."""
+    from types import SimpleNamespace
+
+    from dcc_mcp_core._registration import FeedbackToolPhase
+    import dcc_mcp_core.feedback as feedback
+
+    calls = []
+
+    class AdapterServer:
+        _config = SimpleNamespace(gateway_port=19765)
+        _dcc_name = "maya"
+        _server = object()
+        feedback_store = object()
+        instance_id = "maya-instance-1"
+
+        def _register_feedback_tool(self, _context):
+            raise AssertionError("adapter-specific feedback registration must be ignored")
+
+    monkeypatch.setattr(feedback, "register_feedback_tool", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    FeedbackToolPhase().run(RegistrationContext(server=AdapterServer()))
+
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+    assert args == (AdapterServer._server,)
+    assert kwargs["dcc_name"] == "maya"
+    assert kwargs["gateway_port"] == 19765
+    assert kwargs["instance_id_provider"]() == "maya-instance-1"
 
 
 def test_standard_phases_accept_real_dcc_server_base(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- route live-adapter dcc_feedback__report calls through the gateway-owned feedback endpoint
- intercept the generic sidecar path before host RPC and bind trusted DCC and instance identity
- fail closed on unavailable, rejected, stale, or malformed gateway responses and document request correlation

## Validation
- cargo test -p dcc-mcp-sidecar -- --test-threads=1
- cargo test -p dcc-mcp-gateway feedback -- --test-threads=1
- just clippy
- just check-py37-syntax
- just lint-py
- just lint-skills
- targeted Python tests: 132 passed
- VitePress docs build

Fixes #2257