### PR TITLE
fix(ci): provision Python 3.7 smoke dependencies

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -151,6 +151,11 @@ jobs:
           --platform any
           dist/*.whl
         shell: bash
+      - name: Provision Python 3.7 smoke dependencies
+        shell: bash
+        run: |
+          TYPING_EXTENSIONS_VERSION="$(python -c 'import json; print(json.load(open(".workflow-tools/compatibility/python.json", encoding="utf-8"))["test_toolchain"]["typing_extensions"])')"
+          python -m pip install --disable-pip-version-check "typing-extensions==${TYPING_EXTENSIONS_VERSION}"
       - name: Test py37-lite wheel
         shell: bash
         run: |
@@ -204,6 +209,11 @@ jobs:
           --profile native_py37
           --platform linux-x86_64
           dist/*.whl
+      - name: Provision Python 3.7 smoke dependencies
+        shell: bash
+        run: |
+          TYPING_EXTENSIONS_VERSION="$(python -c 'import json; print(json.load(open(".workflow-tools/compatibility/python.json", encoding="utf-8"))["test_toolchain"]["typing_extensions"])')"
+          python -m pip install --disable-pip-version-check "typing-extensions==${TYPING_EXTENSIONS_VERSION}"
       - name: Test native Python 3.7 wheel with workflow smoke
         shell: bash
         run: |
@@ -244,6 +254,11 @@ jobs:
           --profile native_py37
           --platform windows-x86_64
           dist/*.whl
+      - name: Provision Python 3.7 smoke dependencies
+        shell: bash
+        run: |
+          TYPING_EXTENSIONS_VERSION="$(python -c 'import json; print(json.load(open(".workflow-tools/compatibility/python.json", encoding="utf-8"))["test_toolchain"]["typing_extensions"])')"
+          python -m pip install --disable-pip-version-check "typing-extensions==${TYPING_EXTENSIONS_VERSION}"
       - name: Test native Python 3.7 wheel with workflow smoke
         shell: bash
         run: |

--- a/tests/test_build_wheels_workflow.py
+++ b/tests/test_build_wheels_workflow.py
@@ -83,3 +83,26 @@ def test_release_wheels_are_uploaded_once_after_every_build() -> None:
         "overwrite_files": False,
         "fail_on_unmatched_files": True,
     }
+
+
+def test_python37_runtime_smokes_provision_workflow_owned_typing_extensions() -> None:
+    smoke_steps = {
+        "py37-lite": "Test py37-lite wheel",
+        "linux-py37": "Test native Python 3.7 wheel with workflow smoke",
+        "windows-py37": "Test native Python 3.7 wheel with workflow smoke",
+    }
+
+    for job_id, smoke_step_name in smoke_steps.items():
+        steps = _jobs()[job_id]["steps"]
+        provision_index, provision = next(
+            (index, step)
+            for index, step in enumerate(steps)
+            if step.get("name") == "Provision Python 3.7 smoke dependencies"
+        )
+        smoke_index = next(index for index, step in enumerate(steps) if step.get("name") == smoke_step_name)
+
+        assert provision_index < smoke_index
+        command = provision["run"]
+        assert ".workflow-tools/compatibility/python.json" in command
+        assert '["test_toolchain"]["typing_extensions"]' in command
+        assert '"typing-extensions==${TYPING_EXTENSIONS_VERSION}"' in command


### PR DESCRIPTION
Summary: Install the workflow-contract-pinned typing-extensions version before every Python 3.7 no-deps runtime smoke, covering lite, Linux native, and Windows native wheel jobs. This changes only current workflow validation and preserves immutable release tag contents. Validation: 22 focused tests passed; Python support contract passed; Ruff passed; git diff check passed. Agent skill guidance: no update needed because public APIs and runtime behavior are unchanged. After merge, rerun the existing v0.20.10 immutable-tag backfill.