### PR TITLE
fix: reduce idle HTTP log noise

### DIFF
--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -1,11 +1,17 @@
 //! The main `McpHttpServer` type.
 
 use axum::{Json, Router, routing};
+use http::{Request, Response, StatusCode};
 use parking_lot::RwLock;
 use serde_json::json;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 use tokio::{net::TcpListener, sync::watch, task::JoinHandle};
+use tower_http::classify::{
+    ClassifiedResponse, ClassifyResponse, MakeClassifier, NeverClassifyEos, ServerErrorsAsFailures,
+    ServerErrorsFailureClass,
+};
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
@@ -26,6 +32,55 @@ mod background_impl;
 #[cfg(feature = "auto-gateway")]
 mod gateway_impl;
 mod spawn_impl;
+
+/// Request-aware HTTP failure classification for the server trace layer.
+///
+/// A `503 Service Unavailable` is the documented, structured response while
+/// `/v1/readyz` is red. It is a routine probe result, not a transport or
+/// handler failure. Every other server error keeps tower-http's default
+/// failure classification.
+#[derive(Clone, Copy, Debug, Default)]
+struct HttpTraceClassifier;
+
+#[derive(Clone, Copy, Debug)]
+struct HttpResponseClassifier {
+    readyz: bool,
+}
+
+impl MakeClassifier for HttpTraceClassifier {
+    type Classifier = HttpResponseClassifier;
+    type FailureClass = ServerErrorsFailureClass;
+    type ClassifyEos = NeverClassifyEos<ServerErrorsFailureClass>;
+
+    fn make_classifier<B>(&self, request: &Request<B>) -> Self::Classifier {
+        HttpResponseClassifier {
+            readyz: request.uri().path() == "/v1/readyz",
+        }
+    }
+}
+
+impl ClassifyResponse for HttpResponseClassifier {
+    type FailureClass = ServerErrorsFailureClass;
+    type ClassifyEos = NeverClassifyEos<ServerErrorsFailureClass>;
+
+    fn classify_response<B>(
+        self,
+        response: &Response<B>,
+    ) -> ClassifiedResponse<Self::FailureClass, Self::ClassifyEos> {
+        if self.readyz && response.status() == StatusCode::SERVICE_UNAVAILABLE {
+            ClassifiedResponse::Ready(Ok(()))
+        } else {
+            ServerErrorsAsFailures::new().classify_response(response)
+        }
+    }
+
+    fn classify_error<E>(self, error: &E) -> Self::FailureClass
+    where
+        E: fmt::Display + 'static,
+    {
+        ServerErrorsAsFailures::new().classify_error(error)
+    }
+}
 
 /// Live DCC instance metadata that is propagated to `FileRegistry` on every
 /// heartbeat tick so that `list_dcc_instances` always shows current state.
@@ -593,7 +648,7 @@ impl McpHttpServer {
             .layer(RequestBodyLimitLayer::new(
                 self.config.queue.max_request_body_bytes,
             ))
-            .layer(TraceLayer::new_for_http());
+            .layer(TraceLayer::new(HttpTraceClassifier));
 
         // Prometheus `/metrics` endpoint (issue #331). Mounted on the
         // same router so scrapers share the MCP server's listening

--- a/crates/dcc-mcp-http/src/server/tests.rs
+++ b/crates/dcc-mcp-http/src/server/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use http::{Request, Response, StatusCode};
+use tower_http::classify::{ClassifiedResponse, ClassifyResponse, MakeClassifier};
 
 #[cfg(feature = "auto-gateway")]
 fn unused_local_port() -> u16 {
@@ -78,4 +80,35 @@ async fn instance_id_matches_the_registered_service_key() {
     assert_eq!(instance_id, entries[0].instance_id);
 
     handle.shutdown().await;
+}
+
+fn classify_http_response(path: &str, status: StatusCode) -> bool {
+    let request = Request::builder().uri(path).body(()).unwrap();
+    let response = Response::builder().status(status).body(()).unwrap();
+    let classifier = HttpTraceClassifier.make_classifier(&request);
+
+    matches!(
+        classifier.classify_response(&response),
+        ClassifiedResponse::Ready(Ok(()))
+    )
+}
+
+#[test]
+fn readyz_not_ready_response_is_a_routine_probe_result() {
+    assert!(classify_http_response(
+        "/v1/readyz",
+        StatusCode::SERVICE_UNAVAILABLE
+    ));
+}
+
+#[test]
+fn non_probe_server_errors_remain_trace_failures() {
+    assert!(!classify_http_response(
+        "/v1/call",
+        StatusCode::SERVICE_UNAVAILABLE
+    ));
+    assert!(!classify_http_response(
+        "/v1/readyz",
+        StatusCode::INTERNAL_SERVER_ERROR
+    ));
 }

--- a/crates/dcc-mcp-logging/src/config.rs
+++ b/crates/dcc-mcp-logging/src/config.rs
@@ -14,7 +14,7 @@
 //! already been installed by the Python module-init path in
 //! `dcc_mcp_core._core`. See [`reload_handle`].
 
-use crate::constants::{DEFAULT_LOG_LEVEL, ENV_LOG_LEVEL, LEGACY_ENV_LOG_LEVEL};
+use crate::constants::{DEFAULT_LOG_FILTER, ENV_LOG_LEVEL, LEGACY_ENV_LOG_LEVEL};
 use std::sync::OnceLock;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::reload::{self, Handle};
@@ -86,7 +86,7 @@ static RELOAD_HANDLE: OnceLock<FileLayerReloadHandle> = OnceLock::new();
 /// Initialize the tracing subscriber (called once from Python module init).
 ///
 /// Installs:
-/// - an `EnvFilter` driven by `DCC_MCP_LOG_LEVEL` (fallback [`DEFAULT_LOG_LEVEL`]);
+/// - an `EnvFilter` driven by `DCC_MCP_LOG_LEVEL` (fallback [`DEFAULT_LOG_FILTER`]);
 /// - a stderr `fmt::Layer` (thread names, targets on);
 /// - a [`reload::Layer`] holding an `Option<BoxedLayer>` for dynamic
 ///   attachment of a rolling-file layer by
@@ -99,7 +99,7 @@ pub fn init_logging() {
     INIT.call_once(|| {
         let filter = EnvFilter::try_from_env(ENV_LOG_LEVEL)
             .or_else(|_| EnvFilter::try_from_env(LEGACY_ENV_LOG_LEVEL))
-            .unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_LEVEL));
+            .unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER));
 
         #[cfg(feature = "tracy")]
         let filter = enable_tracy_target(filter);
@@ -193,12 +193,25 @@ impl std::error::Error for FileLayerInstallError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing::Level;
 
     #[test]
     fn test_init_logging_is_idempotent() {
         init_logging();
         init_logging();
         assert!(reload_handle().is_some());
+    }
+
+    #[test]
+    fn default_filter_keeps_core_debug_but_suppresses_dependency_payload_noise() {
+        let subscriber = tracing_subscriber::registry().with(EnvFilter::new(DEFAULT_LOG_FILTER));
+
+        tracing::subscriber::with_default(subscriber, || {
+            assert!(tracing::enabled!(target: "dcc_mcp_http", Level::DEBUG));
+            assert!(!tracing::enabled!(target: "tower_http::trace", Level::DEBUG));
+            assert!(!tracing::enabled!(target: "hyper_util::client", Level::DEBUG));
+            assert!(!tracing::enabled!(target: "rmcp::service", Level::DEBUG));
+        });
     }
 
     #[cfg(feature = "tracy")]

--- a/crates/dcc-mcp-logging/src/constants.rs
+++ b/crates/dcc-mcp-logging/src/constants.rs
@@ -2,6 +2,12 @@
 
 /// Default log level when [`ENV_LOG_LEVEL`] is not set.
 pub const DEFAULT_LOG_LEVEL: &str = "DEBUG";
+/// Default tracing filter when neither supported log-level environment variable is set.
+///
+/// Keep DCC-MCP targets at debug while dependency request/payload chatter stays
+/// quiet during routine idle operation. Operators can still opt into those
+/// targets explicitly through [`ENV_LOG_LEVEL`].
+pub const DEFAULT_LOG_FILTER: &str = "debug,tower_http=info,hyper_util=info,rmcp=warn";
 /// Environment variable name for overriding the log level.
 pub const ENV_LOG_LEVEL: &str = "DCC_MCP_LOG_LEVEL";
 /// Deprecated environment variable accepted for backward compatibility.
@@ -50,5 +56,10 @@ mod tests {
         assert_eq!(ENV_LOG_FILE, "DCC_MCP_LOG_FILE");
         assert_eq!(ENV_LOG_DIR, "DCC_MCP_LOG_DIR");
         assert_eq!(ENV_LOG_FILE_PREFIX, "DCC_MCP_LOG_FILE_PREFIX");
+    }
+
+    #[test]
+    fn default_level_remains_a_backward_compatible_public_value() {
+        assert_eq!(DEFAULT_LOG_LEVEL, "DEBUG");
     }
 }


### PR DESCRIPTION
## Summary
- keep DCC-MCP debug logs while suppressing noisy dependency targets by default
- treat the documented `/v1/readyz` 503 as a routine TraceLayer result
- preserve ERROR classification for other 5xx responses

## Validation
- `vx just dev`
- `vx just preflight`
- `vx just lint`
- `.venv/Scripts/python.exe -m pytest tests/ -q --tb=short --show-capture=no -n 4 --dist loadfile`
- `vx just check-python-support`

Live idle-volume measurement remains outside this environment; this PR does not claim the `<50 KB/h` threshold. Skills guidance is unchanged because this is runtime logging behavior only.

Fixes #2274