### PR TITLE
fix: redact public doctor endpoints

### DIFF
--- a/crates/dcc-mcp-cli/src/domain/feedback_bundle.rs
+++ b/crates/dcc-mcp-cli/src/domain/feedback_bundle.rs
@@ -329,6 +329,9 @@ fn sanitize_json(value: &Value, key: Option<&str>) -> Value {
         if url_key(key) {
             return Value::String("[url-redacted]".to_string());
         }
+        if endpoint_key(key) {
+            return Value::String("[endpoint-redacted]".to_string());
+        }
         if identifier_key(key) {
             return Value::String("[id-redacted]".to_string());
         }
@@ -371,6 +374,13 @@ fn path_key(key: &str) -> bool {
 
 fn url_key(key: &str) -> bool {
     key.to_ascii_lowercase().contains("url")
+}
+
+fn endpoint_key(key: &str) -> bool {
+    matches!(
+        key.to_ascii_lowercase().as_str(),
+        "host" | "hostname" | "port" | "addr" | "address" | "bind" | "endpoint"
+    )
 }
 
 fn identifier_key(key: &str) -> bool {
@@ -481,7 +491,12 @@ mod tests {
             },
             "gateway": {
                 "default_base_url": "http://127.0.0.1:9765",
-                "status": {"healthy": false, "pid": 1234}
+                "status": {
+                    "healthy": false,
+                    "host": "127.0.0.1",
+                    "port": 43210,
+                    "pid": 1234
+                }
             },
             "server_binary": {
                 "path": "C:\\tools\\dcc-mcp-server.exe",
@@ -494,7 +509,17 @@ mod tests {
         assert_eq!(projected["local"]["registry_dir"], "[path-redacted]");
         assert_eq!(projected["local"]["instance_id"], "[id-redacted]");
         assert_eq!(projected["gateway"]["default_base_url"], "[url-redacted]");
+        assert_eq!(
+            projected["gateway"]["status"]["host"],
+            "[endpoint-redacted]"
+        );
+        assert_eq!(
+            projected["gateway"]["status"]["port"],
+            "[endpoint-redacted]"
+        );
         assert_eq!(projected["gateway"]["status"]["pid"], "[id-redacted]");
+        assert!(!encoded.contains("127.0.0.1"));
+        assert!(!encoded.contains("43210"));
         assert!(!encoded.contains("artist"));
         assert!(!encoded.contains("secret-value"));
     }

--- a/crates/dcc-mcp-cli/tests/feedback_cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/feedback_cli_e2e.rs
@@ -261,6 +261,20 @@ fn feedback_bundle_assembles_public_safe_bounded_evidence() {
     assert_eq!(body["components"]["doctor"]["status"], "included");
     assert_eq!(body["components"]["host_errors"]["status"], "included");
     assert_eq!(
+        body["components"]["doctor"]["data"]["gateway"]["status"]["host"],
+        "[endpoint-redacted]"
+    );
+    assert_eq!(
+        body["components"]["doctor"]["data"]["gateway"]["status"]["port"],
+        "[endpoint-redacted]"
+    );
+    assert!(body["finding"]["evidence"].get("dcc_pid").is_none());
+    assert!(
+        body["components"]["host_errors"]["data"]["records"][0]
+            .get("dcc_pid")
+            .is_none()
+    );
+    assert_eq!(
         body["components"]["install_execution_report"]["status"],
         "unavailable"
     );
@@ -268,7 +282,6 @@ fn feedback_bundle_assembles_public_safe_bounded_evidence() {
         "secret.godot",
         "token=private",
         "private traceback",
-        "4321",
         &finding_arg,
         &log_dir_arg,
         &fixture.base_url,


### PR DESCRIPTION
## Summary
- redact host and port fields from public-safe doctor projections
- replace a collision-prone PID substring assertion with explicit projection checks
- add deterministic unit and CLI E2E coverage

## Validation
- `vx cargo fmt --all -- --check`
- `vx cargo clippy -p dcc-mcp-cli --all-targets -- -D warnings`
- `vx cargo test -p dcc-mcp-cli`

No agent skill guidance update is needed because the public contract already requires local URLs and private identifiers to be excluded.

Unblocks release PR #2349. Related to #2253.