### PR TITLE
fix(ci): rebuild missing release assets

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -69,11 +69,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           RELEASE_TAG: ${{ inputs.release-tag-name }}
+          CHECKOUT_REF: ${{ inputs.checkout-ref }}
         shell: bash
         run: |
           set -euo pipefail
           if [ -z "$RELEASE_TAG" ]; then
             echo "::error::release-tag-name is required when reuse-release-assets is true"
+            exit 1
+          fi
+          if [ "$CHECKOUT_REF" != "$RELEASE_TAG" ]; then
+            echo "::error::checkout-ref must exactly match release-tag-name for an immutable backfill"
             exit 1
           fi
           gh release view "$RELEASE_TAG" \

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -46,10 +46,61 @@ permissions:
   contents: read
 
 jobs:
+  classify-release-assets:
+    if: inputs.reuse-release-assets == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      mode: ${{ steps.classify.outputs.mode }}
+    steps:
+      - name: Checkout immutable distribution verification tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .workflow-tools
+          sparse-checkout: |
+            compatibility
+            scripts/ci
+          persist-credentials: false
+
+      - name: Read dcc-mcp-core GitHub Release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.release-tag-name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "::error::release-tag-name is required when reuse-release-assets is true"
+            exit 1
+          fi
+          gh release view "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json assets > release-assets.json
+
+      - name: Classify immutable Core distribution state
+        id: classify
+        env:
+          RELEASE_VERSION: ${{ inputs.release-tag-name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION="${RELEASE_VERSION#v}"
+          python .workflow-tools/scripts/ci/check_release_distribution_set.py \
+            --assets-json release-assets.json \
+            --version "$RELEASE_VERSION" \
+            --classify-assets \
+            --github-output "$GITHUB_OUTPUT"
+
   # ── ABI3 builds (Python 3.8+) — one wheel works for all 3.8+ ──
 
   linux:
-    if: inputs.reuse-release-assets != true
+    needs: [classify-release-assets]
+    if: >-
+      always() && (inputs.reuse-release-assets != true ||
+      needs.classify-release-assets.outputs.mode == 'rebuild')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -79,7 +130,10 @@ jobs:
           --platform linux-x86_64
           dist/*.whl
   windows:
-    if: inputs.reuse-release-assets != true
+    needs: [classify-release-assets]
+    if: >-
+      always() && (inputs.reuse-release-assets != true ||
+      needs.classify-release-assets.outputs.mode == 'rebuild')
     runs-on: windows-latest
     permissions:
       contents: read
@@ -119,7 +173,10 @@ jobs:
   # from python/dcc_mcp_core without maturin, Rust, or just (just>=1.0 is
   # unavailable on Python 3.7 and previously blocked release PyPI publish).
   py37-lite:
-    if: inputs.reuse-release-assets != true
+    needs: [classify-release-assets]
+    if: >-
+      always() && (inputs.reuse-release-assets != true ||
+      needs.classify-release-assets.outputs.mode == 'rebuild')
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -179,7 +236,10 @@ jobs:
   # Uses WHEEL_FEATURES_PY37 (no abi3-py38) via build-wheel action py37 branch.
 
   linux-py37:
-    if: inputs.reuse-release-assets != true
+    needs: [classify-release-assets]
+    if: >-
+      always() && (inputs.reuse-release-assets != true ||
+      needs.classify-release-assets.outputs.mode == 'rebuild')
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -224,7 +284,10 @@ jobs:
             python -c "import dcc_mcp_core"
           fi
   windows-py37:
-    if: inputs.reuse-release-assets != true
+    needs: [classify-release-assets]
+    if: >-
+      always() && (inputs.reuse-release-assets != true ||
+      needs.classify-release-assets.outputs.mode == 'rebuild')
     runs-on: windows-2022
     permissions:
       contents: read
@@ -269,7 +332,10 @@ jobs:
             python -c "import dcc_mcp_core"
           fi
   macos:
-    if: inputs.reuse-release-assets != true
+    needs: [classify-release-assets]
+    if: >-
+      always() && (inputs.reuse-release-assets != true ||
+      needs.classify-release-assets.outputs.mode == 'rebuild')
     runs-on: macos-latest
     permissions:
       contents: read
@@ -300,11 +366,14 @@ jobs:
           --platform macos-universal2
           dist/*.whl
 
-  # Manual release backfills must publish the immutable bytes already archived
-  # on GitHub. Rebuilding can produce different wheel bytes for the same
-  # filename, while PyPI's skip-existing behavior preserves the first upload.
+  # Manual release backfills reuse the immutable bytes already archived on
+  # GitHub. When the first release attempt failed before uploading any Core
+  # distribution, the classifier instead rebuilds the complete set from the
+  # immutable checkout-ref. Partial archived sets fail closed rather than mix
+  # archived and rebuilt bytes for one version.
   reuse-release-assets:
-    if: inputs.reuse-release-assets == true
+    needs: [classify-release-assets]
+    if: needs.classify-release-assets.outputs.mode == 'reuse'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/ci/check_release_distribution_set.py
+++ b/scripts/ci/check_release_distribution_set.py
@@ -156,6 +156,25 @@ def _release_assets(payload: dict, version: str) -> dict[str, dict]:
     return assets
 
 
+def classify_distribution_assets(payload: dict, version: str) -> str:
+    """Choose whether an immutable Core backfill can reuse or must rebuild."""
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:[A-Za-z0-9.+-]*)", version):
+        raise DistributionSetError(f"invalid release version {version!r}")
+    assets = _release_assets(payload, version)
+    if not assets:
+        return "rebuild"
+
+    sdist_name = f"dcc_mcp_core-{version}.tar.gz"
+    wheel_names = {name for name in assets if name.endswith(".whl")}
+    observed_contracts = {_classify_wheel(name, version) for name in wheel_names}
+    expected_contracts = {tuple(contract.split("/", 1)) for contract in _EXPECTED_WHEEL_CONTRACTS}
+    if set(assets) != {*wheel_names, sdist_name} or observed_contracts != expected_contracts:
+        raise DistributionSetError(
+            "GitHub Release has a partial Core distribution set; refuse to mix archived and rebuilt bytes"
+        )
+    return "reuse"
+
+
 def verify_distribution_set(payload: dict, dist_dir: Path, version: str) -> dict[str, int]:
     """Verify the exact seven-file Core distribution set and return evidence."""
     if not re.fullmatch(r"\d+\.\d+\.\d+(?:[A-Za-z0-9.+-]*)", version):
@@ -199,13 +218,24 @@ def main(argv: list[str] | None = None) -> int:
     """Validate Release asset metadata and downloaded distributions."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--assets-json", type=Path, required=True)
-    parser.add_argument("--dist-dir", type=Path, required=True)
+    parser.add_argument("--dist-dir", type=Path)
     parser.add_argument("--version", required=True)
+    parser.add_argument("--classify-assets", action="store_true")
+    parser.add_argument("--github-output", type=Path)
     args = parser.parse_args(argv)
     try:
         payload = json.loads(args.assets_json.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise DistributionSetError(f"cannot read GitHub Release asset JSON: {exc}") from exc
+    if args.classify_assets:
+        mode = classify_distribution_assets(payload, args.version)
+        if args.github_output is not None:
+            with args.github_output.open("a", encoding="utf-8", newline="\n") as stream:
+                stream.write(f"mode={mode}\n")
+        print(f"Core release asset backfill mode: {mode}")
+        return 0
+    if args.dist_dir is None:
+        raise DistributionSetError("--dist-dir is required unless --classify-assets is set")
     evidence = verify_distribution_set(payload, args.dist_dir, args.version)
     print(f"Verified {evidence['asset_count']} immutable Core distribution(s), {evidence['total_bytes']} byte(s)")
     return 0

--- a/tests/test_build_wheels_workflow.py
+++ b/tests/test_build_wheels_workflow.py
@@ -32,11 +32,8 @@ def test_manual_backfill_reuses_verified_github_release_assets() -> None:
     }
 
     jobs = workflow["jobs"]
-    for job_id in BUILD_JOB_IDS:
-        assert jobs[job_id]["if"] == "inputs.reuse-release-assets != true"
-
     reuse = jobs["reuse-release-assets"]
-    assert reuse["if"] == "inputs.reuse-release-assets == true"
+    assert reuse["if"] == "needs.classify-release-assets.outputs.mode == 'reuse'"
     assert reuse["permissions"] == {"contents": "read"}
     commands = "\n".join(step.get("run", "") for step in reuse["steps"])
     assert "gh release download" in commands
@@ -53,6 +50,30 @@ def test_manual_backfill_reuses_verified_github_release_assets() -> None:
         "path": "dist/",
         "retention-days": 30,
     }
+
+
+def test_manual_backfill_rebuilds_from_tag_when_release_has_no_core_assets() -> None:
+    jobs = _jobs()
+    classifier = jobs["classify-release-assets"]
+    assert classifier["if"] == "inputs.reuse-release-assets == true"
+    assert classifier["permissions"] == {"contents": "read"}
+    assert classifier["outputs"] == {"mode": "${{ steps.classify.outputs.mode }}"}
+    classifier_commands = "\n".join(step.get("run", "") for step in classifier["steps"])
+    assert "gh release view" in classifier_commands
+    assert "--classify-assets" in classifier_commands
+    classifier_checkout = next(step for step in classifier["steps"] if step.get("uses") == "actions/checkout@v6")
+    assert classifier_checkout["with"]["ref"] == "${{ github.workflow_sha }}"
+
+    build_condition = (
+        "always() && (inputs.reuse-release-assets != true || needs.classify-release-assets.outputs.mode == 'rebuild')"
+    )
+    for job_id in BUILD_JOB_IDS:
+        assert jobs[job_id]["needs"] == ["classify-release-assets"]
+        assert jobs[job_id]["if"] == build_condition
+
+    reuse = jobs["reuse-release-assets"]
+    assert reuse["needs"] == ["classify-release-assets"]
+    assert reuse["if"] == "needs.classify-release-assets.outputs.mode == 'reuse'"
 
 
 def test_release_wheels_are_uploaded_once_after_every_build() -> None:

--- a/tests/test_build_wheels_workflow.py
+++ b/tests/test_build_wheels_workflow.py
@@ -61,6 +61,11 @@ def test_manual_backfill_rebuilds_from_tag_when_release_has_no_core_assets() -> 
     classifier_commands = "\n".join(step.get("run", "") for step in classifier["steps"])
     assert "gh release view" in classifier_commands
     assert "--classify-assets" in classifier_commands
+    assert 'if [ "$CHECKOUT_REF" != "$RELEASE_TAG" ]' in classifier_commands
+    release_read = next(
+        step for step in classifier["steps"] if step.get("name") == "Read dcc-mcp-core GitHub Release assets"
+    )
+    assert release_read["env"]["CHECKOUT_REF"] == "${{ inputs.checkout-ref }}"
     classifier_checkout = next(step for step in classifier["steps"] if step.get("uses") == "actions/checkout@v6")
     assert classifier_checkout["with"]["ref"] == "${{ github.workflow_sha }}"
 

--- a/tests/test_release_distribution_set.py
+++ b/tests/test_release_distribution_set.py
@@ -14,6 +14,7 @@ import zipfile
 import pytest
 from scripts.ci import check_release_distribution_set
 from scripts.ci.check_release_distribution_set import DistributionSetError
+from scripts.ci.check_release_distribution_set import classify_distribution_assets
 from scripts.ci.check_release_distribution_set import verify_distribution_set
 
 VERSION = "0.20.8"
@@ -26,6 +27,25 @@ WHEEL_NAMES = [
     f"dcc_mcp_core-{VERSION}-py3-none-any.whl",
 ]
 SDIST_NAME = f"dcc_mcp_core-{VERSION}.tar.gz"
+
+
+def test_classify_distribution_assets_rebuilds_when_release_has_no_core_assets() -> None:
+    payload = {"assets": [{"name": "dcc_mcp_server-0.20.8-py3-none-any.whl"}]}
+
+    assert classify_distribution_assets(payload, VERSION) == "rebuild"
+
+
+def test_classify_distribution_assets_rejects_partial_core_asset_sets() -> None:
+    payload = {"assets": [{"name": WHEEL_NAMES[0]}]}
+
+    with pytest.raises(DistributionSetError, match="partial Core distribution set"):
+        classify_distribution_assets(payload, VERSION)
+
+
+def test_classify_distribution_assets_reuses_complete_core_asset_sets() -> None:
+    payload = {"assets": [{"name": name} for name in [*WHEEL_NAMES, SDIST_NAME]]}
+
+    assert classify_distribution_assets(payload, VERSION) == "reuse"
 
 
 def _metadata_bytes(name: str, version: str) -> bytes:
@@ -133,3 +153,25 @@ def test_cli_reads_release_asset_json(monkeypatch: pytest.MonkeyPatch, tmp_path:
         )
         == 0
     )
+
+
+def test_cli_classifies_missing_assets_for_github_actions(tmp_path: Path) -> None:
+    assets_json = tmp_path / "assets.json"
+    assets_json.write_text(json.dumps({"assets": []}), encoding="utf-8")
+    github_output = tmp_path / "github-output.txt"
+
+    assert (
+        check_release_distribution_set.main(
+            [
+                "--assets-json",
+                str(assets_json),
+                "--version",
+                VERSION,
+                "--classify-assets",
+                "--github-output",
+                str(github_output),
+            ]
+        )
+        == 0
+    )
+    assert github_output.read_text(encoding="utf-8") == "mode=rebuild\n"


### PR DESCRIPTION
## Summary
- classify archived Core release assets before a manual backfill
- rebuild the complete distribution set only from the immutable release tag when no Core assets exist
- fail closed for partial archived sets or a checkout ref that differs from the release tag
- keep complete sets on digest-verified reuse

## Validation
- 38 focused workflow and release contract tests passed
- Python support contract
- actionlint
- Ruff check and format
- Rust format pre-push gate

No runtime, package metadata, tag, or adapter skill guidance changes.