### PR TITLE
fix: harden readiness trace logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "workspace-hack",
 ]

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -86,6 +86,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 serde_json.workspace = true
+tracing-subscriber.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 axum-test = "20"
 rstest = "0.26"

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -1,7 +1,7 @@
 //! The main `McpHttpServer` type.
 
 use axum::{Json, Router, routing};
-use http::{Request, Response, StatusCode};
+use http::{Method, Request, Response, StatusCode};
 use parking_lot::RwLock;
 use serde_json::json;
 use std::collections::HashMap;
@@ -14,7 +14,7 @@ use tower_http::classify::{
 };
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
-use tower_http::trace::TraceLayer;
+use tower_http::trace::{MakeSpan, TraceLayer};
 use uuid::Uuid;
 
 use crate::{
@@ -35,10 +35,10 @@ mod spawn_impl;
 
 /// Request-aware HTTP failure classification for the server trace layer.
 ///
-/// A `503 Service Unavailable` is the documented, structured response while
-/// `/v1/readyz` is red. It is a routine probe result, not a transport or
-/// handler failure. Every other server error keeps tower-http's default
-/// failure classification.
+/// A `503 Service Unavailable` is the documented, structured response for an
+/// exact `GET /v1/readyz` request without a query while readiness is red. It is
+/// a routine probe result, not a transport or handler failure. Every other
+/// server error keeps tower-http's default failure classification.
 #[derive(Clone, Copy, Debug, Default)]
 struct HttpTraceClassifier;
 
@@ -54,9 +54,33 @@ impl MakeClassifier for HttpTraceClassifier {
 
     fn make_classifier<B>(&self, request: &Request<B>) -> Self::Classifier {
         HttpResponseClassifier {
-            readyz: request.uri().path() == "/v1/readyz",
+            readyz: request.method() == Method::GET
+                && request.uri().path() == "/v1/readyz"
+                && request.uri().query().is_none(),
         }
     }
+}
+
+/// Build request spans from non-sensitive routing fields only.
+///
+/// tower-http's default span records the full URI, including its query. Query
+/// values and headers are intentionally excluded from operator logs.
+#[derive(Clone, Copy, Debug, Default)]
+struct HttpTraceMakeSpan;
+
+impl<B> MakeSpan<B> for HttpTraceMakeSpan {
+    fn make_span(&mut self, request: &Request<B>) -> tracing::Span {
+        tracing::debug_span!(
+            "request",
+            method = %request.method(),
+            path = %request.uri().path(),
+            version = ?request.version(),
+        )
+    }
+}
+
+fn http_trace_layer() -> TraceLayer<HttpTraceClassifier, HttpTraceMakeSpan> {
+    TraceLayer::new(HttpTraceClassifier).make_span_with(HttpTraceMakeSpan)
 }
 
 impl ClassifyResponse for HttpResponseClassifier {
@@ -648,7 +672,7 @@ impl McpHttpServer {
             .layer(RequestBodyLimitLayer::new(
                 self.config.queue.max_request_body_bytes,
             ))
-            .layer(TraceLayer::new(HttpTraceClassifier));
+            .layer(http_trace_layer());
 
         // Prometheus `/metrics` endpoint (issue #331). Mounted on the
         // same router so scrapers share the MCP server's listening

--- a/crates/dcc-mcp-http/src/server/tests.rs
+++ b/crates/dcc-mcp-http/src/server/tests.rs
@@ -1,6 +1,14 @@
 use super::*;
-use http::{Request, Response, StatusCode};
+use axum::body::Body;
+use http::{Method, Request, Response, StatusCode};
+use parking_lot::Mutex;
+use std::{
+    io::{self, Write},
+    sync::Arc,
+};
+use tower::ServiceExt;
 use tower_http::classify::{ClassifiedResponse, ClassifyResponse, MakeClassifier};
+use tracing_subscriber::fmt::MakeWriter;
 
 #[cfg(feature = "auto-gateway")]
 fn unused_local_port() -> u16 {
@@ -82,8 +90,12 @@ async fn instance_id_matches_the_registered_service_key() {
     handle.shutdown().await;
 }
 
-fn classify_http_response(path: &str, status: StatusCode) -> bool {
-    let request = Request::builder().uri(path).body(()).unwrap();
+fn classify_http_response(method: Method, path: &str, status: StatusCode) -> bool {
+    let request = Request::builder()
+        .method(method)
+        .uri(path)
+        .body(())
+        .unwrap();
     let response = Response::builder().status(status).body(()).unwrap();
     let classifier = HttpTraceClassifier.make_classifier(&request);
 
@@ -96,19 +108,128 @@ fn classify_http_response(path: &str, status: StatusCode) -> bool {
 #[test]
 fn readyz_not_ready_response_is_a_routine_probe_result() {
     assert!(classify_http_response(
+        Method::GET,
         "/v1/readyz",
         StatusCode::SERVICE_UNAVAILABLE
     ));
 }
 
 #[test]
-fn non_probe_server_errors_remain_trace_failures() {
+fn only_exact_get_readyz_without_query_is_a_routine_probe() {
+    for (method, uri) in [
+        (Method::POST, "/v1/readyz"),
+        (Method::GET, "/v1/readyz?token=private-query-value"),
+        (Method::GET, "/v1/%72eadyz"),
+        (Method::GET, "/v1/readyz/"),
+        (Method::GET, "/v1/call"),
+    ] {
+        assert!(
+            !classify_http_response(method.clone(), uri, StatusCode::SERVICE_UNAVAILABLE),
+            "{method} {uri} must keep the standard server-error classification"
+        );
+    }
+
     assert!(!classify_http_response(
-        "/v1/call",
-        StatusCode::SERVICE_UNAVAILABLE
-    ));
-    assert!(!classify_http_response(
+        Method::GET,
         "/v1/readyz",
-        StatusCode::INTERNAL_SERVER_ERROR
+        StatusCode::INTERNAL_SERVER_ERROR,
     ));
+}
+
+#[derive(Clone, Default)]
+struct TraceBuffer(Arc<Mutex<Vec<u8>>>);
+
+struct TraceBufferWriter(TraceBuffer);
+
+impl Write for TraceBufferWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.0.0.lock().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for TraceBuffer {
+    type Writer = TraceBufferWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        TraceBufferWriter(self.clone())
+    }
+}
+
+impl TraceBuffer {
+    fn output(&self) -> String {
+        String::from_utf8(self.0.lock().clone()).unwrap()
+    }
+}
+
+async fn capture_http_trace(method: Method, uri: &str, status: StatusCode) -> String {
+    let output = TraceBuffer::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_max_level(tracing::Level::TRACE)
+        .with_writer(output.clone())
+        .finish();
+    let dispatch = tracing::Dispatch::new(subscriber);
+    let _default = tracing::dispatcher::set_default(&dispatch);
+
+    let request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", "Bearer private-header-value")
+        .body(Body::empty())
+        .unwrap();
+    let service = Router::new()
+        .fallback(move || async move { status })
+        .layer(http_trace_layer());
+
+    service.oneshot(request).await.unwrap();
+    output.output()
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn real_trace_layer_emits_errors_only_for_non_routine_failures() {
+    let routine =
+        capture_http_trace(Method::GET, "/v1/readyz", StatusCode::SERVICE_UNAVAILABLE).await;
+    assert!(!routine.contains("ERROR"), "{routine}");
+
+    for (method, uri, status) in [
+        (Method::GET, "/v1/readyz", StatusCode::INTERNAL_SERVER_ERROR),
+        (Method::GET, "/v1/call", StatusCode::SERVICE_UNAVAILABLE),
+        (Method::GET, "/v1/call", StatusCode::INTERNAL_SERVER_ERROR),
+        (Method::POST, "/v1/readyz", StatusCode::SERVICE_UNAVAILABLE),
+        (
+            Method::GET,
+            "/v1/readyz?token=private-query-value",
+            StatusCode::SERVICE_UNAVAILABLE,
+        ),
+    ] {
+        let trace = capture_http_trace(method.clone(), uri, status).await;
+        assert!(
+            trace.contains("ERROR"),
+            "missing ERROR for {method} {uri}: {trace}"
+        );
+    }
+
+    for status in [StatusCode::OK, StatusCode::BAD_REQUEST] {
+        let trace = capture_http_trace(Method::GET, "/v1/readyz", status).await;
+        assert!(!trace.contains("ERROR"), "{trace}");
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn trace_events_do_not_expose_request_secrets() {
+    let trace = capture_http_trace(
+        Method::GET,
+        "/v1/readyz?token=private-query-value",
+        StatusCode::SERVICE_UNAVAILABLE,
+    )
+    .await;
+
+    assert!(!trace.contains("private-header-value"), "{trace}");
+    assert!(!trace.contains("private-query-value"), "{trace}");
 }

--- a/crates/dcc-mcp-logging/src/config.rs
+++ b/crates/dcc-mcp-logging/src/config.rs
@@ -27,6 +27,8 @@ use tracing_subscriber::fmt::format::DefaultFields;
 #[cfg(feature = "tracy")]
 const TRACY_TARGET: &str = "dcc_mcp::profiling";
 
+const RUST_LOG_ENV: &str = "RUST_LOG";
+
 #[cfg(feature = "tracy")]
 fn is_tracy_profile(target: &str, is_span: bool) -> bool {
     is_span && target == TRACY_TARGET
@@ -86,7 +88,8 @@ static RELOAD_HANDLE: OnceLock<FileLayerReloadHandle> = OnceLock::new();
 /// Initialize the tracing subscriber (called once from Python module init).
 ///
 /// Installs:
-/// - an `EnvFilter` driven by `DCC_MCP_LOG_LEVEL` (fallback [`DEFAULT_LOG_FILTER`]);
+/// - an `EnvFilter` selected from `DCC_MCP_LOG_LEVEL`, legacy
+///   `MCP_LOG_LEVEL`, then `RUST_LOG` (fallback [`DEFAULT_LOG_FILTER`]);
 /// - a stderr `fmt::Layer` (thread names, targets on);
 /// - a [`reload::Layer`] holding an `Option<BoxedLayer>` for dynamic
 ///   attachment of a rolling-file layer by
@@ -97,9 +100,14 @@ static RELOAD_HANDLE: OnceLock<FileLayerReloadHandle> = OnceLock::new();
 /// the internal [`std::sync::Once`].
 pub fn init_logging() {
     INIT.call_once(|| {
-        let filter = EnvFilter::try_from_env(ENV_LOG_LEVEL)
-            .or_else(|_| EnvFilter::try_from_env(LEGACY_ENV_LOG_LEVEL))
-            .unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER));
+        let filter = [ENV_LOG_LEVEL, LEGACY_ENV_LOG_LEVEL, RUST_LOG_ENV]
+            .into_iter()
+            .find_map(|name| {
+                std::env::var(name)
+                    .ok()
+                    .and_then(|value| EnvFilter::try_new(value).ok())
+            })
+            .unwrap_or_else(|| EnvFilter::new(DEFAULT_LOG_FILTER));
 
         #[cfg(feature = "tracy")]
         let filter = enable_tracy_target(filter);
@@ -193,7 +201,10 @@ impl std::error::Error for FileLayerInstallError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
     use tracing::Level;
+
+    const FILTER_CHILD_EXPECT: &str = "DCC_MCP_TEST_FILTER_CHILD_EXPECT";
 
     #[test]
     fn test_init_logging_is_idempotent() {
@@ -212,6 +223,88 @@ mod tests {
             assert!(!tracing::enabled!(target: "hyper_util::client", Level::DEBUG));
             assert!(!tracing::enabled!(target: "rmcp::service", Level::DEBUG));
         });
+    }
+
+    #[test]
+    fn log_filter_precedence_child() {
+        let Some(expected) = std::env::var_os(FILTER_CHILD_EXPECT) else {
+            return;
+        };
+
+        init_logging();
+
+        let enabled = (
+            tracing::enabled!(target: "dcc_mcp_precedence_dcc", Level::TRACE),
+            tracing::enabled!(target: "dcc_mcp_precedence_legacy", Level::TRACE),
+            tracing::enabled!(target: "dcc_mcp_precedence_rust", Level::TRACE),
+        );
+        let expected = expected.to_string_lossy();
+        let expected_enabled = match expected.as_ref() {
+            "dcc" => (true, false, false),
+            "legacy" => (false, true, false),
+            "rust" => (false, false, true),
+            "default" => (false, false, false),
+            value => panic!("unknown child expectation: {value}"),
+        };
+
+        assert_eq!(enabled, expected_enabled);
+        if expected == "default" {
+            assert!(tracing::enabled!(target: "dcc_mcp_http", Level::DEBUG));
+            assert!(!tracing::enabled!(target: "tower_http::trace", Level::DEBUG));
+        }
+    }
+
+    fn run_log_filter_child(
+        dcc_filter: Option<&str>,
+        legacy_filter: Option<&str>,
+        rust_filter: Option<&str>,
+        expected: &str,
+    ) {
+        let mut command = Command::new(std::env::current_exe().expect("test executable exists"));
+        command
+            .arg("--exact")
+            .arg("config::tests::log_filter_precedence_child")
+            .arg("--nocapture")
+            .env_remove(ENV_LOG_LEVEL)
+            .env_remove(LEGACY_ENV_LOG_LEVEL)
+            .env_remove(RUST_LOG_ENV)
+            .env(FILTER_CHILD_EXPECT, expected);
+
+        if let Some(value) = dcc_filter {
+            command.env(ENV_LOG_LEVEL, value);
+        }
+        if let Some(value) = legacy_filter {
+            command.env(LEGACY_ENV_LOG_LEVEL, value);
+        }
+        if let Some(value) = rust_filter {
+            command.env(RUST_LOG_ENV, value);
+        }
+
+        let output = command.output().expect("isolated child process runs");
+        assert!(
+            output.status.success(),
+            "filter child {expected} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn log_filter_precedence_isolated_per_process() {
+        run_log_filter_child(
+            Some("dcc_mcp_precedence_dcc=trace"),
+            Some("dcc_mcp_precedence_legacy=trace"),
+            Some("dcc_mcp_precedence_rust=trace"),
+            "dcc",
+        );
+        run_log_filter_child(
+            None,
+            Some("dcc_mcp_precedence_legacy=trace"),
+            Some("dcc_mcp_precedence_rust=trace"),
+            "legacy",
+        );
+        run_log_filter_child(None, None, Some("dcc_mcp_precedence_rust=trace"), "rust");
+        run_log_filter_child(None, None, None, "default");
     }
 
     #[cfg(feature = "tracy")]


### PR DESCRIPTION
Closes #2274

- Restrict routine readiness tracing to exact query-free `GET /v1/readyz` requests.
- Keep headers and query values out of request spans.
- Restore `DCC_MCP_LOG_LEVEL` > `MCP_LOG_LEVEL` > `RUST_LOG` > default precedence.

This is the post-merge follow-up for the logging gap shipped in v0.20.17. Focused Rust, Python readiness/logging, formatting, Clippy, Hakari, and file-size gates pass. The live idle `<50 KB/hour` target remains unverified; no operator gateway was used.