### PR TITLE
test: avoid feedback bundle redaction substring false positives

### DIFF
--- a/crates/dcc-mcp-cli/tests/feedback_cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/feedback_cli_e2e.rs
@@ -181,7 +181,7 @@ fn feedback_bundle_assembles_public_safe_bounded_evidence() {
             "phase": "startup",
             "severity": "blocker",
             "intent": "Start the Godot adapter",
-            "observed": "The bridge did not start",
+            "observed": "The bridge did not start; public support code 4321",
             "expected": "The bridge becomes ready",
             "repro": {"argv": ["dcc-mcp-cli", "status"]},
             "evidence": {
@@ -257,6 +257,10 @@ fn feedback_bundle_assembles_public_safe_bounded_evidence() {
     assert_eq!(body["schema_version"], "dcc-mcp.feedback-bundle.v1");
     assert_eq!(body["privacy_mode"], "public-safe");
     assert_eq!(body["complete"], false);
+    assert_eq!(
+        body["finding"]["observed"],
+        "The bridge did not start; public support code 4321"
+    );
     assert_eq!(body["components"]["issue_report"]["status"], "included");
     assert_eq!(body["components"]["doctor"]["status"], "included");
     assert_eq!(body["components"]["host_errors"]["status"], "included");


### PR DESCRIPTION
## Summary
- preserve unrelated public text that contains the same digits as a redacted PID
- assert PID removal structurally while retaining private path, token, traceback, and endpoint checks

## Validation
- `cargo test -p dcc-mcp-cli feedback_bundle -- --nocapture`
- `cargo test -p dcc-mcp-cli --test feedback_cli_e2e -- --nocapture`
- `just preflight` (3,720 workspace tests passed)

No production or skill guidance changes are required.

Fixes #2352