### PR TITLE
fix: log registry membership changes only

### DIFF
--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -21,6 +21,9 @@ use super::types::{
 };
 use crate::error::{TransportError, TransportResult};
 
+mod membership;
+use membership::membership_delta;
+
 /// File name for the registry JSON.
 const REGISTRY_FILE: &str = "services.json";
 const REGISTRY_LOCK_FILE: &str = "services.lock";
@@ -1348,6 +1351,9 @@ impl FileRegistry {
     /// concurrent `rename` returns `PermissionDenied` to the reader.
     fn load_from_file(&self) -> TransportResult<()> {
         let entries = self.read_entries_from_file()?;
+        let current = entries_to_map(self.list_all_in_memory());
+        let loaded = entries_to_map(entries.iter().cloned());
+        let (added, removed) = membership_delta(&current, &loaded);
         if entries.is_empty() && !self.services.is_empty() {
             tracing::warn!(
                 path = %self.registry_file_path().display(),
@@ -1355,8 +1361,14 @@ impl FileRegistry {
             );
         }
         self.replace_services(&entries);
-
-        tracing::debug!(count = self.services.len(), "loaded services from file");
+        if added > 0 || removed > 0 {
+            tracing::debug!(
+                count = loaded.len(),
+                added,
+                removed,
+                "registry membership changed"
+            );
+        }
         Ok(())
     }
 
@@ -1483,3 +1495,6 @@ impl FileRegistry {
 #[cfg(test)]
 #[path = "file_registry_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+mod logging_tests;

--- a/crates/dcc-mcp-transport/src/discovery/file_registry/logging_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry/logging_tests.rs
@@ -1,0 +1,86 @@
+use super::*;
+use std::{collections::HashMap, fmt, sync::Arc};
+use tracing::{
+    Event, Metadata, Subscriber,
+    field::{Field, Visit},
+    span::{Attributes, Id, Record},
+};
+
+#[derive(Clone, Default)]
+struct EventRecorder {
+    events: Arc<Mutex<Vec<HashMap<String, String>>>>,
+}
+
+#[derive(Default)]
+struct FieldRecorder(HashMap<String, String>);
+
+impl Visit for FieldRecorder {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.0.insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.0.insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.0.insert(field.name().to_owned(), format!("{value:?}"));
+    }
+}
+
+impl Subscriber for EventRecorder {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _span: &Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut fields = FieldRecorder::default();
+        event.record(&mut fields);
+        self.events.lock().unwrap().push(fields.0);
+    }
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+#[test]
+fn duplicate_service_keys_log_the_loaded_membership_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+    let first = ServiceEntry::new("maya", "127.0.0.1", 18812);
+    let mut duplicate = first.clone();
+    duplicate.port = 18813;
+    duplicate.touch();
+    std::fs::write(
+        registry.registry_file_path(),
+        serde_json::to_string(&[first, duplicate]).unwrap(),
+    )
+    .unwrap();
+
+    let recorder = EventRecorder::default();
+    let dispatch = tracing::Dispatch::new(recorder.clone());
+    tracing::dispatcher::with_default(&dispatch, || registry.load_from_file().unwrap());
+
+    assert_eq!(registry.len(), 1, "duplicate keys collapse to one member");
+    let events = recorder.events.lock().unwrap();
+    let fields = events
+        .iter()
+        .find(|fields| {
+            fields
+                .get("message")
+                .is_some_and(|message| message.contains("registry membership changed"))
+        })
+        .expect("membership change event");
+    assert_eq!(fields.get("count").map(String::as_str), Some("1"));
+    assert_eq!(fields.get("added").map(String::as_str), Some("1"));
+    assert_eq!(fields.get("removed").map(String::as_str), Some("0"));
+}

--- a/crates/dcc-mcp-transport/src/discovery/file_registry/membership.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry/membership.rs
@@ -1,0 +1,13 @@
+use super::EntryMap;
+
+pub(super) fn membership_delta(current: &EntryMap, loaded: &EntryMap) -> (usize, usize) {
+    let added = loaded
+        .keys()
+        .filter(|key| !current.contains_key(*key))
+        .count();
+    let removed = current
+        .keys()
+        .filter(|key| !loaded.contains_key(*key))
+        .count();
+    (added, removed)
+}

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -41,6 +41,23 @@ fn temp_registry_file_names(dir: &std::path::Path) -> Vec<String> {
 }
 
 #[test]
+fn test_membership_delta_ignores_metadata_only_changes() {
+    let original = ServiceEntry::new("maya", "127.0.0.1", 18812);
+    let mut refreshed = original.clone();
+    refreshed.port = 18813;
+    refreshed.touch();
+
+    let current = entries_to_map([original]);
+    let refreshed = entries_to_map([refreshed]);
+    assert_eq!(membership_delta(&current, &refreshed), (0, 0));
+
+    let added = ServiceEntry::new("blender", "127.0.0.1", 9090);
+    let expanded = entries_to_map(refreshed.into_values().chain([added]));
+    assert_eq!(membership_delta(&current, &expanded), (1, 0));
+    assert_eq!(membership_delta(&expanded, &current), (0, 1));
+}
+
+#[test]
 fn test_file_registry_register_and_list() {
     let dir = tempfile::tempdir().unwrap();
     let registry = FileRegistry::new(dir.path()).unwrap();


### PR DESCRIPTION
## Summary

- Compare FileRegistry snapshots by `ServiceKey` membership, so heartbeat and metadata refreshes stay quiet.
- Emit one DEBUG event only for real membership changes, with stable `added`, `removed`, and actual loaded-member `count` fields.
- Cover duplicate accepted keys through the real tracing event path, where two rows collapse to one live member.

## Validation

- Red: duplicate `ServiceKey` rows emitted `count=2` while the loaded registry contained one member.
- Green: the captured event reports `count=1`, `added=1`, and `removed=0`.
- `vx just preflight` — workspace checks, Clippy, formatting, 3,739/3,739 nextest tests, and doc tests passed.
- `vx cargo test -p dcc-mcp-transport` — 217 unit, 7 fault-injection, and 3 turmoil tests passed.
- `vx cargo clippy -p dcc-mcp-transport --all-targets -- -D warnings`
- Rust file-size checks passed; `file_registry.rs` is 1,500 lines and the tracing regression module is 86 lines, with no exemption.

No public API, skill guidance, or documentation contract changed. No real DCC, operator gateway, or external service was used.

Fixes #2276
