### PR TITLE
feat(cli): emit install execution reports

### DIFF
--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -1,8 +1,7 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use dcc_mcp_models::DccName;
 use serde::Serialize;
@@ -14,9 +13,19 @@ use crate::domain::install::{
 };
 
 const BUNDLED_CATALOG: &str = include_str!("../../../../dcc-mcp-catalog.yml");
-const INSTALL_DISABLED_ENV: &str = "DCC_MCP_INSTALL_DISABLED";
-const INSTALL_DISABLED_PROMPT_ENV: &str = "DCC_MCP_INSTALL_DISABLED_PROMPT";
-const DEFAULT_INSTALL_DISABLED_PROMPT: &str = "Automatic DCC adapter installation is disabled in this environment. Ask your Pipeline TD or studio deployment owner to deploy {adapter} for {dcc_type}, then start the DCC plugin and rerun `dcc-mcp-cli list`.";
+
+mod policy;
+mod report;
+
+use policy::{AutoInstallPolicy, ask_consent, render_install_policy_prompt};
+pub use report::{
+    InstallExecutionError, InstallExecutionReport, InstallReportNextStep, InstallRollbackReport,
+    InstallStepReport, InstallStepRollbackReport, InstallVerifyReport,
+};
+use report::{
+    action_failure, empty_execution_report, execution_report_for_plan, failed_report,
+    safe_report_identifier, stable_step_id, success_next_steps,
+};
 
 #[derive(Debug, Error)]
 pub enum InstallError {
@@ -55,13 +64,6 @@ pub struct DccAdapterSummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     pub catalog_install_available: bool,
-}
-
-/// Result of a single executed step with optional rollback data.
-struct StepResult {
-    step_name: String,
-    /// Rollback action to undo this step, if applicable.
-    rollback: Option<StepRollback>,
 }
 
 /// Describes how to undo a completed step.
@@ -157,16 +159,24 @@ impl InstallService {
 
     /// Generate and execute an install plan with user consent.
     ///
-    /// Steps are executed sequentially.  If any step fails, all prior steps
-    /// are rolled back in reverse order.  Returns the full plan (with step
-    /// results) on success.
+    /// Execution always returns one machine-readable Install SOP v1 report.
+    /// Internal errors are reduced to stable public codes before serialization.
     pub fn execute(
         &self,
         request: InstallRequest,
         skip_confirmation: bool,
-    ) -> Result<InstallPlan, InstallError> {
-        let plan = self.plan(request)?;
-        self.execute_plan(&plan, skip_confirmation)
+    ) -> InstallExecutionReport {
+        let requested_dcc = safe_report_identifier(&request.dcc_type, "unknown");
+        match self.plan(request) {
+            Ok(plan) => self.execute_plan(&plan, skip_confirmation),
+            Err(_) => failed_report(
+                empty_execution_report(requested_dcc),
+                "preflight",
+                10,
+                "INSTALL_PLAN_FAILED",
+                None,
+            ),
+        }
     }
 
     fn load_entries(
@@ -195,135 +205,141 @@ impl InstallService {
         plan
     }
 
-    fn execute_plan(
+    fn execute_plan(&self, plan: &InstallPlan, skip_confirmation: bool) -> InstallExecutionReport {
+        self.execute_plan_with(
+            plan,
+            skip_confirmation,
+            |action, plan| match action {
+                InstallStepAction::Verify => execute_verify(plan),
+                _ => execute_action(action),
+            },
+            execute_rollback,
+        )
+    }
+
+    fn execute_plan_with<E, R>(
         &self,
         plan: &InstallPlan,
         skip_confirmation: bool,
-    ) -> Result<InstallPlan, InstallError> {
+        mut execute_step: E,
+        mut rollback_step: R,
+    ) -> InstallExecutionReport
+    where
+        E: FnMut(&InstallStepAction, &InstallPlan) -> Result<Option<StepRollback>, InstallError>,
+        R: FnMut(&StepRollback) -> Result<(), InstallError>,
+    {
+        let mut report = execution_report_for_plan(plan);
+
         if !plan.install_policy.auto_install_enabled {
-            if let Some(prompt) = &plan.install_policy.prompt {
-                eprintln!("{prompt}");
-            }
-            return Ok(plan.clone());
+            eprintln!("Automatic installation is disabled by policy.");
+            return failed_report(report, "preflight", 10, "AUTO_INSTALL_DISABLED", None);
         }
 
-        // Filter to executable steps
-        let executable_steps: Vec<_> = plan.steps.iter().filter(|s| s.action.is_some()).collect();
+        let executable_steps = plan
+            .steps
+            .iter()
+            .enumerate()
+            .filter_map(|(index, step)| step.action.as_ref().map(|action| (index, action)))
+            .collect::<Vec<_>>();
 
         if executable_steps.is_empty() {
             eprintln!("No executable steps in the install plan.");
-            return Ok(plan.clone());
+            return failed_report(report, "preflight", 10, "NO_EXECUTABLE_STEPS", None);
         }
 
-        // ── consent gating ────────────────────────────────────────────────
-        eprintln!();
-        eprintln!("╔══════════════════════════════════════════════╗");
-        eprintln!("║         DCC-MCP Install Plan                ║");
-        eprintln!("╠══════════════════════════════════════════════╣");
-        eprintln!("║  Adapter:  {:<30} ║", plan.adapter.name);
-        eprintln!("║  DCC type: {:<30} ║", plan.dcc_type);
-        if let Some(ver) = &plan.version {
-            eprintln!("║  Version:  {:<30} ║", ver);
-        }
-        eprintln!("╠══════════════════════════════════════════════╣");
-        eprintln!("║  Steps:                                    ║");
-        for (i, step) in executable_steps.iter().enumerate() {
-            eprintln!("║    {}. {:<34} ║", i + 1, step.name);
-            eprintln!("║       {:<34} ║", step.description);
-        }
-        eprintln!("╚══════════════════════════════════════════════╝");
-        eprintln!();
-
-        if !skip_confirmation && !ask_consent("Proceed with installation? [Y/n]")? {
-            return Err(InstallError::ConsentDenied);
-        }
-
-        // ── execute with rollback support ────────────────────────────────
-        let mut completed: Vec<StepResult> = Vec::new();
-
-        for step in &executable_steps {
-            let action = step.action.as_ref().expect("filtered to Some above");
-            eprint!(
-                "  [{}/{}] {} ... ",
-                completed.len() + 1,
-                executable_steps.len(),
-                step.name
-            );
-
-            let result = match action {
-                InstallStepAction::Verify => execute_verify(plan),
-                _ => execute_action(action),
-            };
-
-            match result {
-                Ok(rollback) => {
-                    eprintln!("OK");
-                    completed.push(StepResult {
-                        step_name: step.name.clone(),
-                        rollback,
-                    });
+        eprintln!(
+            "Install execution requires {} step(s).",
+            executable_steps.len()
+        );
+        if !skip_confirmation {
+            match ask_consent("Proceed with installation? [Y/n]") {
+                Ok(true) => {}
+                Ok(false) => {
+                    return failed_report(report, "preflight", 10, "CONSENT_DENIED", None);
                 }
-                Err(e) => {
-                    eprintln!("FAILED");
-                    // Roll back all completed steps in reverse order
-                    eprintln!("  Rolling back...");
-                    rollback_all(&completed);
-                    return Err(InstallError::StepFailed {
-                        step: step.name.clone(),
-                        message: e.to_string(),
-                    });
+                Err(_) => {
+                    return failed_report(report, "preflight", 10, "CONSENT_INPUT_FAILED", None);
                 }
             }
         }
 
-        eprintln!();
-        eprintln!("Installation complete for {}.", plan.adapter.name);
-        Ok(plan.clone())
-    }
-}
+        let mut completed: Vec<(usize, Option<StepRollback>)> = Vec::new();
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct AutoInstallPolicy {
-    enabled: bool,
-    prompt_template: String,
-}
+        for (ordinal, (step_index, action)) in executable_steps.iter().enumerate() {
+            let step_id = stable_step_id(action);
+            eprint!(
+                "  [{}/{}] {step_id} ... ",
+                ordinal + 1,
+                executable_steps.len()
+            );
+            match execute_step(action, plan) {
+                Ok(rollback) => {
+                    eprintln!("OK");
+                    report.steps[*step_index].status = "ok".into();
+                    report.steps[*step_index].rollback.status = if rollback.is_some() {
+                        "available".into()
+                    } else {
+                        "not_available".into()
+                    };
+                    completed.push((*step_index, rollback));
+                }
+                Err(_) => {
+                    eprintln!("FAILED");
+                    report.steps[*step_index].status = "failed".into();
+                    report.steps[*step_index].rollback.status = "not_available".into();
+                    let (failure_stage, failure_exit, failure_code) = action_failure(action);
 
-impl AutoInstallPolicy {
-    fn from_env() -> Self {
-        let disabled = std::env::var(INSTALL_DISABLED_ENV)
-            .ok()
-            .is_some_and(|value| env_flag_enabled(&value));
-        let prompt_template = std::env::var(INSTALL_DISABLED_PROMPT_ENV)
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| DEFAULT_INSTALL_DISABLED_PROMPT.to_string());
-        Self {
-            enabled: !disabled,
-            prompt_template,
+                    let mut rollback_attempted = false;
+                    let mut rollback_failures = 0;
+                    for (completed_index, rollback) in completed.iter().rev() {
+                        let Some(rollback) = rollback else {
+                            continue;
+                        };
+                        rollback_attempted = true;
+                        let rollback_report = &mut report.steps[*completed_index].rollback;
+                        rollback_report.attempted = true;
+                        if rollback_step(rollback).is_ok() {
+                            rollback_report.status = "ok".into();
+                        } else {
+                            rollback_report.status = "failed".into();
+                            rollback_failures += 1;
+                        }
+                    }
+                    report.rollback = InstallRollbackReport {
+                        attempted: rollback_attempted,
+                        status: if rollback_failures > 0 {
+                            "failed".into()
+                        } else if rollback_attempted {
+                            "ok".into()
+                        } else {
+                            "not_attempted".into()
+                        },
+                        failure_count: rollback_failures,
+                    };
+
+                    if rollback_failures > 0 {
+                        return failed_report(
+                            report,
+                            "rollback",
+                            30,
+                            "ROLLBACK_FAILED",
+                            Some(failure_code),
+                        );
+                    }
+                    return failed_report(report, failure_stage, failure_exit, failure_code, None);
+                }
+            }
         }
+
+        eprintln!("Installation execution completed.");
+        report.status = "ok".into();
+        report.stage = "complete".into();
+        report.exit_code = 0;
+        report.next_steps = success_next_steps(&report.dcc_type);
+        report.verify.failure_stage = Some("host-readiness".into());
+        report.verify.failure_reason = Some("LIVE_DCC_VERIFICATION_REQUIRED".into());
+        report
     }
-
-    #[cfg(test)]
-    fn disabled(prompt_template: impl Into<String>) -> Self {
-        Self {
-            enabled: false,
-            prompt_template: prompt_template.into(),
-        }
-    }
-}
-
-fn env_flag_enabled(value: &str) -> bool {
-    matches!(
-        value.trim().to_ascii_lowercase().as_str(),
-        "1" | "true" | "yes" | "on" | "disabled" | "disable"
-    )
-}
-
-fn render_install_policy_prompt(template: &str, plan: &InstallPlan) -> String {
-    template
-        .replace("{adapter}", &plan.adapter.name)
-        .replace("{dcc_type}", &plan.dcc_type)
-        .replace("{version}", plan.version.as_deref().unwrap_or(""))
 }
 
 // ── step executors ───────────────────────────────────────────────────────────────
@@ -376,7 +392,9 @@ fn execute_pip_install(
     let python_cmd = python.unwrap_or("python");
     let package_spec = verified_pip_artifact_spec(package, version, extras, artifact_url, sha256)?;
     let mut cmd = Command::new(python_cmd);
-    cmd.args(pip_install_args(&package_spec));
+    cmd.args(pip_install_args(&package_spec))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
 
     let status = cmd.status().map_err(|e| InstallError::StepFailed {
         step: format!("pip-install-{package}"),
@@ -694,19 +712,14 @@ fn execute_path_copy(source: &Path, dest: &Path) -> Result<Option<StepRollback>,
 }
 
 fn execute_register_dcc(
-    dcc_type: &str,
+    _dcc_type: &str,
     _entry_point: Option<&str>,
-    dcc_path: Option<&Path>,
+    _dcc_path: Option<&Path>,
 ) -> Result<Option<StepRollback>, InstallError> {
     // Registration is owned by the DCC plugin's sidecar. The CLI can install
     // packages, but it must not pretend a host process is registered until the
     // plugin starts, stays alive, and advertises itself in the registry.
-    eprintln!();
-    if let Some(path) = dcc_path {
-        eprintln!("    └─ host path: {}", path.display());
-    }
-    eprint!("    └─ note: start or enable the '{dcc_type}' plugin, ");
-    eprintln!("then re-run `dcc-mcp-cli list` to confirm self-registration.");
+    eprintln!("Start or enable the requested DCC plugin, then confirm self-registration.");
     Ok(None)
 }
 
@@ -793,44 +806,7 @@ fn verify_pip_package(
     Ok(())
 }
 
-// ── consent ──────────────────────────────────────────────────────────────────────
-
-/// Prompt the user for Y/n consent.  Returns `true` if the user agrees.
-fn ask_consent(prompt: &str) -> Result<bool, InstallError> {
-    let stdin = std::io::stdin();
-    let mut stdout = std::io::stdout();
-
-    loop {
-        write!(stdout, "{prompt} ")?;
-        stdout.flush()?;
-
-        let mut line = String::new();
-        stdin.lock().read_line(&mut line)?;
-        let trimmed = line.trim().to_lowercase();
-
-        match trimmed.as_str() {
-            "" | "y" | "yes" => return Ok(true),
-            "n" | "no" => return Ok(false),
-            _ => {
-                write!(stdout, "  Please answer Y or n: ")?;
-                stdout.flush()?;
-            }
-        }
-    }
-}
-
 // ── rollback ─────────────────────────────────────────────────────────────────────
-
-/// Roll back all completed steps in reverse order, best-effort.
-fn rollback_all(completed: &[StepResult]) {
-    for result in completed.iter().rev() {
-        if let Some(rollback) = &result.rollback
-            && let Err(e) = execute_rollback(rollback)
-        {
-            eprintln!("  ⚠  rollback of '{}' failed: {e}", result.step_name);
-        }
-    }
-}
 
 fn execute_rollback(rollback: &StepRollback) -> Result<(), InstallError> {
     match rollback {
@@ -845,12 +821,15 @@ fn execute_rollback(rollback: &StepRollback) -> Result<(), InstallError> {
             Ok(())
         }
         StepRollback::Command { program, args } => {
-            let status = Command::new(program).args(args).status().map_err(|e| {
-                InstallError::RollbackFailed {
+            let status = Command::new(program)
+                .args(args)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .map_err(|e| InstallError::RollbackFailed {
                     step: program.clone(),
                     message: format!("failed to launch {program}: {e}"),
-                }
-            })?;
+                })?;
             if !status.success() {
                 return Err(InstallError::RollbackFailed {
                     step: program.clone(),
@@ -1013,7 +992,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_returns_plan_without_running_steps_when_auto_install_is_disabled() {
+    fn execute_reports_preflight_failure_when_auto_install_is_disabled() {
         let service = InstallService::with_auto_install_policy(
             PathBuf::from("__missing_dcc_mcp_catalog__.yml"),
             AutoInstallPolicy::disabled(
@@ -1021,21 +1000,28 @@ mod tests {
             ),
         );
 
-        let plan = service
-            .execute(
-                InstallRequest {
-                    dcc_type: "maya".into(),
-                    version: None,
-                    catalog_path: None,
-                    python: Some("/__nonexistent__/python".into()),
-                    dcc_path: None,
-                },
-                true,
-            )
-            .unwrap();
+        let report = service.execute(
+            InstallRequest {
+                dcc_type: "maya".into(),
+                version: None,
+                catalog_path: None,
+                python: Some("/__nonexistent__/python".into()),
+                dcc_path: None,
+            },
+            true,
+        );
 
-        assert!(!plan.install_policy.auto_install_enabled);
-        assert_eq!(plan.steps[0].name, "install-pip");
+        assert_eq!(report.status, "failed");
+        assert_eq!(report.stage, "preflight");
+        assert_eq!(report.exit_code, 10);
+        assert_eq!(report.error.as_ref().unwrap().code, "AUTO_INSTALL_DISABLED");
+        assert!(report.steps.iter().all(|step| step.status == "not_run"));
+        assert!(!report.verify.directly_usable);
+        assert_eq!(report.verify.failure_stage.as_deref(), Some("preflight"));
+        assert_eq!(
+            report.verify.failure_reason.as_deref(),
+            Some("AUTO_INSTALL_DISABLED")
+        );
     }
 
     #[test]
@@ -1260,5 +1246,235 @@ mod tests {
                 if step == "verify" && message.contains("installed directory is empty")),
             "expected verify StepFailed, got {err}"
         );
+    }
+
+    #[test]
+    fn execution_report_success_keeps_live_dcc_readiness_unproven() {
+        let service = InstallService::new(PathBuf::from("__unused__.yml"));
+        let plan = verify_plan(InstallStepAction::PathCopy {
+            source: PathBuf::from("source"),
+            dest: PathBuf::from("dest"),
+        });
+
+        let report =
+            service.execute_plan_with(&plan, true, |_action, _plan| Ok(None), |_rollback| Ok(()));
+
+        assert_eq!(report.status, "ok");
+        assert_eq!(report.stage, "complete");
+        assert_eq!(report.exit_code, 0);
+        assert!(report.error.is_none());
+        assert_eq!(report.steps[0].id, "install-path");
+        assert_eq!(report.steps[0].status, "ok");
+        assert_eq!(report.steps[0].rollback.status, "not_available");
+        assert_eq!(report.steps[1].id, "verify");
+        assert_eq!(report.steps[1].status, "ok");
+        assert!(!report.verify.directly_usable);
+        assert_eq!(
+            report.verify.failure_stage.as_deref(),
+            Some("host-readiness")
+        );
+        assert_eq!(
+            report.verify.failure_reason.as_deref(),
+            Some("LIVE_DCC_VERIFICATION_REQUIRED")
+        );
+        assert_eq!(report.receipt_path, None);
+
+        let mut actual = serde_json::to_value(report).unwrap();
+        actual["core_version"] = serde_json::json!("0.0.0-test");
+        let expected: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../../tests/fixtures/install-execution-report-v1-success.json"
+        ))
+        .unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn execution_report_mid_failure_rolls_back_completed_steps_in_reverse() {
+        let service = InstallService::new(PathBuf::from("__unused__.yml"));
+        let mut plan = verify_plan(InstallStepAction::PathCopy {
+            source: PathBuf::from("source"),
+            dest: PathBuf::from("dest"),
+        });
+        plan.steps.insert(
+            1,
+            InstallStep {
+                name: "register-dcc".into(),
+                description: "Register adapter".into(),
+                action: Some(InstallStepAction::RegisterDcc {
+                    dcc_type: "maya".into(),
+                    entry_point: None,
+                    dcc_path: None,
+                }),
+            },
+        );
+        let mut calls = 0;
+        let mut rollback_order = Vec::new();
+
+        let report = service.execute_plan_with(
+            &plan,
+            true,
+            |_action, _plan| {
+                calls += 1;
+                if calls == 1 {
+                    Ok(Some(StepRollback::RemovePath(PathBuf::from("secret-a"))))
+                } else {
+                    Err(InstallError::StepFailed {
+                        step: "secret-stage".into(),
+                        message: "token=super-secret".into(),
+                    })
+                }
+            },
+            |rollback| {
+                if let StepRollback::RemovePath(path) = rollback {
+                    rollback_order.push(path.clone());
+                }
+                Ok(())
+            },
+        );
+
+        assert_eq!(rollback_order, vec![PathBuf::from("secret-a")]);
+        assert_eq!(report.status, "failed");
+        assert_eq!(report.stage, "install");
+        assert_eq!(report.exit_code, 30);
+        assert_eq!(report.error.as_ref().unwrap().code, "INSTALL_STEP_FAILED");
+        assert_eq!(report.steps[0].status, "ok");
+        assert!(report.steps[0].rollback.attempted);
+        assert_eq!(report.steps[0].rollback.status, "ok");
+        assert_eq!(report.steps[1].status, "failed");
+        assert_eq!(report.steps[2].status, "not_run");
+        assert!(report.rollback.attempted);
+        assert_eq!(report.rollback.status, "ok");
+        assert_eq!(report.rollback.failure_count, 0);
+        assert_eq!(
+            report.verify.failure_reason.as_deref(),
+            Some("INSTALL_STEP_FAILED")
+        );
+
+        let public = serde_json::to_string(&report).unwrap();
+        assert!(!public.contains("secret-a"));
+        assert!(!public.contains("secret-stage"));
+        assert!(!public.contains("super-secret"));
+    }
+
+    #[test]
+    fn execution_report_rollback_failure_is_partial_and_stable() {
+        let service = InstallService::new(PathBuf::from("__unused__.yml"));
+        let mut plan = verify_plan(InstallStepAction::PathCopy {
+            source: PathBuf::from("source"),
+            dest: PathBuf::from("dest"),
+        });
+        plan.steps.insert(
+            1,
+            InstallStep {
+                name: "register-dcc".into(),
+                description: "Register adapter".into(),
+                action: Some(InstallStepAction::RegisterDcc {
+                    dcc_type: "maya".into(),
+                    entry_point: None,
+                    dcc_path: None,
+                }),
+            },
+        );
+        let mut calls = 0;
+
+        let report = service.execute_plan_with(
+            &plan,
+            true,
+            |_action, _plan| {
+                calls += 1;
+                if calls == 1 {
+                    Ok(Some(StepRollback::RemovePath(PathBuf::from("secret-path"))))
+                } else {
+                    Err(InstallError::StepFailed {
+                        step: "install".into(),
+                        message: "primary secret".into(),
+                    })
+                }
+            },
+            |_rollback| {
+                Err(InstallError::RollbackFailed {
+                    step: "secret-program".into(),
+                    message: "rollback secret".into(),
+                })
+            },
+        );
+
+        assert_eq!(report.status, "partial");
+        assert_eq!(report.stage, "rollback");
+        assert_eq!(report.exit_code, 30);
+        let error = report.error.as_ref().unwrap();
+        assert_eq!(error.code, "ROLLBACK_FAILED");
+        assert_eq!(error.primary_code.as_deref(), Some("INSTALL_STEP_FAILED"));
+        assert_eq!(report.steps[0].rollback.status, "failed");
+        assert_eq!(report.rollback.status, "failed");
+        assert_eq!(report.rollback.failure_count, 1);
+        assert_eq!(
+            report.verify.failure_reason.as_deref(),
+            Some("ROLLBACK_FAILED")
+        );
+
+        let public = serde_json::to_string(&report).unwrap();
+        for secret in [
+            "secret-path",
+            "secret-program",
+            "primary secret",
+            "rollback secret",
+        ] {
+            assert!(!public.contains(secret));
+        }
+
+        let mut actual = serde_json::to_value(report).unwrap();
+        actual["core_version"] = serde_json::json!("0.0.0-test");
+        let expected: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../../tests/fixtures/install-execution-report-v1-rollback-failed.json"
+        ))
+        .unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn failed_execution_report_matches_shared_cross_language_fixture() {
+        let service = InstallService::new(PathBuf::from("__unused__.yml"));
+        let mut plan = verify_plan(InstallStepAction::PathCopy {
+            source: PathBuf::from("source"),
+            dest: PathBuf::from("dest"),
+        });
+        plan.steps.insert(
+            1,
+            InstallStep {
+                name: "register-dcc".into(),
+                description: "Register adapter".into(),
+                action: Some(InstallStepAction::RegisterDcc {
+                    dcc_type: "maya".into(),
+                    entry_point: None,
+                    dcc_path: None,
+                }),
+            },
+        );
+        let mut calls = 0;
+        let report = service.execute_plan_with(
+            &plan,
+            true,
+            |_action, _plan| {
+                calls += 1;
+                if calls == 1 {
+                    Ok(Some(StepRollback::RemovePath(PathBuf::from("private"))))
+                } else {
+                    Err(InstallError::StepFailed {
+                        step: "private".into(),
+                        message: "private".into(),
+                    })
+                }
+            },
+            |_rollback| Ok(()),
+        );
+        let mut actual = serde_json::to_value(report).unwrap();
+        actual["core_version"] = serde_json::json!("0.0.0-test");
+        let expected: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../../tests/fixtures/install-execution-report-v1-failed.json"
+        ))
+        .unwrap();
+
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/dcc-mcp-cli/src/application/install/policy.rs
+++ b/crates/dcc-mcp-cli/src/application/install/policy.rs
@@ -1,0 +1,77 @@
+use std::io::{BufRead, Write};
+
+use crate::domain::install::InstallPlan;
+
+use super::InstallError;
+
+const INSTALL_DISABLED_ENV: &str = "DCC_MCP_INSTALL_DISABLED";
+const INSTALL_DISABLED_PROMPT_ENV: &str = "DCC_MCP_INSTALL_DISABLED_PROMPT";
+const DEFAULT_INSTALL_DISABLED_PROMPT: &str = "Automatic DCC adapter installation is disabled in this environment. Ask your Pipeline TD or studio deployment owner to deploy {adapter} for {dcc_type}, then start the DCC plugin and rerun `dcc-mcp-cli list`.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct AutoInstallPolicy {
+    pub(super) enabled: bool,
+    pub(super) prompt_template: String,
+}
+
+impl AutoInstallPolicy {
+    pub(super) fn from_env() -> Self {
+        let disabled = std::env::var(INSTALL_DISABLED_ENV)
+            .ok()
+            .is_some_and(|value| env_flag_enabled(&value));
+        let prompt_template = std::env::var(INSTALL_DISABLED_PROMPT_ENV)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_INSTALL_DISABLED_PROMPT.to_string());
+        Self {
+            enabled: !disabled,
+            prompt_template,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn disabled(prompt_template: impl Into<String>) -> Self {
+        Self {
+            enabled: false,
+            prompt_template: prompt_template.into(),
+        }
+    }
+}
+
+pub(super) fn render_install_policy_prompt(template: &str, plan: &InstallPlan) -> String {
+    template
+        .replace("{adapter}", &plan.adapter.name)
+        .replace("{dcc_type}", &plan.dcc_type)
+        .replace("{version}", plan.version.as_deref().unwrap_or(""))
+}
+
+/// Prompt the user for Y/n consent. Returns `true` if the user agrees.
+pub(super) fn ask_consent(prompt: &str) -> Result<bool, InstallError> {
+    let stdin = std::io::stdin();
+    let mut stderr = std::io::stderr();
+
+    loop {
+        write!(stderr, "{prompt} ")?;
+        stderr.flush()?;
+
+        let mut line = String::new();
+        stdin.lock().read_line(&mut line)?;
+        let trimmed = line.trim().to_lowercase();
+
+        match trimmed.as_str() {
+            "" | "y" | "yes" => return Ok(true),
+            "n" | "no" => return Ok(false),
+            _ => {
+                write!(stderr, "  Please answer Y or n: ")?;
+                stderr.flush()?;
+            }
+        }
+    }
+}
+
+fn env_flag_enabled(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on" | "disabled" | "disable"
+    )
+}

--- a/crates/dcc-mcp-cli/src/application/install/report.rs
+++ b/crates/dcc-mcp-cli/src/application/install/report.rs
@@ -1,0 +1,260 @@
+use serde::Serialize;
+
+use crate::domain::install::{InstallPlan, InstallStepAction, normalized_dcc_key};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InstallExecutionReport {
+    pub schema_version: u8,
+    pub status: String,
+    pub dcc_type: String,
+    pub adapter_version: String,
+    pub core_version: String,
+    pub stage: String,
+    pub exit_code: i32,
+    pub steps: Vec<InstallStepReport>,
+    pub rollback: InstallRollbackReport,
+    pub next_steps: Vec<InstallReportNextStep>,
+    pub receipt_path: Option<String>,
+    pub verify: InstallVerifyReport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<InstallExecutionError>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InstallStepReport {
+    pub id: String,
+    pub status: String,
+    pub rollback: InstallStepRollbackReport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InstallStepRollbackReport {
+    pub attempted: bool,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InstallRollbackReport {
+    pub attempted: bool,
+    pub status: String,
+    pub failure_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InstallReportNextStep {
+    pub id: String,
+    pub description: String,
+    pub why: String,
+    pub command: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InstallVerifyReport {
+    pub directly_usable: bool,
+    pub failure_stage: Option<String>,
+    pub failure_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InstallExecutionError {
+    pub code: String,
+    pub stage: String,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_code: Option<String>,
+}
+
+pub(super) fn execution_report_for_plan(plan: &InstallPlan) -> InstallExecutionReport {
+    let dcc_type = safe_plan_dcc_type(plan);
+    let steps = plan
+        .steps
+        .iter()
+        .enumerate()
+        .map(|(index, step)| InstallStepReport {
+            id: step
+                .action
+                .as_ref()
+                .map(stable_step_id)
+                .unwrap_or_else(|| format!("informational-{}", index + 1)),
+            status: "not_run".into(),
+            rollback: InstallStepRollbackReport {
+                attempted: false,
+                status: "not_attempted".into(),
+            },
+        })
+        .collect();
+    InstallExecutionReport {
+        schema_version: 1,
+        status: "running".into(),
+        dcc_type: dcc_type.clone(),
+        adapter_version: plan
+            .version
+            .as_deref()
+            .or(plan.adapter.version.as_deref())
+            .map(|value| safe_report_identifier(value, "unknown"))
+            .unwrap_or_else(|| "unknown".into()),
+        core_version: env!("CARGO_PKG_VERSION").into(),
+        stage: "preflight".into(),
+        exit_code: 0,
+        steps,
+        rollback: InstallRollbackReport {
+            attempted: false,
+            status: "not_attempted".into(),
+            failure_count: 0,
+        },
+        next_steps: failure_next_steps(&dcc_type),
+        receipt_path: None,
+        verify: InstallVerifyReport {
+            directly_usable: false,
+            failure_stage: None,
+            failure_reason: None,
+        },
+        error: None,
+    }
+}
+
+pub(super) fn empty_execution_report(dcc_type: String) -> InstallExecutionReport {
+    InstallExecutionReport {
+        schema_version: 1,
+        status: "running".into(),
+        dcc_type: dcc_type.clone(),
+        adapter_version: "unknown".into(),
+        core_version: env!("CARGO_PKG_VERSION").into(),
+        stage: "preflight".into(),
+        exit_code: 0,
+        steps: Vec::new(),
+        rollback: InstallRollbackReport {
+            attempted: false,
+            status: "not_attempted".into(),
+            failure_count: 0,
+        },
+        next_steps: failure_next_steps(&dcc_type),
+        receipt_path: None,
+        verify: InstallVerifyReport {
+            directly_usable: false,
+            failure_stage: None,
+            failure_reason: None,
+        },
+        error: None,
+    }
+}
+
+pub(super) fn failed_report(
+    mut report: InstallExecutionReport,
+    stage: &str,
+    exit_code: i32,
+    code: &str,
+    primary_code: Option<&str>,
+) -> InstallExecutionReport {
+    report.status = if code == "ROLLBACK_FAILED" {
+        "partial".into()
+    } else {
+        "failed".into()
+    };
+    report.stage = stage.into();
+    report.exit_code = exit_code;
+    report.verify.directly_usable = false;
+    report.verify.failure_stage = Some(stage.into());
+    report.verify.failure_reason = Some(code.into());
+    report.error = Some(InstallExecutionError {
+        code: code.into(),
+        stage: stage.into(),
+        exit_code,
+        primary_code: primary_code.map(Into::into),
+    });
+    report
+}
+
+pub(super) fn safe_report_identifier(value: &str, fallback: &str) -> String {
+    let trimmed = value.trim();
+    let valid = !trimmed.is_empty()
+        && trimmed.chars().count() <= 64
+        && trimmed.chars().all(|character| {
+            character.is_ascii_alphanumeric()
+                || matches!(character, '-' | '_' | '.' | ' ' | '+' | '(' | ')')
+        });
+    if valid {
+        trimmed.into()
+    } else {
+        fallback.into()
+    }
+}
+
+pub(super) fn stable_step_id(action: &InstallStepAction) -> String {
+    match action {
+        InstallStepAction::PipInstall { .. } => "install-pip",
+        InstallStepAction::GitClone { .. } => "install-git",
+        InstallStepAction::ZipExtract { .. } => "install-zip",
+        InstallStepAction::PathCopy { .. } => "install-path",
+        InstallStepAction::RegisterDcc { .. } => "register-dcc",
+        InstallStepAction::Verify => "verify",
+    }
+    .into()
+}
+
+pub(super) fn action_failure(action: &InstallStepAction) -> (&'static str, i32, &'static str) {
+    match action {
+        InstallStepAction::GitClone { .. } | InstallStepAction::ZipExtract { .. } => {
+            ("acquire", 20, "ACQUIRE_STEP_FAILED")
+        }
+        InstallStepAction::Verify => ("verify", 40, "VERIFY_FAILED"),
+        InstallStepAction::PipInstall { .. }
+        | InstallStepAction::PathCopy { .. }
+        | InstallStepAction::RegisterDcc { .. } => ("install", 30, "INSTALL_STEP_FAILED"),
+    }
+}
+
+pub(super) fn success_next_steps(dcc_type: &str) -> Vec<InstallReportNextStep> {
+    vec![
+        InstallReportNextStep {
+            id: "inspect-runtime".into(),
+            description: "Inspect safe local runtime diagnostics.".into(),
+            why: "Diagnostics confirm the installed CLI and local gateway prerequisites.".into(),
+            command: vec!["dcc-mcp-cli".into(), "doctor".into()],
+        },
+        InstallReportNextStep {
+            id: "confirm-readiness".into(),
+            description: format!("Confirm that a live {dcc_type} adapter becomes ready."),
+            why: "Host readiness is separate from local installation success.".into(),
+            command: vec![
+                "dcc-mcp-cli".into(),
+                "wait-ready".into(),
+                "--dcc-type".into(),
+                dcc_type.into(),
+            ],
+        },
+    ]
+}
+
+fn safe_plan_dcc_type(plan: &InstallPlan) -> String {
+    let normalized = normalized_dcc_key(&plan.dcc_type);
+    plan.adapter
+        .dcc
+        .iter()
+        .find(|candidate| normalized_dcc_key(candidate) == normalized)
+        .map(|candidate| safe_report_identifier(candidate, "unknown"))
+        .unwrap_or_else(|| safe_report_identifier(&plan.dcc_type, "unknown"))
+}
+
+fn failure_next_steps(dcc_type: &str) -> Vec<InstallReportNextStep> {
+    vec![
+        InstallReportNextStep {
+            id: "inspect-runtime".into(),
+            description: "Inspect safe local runtime diagnostics.".into(),
+            why: "Diagnostics can identify a safe remediation before retrying installation.".into(),
+            command: vec!["dcc-mcp-cli".into(), "doctor".into()],
+        },
+        InstallReportNextStep {
+            id: "review-plan".into(),
+            description: format!("Review a fresh non-mutating install plan for {dcc_type}."),
+            why: "The plan can be reviewed safely before another authorized execution.".into(),
+            command: vec![
+                "dcc-mcp-cli".into(),
+                "install".into(),
+                "--dcc-type".into(),
+                dcc_type.into(),
+                "--json".into(),
+            ],
+        },
+    ]
+}

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -314,6 +314,9 @@ enum Command {
         /// Execute the install plan with consent gating.
         #[arg(long, short = 'x')]
         execute: bool,
+        /// Emit the plan or execution report as one compact JSON document.
+        #[arg(long)]
+        json: bool,
     },
     /// Search and manage DCC-MCP marketplace sources.
     Marketplace {
@@ -572,6 +575,7 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
 
     let output = match &command {
         Command::Feedback(args) => args.resolve_output(output),
+        Command::Install { json: true, .. } => Ok(OutputFormat::Json),
         _ => Ok(output.unwrap_or_else(OutputFormat::auto_detect)),
     };
     let writer = OutputWriter::new(output.map_err(anyhow::Error::msg)?);
@@ -620,6 +624,7 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
 
     let mut failed = false;
     let mut exit_code = ExitCode::GeneralError;
+    let mut explicit_exit_code = None;
     let mut value = match command {
         Command::Smoke {
             url,
@@ -916,6 +921,7 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
             python,
             dcc_path,
             execute,
+            json,
         } => {
             let service = InstallService::new(PathBuf::from("dcc-mcp-catalog.yml"));
             let req = InstallRequest {
@@ -926,7 +932,11 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                 dcc_path,
             };
             if execute {
-                to_json(service.execute(req, non_interactive)?)?
+                // `--execute` is the mutation opt-in; JSON mode must never add
+                // an interactive prompt to the machine-readable contract.
+                let report = service.execute(req, non_interactive || json);
+                explicit_exit_code = Some(report.exit_code);
+                to_json(report)?
             } else {
                 to_json(service.plan(req)?)?
             }
@@ -1144,6 +1154,11 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
     }
 
     writer.write_data(&value)?;
+    if let Some(code) = explicit_exit_code
+        && code != 0
+    {
+        std::process::exit(code);
+    }
     if failed {
         let envelope = ErrorEnvelope::new(
             exit_code_to_error_code(exit_code),

--- a/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
@@ -6,7 +6,7 @@ use tempfile::NamedTempFile;
 use support::*;
 
 #[test]
-fn non_interactive_install_execute_skips_confirmation_and_runs_plan() {
+fn install_execute_json_failure_emits_one_safe_execution_report() {
     let output = cli_command()
         .args([
             "install",
@@ -15,20 +15,59 @@ fn non_interactive_install_execute_skips_confirmation_and_runs_plan() {
             "--python",
             "/__nonexistent__/python",
             "--execute",
-            "--non-interactive",
-            "--output",
-            "json",
+            "--json",
         ])
         .env_remove("DCC_MCP_INSTALL_DISABLED")
         .output()
         .unwrap();
 
-    assert_ne!(output.status.code(), Some(2));
-    assert!(output.stdout.is_empty());
+    assert_eq!(output.status.code(), Some(30));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["schema_version"], 1);
+    assert_eq!(report["status"], "failed");
+    assert_eq!(report["dcc_type"], "maya");
+    assert_eq!(report["exit_code"], 30);
+    assert_eq!(report["stage"], "install");
+    assert_eq!(report["error"]["code"], "INSTALL_STEP_FAILED");
+    assert_eq!(report["error"]["stage"], "install");
+    assert_eq!(report["error"]["exit_code"], 30);
+    assert_eq!(report["steps"][0]["id"], "install-pip");
+    assert_eq!(report["steps"][0]["status"], "failed");
+    assert_eq!(report["steps"][1]["status"], "not_run");
+    assert_eq!(report["receipt_path"], serde_json::Value::Null);
+    assert_eq!(report["verify"]["directly_usable"], false);
+    assert_eq!(report["verify"]["failure_stage"], "install");
+    assert_eq!(report["verify"]["failure_reason"], "INSTALL_STEP_FAILED");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("failed to launch /__nonexistent__/python"));
+    for public_output in [&*stdout, &*stderr] {
+        assert!(!public_output.contains("/__nonexistent__/python"));
+        assert!(!public_output.contains("failed to launch"));
+        assert!(!public_output.contains("No such file"));
+    }
     assert!(!stderr.contains("requires confirmation"));
     assert!(!stderr.contains("Proceed with installation?"));
+}
+
+#[test]
+fn install_json_alias_preserves_the_plan_only_response() {
+    let output = cli_command()
+        .args(["install", "--dcc-type", "maya", "--json"])
+        .env_remove("DCC_MCP_INSTALL_DISABLED")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let plan: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(plan["dcc_type"], "maya");
+    assert_eq!(plan["adapter"]["name"], "dcc-mcp-maya");
+    assert!(plan.get("schema_version").is_none());
+    assert!(
+        plan["steps"]
+            .as_array()
+            .is_some_and(|steps| !steps.is_empty())
+    );
 }
 
 #[test]
@@ -152,38 +191,49 @@ fn install_uses_bundled_adapter_metadata_and_python_override() {
 }
 
 #[test]
-fn install_policy_env_disables_execute_and_returns_custom_prompt() {
-    let plan = run_json_with_env_removed(
-        &[
+fn install_policy_env_disables_execute_with_a_stable_preflight_report() {
+    let output = cli_command()
+        .args([
             "install",
             "--dcc-type",
             "maya",
             "--python",
             "/__nonexistent__/python",
             "--execute",
-        ],
-        &[
-            ("DCC_MCP_INSTALL_DISABLED", "1"),
-            (
-                "DCC_MCP_INSTALL_DISABLED_PROMPT",
-                "Auto install unavailable; contact PipelineTD to deploy {adapter} for {dcc_type}.",
-            ),
-        ],
-        &["DCC_MCP_CATALOG_PATH", "DCC_MCP_INSTALL_PYTHON"],
-    );
+            "--json",
+        ])
+        .env("DCC_MCP_INSTALL_DISABLED", "1")
+        .env(
+            "DCC_MCP_INSTALL_DISABLED_PROMPT",
+            "Auto install unavailable; contact PipelineTD to deploy {adapter} for {dcc_type}.",
+        )
+        .env_remove("DCC_MCP_CATALOG_PATH")
+        .env_remove("DCC_MCP_INSTALL_PYTHON")
+        .output()
+        .unwrap();
 
-    assert_eq!(plan["dcc_type"], "maya");
-    assert_eq!(plan["adapter"]["name"], "dcc-mcp-maya");
-    assert_eq!(plan["steps"][0]["action"]["type"], "PipInstall");
-    assert_eq!(
-        plan["steps"][0]["action"]["python"],
-        "/__nonexistent__/python"
+    assert_eq!(output.status.code(), Some(10));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["schema_version"], 1);
+    assert_eq!(report["status"], "failed");
+    assert_eq!(report["dcc_type"], "maya");
+    assert_eq!(report["stage"], "preflight");
+    assert_eq!(report["exit_code"], 10);
+    assert_eq!(report["error"]["code"], "AUTO_INSTALL_DISABLED");
+    assert!(
+        report["steps"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|step| step["status"] == "not_run")
     );
-    assert_eq!(plan["install_policy"]["auto_install_enabled"], false);
-    assert_eq!(
-        plan["install_policy"]["prompt"],
-        "Auto install unavailable; contact PipelineTD to deploy dcc-mcp-maya for maya."
+    let public = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
     );
+    assert!(!public.contains("/__nonexistent__/python"));
+    assert!(!public.contains("PipelineTD"));
 }
 
 #[test]

--- a/docs/guide/adapter-install-sop.md
+++ b/docs/guide/adapter-install-sop.md
@@ -7,9 +7,11 @@ commands or interpreting prose.
 
 The words **MUST**, **MUST NOT**, **SHOULD**, and **MAY** are normative. The
 contract applies to adapter-owned installers now and to the shared Core
-installer as its remaining execution slices adopt the same behavior. This
-foundation does not itself implement the Rust installer executor, verification
-command, uninstall command, or catalog migration.
+installer as its remaining execution slices adopt the same behavior. The Core
+CLI now emits this schema for plan execution, including real step and rollback
+outcomes. Interpreter discovery, receipt ownership, a standalone verification
+command, uninstall, idempotent retry, and catalog migration remain separate
+implementation slices.
 
 See [Adapter Install Lifecycle](adapter-install-lifecycle.md) for Core's
 import-light sidecar, readiness, process, and lock-classification primitives.
@@ -134,6 +136,24 @@ The required top-level fields are stable for schema v1. Additive adapter fields
 are allowed. A consumer MUST reject an unsupported higher schema version with
 an upgrade diagnostic; it MUST NOT silently reinterpret, delete, or rewrite the
 result.
+
+For the Core CLI, `install --dcc-type <dcc> --json` remains a non-mutating plan
+with its existing plan shape. `install --dcc-type <dcc> --execute --json`
+instead emits exactly one post-execution schema-v1 document and uses the stable
+Install SOP process exit code reported in `exit_code`. It never echoes the
+pre-execution plan as an execution result. The report includes stable step IDs,
+observed step states, rollback attempts and outcomes, executable recovery
+commands, nullable receipt state, and verification state. Raw paths, subprocess
+output, exception text, and credentials do not enter public fields or operator
+diagnostics. `--execute` is the explicit mutation opt-in, so JSON execution does
+not add an interactive prompt.
+
+The current Core executor verifies local install artifacts but does not launch
+or control the DCC. A locally successful execution therefore reports the
+install steps as `ok` while keeping `verify.directly_usable` false with
+`LIVE_DCC_VERIFICATION_REQUIRED`; `confirm-readiness` is returned as an
+executable next step. This is a truthful boundary, not a substitute for the
+later standalone verification slice.
 
 `status` is one of `planned`, `running`, `ok`, `failed`, `partial`, or
 `requires_restart`. Each `steps[]` entry has a stable `id` and `status`.

--- a/skills/dcc-mcp-creator/references/TESTING_AND_RELEASE.md
+++ b/skills/dcc-mcp-creator/references/TESTING_AND_RELEASE.md
@@ -24,6 +24,18 @@ Adapter lifecycle commands must follow
 `dcc_mcp_core.deployment` so machine-readable results and process exit codes
 stay compatible across adapters.
 
+The shared Core front door preserves `install --json` as a plan and emits a
+post-execution Install SOP v1 result for `install --execute --json`. Treat the
+execution result as evidence: assert stable per-step states, rollback outcomes,
+exit/stage/error codes, executable `next_steps`, nullable receipt state, and
+verification state. Do not infer success from the earlier plan or expose raw
+paths, subprocess output, exceptions, or secrets in either output stream.
+
+Until live-host verification is implemented for the shared executor, a local
+artifact verification step may be `ok` while `verify.directly_usable` remains
+false with `LIVE_DCC_VERIFICATION_REQUIRED`. Keep that boundary in adapter
+tests instead of treating package installation as live DCC readiness.
+
 Exercise the complete `plan -> execute -> verify -> status -> uninstall`
 round trip in CI. The gate must also prove that failed replacement restores the
 previous usable install, stale receipt paths are diagnosed precisely, and

--- a/tests/fixtures/install-execution-report-v1-failed.json
+++ b/tests/fixtures/install-execution-report-v1-failed.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "status": "failed",
+  "dcc_type": "maya",
+  "adapter_version": "unknown",
+  "core_version": "0.0.0-test",
+  "stage": "install",
+  "exit_code": 30,
+  "steps": [
+    {
+      "id": "install-path",
+      "status": "ok",
+      "rollback": {"attempted": true, "status": "ok"}
+    },
+    {
+      "id": "register-dcc",
+      "status": "failed",
+      "rollback": {"attempted": false, "status": "not_available"}
+    },
+    {
+      "id": "verify",
+      "status": "not_run",
+      "rollback": {"attempted": false, "status": "not_attempted"}
+    }
+  ],
+  "rollback": {"attempted": true, "status": "ok", "failure_count": 0},
+  "next_steps": [
+    {
+      "id": "inspect-runtime",
+      "description": "Inspect safe local runtime diagnostics.",
+      "why": "Diagnostics can identify a safe remediation before retrying installation.",
+      "command": ["dcc-mcp-cli", "doctor"]
+    },
+    {
+      "id": "review-plan",
+      "description": "Review a fresh non-mutating install plan for maya.",
+      "why": "The plan can be reviewed safely before another authorized execution.",
+      "command": ["dcc-mcp-cli", "install", "--dcc-type", "maya", "--json"]
+    }
+  ],
+  "receipt_path": null,
+  "verify": {
+    "directly_usable": false,
+    "failure_stage": "install",
+    "failure_reason": "INSTALL_STEP_FAILED"
+  },
+  "error": {
+    "code": "INSTALL_STEP_FAILED",
+    "stage": "install",
+    "exit_code": 30
+  }
+}

--- a/tests/fixtures/install-execution-report-v1-rollback-failed.json
+++ b/tests/fixtures/install-execution-report-v1-rollback-failed.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "status": "partial",
+  "dcc_type": "maya",
+  "adapter_version": "unknown",
+  "core_version": "0.0.0-test",
+  "stage": "rollback",
+  "exit_code": 30,
+  "steps": [
+    {
+      "id": "install-path",
+      "status": "ok",
+      "rollback": {"attempted": true, "status": "failed"}
+    },
+    {
+      "id": "register-dcc",
+      "status": "failed",
+      "rollback": {"attempted": false, "status": "not_available"}
+    },
+    {
+      "id": "verify",
+      "status": "not_run",
+      "rollback": {"attempted": false, "status": "not_attempted"}
+    }
+  ],
+  "rollback": {"attempted": true, "status": "failed", "failure_count": 1},
+  "next_steps": [
+    {
+      "id": "inspect-runtime",
+      "description": "Inspect safe local runtime diagnostics.",
+      "why": "Diagnostics can identify a safe remediation before retrying installation.",
+      "command": ["dcc-mcp-cli", "doctor"]
+    },
+    {
+      "id": "review-plan",
+      "description": "Review a fresh non-mutating install plan for maya.",
+      "why": "The plan can be reviewed safely before another authorized execution.",
+      "command": ["dcc-mcp-cli", "install", "--dcc-type", "maya", "--json"]
+    }
+  ],
+  "receipt_path": null,
+  "verify": {
+    "directly_usable": false,
+    "failure_stage": "rollback",
+    "failure_reason": "ROLLBACK_FAILED"
+  },
+  "error": {
+    "code": "ROLLBACK_FAILED",
+    "stage": "rollback",
+    "exit_code": 30,
+    "primary_code": "INSTALL_STEP_FAILED"
+  }
+}

--- a/tests/fixtures/install-execution-report-v1-success.json
+++ b/tests/fixtures/install-execution-report-v1-success.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "status": "ok",
+  "dcc_type": "maya",
+  "adapter_version": "unknown",
+  "core_version": "0.0.0-test",
+  "stage": "complete",
+  "exit_code": 0,
+  "steps": [
+    {
+      "id": "install-path",
+      "status": "ok",
+      "rollback": {"attempted": false, "status": "not_available"}
+    },
+    {
+      "id": "verify",
+      "status": "ok",
+      "rollback": {"attempted": false, "status": "not_available"}
+    }
+  ],
+  "rollback": {"attempted": false, "status": "not_attempted", "failure_count": 0},
+  "next_steps": [
+    {
+      "id": "inspect-runtime",
+      "description": "Inspect safe local runtime diagnostics.",
+      "why": "Diagnostics confirm the installed CLI and local gateway prerequisites.",
+      "command": ["dcc-mcp-cli", "doctor"]
+    },
+    {
+      "id": "confirm-readiness",
+      "description": "Confirm that a live maya adapter becomes ready.",
+      "why": "Host readiness is separate from local installation success.",
+      "command": ["dcc-mcp-cli", "wait-ready", "--dcc-type", "maya"]
+    }
+  ],
+  "receipt_path": null,
+  "verify": {
+    "directly_usable": false,
+    "failure_stage": "host-readiness",
+    "failure_reason": "LIVE_DCC_VERIFICATION_REQUIRED"
+  }
+}

--- a/tests/test_install_sop_contract.py
+++ b/tests/test_install_sop_contract.py
@@ -268,6 +268,54 @@ def test_reusable_install_template_usable_result_is_schema_valid() -> None:
     Draft202012Validator(load_install_sop_schema()).validate(json.loads(result_text))
 
 
+def test_rust_cli_failed_execution_report_fixture_is_schema_valid() -> None:
+    from dcc_mcp_core import load_install_sop_schema
+
+    fixture = REPO_ROOT / "tests" / "fixtures" / "install-execution-report-v1-failed.json"
+    report = json.loads(fixture.read_text(encoding="utf-8"))
+
+    Draft202012Validator(load_install_sop_schema()).validate(report)
+    assert report["exit_code"] == 30
+    assert report["stage"] == "install"
+    assert report["error"]["code"] == "INSTALL_STEP_FAILED"
+    assert report["rollback"] == {"attempted": True, "status": "ok", "failure_count": 0}
+    assert [step["status"] for step in report["steps"]] == ["ok", "failed", "not_run"]
+
+
+def test_rust_cli_success_execution_report_fixture_is_schema_valid() -> None:
+    from dcc_mcp_core import load_install_sop_schema
+
+    fixture = REPO_ROOT / "tests" / "fixtures" / "install-execution-report-v1-success.json"
+    report = json.loads(fixture.read_text(encoding="utf-8"))
+
+    Draft202012Validator(load_install_sop_schema()).validate(report)
+    assert report["status"] == "ok"
+    assert report["exit_code"] == 0
+    assert report["receipt_path"] is None
+    assert report["verify"] == {
+        "directly_usable": False,
+        "failure_stage": "host-readiness",
+        "failure_reason": "LIVE_DCC_VERIFICATION_REQUIRED",
+    }
+
+
+def test_rust_cli_rollback_failure_report_fixture_is_schema_valid() -> None:
+    from dcc_mcp_core import load_install_sop_schema
+
+    fixture = REPO_ROOT / "tests" / "fixtures" / "install-execution-report-v1-rollback-failed.json"
+    report = json.loads(fixture.read_text(encoding="utf-8"))
+
+    Draft202012Validator(load_install_sop_schema()).validate(report)
+    assert report["status"] == "partial"
+    assert report["error"] == {
+        "code": "ROLLBACK_FAILED",
+        "stage": "rollback",
+        "exit_code": 30,
+        "primary_code": "INSTALL_STEP_FAILED",
+    }
+    assert report["rollback"] == {"attempted": True, "status": "failed", "failure_count": 1}
+
+
 def test_adapter_onboarding_and_release_gate_the_install_sop() -> None:
     onboarding = (REPO_ROOT / "docs" / "guide" / "new-adapter-onboarding.md").read_text(encoding="utf-8")
     release = (REPO_ROOT / "docs" / "guide" / "adapter-release-checklist.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- emit one Install SOP v1 post-execution report for install --execute --json
- preserve the plan-only JSON response while reporting real step and rollback outcomes
- keep failure output path-, command-, exception-, and secret-safe with stable exit codes
- document the truthful local-verify versus live-DCC readiness boundary

## Validation
- vx just preflight (3725 Rust tests plus workspace checks and doctests)
- vx cargo test -p dcc-mcp-cli --test cli_install_e2e
- Python Install SOP schema tests (17 passed)
- VitePress build and markdownlint

Closes #2361
Refs #2252
Refs #2253