### PR TITLE
Fix UI recording session scope

### DIFF
--- a/python/dcc_mcp_core/skills/ui-control/scripts/_cua_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_cua_backend.py
@@ -259,6 +259,17 @@ def _client_for(session_id: str, params: Dict[str, Any], policy: UiControlPolicy
         return entry["client"], entry
 
 
+def _client_for_existing_session_or_scope(
+    session_id: str, params: Dict[str, Any], policy: UiControlPolicy
+) -> Tuple[Any, Dict[str, Any]]:
+    """Reuse an already-authorized session before resolving mutable window state."""
+    with _CLIENTS_LOCK:
+        entry = _CLIENTS.get(session_id)
+        if entry is not None:
+            return entry["client"], entry
+    return _client_for(session_id, params, policy)
+
+
 def _host_error(exc: Exception) -> Dict[str, Any]:
     message = str(exc)
     code = str(getattr(exc, "code", None) or UiErrorCode.BACKEND_UNAVAILABLE)
@@ -529,7 +540,7 @@ def recording_stop_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, An
     if not policy.allow_snapshot:
         return skill_error("ui_control recording disabled by policy", UiErrorCode.POLICY_DISABLED)
     try:
-        client, entry = _client_for(session_id, params, policy)
+        client, entry = _client_for_existing_session_or_scope(session_id, params, policy)
         recording = client.recording_stop()
     except (UiControlHostError, OSError, ValueError) as exc:
         return _host_error(exc)
@@ -556,7 +567,7 @@ def recording_state_tool(params: Optional[Dict[str, Any]] = None) -> Dict[str, A
     if not policy.allow_snapshot:
         return skill_error("ui_control recording disabled by policy", UiErrorCode.POLICY_DISABLED)
     try:
-        client, _entry = _client_for(session_id, params, policy)
+        client, _entry = _client_for_existing_session_or_scope(session_id, params, policy)
         recording = client.recording_state()
     except (UiControlHostError, OSError, ValueError) as exc:
         return _host_error(exc)

--- a/tests/test_ui_control_skill.py
+++ b/tests/test_ui_control_skill.py
@@ -1096,8 +1096,13 @@ def test_ui_control_cua_host_recording_accepts_trusted_adapter_scope(tmp_path: P
             },
         }
     )
+    state = backend.recording_state_tool({"session_id": "unreal-playtest"})
+    stopped = backend.recording_stop_tool({"session_id": "unreal-playtest"})
 
     assert started["success"] is True
+    assert state["success"] is True
+    assert stopped["success"] is True
+    assert len(_FakeHostClient.instances) == 1
     assert _FakeHostClient.instances[0].kwargs["dcc_type"] == "unreal"
     assert _FakeHostClient.instances[0].kwargs["process_id"] == 4242
     assert _FakeHostClient.instances[0].kwargs["window_handle"] == 9001
@@ -1112,6 +1117,20 @@ def test_ui_control_cua_host_requires_operator_bound_scope(monkeypatch: Any) -> 
     monkeypatch.delenv("DCC_MCP_UI_CONTROL_WINDOW_HANDLE", raising=False)
 
     result = backend.snapshot_tool({"session_id": "untrusted", "process_id": 1234})
+
+    assert result["success"] is False
+    assert result["error"] == "permission_denied"
+    assert not _FakeHostClient.instances
+
+
+def test_ui_control_cua_host_recording_state_without_existing_session_requires_scope(monkeypatch: Any) -> None:
+    backend = _load_cua_module()
+    _FakeHostClient.instances.clear()
+    monkeypatch.setattr(backend, "_HostClient", _FakeHostClient)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_PROCESS_ID", raising=False)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_WINDOW_HANDLE", raising=False)
+
+    result = backend.recording_state_tool({"session_id": "untrusted-recording"})
 
     assert result["success"] is False
     assert result["error"] == "permission_denied"


### PR DESCRIPTION
## Summary
- reuse the already-authorized UI session for recording state and stop
- avoid re-resolving mutable window state during recording finalization
- keep first-use scope validation fail closed

## Validation
- 47 focused UI control tests passed
- Ruff checks passed