### PR TITLE
fix: isolate pytest sessions from operator gateway

### DIFF
--- a/crates/dcc-mcp-http-py/src/config/build.rs
+++ b/crates/dcc-mcp-http-py/src/config/build.rs
@@ -1,5 +1,15 @@
 use dcc_mcp_http_types::config::{McpHttpConfig, ServerSpawnMode};
 
+const DEFAULT_GATEWAY_PORT: u16 = 9765;
+const GATEWAY_PORT_ENV: &str = "DCC_MCP_GATEWAY_PORT";
+
+fn gateway_port_from_env() -> u16 {
+    std::env::var(GATEWAY_PORT_ENV)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_GATEWAY_PORT)
+}
+
 /// Build the Rust config backing `PyMcpHttpConfig.__new__`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_config(
@@ -27,7 +37,7 @@ pub(crate) fn build_config(
     }
     cfg.server.enable_cors = enable_cors;
     cfg.server.request_timeout_ms = request_timeout_ms;
-    cfg.gateway.gateway_port = 9765;
+    cfg.gateway.gateway_port = gateway_port_from_env();
     cfg.gateway.remote_host = Some("0.0.0.0".to_string());
     cfg.gateway.remote_gateway_port = 59765;
     cfg.gateway.backend_timeout_ms = backend_timeout_ms;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 Auto-use fixtures in this file provide:
 - Session-scoped registry directory isolation (``DCC_MCP_REGISTRY_DIR``)
+- Gateway isolation for ordinary tests (``DCC_MCP_GATEWAY_PORT=0``)
 - Default skill-path isolation (``DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS``)
 - Env-var restore guard that snapshots env before the session and restores
   on teardown, preventing env-var-based test-order dependency.
@@ -57,6 +58,7 @@ SKILLS_DIR = str(REPO_ROOT / "skills")
 #: Environment variable read by the Rust GatewayRunner / McpHttpConfig to
 #: override the default shared registry directory (issue #793).
 _DCC_MCP_REGISTRY_ENV = "DCC_MCP_REGISTRY_DIR"
+_DCC_MCP_GATEWAY_PORT_ENV = "DCC_MCP_GATEWAY_PORT"
 _DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS_ENV = "DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS"
 
 
@@ -70,6 +72,18 @@ def _isolated_default_skill_paths():
         os.environ.pop(_DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS_ENV, None)
     else:
         os.environ[_DCC_MCP_DISABLE_DEFAULT_SKILL_PATHS_ENV] = previous
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _disabled_default_gateway():
+    """Keep ordinary tests from joining or preempting an operator gateway."""
+    previous = os.environ.get(_DCC_MCP_GATEWAY_PORT_ENV)
+    os.environ[_DCC_MCP_GATEWAY_PORT_ENV] = "0"
+    yield
+    if previous is None:
+        os.environ.pop(_DCC_MCP_GATEWAY_PORT_ENV, None)
+    else:
+        os.environ[_DCC_MCP_GATEWAY_PORT_ENV] = previous
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_dcc_server_options.py
+++ b/tests/test_dcc_server_options.py
@@ -42,6 +42,11 @@ class TestGatewayOptions:
         assert gw.registry_dir is None
         assert gw.enable_failover is True
 
+    def test_pytest_session_disables_default_gateway(self):
+        """Ordinary pytest sessions must not join the operator gateway."""
+        assert os.environ["DCC_MCP_GATEWAY_PORT"] == "0"
+        assert GatewayOptions.from_env().port == 0
+
     def test_from_env_reads_gateway_port(self, monkeypatch):
         monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "9999")
         gw = GatewayOptions.from_env()

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -106,6 +106,7 @@ def test_ensure_gateway_daemon_spawns_and_becomes_healthy(tmp_path, monkeypatch)
     monkeypatch.setattr(gg, "urlopen", _urlopen)
     monkeypatch.setattr(gg, "launch_detached", _launch_detached)
     monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
+    monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "9876")
     result = gg.ensure_gateway_daemon(
         gateway_host="127.0.0.1",
         gateway_port=9876,

--- a/tests/test_gateway_reachability.py
+++ b/tests/test_gateway_reachability.py
@@ -63,7 +63,8 @@ def _http_status(url: str) -> int:
 class TestAdminDefaults:
     """Admin/gateway defaults must match the documented Python API contract."""
 
-    def test_python_config_defaults_gateway_and_admin_on(self):
+    def test_python_config_defaults_gateway_and_admin_on(self, monkeypatch):
+        monkeypatch.delenv("DCC_MCP_GATEWAY_PORT", raising=False)
         config = McpHttpConfig(port=0, server_name="admin-defaults")
         assert config.gateway_port == 9765
         assert config.admin_enabled is True
@@ -116,9 +117,24 @@ class TestAdminDefaults:
 class TestInstanceListenerReachable:
     """Instance MCP listener must be reachable whenever ``.start()`` returns."""
 
+    def test_pytest_gateway_opt_out_reaches_native_config_and_start(self, monkeypatch):
+        """The public native config must honor the pytest gateway opt-out."""
+        monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "0")
+        config = McpHttpConfig(port=0, server_name="reach-py-no-gateway")
+        assert config.gateway_port == 0
+
+        server = McpHttpServer(_empty_registry(), config)
+        handle = server.start()
+        try:
+            assert handle.is_gateway is False
+            assert _wait_reachable("127.0.0.1", handle.port, budget=1.0)
+        finally:
+            handle.shutdown()
+
     def test_dedicated_default_reachable(self):
         """The Python default (dedicated spawn mode) must produce a reachable listener."""
         config = McpHttpConfig(port=0, server_name="reach-py-dedicated")
+        config.gateway_port = 0
         # Issue #303: Python default is "dedicated".
         assert config.spawn_mode == "dedicated"
         server = McpHttpServer(_empty_registry(), config)
@@ -133,6 +149,7 @@ class TestInstanceListenerReachable:
     def test_ambient_opt_out_reachable(self):
         """When the caller explicitly opts out of Dedicated mode it must still work."""
         config = McpHttpConfig(port=0, server_name="reach-py-ambient")
+        config.gateway_port = 0
         config.spawn_mode = "ambient"
         server = McpHttpServer(_empty_registry(), config)
         handle = server.start()
@@ -147,6 +164,7 @@ class TestInstanceListenerReachable:
     def test_repeated_start_shutdown_cycles(self, round_):
         """Starting/stopping several times must remain reachable every time."""
         config = McpHttpConfig(port=0, server_name=f"reach-py-cycle-{round_}")
+        config.gateway_port = 0
         server = McpHttpServer(_empty_registry(), config)
         handle = server.start()
         try:
@@ -180,6 +198,7 @@ class TestGILPressure:
             # Start server *after* GIL burners are active.
             time.sleep(0.05)
             config = McpHttpConfig(port=0, server_name="reach-py-gil")
+            config.gateway_port = 0
             server = McpHttpServer(_empty_registry(), config)
             handle = server.start()
             try:

--- a/tests/test_install_lifecycle.py
+++ b/tests/test_install_lifecycle.py
@@ -1294,6 +1294,7 @@ def test_launch_sidecar_uses_detached_popen_contract(
             captured["kwargs"] = kwargs
 
     monkeypatch.setattr(sidecar_lifecycle.subprocess, "Popen", FakePopen)
+    monkeypatch.delenv("DCC_MCP_GATEWAY_PORT", raising=False)
 
     result = lifecycle.launch_sidecar(
         dcc_type="houdini",


### PR DESCRIPTION
Closes #2341.

## Summary
- disable gateway participation by default for ordinary pytest sessions
- propagate the pytest gateway opt-out through the public native `McpHttpConfig`
- keep ordinary native listener tests explicit and gateway-specific tests on allocated ports
- restore the caller environment after the session

## Validation
- Red: native `McpHttpConfig` resolved 9765 instead of 0 before any server start
- 199 Windows xdist-focused tests passed
- fixture teardown restored the caller gateway port
- 10,375 Python tests passed, 84 skipped, 3 xfailed
- 3,737 Rust tests passed
- `vx just preflight`
- `vx just lint`
- Python 3.7-3.14 support contract
- Rust and Python file-size gates

No live DCC or operator gateway was used, and no test interacted with port 9765. Gateway tests used only dynamically allocated test ports. Existing agent-facing guidance already documents `DCC_MCP_GATEWAY_PORT=0`, so no skill update is needed.