### PR TITLE
fix: latch repeated job storage failures

### DIFF
--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -106,6 +106,14 @@ impl ClassifyResponse for HttpResponseClassifier {
     }
 }
 
+fn health_payload(jobs: &crate::job::JobManager) -> serde_json::Value {
+    json!({
+        "ok": true,
+        "service": "dcc-mcp-http",
+        "job_persistence": jobs.persistence_status(),
+    })
+}
+
 /// Live DCC instance metadata that is propagated to `FileRegistry` on every
 /// heartbeat tick so that `list_dcc_instances` always shows current state.
 ///
@@ -646,7 +654,7 @@ impl McpHttpServer {
                 )
                 .with_cancelled_requests(cancelled_requests)
                 .with_declared_capabilities(self.config.instance.declared_capabilities.clone())
-                .with_jobs(jobs)
+                .with_jobs(jobs.clone())
                 .with_job_notifier(job_notifier)
                 .with_tool_cache_enabled(self.config.session.enable_tool_cache);
         #[cfg(feature = "prometheus")]
@@ -665,7 +673,10 @@ impl McpHttpServer {
         let mut router = Router::new()
             .route(
                 "/health",
-                routing::get(|| async { Json(json!({"ok": true, "service": "dcc-mcp-http"})) }),
+                routing::get(move || {
+                    let jobs = jobs.clone();
+                    async move { Json(health_payload(&jobs)) }
+                }),
             )
             .with_state(state)
             .merge(rest_router)

--- a/crates/dcc-mcp-http/src/server/tests.rs
+++ b/crates/dcc-mcp-http/src/server/tests.rs
@@ -10,6 +10,16 @@ use tower::ServiceExt;
 use tower_http::classify::{ClassifiedResponse, ClassifyResponse, MakeClassifier};
 use tracing_subscriber::fmt::MakeWriter;
 
+#[test]
+fn health_payload_surfaces_job_persistence_state() {
+    let payload = health_payload(&crate::job::JobManager::new());
+
+    assert_eq!(payload["ok"], true);
+    assert_eq!(payload["job_persistence"]["state"], "not_configured");
+    assert_eq!(payload["job_persistence"]["consecutive_failures"], 0);
+    assert!(payload["job_persistence"]["last_error_kind"].is_null());
+}
+
 #[cfg(feature = "auto-gateway")]
 fn unused_local_port() -> u16 {
     let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();

--- a/crates/dcc-mcp-job/src/job/manager.rs
+++ b/crates/dcc-mcp-job/src/job/manager.rs
@@ -133,11 +133,18 @@ impl JobManager {
         let Some(storage) = &self.storage else {
             return;
         };
+        if !self.persistence.lock().can_write() {
+            return;
+        }
+        let result = storage.put(job);
         let mut persistence = self.persistence.lock();
+        // Another in-flight write may have crossed the sticky failure
+        // threshold while this backend call was running. Do not recover or
+        // mutate a circuit that has already been disabled.
         if !persistence.can_write() {
             return;
         }
-        match storage.put(job) {
+        match result {
             Ok(()) => {
                 if persistence.record_success() {
                     tracing::info!("job persistence recovered after a transient write failure");

--- a/crates/dcc-mcp-job/src/job/manager.rs
+++ b/crates/dcc-mcp-job/src/job/manager.rs
@@ -11,9 +11,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 use super::types::{Job, JobEvent, JobProgress, JobStatus, JobSubscriber};
+use super::{JobPersistenceStatus, persistence::PersistenceCircuit};
 
 /// Thread-safe registry of [`Job`]s.
-#[derive(Default)]
 pub struct JobManager {
     jobs: DashMap<String, Arc<RwLock<Job>>>,
     /// Subscribers invoked on every status transition. See [`Self::subscribe`].
@@ -22,6 +22,13 @@ pub struct JobManager {
     /// mutation is written through to storage so the next process
     /// incarnation can see and mark-interrupted any in-flight jobs.
     storage: Option<Arc<dyn crate::job_storage::JobStorage>>,
+    persistence: parking_lot::Mutex<PersistenceCircuit>,
+}
+
+impl Default for JobManager {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl std::fmt::Debug for JobManager {
@@ -30,6 +37,7 @@ impl std::fmt::Debug for JobManager {
             .field("jobs", &self.jobs.len())
             .field("subscribers", &self.subscribers.read().len())
             .field("has_storage", &self.storage.is_some())
+            .field("persistence", &self.persistence_status())
             .finish()
     }
 }
@@ -41,6 +49,7 @@ impl JobManager {
             jobs: DashMap::new(),
             subscribers: RwLock::new(Vec::new()),
             storage: None,
+            persistence: parking_lot::Mutex::new(PersistenceCircuit::default()),
         }
     }
 
@@ -55,6 +64,7 @@ impl JobManager {
             jobs: DashMap::new(),
             subscribers: RwLock::new(Vec::new()),
             storage: Some(storage),
+            persistence: parking_lot::Mutex::new(PersistenceCircuit::configured()),
         }
     }
 
@@ -63,11 +73,17 @@ impl JobManager {
     /// [`Self::with_storage`].
     pub fn set_storage(&mut self, storage: Arc<dyn crate::job_storage::JobStorage>) {
         self.storage = Some(storage);
+        self.persistence = parking_lot::Mutex::new(PersistenceCircuit::configured());
     }
 
     /// Borrow the underlying storage, if any.
     pub fn storage(&self) -> Option<Arc<dyn crate::job_storage::JobStorage>> {
         self.storage.clone()
+    }
+
+    /// Return a payload-safe snapshot of persistence health.
+    pub fn persistence_status(&self) -> JobPersistenceStatus {
+        self.persistence.lock().status()
     }
 
     /// Recover any in-flight rows left over by a previous process
@@ -114,10 +130,39 @@ impl JobManager {
     }
 
     fn persist_put(&self, job: &Job) {
-        if let Some(storage) = &self.storage
-            && let Err(e) = storage.put(job)
-        {
-            tracing::warn!(job_id = %job.id, error = %e, "JobStorage.put failed");
+        let Some(storage) = &self.storage else {
+            return;
+        };
+        let mut persistence = self.persistence.lock();
+        if !persistence.can_write() {
+            return;
+        }
+        match storage.put(job) {
+            Ok(()) => {
+                if persistence.record_success() {
+                    tracing::info!("job persistence recovered after a transient write failure");
+                }
+            }
+            Err(error) => {
+                let disabled = persistence.record_failure(&error);
+                let status = persistence.status();
+                drop(persistence);
+                if disabled {
+                    tracing::warn!(
+                        error = %error,
+                        error_kind = status.last_error_kind.as_deref().unwrap_or("unknown"),
+                        consecutive_failures = status.consecutive_failures,
+                        "job persistence disabled after repeated identical write failures"
+                    );
+                } else {
+                    tracing::debug!(
+                        job_id = %job.id,
+                        error = %error,
+                        consecutive_failures = status.consecutive_failures,
+                        "JobStorage.put failed"
+                    );
+                }
+            }
         }
     }
 

--- a/crates/dcc-mcp-job/src/job/mod.rs
+++ b/crates/dcc-mcp-job/src/job/mod.rs
@@ -46,6 +46,7 @@
 
 mod chunked;
 mod manager;
+mod persistence;
 mod types;
 
 #[cfg(test)]
@@ -53,4 +54,5 @@ mod tests;
 
 pub use chunked::{ChunkedJobRunner, ChunkedStep, ChunkedStepOutput};
 pub use manager::JobManager;
+pub use persistence::{JobPersistenceState, JobPersistenceStatus};
 pub use types::{Job, JobEvent, JobProgress, JobStatus, JobSubscriber};

--- a/crates/dcc-mcp-job/src/job/persistence.rs
+++ b/crates/dcc-mcp-job/src/job/persistence.rs
@@ -1,0 +1,103 @@
+use serde::{Deserialize, Serialize};
+
+use crate::job_storage::JobStorageError;
+
+pub(super) const PERSISTENCE_FAILURE_THRESHOLD: u32 = 3;
+
+/// Runtime state of the optional job-persistence backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobPersistenceState {
+    /// No persistence backend was configured.
+    NotConfigured,
+    /// The configured backend is accepting writes.
+    Healthy,
+    /// A transient write failure occurred below the disable threshold.
+    Degraded,
+    /// Repeated identical write failures disabled persistence for this manager.
+    Disabled,
+}
+
+/// Public, payload-safe snapshot of job-persistence health.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JobPersistenceStatus {
+    /// Current persistence state.
+    pub state: JobPersistenceState,
+    /// Consecutive occurrences of the same write error.
+    pub consecutive_failures: u32,
+    /// Stable error category without backend paths or raw messages.
+    pub last_error_kind: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct PersistenceCircuit {
+    configured: bool,
+    disabled: bool,
+    consecutive_failures: u32,
+    last_error: Option<String>,
+    last_error_kind: Option<String>,
+}
+
+impl PersistenceCircuit {
+    pub(super) fn configured() -> Self {
+        Self {
+            configured: true,
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn can_write(&self) -> bool {
+        self.configured && !self.disabled
+    }
+
+    pub(super) fn record_success(&mut self) -> bool {
+        let recovered = self.consecutive_failures > 0;
+        self.consecutive_failures = 0;
+        self.last_error = None;
+        self.last_error_kind = None;
+        recovered
+    }
+
+    pub(super) fn record_failure(&mut self, error: &JobStorageError) -> bool {
+        let fingerprint = error.to_string();
+        if self.last_error.as_deref() == Some(fingerprint.as_str()) {
+            self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        } else {
+            self.consecutive_failures = 1;
+            self.last_error = Some(fingerprint);
+        }
+        self.last_error_kind = Some(error_kind(error).to_string());
+
+        if self.consecutive_failures >= PERSISTENCE_FAILURE_THRESHOLD {
+            self.disabled = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(super) fn status(&self) -> JobPersistenceStatus {
+        let state = if !self.configured {
+            JobPersistenceState::NotConfigured
+        } else if self.disabled {
+            JobPersistenceState::Disabled
+        } else if self.consecutive_failures > 0 {
+            JobPersistenceState::Degraded
+        } else {
+            JobPersistenceState::Healthy
+        };
+        JobPersistenceStatus {
+            state,
+            consecutive_failures: self.consecutive_failures,
+            last_error_kind: self.last_error_kind.clone(),
+        }
+    }
+}
+
+fn error_kind(error: &JobStorageError) -> &'static str {
+    match error {
+        JobStorageError::Backend(_) => "backend",
+        JobStorageError::Decode(_) => "decode",
+        JobStorageError::FeatureDisabled => "feature_disabled",
+    }
+}

--- a/crates/dcc-mcp-job/src/job/tests.rs
+++ b/crates/dcc-mcp-job/src/job/tests.rs
@@ -5,7 +5,9 @@ use crate::job_storage::{JobFilter, JobStorage, JobStorageError};
 use serde_json::json;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
 
 #[derive(Debug, Default)]
 struct FailingStorage {
@@ -27,6 +29,51 @@ impl JobStorage for FailingStorage {
         let attempt = self.puts.fetch_add(1, Ordering::SeqCst);
         let suffix = if self.alternating { attempt % 2 } else { 0 };
         Err(JobStorageError::Backend(format!("readonly-{suffix}")))
+    }
+
+    fn get(&self, _job_id: &str) -> Result<Option<Job>, JobStorageError> {
+        Ok(None)
+    }
+
+    fn list(&self, _filter: JobFilter) -> Result<Vec<Job>, JobStorageError> {
+        Ok(Vec::new())
+    }
+
+    fn update_status(
+        &self,
+        _job_id: &str,
+        _status: JobStatus,
+        _at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), JobStorageError> {
+        Ok(())
+    }
+
+    fn delete_older_than(
+        &self,
+        _cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, JobStorageError> {
+        Ok(0)
+    }
+}
+
+struct BlockingStorage {
+    entered: mpsc::SyncSender<()>,
+    release: std::sync::Mutex<mpsc::Receiver<()>>,
+}
+
+impl std::fmt::Debug for BlockingStorage {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("BlockingStorage")
+            .finish_non_exhaustive()
+    }
+}
+
+impl JobStorage for BlockingStorage {
+    fn put(&self, _job: &Job) -> Result<(), JobStorageError> {
+        self.entered.send(()).unwrap();
+        self.release.lock().unwrap().recv().unwrap();
+        Ok(())
     }
 
     fn get(&self, _job_id: &str) -> Result<Option<Job>, JobStorageError> {
@@ -446,4 +493,35 @@ fn different_put_failures_do_not_trip_identical_error_latch() {
         JobPersistenceState::Degraded
     );
     assert_eq!(jobs.persistence_status().consecutive_failures, 1);
+}
+
+#[test]
+fn persistence_status_does_not_wait_for_a_blocked_storage_write() {
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+    let storage = Arc::new(BlockingStorage {
+        entered: entered_tx,
+        release: std::sync::Mutex::new(release_rx),
+    });
+    let jobs = Arc::new(JobManager::with_storage(storage));
+
+    let writer_jobs = jobs.clone();
+    let writer = thread::spawn(move || writer_jobs.create("scene.inspect"));
+    entered_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("storage write did not start");
+
+    let (status_tx, status_rx) = mpsc::sync_channel(1);
+    let status_jobs = jobs.clone();
+    let status_reader = thread::spawn(move || {
+        status_tx.send(status_jobs.persistence_status()).unwrap();
+    });
+    let status = status_rx.recv_timeout(Duration::from_secs(2));
+
+    release_tx.send(()).unwrap();
+    writer.join().unwrap();
+    status_reader.join().unwrap();
+
+    let status = status.expect("persistence health blocked behind storage I/O");
+    assert_eq!(status.state, JobPersistenceState::Healthy);
 }

--- a/crates/dcc-mcp-job/src/job/tests.rs
+++ b/crates/dcc-mcp-job/src/job/tests.rs
@@ -1,9 +1,58 @@
 //! Unit tests for [`crate::job::JobManager`].
 
 use super::*;
+use crate::job_storage::{JobFilter, JobStorage, JobStorageError};
 use serde_json::json;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
+
+#[derive(Debug, Default)]
+struct FailingStorage {
+    puts: AtomicUsize,
+    alternating: bool,
+}
+
+impl FailingStorage {
+    fn alternating() -> Self {
+        Self {
+            puts: AtomicUsize::new(0),
+            alternating: true,
+        }
+    }
+}
+
+impl JobStorage for FailingStorage {
+    fn put(&self, _job: &Job) -> Result<(), JobStorageError> {
+        let attempt = self.puts.fetch_add(1, Ordering::SeqCst);
+        let suffix = if self.alternating { attempt % 2 } else { 0 };
+        Err(JobStorageError::Backend(format!("readonly-{suffix}")))
+    }
+
+    fn get(&self, _job_id: &str) -> Result<Option<Job>, JobStorageError> {
+        Ok(None)
+    }
+
+    fn list(&self, _filter: JobFilter) -> Result<Vec<Job>, JobStorageError> {
+        Ok(Vec::new())
+    }
+
+    fn update_status(
+        &self,
+        _job_id: &str,
+        _status: JobStatus,
+        _at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), JobStorageError> {
+        Ok(())
+    }
+
+    fn delete_older_than(
+        &self,
+        _cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, JobStorageError> {
+        Ok(0)
+    }
+}
 
 #[test]
 fn full_lifecycle_create_start_progress_complete_get() {
@@ -347,4 +396,54 @@ fn serde_status_lowercase() {
     );
     let s: JobStatus = serde_json::from_str("\"completed\"").unwrap();
     assert_eq!(s, JobStatus::Completed);
+}
+
+#[test]
+fn persistence_status_is_not_configured_without_storage() {
+    assert_eq!(
+        JobManager::new().persistence_status(),
+        JobPersistenceStatus {
+            state: JobPersistenceState::NotConfigured,
+            consecutive_failures: 0,
+            last_error_kind: None,
+        }
+    );
+}
+
+#[test]
+fn repeated_identical_put_failures_latch_persistence() {
+    let storage = Arc::new(FailingStorage::default());
+    let jobs = JobManager::with_storage(storage.clone());
+
+    for _ in 0..5 {
+        jobs.create("scene.inspect");
+    }
+
+    assert_eq!(storage.puts.load(Ordering::SeqCst), 3);
+    assert_eq!(
+        jobs.persistence_status(),
+        JobPersistenceStatus {
+            state: JobPersistenceState::Disabled,
+            consecutive_failures: 3,
+            last_error_kind: Some("backend".to_string()),
+        }
+    );
+    assert_eq!(jobs.list().len(), 5, "in-memory jobs must keep working");
+}
+
+#[test]
+fn different_put_failures_do_not_trip_identical_error_latch() {
+    let storage = Arc::new(FailingStorage::alternating());
+    let jobs = JobManager::with_storage(storage.clone());
+
+    for _ in 0..6 {
+        jobs.create("scene.inspect");
+    }
+
+    assert_eq!(storage.puts.load(Ordering::SeqCst), 6);
+    assert_eq!(
+        jobs.persistence_status().state,
+        JobPersistenceState::Degraded
+    );
+    assert_eq!(jobs.persistence_status().consecutive_failures, 1);
 }

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -153,7 +153,7 @@ The server implements the MCP 2025-03-26 spec:
 | `/mcp` | POST | MCP request (JSON-RPC 2.0) |
 | `/mcp` | GET | SSE-compatible event stream |
 | `/mcp` | DELETE | Terminate MCP session |
-| `/health` | GET | Health check |
+| `/health` | GET | Health check with `job_persistence` state |
 
 ### Request/Response Format
 
@@ -293,7 +293,7 @@ When multiple DCC instances start simultaneously, one automatically becomes the 
 |----------|--------|-------------|
 | `/instances` | GET | JSON list of all live instances |
 | `/v1/instances` | GET | REST alias for instance discovery |
-| `/health` | GET | `{"ok": true}` health check |
+| `/health` | GET | Health check with a payload-safe `job_persistence` state snapshot |
 | `/mcp` | POST | Bounded MCP endpoint with gateway workflow primitives (`search`, `describe`, `load_skill`, `call`) |
 | `/mcp` | GET | SSE stream for progress, job/workflow, resource, and prompt notifications |
 | `/v1/search` | POST | Search compact backend capability records |

--- a/docs/guide/job-persistence.md
+++ b/docs/guide/job-persistence.md
@@ -59,6 +59,35 @@ If `job_storage_path` is set but the wheel was built **without**
 `job-persist-sqlite`, `server.start()` fails fast with a descriptive error
 rather than silently falling back to the in-memory store.
 
+## Runtime write failures
+
+Persistence is fail-soft after startup: jobs continue to run from the
+in-process map if the configured backend becomes unwritable. A manager records
+consecutive write failures and disables further persistence attempts after
+three identical errors. Transient failures below that threshold are logged at
+`DEBUG`; crossing the threshold emits one `WARN`, so a broken SQLite file does
+not produce a warning for every later job transition.
+
+`GET /health` exposes a payload-safe snapshot without filesystem paths or raw
+backend messages:
+
+```json
+{
+  "ok": true,
+  "service": "dcc-mcp-http",
+  "job_persistence": {
+    "state": "disabled",
+    "consecutive_failures": 3,
+    "last_error_kind": "backend"
+  }
+}
+```
+
+`state` is one of `not_configured`, `healthy`, `degraded`, or `disabled`.
+Installing a storage backend on a new manager resets the circuit. A disabled
+manager does not probe or automatically repair the database; replace or
+restart it after correcting the backend fault.
+
 ## Startup recovery
 
 When `JobManager` boots with a storage backend, it scans for rows whose status
@@ -168,3 +197,4 @@ JSON-serialized — the schema stays stable even if internal `Job` fields evolve
 - #371 — `jobs_get_status` tool
 - **#328** — this document
 - **#567** — `job_recovery` policy contract (`drop` / `requeue`)
+- **#2277** — bounded write-failure latching and health visibility

--- a/docs/zh/api/http.md
+++ b/docs/zh/api/http.md
@@ -140,7 +140,7 @@ server = McpHttpServer(
 | `/mcp` | POST | MCP 请求（JSON-RPC 2.0） |
 | `/mcp` | GET | SSE 兼容的事件流 |
 | `/mcp` | DELETE | 终止 MCP 会话 |
-| `/health` | GET | 健康检查 |
+| `/health` | GET | 健康检查，并包含 `job_persistence` 状态 |
 
 ### 请求/响应格式
 
@@ -234,7 +234,7 @@ print(f"Maya MCP 服务器: {handle.mcp_url()}")
 |------|------|------|
 | `/instances` | GET | 所有活跃实例的 JSON 列表 |
 | `/v1/instances` | GET | 实例发现的 REST 别名 |
-| `/health` | GET | `{"ok": true}` 健康检查 |
+| `/health` | GET | 健康检查，并包含安全的 `job_persistence` 状态快照 |
 | `/mcp` | POST | 有界 MCP 端点，只暴露网关发现原语（`search`、`describe`） |
 | `/mcp` | GET | SSE 事件流 — 进度、作业/工作流、资源、prompt 通知 |
 | `/v1/search` | POST | 搜索紧凑后端能力记录 |

--- a/docs/zh/guide/job-persistence.md
+++ b/docs/zh/guide/job-persistence.md
@@ -59,6 +59,31 @@ handle = server.start()
 `job-persist-sqlite` 的情况下构建的，`server.start()` 会快速失败并返回
 描述性错误，而不是静默回退到内存存储。
 
+## 运行时写入失败
+
+启动后的持久化采用 fail-soft 语义：如果已配置的后端变为不可写，作业仍会
+依靠进程内映射继续运行。管理器会记录连续写入失败；同一错误连续出现三次后，
+停止后续持久化尝试。未达到阈值的瞬时失败记录为 `DEBUG`；达到阈值时只发出
+一次 `WARN`，因此损坏的 SQLite 文件不会在每次后续作业转换时持续刷警告。
+
+`GET /health` 会公开不含文件系统路径和原始后端消息的安全状态快照：
+
+```json
+{
+  "ok": true,
+  "service": "dcc-mcp-http",
+  "job_persistence": {
+    "state": "disabled",
+    "consecutive_failures": 3,
+    "last_error_kind": "backend"
+  }
+}
+```
+
+`state` 取值为 `not_configured`、`healthy`、`degraded` 或 `disabled`。
+在新管理器中安装存储后端会重置熔断状态。已禁用的管理器不会探测或自动修复
+数据库；修复后端故障后，需要替换或重启管理器。
+
 ## 启动恢复
 
 当 `JobManager` 以存储后端启动时，它会扫描状态为 `Pending` 或
@@ -133,3 +158,4 @@ CREATE INDEX IF NOT EXISTS jobs_updated_idx ON jobs(updated_at);
 - #326 — `$/dcc.jobUpdated` 通知
 - #371 — `jobs_get_status` 工具
 - **#328** — 本文档
+- **#2277** — 有界写入失败熔断与健康状态可见性

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -313,6 +313,10 @@ would be unsafe.
   DCC/sidecar process, that status tool must be owned by the worker/service or
   another independently live control process; gateway restart alone cannot
   recreate an API whose owner exited.
+- Read `job_persistence` from the server `/health` payload before claiming
+  durable job history. `degraded` means recent writes failed; `disabled` means
+  the manager latched repeated failures and is serving jobs from memory only.
+  Do not expose backend messages or filesystem paths from that status.
 - Make every adapter-owned launch return its durable `job_id` and one canonical
   status (`pending`, `running`, `completed`, `failed`, `cancelled`, or
   `interrupted`). Declare its status tool in `next-tools.on-success`. Automatic


### PR DESCRIPTION
## Summary
- stop runtime job persistence writes after three consecutive identical backend failures while preserving in-memory execution
- keep persistence health snapshots responsive when a backend write blocks
- expose only payload-safe `job_persistence` state on `/health` and document the adapter-facing contract

This slice intentionally does not change SQLite ownership, repair WAL files, add retention, or add automatic recovery without a proven multi-process ownership contract. Issue #2277 remains open for that remaining work.

## Validation
- `vx just preflight` (workspace check, Clippy with warnings denied, formatting, 3,754 nextest tests, and doctests)
- `vx cargo test -p dcc-mcp-job` (23 passed)
- `vx cargo test -p dcc-mcp-http --lib` (65 passed)
- blocked-storage health regression
- `vx just hakari-verify`
- `vx just lint-skills` (31 skills, 59 execution contracts, no findings)
- VitePress production build
- Rust, Python, Admin UI, and Rust-test file-size gates
- one initial preflight encountered a pre-existing Windows loopback fixture reset; its exact test and the complete settled preflight passed

No real DCC or operator gateway was used.

Refs #2277