### PR TITLE
fix(cli): report manual registration as deferred

### DIFF
--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -14,9 +14,11 @@ use crate::domain::install::{
 
 const BUNDLED_CATALOG: &str = include_str!("../../../../dcc-mcp-catalog.yml");
 
+mod pip;
 mod policy;
 mod report;
 
+use pip::{pip_install_args, pip_show_args, pip_uninstall_args};
 use policy::{AutoInstallPolicy, ask_consent, render_install_policy_prompt};
 pub use report::{
     InstallExecutionError, InstallExecutionReport, InstallReportNextStep, InstallRollbackReport,
@@ -73,6 +75,12 @@ enum StepRollback {
     RemovePath(PathBuf),
     /// Run a shell command to revert.
     Command { program: String, args: Vec<String> },
+}
+
+#[derive(Debug)]
+enum StepExecution {
+    Completed(Option<StepRollback>),
+    Deferred,
 }
 
 pub struct InstallService {
@@ -210,7 +218,7 @@ impl InstallService {
             plan,
             skip_confirmation,
             |action, plan| match action {
-                InstallStepAction::Verify => execute_verify(plan),
+                InstallStepAction::Verify => execute_verify(plan).map(StepExecution::Completed),
                 _ => execute_action(action),
             },
             execute_rollback,
@@ -225,7 +233,7 @@ impl InstallService {
         mut rollback_step: R,
     ) -> InstallExecutionReport
     where
-        E: FnMut(&InstallStepAction, &InstallPlan) -> Result<Option<StepRollback>, InstallError>,
+        E: FnMut(&InstallStepAction, &InstallPlan) -> Result<StepExecution, InstallError>,
         R: FnMut(&StepRollback) -> Result<(), InstallError>,
     {
         let mut report = execution_report_for_plan(plan);
@@ -264,6 +272,7 @@ impl InstallService {
         }
 
         let mut completed: Vec<(usize, Option<StepRollback>)> = Vec::new();
+        let mut has_deferred_steps = false;
 
         for (ordinal, (step_index, action)) in executable_steps.iter().enumerate() {
             let step_id = stable_step_id(action);
@@ -273,7 +282,7 @@ impl InstallService {
                 executable_steps.len()
             );
             match execute_step(action, plan) {
-                Ok(rollback) => {
+                Ok(StepExecution::Completed(rollback)) => {
                     eprintln!("OK");
                     report.steps[*step_index].status = "ok".into();
                     report.steps[*step_index].rollback.status = if rollback.is_some() {
@@ -282,6 +291,12 @@ impl InstallService {
                         "not_available".into()
                     };
                     completed.push((*step_index, rollback));
+                }
+                Ok(StepExecution::Deferred) => {
+                    eprintln!("DEFERRED");
+                    report.steps[*step_index].status = "deferred".into();
+                    report.steps[*step_index].rollback.status = "not_available".into();
+                    has_deferred_steps = true;
                 }
                 Err(_) => {
                     eprintln!("FAILED");
@@ -331,8 +346,13 @@ impl InstallService {
             }
         }
 
-        eprintln!("Installation execution completed.");
-        report.status = "ok".into();
+        if has_deferred_steps {
+            eprintln!("Installation execution completed with deferred manual steps.");
+            report.status = "partial".into();
+        } else {
+            eprintln!("Installation execution completed.");
+            report.status = "ok".into();
+        }
         report.stage = "complete".into();
         report.exit_code = 0;
         report.next_steps = success_next_steps(&report.dcc_type);
@@ -344,8 +364,8 @@ impl InstallService {
 
 // ── step executors ───────────────────────────────────────────────────────────────
 
-/// Execute a single install action, returning an optional rollback handle.
-fn execute_action(action: &InstallStepAction) -> Result<Option<StepRollback>, InstallError> {
+/// Execute a single install action, distinguishing completed work from manual deferral.
+fn execute_action(action: &InstallStepAction) -> Result<StepExecution, InstallError> {
     match action {
         InstallStepAction::PipInstall {
             package,
@@ -361,19 +381,26 @@ fn execute_action(action: &InstallStepAction) -> Result<Option<StepRollback>, In
             python.as_deref(),
             artifact_url.as_deref(),
             sha256.as_deref(),
-        ),
+        )
+        .map(StepExecution::Completed),
         InstallStepAction::GitClone { url, ref_, dest } => {
-            execute_git_clone(url, ref_.as_deref(), dest)
+            execute_git_clone(url, ref_.as_deref(), dest).map(StepExecution::Completed)
         }
         InstallStepAction::ZipExtract { url, sha256, dest } => {
-            execute_zip_extract(url, sha256.as_deref(), dest)
+            execute_zip_extract(url, sha256.as_deref(), dest).map(StepExecution::Completed)
         }
-        InstallStepAction::PathCopy { source, dest } => execute_path_copy(source, dest),
+        InstallStepAction::PathCopy { source, dest } => {
+            execute_path_copy(source, dest).map(StepExecution::Completed)
+        }
         InstallStepAction::RegisterDcc {
             dcc_type,
             entry_point,
             dcc_path,
-        } => execute_register_dcc(dcc_type, entry_point.as_deref(), dcc_path.as_deref()),
+        } => Ok(execute_register_dcc(
+            dcc_type,
+            entry_point.as_deref(),
+            dcc_path.as_deref(),
+        )),
         InstallStepAction::Verify => Err(InstallError::StepFailed {
             step: "verify".into(),
             message: "verify requires the full install plan".into(),
@@ -492,35 +519,6 @@ fn verified_pip_artifact_spec(
         "{package_with_extras} @ {artifact_url}#sha256={}",
         checksum.to_ascii_lowercase()
     ))
-}
-
-fn pip_install_args(package_spec: &str) -> Vec<String> {
-    vec![
-        "-m".into(),
-        "pip".into(),
-        "install".into(),
-        "--upgrade".into(),
-        package_spec.into(),
-    ]
-}
-
-fn pip_uninstall_args(package: &str) -> Vec<String> {
-    vec![
-        "-m".into(),
-        "pip".into(),
-        "uninstall".into(),
-        "-y".into(),
-        package.to_string(),
-    ]
-}
-
-fn pip_show_args(package: &str) -> Vec<String> {
-    vec![
-        "-m".into(),
-        "pip".into(),
-        "show".into(),
-        package.to_string(),
-    ]
 }
 
 fn execute_git_clone(
@@ -715,12 +713,11 @@ fn execute_register_dcc(
     _dcc_type: &str,
     _entry_point: Option<&str>,
     _dcc_path: Option<&Path>,
-) -> Result<Option<StepRollback>, InstallError> {
+) -> StepExecution {
     // Registration is owned by the DCC plugin's sidecar. The CLI can install
     // packages, but it must not pretend a host process is registered until the
     // plugin starts, stays alive, and advertises itself in the registry.
-    eprintln!("Start or enable the requested DCC plugin, then confirm self-registration.");
-    Ok(None)
+    StepExecution::Deferred
 }
 
 fn execute_verify(plan: &InstallPlan) -> Result<Option<StepRollback>, InstallError> {
@@ -863,6 +860,10 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), InstallError> {
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[path = "install/recovery_tests.rs"]
+mod recovery_tests;
 
 #[cfg(test)]
 mod tests {
@@ -1096,10 +1097,9 @@ mod tests {
     }
 
     #[test]
-    fn register_dcc_is_noop() {
+    fn register_dcc_is_explicitly_deferred() {
         let result = execute_register_dcc("maya", Some("dcc_mcp_maya.cli:main"), None);
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert!(matches!(result, StepExecution::Deferred));
     }
 
     #[test]
@@ -1256,8 +1256,12 @@ mod tests {
             dest: PathBuf::from("dest"),
         });
 
-        let report =
-            service.execute_plan_with(&plan, true, |_action, _plan| Ok(None), |_rollback| Ok(()));
+        let report = service.execute_plan_with(
+            &plan,
+            true,
+            |_action, _plan| Ok(StepExecution::Completed(None)),
+            |_rollback| Ok(()),
+        );
 
         assert_eq!(report.status, "ok");
         assert_eq!(report.stage, "complete");
@@ -1316,7 +1320,9 @@ mod tests {
             |_action, _plan| {
                 calls += 1;
                 if calls == 1 {
-                    Ok(Some(StepRollback::RemovePath(PathBuf::from("secret-a"))))
+                    Ok(StepExecution::Completed(Some(StepRollback::RemovePath(
+                        PathBuf::from("secret-a"),
+                    ))))
                 } else {
                     Err(InstallError::StepFailed {
                         step: "secret-stage".into(),
@@ -1383,7 +1389,9 @@ mod tests {
             |_action, _plan| {
                 calls += 1;
                 if calls == 1 {
-                    Ok(Some(StepRollback::RemovePath(PathBuf::from("secret-path"))))
+                    Ok(StepExecution::Completed(Some(StepRollback::RemovePath(
+                        PathBuf::from("secret-path"),
+                    ))))
                 } else {
                     Err(InstallError::StepFailed {
                         step: "install".into(),
@@ -1458,7 +1466,9 @@ mod tests {
             |_action, _plan| {
                 calls += 1;
                 if calls == 1 {
-                    Ok(Some(StepRollback::RemovePath(PathBuf::from("private"))))
+                    Ok(StepExecution::Completed(Some(StepRollback::RemovePath(
+                        PathBuf::from("private"),
+                    ))))
                 } else {
                     Err(InstallError::StepFailed {
                         step: "private".into(),

--- a/crates/dcc-mcp-cli/src/application/install/pip.rs
+++ b/crates/dcc-mcp-cli/src/application/install/pip.rs
@@ -1,0 +1,28 @@
+pub(super) fn pip_install_args(package_spec: &str) -> Vec<String> {
+    vec![
+        "-m".into(),
+        "pip".into(),
+        "install".into(),
+        "--upgrade".into(),
+        package_spec.into(),
+    ]
+}
+
+pub(super) fn pip_uninstall_args(package: &str) -> Vec<String> {
+    vec![
+        "-m".into(),
+        "pip".into(),
+        "uninstall".into(),
+        "-y".into(),
+        package.to_string(),
+    ]
+}
+
+pub(super) fn pip_show_args(package: &str) -> Vec<String> {
+    vec![
+        "-m".into(),
+        "pip".into(),
+        "show".into(),
+        package.to_string(),
+    ]
+}

--- a/crates/dcc-mcp-cli/src/application/install/recovery_tests.rs
+++ b/crates/dcc-mcp-cli/src/application/install/recovery_tests.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+#[test]
+fn actual_planner_never_reports_manual_registration_as_ok() {
+    let service = InstallService::new(PathBuf::from("__missing_dcc_mcp_catalog__.yml"));
+    let plan = service
+        .plan(InstallRequest {
+            dcc_type: "maya".into(),
+            version: None,
+            catalog_path: None,
+            python: Some("test-python".into()),
+            dcc_path: None,
+        })
+        .unwrap();
+    let register_index = plan
+        .steps
+        .iter()
+        .position(|step| matches!(step.action, Some(InstallStepAction::RegisterDcc { .. })))
+        .expect("the real planner must include register-dcc");
+
+    let report = service.execute_plan_with(
+        &plan,
+        true,
+        |action, _plan| match action {
+            InstallStepAction::RegisterDcc { .. } => execute_action(action),
+            _ => Ok(StepExecution::Completed(None)),
+        },
+        |_rollback| Ok(()),
+    );
+
+    assert_eq!(report.steps[register_index].id, "register-dcc");
+    assert_eq!(report.steps[register_index].status, "deferred");
+    assert_ne!(report.steps[register_index].status, "ok");
+    assert_eq!(report.status, "partial");
+    assert_eq!(report.stage, "complete");
+    assert_eq!(report.exit_code, 0);
+    assert!(report.error.is_none());
+    assert!(!report.verify.directly_usable);
+
+    let mut actual = serde_json::to_value(&report).unwrap();
+    actual["adapter_version"] = serde_json::json!("0.0.0-test");
+    actual["core_version"] = serde_json::json!("0.0.0-test");
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../../../tests/fixtures/install-execution-report-v1-deferred.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+}

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -4,10 +4,11 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, anyhow};
 use clap::{Parser, Subcommand};
-use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::output::{ErrorEnvelope, ExitCode, OutputFormat, OutputWriter};
+use super::output::{
+    ErrorEnvelope, ExitCode, OutputFormat, OutputWriter, exit_code_to_error_code, to_json,
+};
 
 use crate::application::call_attribution::{
     attach_agent_session_id, attach_batch_agent_session_id,
@@ -1467,10 +1468,6 @@ fn endpoint_for_mcp(raw: &str) -> String {
     }
 }
 
-fn to_json(value: impl Serialize) -> anyhow::Result<Value> {
-    serde_json::to_value(value).context("failed to serialize command output")
-}
-
 /// Check whether a command timeout would be ignored in favor of a distinct global timeout.
 fn command_has_distinct_per_timeout(command: &Command, global_timeout_secs: Option<u64>) -> bool {
     let per_command_timeout = match command {
@@ -1493,19 +1490,6 @@ fn command_has_configured_timeout_env(command: &Command) -> bool {
         command,
         Command::Call { .. } | Command::CallBatch { .. } | Command::UiControl { .. }
     ) && std::env::var_os("DCC_MCP_CLI_CALL_TIMEOUT_SECS").is_some()
-}
-
-fn exit_code_to_error_code(exit_code: ExitCode) -> &'static str {
-    match exit_code {
-        ExitCode::Success => "OK",
-        ExitCode::GeneralError => "GENERAL_ERROR",
-        ExitCode::InvalidInput => "INVALID_INPUT",
-        ExitCode::Unavailable => "UNAVAILABLE",
-        ExitCode::Timeout => "TIMEOUT",
-        ExitCode::Cancelled => "CANCELLED",
-        ExitCode::PermissionDenied => "PERMISSION_DENIED",
-        ExitCode::Conflict => "CONFLICT",
-    }
 }
 
 #[cfg(test)]

--- a/crates/dcc-mcp-cli/src/presentation/output.rs
+++ b/crates/dcc-mcp-cli/src/presentation/output.rs
@@ -9,8 +9,26 @@
 
 use std::io::{IsTerminal, Write};
 
+use anyhow::Context;
 use serde::Serialize;
 use serde_json::Value;
+
+pub(crate) fn to_json(value: impl Serialize) -> anyhow::Result<Value> {
+    serde_json::to_value(value).context("failed to serialize command output")
+}
+
+pub(crate) fn exit_code_to_error_code(exit_code: ExitCode) -> &'static str {
+    match exit_code {
+        ExitCode::Success => "OK",
+        ExitCode::GeneralError => "GENERAL_ERROR",
+        ExitCode::InvalidInput => "INVALID_INPUT",
+        ExitCode::Unavailable => "UNAVAILABLE",
+        ExitCode::Timeout => "TIMEOUT",
+        ExitCode::Cancelled => "CANCELLED",
+        ExitCode::PermissionDenied => "PERMISSION_DENIED",
+        ExitCode::Conflict => "CONFLICT",
+    }
+}
 
 // ---------------------------------------------------------------------------
 // OutputFormat

--- a/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_install_e2e.rs
@@ -1,9 +1,78 @@
 mod support;
 
 use serde_json::json;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 
 use support::*;
+
+fn fake_pip(temp: &TempDir, version: &str) -> std::path::PathBuf {
+    let package = temp.path().join("pip");
+    std::fs::create_dir(&package).unwrap();
+    std::fs::write(package.join("__init__.py"), "").unwrap();
+    std::fs::write(
+        package.join("__main__.py"),
+        format!(
+            "import sys\nif len(sys.argv) > 1 and sys.argv[1] == 'show':\n    print('Name: dcc-mcp-maya')\n    print('Version: {version}')\n"
+        ),
+    )
+    .unwrap();
+    temp.path().to_path_buf()
+}
+
+#[test]
+fn install_execute_json_reports_manual_registration_as_deferred() {
+    let temp = TempDir::new().unwrap();
+    let plan = run_json(&["install", "--dcc-type", "maya", "--python", "python"]);
+    let python_path = fake_pip(&temp, plan["version"].as_str().unwrap());
+    let output = cli_command()
+        .args([
+            "install",
+            "--dcc-type",
+            "maya",
+            "--python",
+            "python",
+            "--execute",
+            "--json",
+        ])
+        .env_remove("DCC_MCP_INSTALL_DISABLED")
+        .env_remove("DCC_MCP_CATALOG_PATH")
+        .env_remove("DCC_MCP_INSTALL_PYTHON")
+        .env("PYTHONPATH", &python_path)
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["status"], "partial");
+    assert_eq!(report["stage"], "complete");
+    assert_eq!(report["exit_code"], 0);
+    assert_eq!(report["error"], serde_json::Value::Null);
+    let register_step = report["steps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|step| step["id"] == "register-dcc")
+        .expect("real planner report must include register-dcc");
+    assert_eq!(register_step["status"], "deferred");
+    assert_ne!(register_step["status"], "ok");
+    assert_eq!(register_step["rollback"]["attempted"], false);
+    assert_eq!(register_step["rollback"]["status"], "not_available");
+    assert_eq!(report["verify"]["directly_usable"], false);
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(stdout.lines().count(), 1);
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("register-dcc ... DEFERRED"));
+    assert!(!stderr.contains("register-dcc ... OK"));
+    assert!(!stdout.contains(python_path.to_str().unwrap()));
+    assert!(!stderr.contains(python_path.to_str().unwrap()));
+}
 
 #[test]
 fn install_execute_json_failure_emits_one_safe_execution_report() {

--- a/docs/guide/adapter-install-sop.md
+++ b/docs/guide/adapter-install-sop.md
@@ -149,9 +149,10 @@ diagnostics. `--execute` is the explicit mutation opt-in, so JSON execution does
 not add an interactive prompt.
 
 The current Core executor verifies local install artifacts but does not launch
-or control the DCC. A locally successful execution therefore reports the
-install steps as `ok` while keeping `verify.directly_usable` false with
-`LIVE_DCC_VERIFICATION_REQUIRED`; `confirm-readiness` is returned as an
+or control the DCC. Locally completed artifact steps report `ok`, while the
+manual `register-dcc` step reports `deferred`; the overall result is `partial`
+with exit `0`, and `verify.directly_usable` remains false with
+`LIVE_DCC_VERIFICATION_REQUIRED`. `confirm-readiness` is returned as an
 executable next step. This is a truthful boundary, not a substitute for the
 later standalone verification slice.
 

--- a/skills/dcc-mcp-creator/references/TESTING_AND_RELEASE.md
+++ b/skills/dcc-mcp-creator/references/TESTING_AND_RELEASE.md
@@ -35,6 +35,9 @@ Until live-host verification is implemented for the shared executor, a local
 artifact verification step may be `ok` while `verify.directly_usable` remains
 false with `LIVE_DCC_VERIFICATION_REQUIRED`. Keep that boundary in adapter
 tests instead of treating package installation as live DCC readiness.
+Any planner step that still requires operator or live-host work, such as
+`register-dcc`, must be `deferred` rather than `ok`; a zero exit code does not
+turn that manual boundary into completed registration.
 
 Exercise the complete `plan -> execute -> verify -> status -> uninstall`
 round trip in CI. The gate must also prove that failed replacement restores the

--- a/tests/fixtures/install-execution-report-v1-deferred.json
+++ b/tests/fixtures/install-execution-report-v1-deferred.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "status": "partial",
+  "dcc_type": "maya",
+  "adapter_version": "0.0.0-test",
+  "core_version": "0.0.0-test",
+  "stage": "complete",
+  "exit_code": 0,
+  "steps": [
+    {
+      "id": "install-pip",
+      "status": "ok",
+      "rollback": {"attempted": false, "status": "not_available"}
+    },
+    {
+      "id": "register-dcc",
+      "status": "deferred",
+      "rollback": {"attempted": false, "status": "not_available"}
+    },
+    {
+      "id": "verify",
+      "status": "ok",
+      "rollback": {"attempted": false, "status": "not_available"}
+    }
+  ],
+  "rollback": {"attempted": false, "status": "not_attempted", "failure_count": 0},
+  "next_steps": [
+    {
+      "id": "inspect-runtime",
+      "description": "Inspect safe local runtime diagnostics.",
+      "why": "Diagnostics confirm the installed CLI and local gateway prerequisites.",
+      "command": ["dcc-mcp-cli", "doctor"]
+    },
+    {
+      "id": "confirm-readiness",
+      "description": "Confirm that a live maya adapter becomes ready.",
+      "why": "Host readiness is separate from local installation success.",
+      "command": ["dcc-mcp-cli", "wait-ready", "--dcc-type", "maya"]
+    }
+  ],
+  "receipt_path": null,
+  "verify": {
+    "directly_usable": false,
+    "failure_stage": "host-readiness",
+    "failure_reason": "LIVE_DCC_VERIFICATION_REQUIRED"
+  }
+}

--- a/tests/test_install_sop_contract.py
+++ b/tests/test_install_sop_contract.py
@@ -299,6 +299,19 @@ def test_rust_cli_success_execution_report_fixture_is_schema_valid() -> None:
     }
 
 
+def test_rust_cli_deferred_registration_report_fixture_is_schema_valid() -> None:
+    from dcc_mcp_core import load_install_sop_schema
+
+    fixture = REPO_ROOT / "tests" / "fixtures" / "install-execution-report-v1-deferred.json"
+    report = json.loads(fixture.read_text(encoding="utf-8"))
+
+    Draft202012Validator(load_install_sop_schema()).validate(report)
+    assert report["status"] == "partial"
+    assert report["exit_code"] == 0
+    assert [step["status"] for step in report["steps"]] == ["ok", "deferred", "ok"]
+    assert report["verify"]["directly_usable"] is False
+
+
 def test_rust_cli_rollback_failure_report_fixture_is_schema_valid() -> None:
     from dcc_mcp_core import load_install_sop_schema
 


### PR DESCRIPTION
## Summary
- report the real planner's manual register-dcc step as deferred instead of ok
- preserve one schema-valid Install SOP v1 envelope with exit 0, partial status, and directly_usable=false
- move CLI serialization and pip argument construction into focused modules so file-size gates pass without exemptions
- document and validate the deferred registration boundary across Rust, Python, CLI, and skill guidance

## Validation
- vx cargo test -p dcc-mcp-cli
- vx just clippy
- vx cargo fmt --all -- --check
- Python Install SOP and wheel contracts: 40 passed
- Python lint and format: 600 files checked
- skill lint: 31 skills and 59 execution contracts, 0 errors/warnings
- Rust file-size gates: cli.rs 1497 lines; install.rs 1490 lines
- VitePress production build

No live DCC or gateway was used.

Closes #2367
Refs #2361
Refs #2252
Refs #2253