### PR TITLE
feat: persist accepted feedback reports

### DIFF
--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -244,8 +244,13 @@ omit the argument and exposes an explicit test reset seam.
 `DccServerBase` also owns `feedback_store`, `script_execution_context`, and
 `checkpoint_store`. The base registration wires `dcc_feedback__report` to the
 configured gateway `/v1/feedback` endpoint, late-binds the current instance id,
-and mirrors only gateway-accepted receipts into `feedback_store`; adapters must
-not override this shared forwarder or add host-specific feedback actions.
+and mirrors only gateway-accepted receipts into a bounded, write-through JSONL
+store at `<registry_dir>/feedback/<dcc>-<pid>.jsonl`. Each append is synced
+before it becomes visible in memory, files rotate with bounded backups, and
+`SESSION_END` syncs the active file again. A local persistence failure is an
+explicit `feedback_persistence_failed` result even when the gateway accepted
+the report; adapters must not override this shared forwarder or add
+host-specific feedback actions.
 Pass the other components to `execute_with_context(..., context=...)` and
 checkpoint helpers' existing `store=` parameter. Module-level convenience calls
 use explicit compatibility holders with `reset_default_*_for_tests()` seams;

--- a/python/dcc_mcp_core/_server/observability_facade.py
+++ b/python/dcc_mcp_core/_server/observability_facade.py
@@ -260,6 +260,10 @@ class ObservabilityFacade:
         session_id: str,
         payload: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        try:
+            self._owner.feedback_store.flush()
+        except Exception as exc:
+            logger.warning("[%s] Could not flush feedback on session end: %s", self._owner._dcc_name, exc)
         return self.dispatch_lifecycle_event("on_session_end", payload, session_id=session_id)
 
     def dispatch_before_tool_call(

--- a/python/dcc_mcp_core/feedback.py
+++ b/python/dcc_mcp_core/feedback.py
@@ -54,6 +54,8 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
+import re
 import threading
 import time
 from typing import Any
@@ -76,26 +78,115 @@ from dcc_mcp_core.result_envelope import ToolResultEnvelope
 logger = logging.getLogger(__name__)
 
 _MAX_FEEDBACK_ENTRIES = 500
+_DEFAULT_FEEDBACK_MAX_BYTES = 5 * 1024 * 1024
+_DEFAULT_FEEDBACK_BACKUP_COUNT = 4
 _DEFAULT_GATEWAY_HOST = "127.0.0.1"
 _DEFAULT_GATEWAY_PORT = 9765
 _GATEWAY_FEEDBACK_TIMEOUT_SECS = 5.0
 _GATEWAY_EVENTS_URI = "resources://gateway/events"
+_SAFE_FEEDBACK_PATH_SEGMENT = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+class FeedbackPersistenceError(RuntimeError):
+    """Raised when an enabled feedback store cannot durably append a record."""
+
+
+def feedback_store_path(
+    registry_dir: str | os.PathLike[str],
+    dcc_name: str,
+    pid: int,
+) -> Path:
+    """Return the per-process JSONL path for one DCC feedback store."""
+    raw_name = str(dcc_name).strip().replace("\\", "_").replace("/", "_").replace(":", "_")
+    safe_name = _SAFE_FEEDBACK_PATH_SEGMENT.sub("_", raw_name).strip("._-") or "dcc"
+    return Path(registry_dir).expanduser() / "feedback" / f"{safe_name[:96]}-{int(pid)}.jsonl"
 
 
 class FeedbackStore:
-    """Thread-safe bounded feedback state for one server instance."""
+    """Thread-safe bounded feedback state for one server instance.
 
-    def __init__(self, max_entries: int = _MAX_FEEDBACK_ENTRIES) -> None:
+    ``path`` enables a write-through JSONL mirror. Each append is flushed and
+    synced before the in-memory entry becomes visible. The active file and its
+    numbered backups remain bounded by ``max_bytes`` and ``backup_count``.
+    """
+
+    def __init__(
+        self,
+        max_entries: int = _MAX_FEEDBACK_ENTRIES,
+        *,
+        path: str | os.PathLike[str] | None = None,
+        max_bytes: int = _DEFAULT_FEEDBACK_MAX_BYTES,
+        backup_count: int = _DEFAULT_FEEDBACK_BACKUP_COUNT,
+    ) -> None:
         self._lock = threading.Lock()
         self._entries: list[dict[str, Any]] = []
         self._max_entries = max(1, int(max_entries))
+        self._path = Path(path).expanduser() if path is not None else None
+        self._max_bytes = int(max_bytes)
+        self._backup_count = int(backup_count)
+        if self._max_bytes <= 0:
+            raise ValueError("max_bytes must be greater than zero")
+        if self._backup_count <= 0:
+            raise ValueError("backup_count must be greater than zero")
+
+    @property
+    def path(self) -> Path | None:
+        """Return the configured JSONL path, if persistence is enabled."""
+        return self._path
+
+    def _backup_path(self, index: int) -> Path:
+        assert self._path is not None
+        return self._path.with_name(f"{self._path.name}.{index}")
+
+    def _rotate_unlocked(self) -> None:
+        assert self._path is not None
+        for index in range(self._backup_count - 1, 0, -1):
+            source = self._backup_path(index)
+            if source.exists():
+                source.replace(self._backup_path(index + 1))
+        if self._path.exists():
+            self._path.replace(self._backup_path(1))
+
+    def _persist_unlocked(self, entry: dict[str, Any]) -> None:
+        if self._path is None:
+            return
+        try:
+            record = (json_dumps(entry) + "\n").encode("utf-8")
+            if len(record) > self._max_bytes:
+                raise FeedbackPersistenceError(f"feedback entry size {len(record)} exceeds max_bytes={self._max_bytes}")
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            current_size = self._path.stat().st_size if self._path.exists() else 0
+            if current_size and current_size + len(record) > self._max_bytes:
+                self._rotate_unlocked()
+            with self._path.open("ab") as stream:
+                stream.write(record)
+                stream.flush()
+                os.fsync(stream.fileno())
+        except FeedbackPersistenceError:
+            raise
+        except (OSError, TypeError, ValueError) as exc:
+            raise FeedbackPersistenceError(f"could not persist feedback to {self._path}: {exc}") from exc
 
     def append(self, entry: dict[str, Any]) -> None:
-        """Append one entry and evict the oldest overflow."""
+        """Durably append one entry and evict the oldest memory overflow."""
         with self._lock:
-            self._entries.append(dict(entry))
+            stored_entry = dict(entry)
+            self._persist_unlocked(stored_entry)
+            self._entries.append(stored_entry)
             if len(self._entries) > self._max_entries:
                 del self._entries[: len(self._entries) - self._max_entries]
+
+    def flush(self) -> None:
+        """Sync the active JSONL file, if one exists."""
+        with self._lock:
+            if self._path is None or not self._path.exists():
+                return
+            try:
+                with self._path.open("ab") as stream:
+                    stream.flush()
+                    os.fsync(stream.fileno())
+            except OSError as exc:
+                raise FeedbackPersistenceError(f"could not flush feedback at {self._path}: {exc}") from exc
 
     def recent(
         self,
@@ -478,14 +569,24 @@ def _handle_gateway_feedback_report(
             "gateway_feedback_invalid_receipt",
         )
 
-    _store_feedback(
-        {
-            "id": feedback_id,
-            "timestamp": time.time(),
-            **report,
-        },
-        store=store,
-    )
+    try:
+        _store_feedback(
+            {
+                "id": feedback_id,
+                "timestamp": time.time(),
+                **report,
+            },
+            store=store,
+        )
+    except FeedbackPersistenceError as exc:
+        logger.error("Gateway accepted feedback but the local JSONL mirror failed: %s", exc)
+        return _feedback_error(
+            "Feedback was accepted at the gateway, but local persistence failed.",
+            "feedback_persistence_failed",
+            feedback_id=feedback_id,
+            recorded_at=recorded_at,
+            event_resource_uri=event_resource_uri,
+        )
     logger.info(
         "dcc_feedback__report forwarded: id=%s tool=%s severity=%s",
         feedback_id,
@@ -516,7 +617,14 @@ def _handle_feedback_report(params: str, *, store: FeedbackStore | None = None) 
         "blocker": args.get("blocker", ""),
         "severity": args.get("severity", "blocked"),
     }
-    _store_feedback(entry, store=store)
+    try:
+        _store_feedback(entry, store=store)
+    except FeedbackPersistenceError as exc:
+        logger.error("Could not persist feedback: %s", exc)
+        return _feedback_error(
+            "Feedback could not be persisted.",
+            "feedback_persistence_failed",
+        )
     logger.info(
         "dcc_feedback__report: id=%s tool=%s severity=%s",
         entry["id"],
@@ -618,9 +726,11 @@ def register_feedback_tool(
 # ── Public API ─────────────────────────────────────────────────────────────
 
 __all__ = [
+    "FeedbackPersistenceError",
     "FeedbackStore",
     "clear_feedback",
     "extract_rationale",
+    "feedback_store_path",
     "get_default_feedback_store",
     "get_feedback_entries",
     "make_rationale_meta",

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -21,6 +21,7 @@ import sys
 from typing import Any
 from typing import Callable
 
+from dcc_mcp_core._install_lifecycle_runtime import default_registry_dir
 from dcc_mcp_core._lifecycle_events import LifecycleEventDispatcher
 from dcc_mcp_core._runtime.core_availability import is_core_extension_available
 from dcc_mcp_core._runtime.server_factory import create_adapter_server
@@ -44,6 +45,7 @@ from dcc_mcp_core._server.skill_discovery import SkillDiscoveryController
 from dcc_mcp_core._version_util import package_version
 from dcc_mcp_core.checkpoint import CheckpointStore
 from dcc_mcp_core.feedback import FeedbackStore
+from dcc_mcp_core.feedback import feedback_store_path
 from dcc_mcp_core.script_execution import ScriptExecutionContext
 
 try:
@@ -128,7 +130,10 @@ class DccServerBase:
         self._dcc_window_title: str | None = diag.window_title
         self._dcc_window_handle: int | None = diag.window_handle
         self._diagnostic_state = DiagnosticRuntimeState(options.dcc_name)
-        self._feedback_store = FeedbackStore()
+        feedback_registry_dir = options.gateway.registry_dir or default_registry_dir()
+        self._feedback_store = FeedbackStore(
+            path=feedback_store_path(feedback_registry_dir, options.dcc_name, self._dcc_pid)
+        )
         self._script_execution_context = ScriptExecutionContext()
         self._checkpoint_store = CheckpointStore()
 

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -126,6 +126,10 @@ the server from its exact target environment. Gateway Admin is check-only.
    It also owns `feedback_store`, `script_execution_context`, and
    `checkpoint_store`; inject them into core helpers instead of creating
    adapter-level feedback buffers, persistent exec namespaces, or default stores.
+   Core persists gateway-accepted feedback under
+   `<registry_dir>/feedback/<dcc>-<pid>.jsonl` with bounded rotation and
+   session-end syncing. Treat `feedback_persistence_failed` as a real degraded
+   result; never add an adapter-local success fallback.
    - For native visual UI fallback, reuse the bundled `ui-control` skill with
      standalone `dcc-cua` 0.4.0 or newer; do not add adapter-local capture,
      accessibility, or raw-input wrappers. Keep stateful UI calls in one

--- a/tests/test_dcc_server_options.py
+++ b/tests/test_dcc_server_options.py
@@ -576,6 +576,33 @@ class TestDccServerBaseOptionsPath:
         assert first.script_execution_context is not second.script_execution_context
         assert first.checkpoint_store is not second.checkpoint_store
 
+    def test_feedback_store_uses_instance_registry_path_and_flushes_on_session_end(self, tmp_path):
+        from unittest.mock import patch
+
+        from dcc_mcp_core.server_base import DccServerBase
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        registry_dir = tmp_path / "registry"
+        opts = DccServerOptions.from_env(
+            "Studio Host/Custom",
+            skills_dir,
+            registry_dir=str(registry_dir),
+            dcc_pid=4242,
+        )
+        with patch(
+            "dcc_mcp_core.server_base.create_adapter_server",
+            return_value=_FakeDccServer(),
+        ):
+            server = DccServerBase(opts)
+
+        assert server.feedback_store.path == registry_dir / "feedback" / "Studio_Host_Custom-4242.jsonl"
+        server.feedback_store.flush = MagicMock()
+
+        server.dispatch_session_end(session_id="session-1")
+
+        server.feedback_store.flush.assert_called_once_with()
+
 
 def test_dcc_server_base_requires_options_argument() -> None:
     from dcc_mcp_core.server_base import DccServerBase

--- a/tests/test_feedback_and_rationale.py
+++ b/tests/test_feedback_and_rationale.py
@@ -106,6 +106,61 @@ def test_feedback_stores_are_isolated() -> None:
     assert get_feedback_entries(store=blender) == []
 
 
+def test_feedback_store_flushes_each_append_to_bounded_jsonl(tmp_path) -> None:
+    from dcc_mcp_core.feedback import FeedbackStore
+
+    path = tmp_path / "feedback" / "maya-4242.jsonl"
+    store = FeedbackStore(path=path, max_bytes=4096, backup_count=2)
+    entry = {
+        "id": "feedback-1",
+        "timestamp": 1.0,
+        "tool_name": "maya_scene__save",
+        "severity": "blocked",
+    }
+
+    store.append(entry)
+
+    assert store.path == path
+    assert [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()] == [entry]
+
+
+def test_feedback_store_rotates_and_prunes_jsonl_backups(tmp_path) -> None:
+    from dcc_mcp_core.feedback import FeedbackStore
+
+    path = tmp_path / "feedback" / "houdini-5252.jsonl"
+    store = FeedbackStore(path=path, max_bytes=220, backup_count=2)
+    for index in range(8):
+        store.append(
+            {
+                "id": f"feedback-{index}",
+                "tool_name": "houdini_scene__save",
+                "blocker": "x" * 72,
+                "severity": "blocked",
+            }
+        )
+
+    files = sorted(path.parent.glob(f"{path.name}*"))
+    assert files == [path, path.with_name(f"{path.name}.1"), path.with_name(f"{path.name}.2")]
+    persisted = [json.loads(line) for file in files for line in file.read_text(encoding="utf-8").splitlines()]
+    assert all(isinstance(entry, dict) for entry in persisted)
+    assert {entry["id"] for entry in persisted} < {f"feedback-{index}" for index in range(8)}
+    assert json.loads(path.read_text(encoding="utf-8"))["id"] == "feedback-7"
+
+
+def test_feedback_store_fails_closed_when_one_entry_exceeds_bound(tmp_path) -> None:
+    from dcc_mcp_core.feedback import FeedbackPersistenceError
+    from dcc_mcp_core.feedback import FeedbackStore
+
+    path = tmp_path / "feedback" / "blender-6262.jsonl"
+    store = FeedbackStore(path=path, max_bytes=64, backup_count=2)
+
+    with pytest.raises(FeedbackPersistenceError, match="exceeds max_bytes"):
+        store.append({"id": "feedback-large", "blocker": "x" * 128})
+
+    assert store.recent() == []
+    assert not path.exists()
+
+
 def test_feedback_report_and_retrieve():
     from dcc_mcp_core.feedback import _handle_feedback_report
     from dcc_mcp_core.feedback import get_feedback_entries
@@ -347,6 +402,54 @@ def test_registered_feedback_handler_fails_closed_when_gateway_is_unavailable(mo
     assert result["success"] is False
     assert result["error"] == "gateway_feedback_unavailable"
     assert get_feedback_entries(store=store) == []
+
+
+def test_registered_feedback_handler_surfaces_local_persistence_failure(monkeypatch, tmp_path):
+    import dcc_mcp_core.feedback as feedback_module
+    from dcc_mcp_core.feedback import FeedbackStore
+    from dcc_mcp_core.feedback import register_feedback_tool
+
+    def _urlopen(request, *, timeout):
+        headers = {name.lower(): value for name, value in request.header_items()}
+        return _GatewayResponse(
+            {
+                "ok": True,
+                "success": True,
+                "feedback_id": "11111111-1111-4111-8111-111111111111",
+                "recorded_at": "2026-08-24T00:00:00.000Z",
+                "event_resource_uri": "resources://gateway/events",
+            },
+            request_id=headers["x-request-id"],
+        )
+
+    monkeypatch.setattr(feedback_module, "urlopen", _urlopen)
+    store = FeedbackStore(
+        path=tmp_path / "feedback" / "photoshop-7272.jsonl",
+        max_bytes=64,
+        backup_count=2,
+    )
+    server = MagicMock()
+    server.registry = MagicMock()
+    register_feedback_tool(
+        server,
+        dcc_name="photoshop",
+        store=store,
+        gateway_endpoint="http://127.0.0.1:19765/v1/feedback",
+    )
+
+    result = server.register_handler.call_args.args[1](
+        {
+            "tool_name": "photoshop_layers__merge",
+            "intent": "Merge layers for a very long compositing operation",
+            "blocker": "The document remained locked after the merge request",
+            "severity": "blocked",
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "feedback_persistence_failed"
+    assert result["context"]["feedback_id"] == "11111111-1111-4111-8111-111111111111"
+    assert store.recent() == []
 
 
 def test_registered_feedback_handler_rejects_desynchronized_gateway_receipt(monkeypatch):


### PR DESCRIPTION
## Summary
- persist gateway-accepted adapter feedback to bounded per-instance JSONL files
- sync every append and session end, rotate with same-volume replacement, and fail closed on persistence errors
- document the shared adapter contract

## Validation
- 126 focused Python tests passed
- `just check-python-support`
- `just lint-py`
- pre-push `cargo fmt --all -- --check`

## Remaining #2253 work
- gateway aggregation and CLI list/export
- finding schema v1 across Rust and Python
- route, bundle, and authorized file commands
- install/startup report generation, issue templates, eval integration, and closure-loop docs

Refs #2253