### PR TITLE
fix: accept trusted scope for UI recording

### DIFF
--- a/python/dcc_mcp_core/skills/ui-control/scripts/_cua_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_cua_backend.py
@@ -477,6 +477,7 @@ def recording_start_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, A
         "output_dir",
         "record_video",
         "policy",
+        "trusted_adapter_scope",
     }
     if set(params) - allowed:
         return skill_error(

--- a/tests/test_ui_control_skill.py
+++ b/tests/test_ui_control_skill.py
@@ -1074,6 +1074,36 @@ def test_ui_control_cua_host_controls_trajectory_recording(tmp_path: Path, monke
     ]
 
 
+def test_ui_control_cua_host_recording_accepts_trusted_adapter_scope(tmp_path: Path, monkeypatch: Any) -> None:
+    backend = _load_cua_module()
+    _FakeHostClient.instances.clear()
+    monkeypatch.setattr(backend, "_HostClient", _FakeHostClient)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_DCC_TYPE", raising=False)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_PROCESS_ID", raising=False)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_WINDOW_HANDLE", raising=False)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_WINDOW_TITLE", raising=False)
+
+    started = backend.recording_start_tool(
+        {
+            "session_id": "unreal-playtest",
+            "output_dir": str(tmp_path),
+            "record_video": True,
+            "trusted_adapter_scope": {
+                "dcc_type": "unreal",
+                "process_id": 4242,
+                "window_handle": 9001,
+                "window_title": "Unreal Editor",
+            },
+        }
+    )
+
+    assert started["success"] is True
+    assert _FakeHostClient.instances[0].kwargs["dcc_type"] == "unreal"
+    assert _FakeHostClient.instances[0].kwargs["process_id"] == 4242
+    assert _FakeHostClient.instances[0].kwargs["window_handle"] == 9001
+    assert _FakeHostClient.instances[0].kwargs["window_title"] == "Unreal Editor"
+
+
 def test_ui_control_cua_host_requires_operator_bound_scope(monkeypatch: Any) -> None:
     backend = _load_cua_module()
     _FakeHostClient.instances.clear()


### PR DESCRIPTION
## Summary

- accept the server-injected trusted adapter scope in recording startup
- preserve exact PID/HWND narrowing for the persistent CUA host
- add a regression test for adapter-bound video recording

## Validation

- 107 focused UI Control and in-process executor tests passed
- Ruff check and format passed

No public API or skill documentation changes are required.