### PR TITLE
test: isolate catalog cache fixtures

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/catalog.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/catalog.rs
@@ -370,6 +370,20 @@ mod tests {
         f
     }
 
+    async fn build_payload_with_catalog(content: &str, query: &Query) -> Result<Value, String> {
+        let file = write_catalog_yaml(content);
+        let catalog_path = file
+            .path()
+            .to_str()
+            .expect("temporary path should be UTF-8");
+        let _env = EnvVarsGuard::set(&[
+            ("DCC_MCP_MARKETPLACE_OFFLINE", Some("1")),
+            ("DCC_MCP_CATALOG_PATH", Some(catalog_path)),
+        ]);
+        LOADER.clear_cache().await;
+        build_payload(query).await
+    }
+
     const TWO_ENTRY_YAML: &str = r#"
 version: "1"
 entries:
@@ -397,18 +411,14 @@ entries:
 
     #[tokio::test]
     async fn build_payload_list_empty_query_returns_all() {
-        LOADER.clear_cache().await;
-        let f = write_catalog_yaml(TWO_ENTRY_YAML);
-        let _g = EnvVarsGuard::set(&[
-            ("DCC_MCP_MARKETPLACE_OFFLINE", Some("1")),
-            ("DCC_MCP_CATALOG_PATH", f.path().to_str()),
-        ]);
-
-        let v = build_payload(&Query::List {
-            query: String::new(),
-            limit: None,
-            offset: 0,
-        })
+        let v = build_payload_with_catalog(
+            TWO_ENTRY_YAML,
+            &Query::List {
+                query: String::new(),
+                limit: None,
+                offset: 0,
+            },
+        )
         .await
         .expect("build_payload should succeed");
 
@@ -417,18 +427,14 @@ entries:
 
     #[tokio::test]
     async fn build_payload_list_keyword_filters_results() {
-        LOADER.clear_cache().await;
-        let f = write_catalog_yaml(TWO_ENTRY_YAML);
-        let _g = EnvVarsGuard::set(&[
-            ("DCC_MCP_MARKETPLACE_OFFLINE", Some("1")),
-            ("DCC_MCP_CATALOG_PATH", f.path().to_str()),
-        ]);
-
-        let v = build_payload(&Query::List {
-            query: "maya".to_string(),
-            limit: None,
-            offset: 0,
-        })
+        let v = build_payload_with_catalog(
+            TWO_ENTRY_YAML,
+            &Query::List {
+                query: "maya".to_string(),
+                limit: None,
+                offset: 0,
+            },
+        )
         .await
         .expect("build_payload should succeed");
 
@@ -438,18 +444,14 @@ entries:
 
     #[tokio::test]
     async fn build_payload_list_paginated_limit() {
-        LOADER.clear_cache().await;
-        let f = write_catalog_yaml(TWO_ENTRY_YAML);
-        let _g = EnvVarsGuard::set(&[
-            ("DCC_MCP_MARKETPLACE_OFFLINE", Some("1")),
-            ("DCC_MCP_CATALOG_PATH", f.path().to_str()),
-        ]);
-
-        let v = build_payload(&Query::List {
-            query: String::new(),
-            limit: Some(1),
-            offset: 0,
-        })
+        let v = build_payload_with_catalog(
+            TWO_ENTRY_YAML,
+            &Query::List {
+                query: String::new(),
+                limit: Some(1),
+                offset: 0,
+            },
+        )
         .await
         .expect("build_payload should succeed");
 
@@ -460,18 +462,14 @@ entries:
 
     #[tokio::test]
     async fn build_payload_list_paginated_offset() {
-        LOADER.clear_cache().await;
-        let f = write_catalog_yaml(TWO_ENTRY_YAML);
-        let _g = EnvVarsGuard::set(&[
-            ("DCC_MCP_MARKETPLACE_OFFLINE", Some("1")),
-            ("DCC_MCP_CATALOG_PATH", f.path().to_str()),
-        ]);
-
-        let v = build_payload(&Query::List {
-            query: String::new(),
-            limit: None,
-            offset: 1,
-        })
+        let v = build_payload_with_catalog(
+            TWO_ENTRY_YAML,
+            &Query::List {
+                query: String::new(),
+                limit: None,
+                offset: 1,
+            },
+        )
         .await
         .expect("build_payload should succeed");
 
@@ -482,16 +480,12 @@ entries:
 
     #[tokio::test]
     async fn build_payload_single_existing_entry_returns_data() {
-        LOADER.clear_cache().await;
-        let f = write_catalog_yaml(ONE_ENTRY_YAML);
-        let _g = EnvVarsGuard::set(&[
-            ("DCC_MCP_MARKETPLACE_OFFLINE", Some("1")),
-            ("DCC_MCP_CATALOG_PATH", f.path().to_str()),
-        ]);
-
-        let v = build_payload(&Query::Single {
-            name: "maya-skills".to_string(),
-        })
+        let v = build_payload_with_catalog(
+            ONE_ENTRY_YAML,
+            &Query::Single {
+                name: "maya-skills".to_string(),
+            },
+        )
         .await
         .expect("describe should succeed");
 
@@ -501,19 +495,46 @@ entries:
 
     #[tokio::test]
     async fn build_payload_single_missing_entry_errors() {
-        LOADER.clear_cache().await;
-        let f = write_catalog_yaml(ONE_ENTRY_YAML);
-        let _g = EnvVarsGuard::set(&[
-            ("DCC_MCP_MARKETPLACE_OFFLINE", Some("1")),
-            ("DCC_MCP_CATALOG_PATH", f.path().to_str()),
-        ]);
-
-        let err = build_payload(&Query::Single {
-            name: "does-not-exist".to_string(),
-        })
+        let err = build_payload_with_catalog(
+            ONE_ENTRY_YAML,
+            &Query::Single {
+                name: "does-not-exist".to_string(),
+            },
+        )
         .await
         .expect_err("missing entry should return Err");
 
         assert!(err.contains("not found"));
+    }
+
+    #[test]
+    fn concurrent_catalog_fixtures_do_not_share_cached_entries() {
+        let fixtures = [(ONE_ENTRY_YAML, 1), (TWO_ENTRY_YAML, 2)];
+        let workers = fixtures.map(|(fixture, expected_total)| {
+            std::thread::spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("test runtime should build");
+
+                for _ in 0..16 {
+                    let payload = runtime
+                        .block_on(build_payload_with_catalog(
+                            fixture,
+                            &Query::List {
+                                query: String::new(),
+                                limit: None,
+                                offset: 0,
+                            },
+                        ))
+                        .expect("fixture payload should load");
+                    assert_eq!(payload["total"], expected_total);
+                }
+            })
+        });
+
+        for worker in workers {
+            worker.join().expect("fixture worker should not panic");
+        }
     }
 }

--- a/crates/dcc-mcp-test-utils/src/lib.rs
+++ b/crates/dcc-mcp-test-utils/src/lib.rs
@@ -45,6 +45,14 @@ pub mod skill_rest {
 /// `remove_var` race on the process-global environment table.
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+fn lock_env() -> MutexGuard<'static, ()> {
+    // The panicking test already failed; recover the guard so unrelated tests
+    // can restore their own environment instead of failing secondarily.
+    ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// RAII guard that sets an environment variable and restores the previous
 /// value (or removes it) when dropped.
 ///
@@ -60,7 +68,7 @@ impl EnvVarGuard {
     /// Set `key` to `value` (or remove it when `value` is `None`), saving
     /// the previous value so it can be restored on drop.
     pub fn set(key: &'static str, value: Option<&str>) -> Self {
-        let lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let lock = lock_env();
         let previous = std::env::var(key).ok();
         // SAFETY: serialised by ENV_LOCK; the previous value is restored on
         // drop so no other test can observe the side-effect past this guard's
@@ -102,7 +110,7 @@ impl EnvVarsGuard {
     /// Set each var in `vars` to its corresponding value (or remove it
     /// when the value is `None`), saving all previous values.
     pub fn set(vars: &[(&'static str, Option<&str>)]) -> Self {
-        let lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let lock = lock_env();
         let previous = vars
             .iter()
             .map(|(key, _)| (*key, std::env::var(key).ok()))
@@ -172,6 +180,20 @@ mod tests {
         ]);
         assert_eq!(std::env::var("DCC_MCP_TEST_UTILS_A").unwrap(), "1");
         assert_eq!(std::env::var("DCC_MCP_TEST_UTILS_B").unwrap(), "2");
+    }
+
+    #[test]
+    fn poisoned_env_lock_does_not_break_later_guard() {
+        const KEY: &str = "DCC_MCP_TEST_UTILS_POISON_RECOVERY";
+
+        let poisoner = std::thread::spawn(|| {
+            let _guard = EnvVarGuard::set(KEY, Some("before-panic"));
+            panic!("intentional test panic while holding the env lock");
+        });
+        assert!(poisoner.join().is_err());
+
+        let _guard = EnvVarGuard::set(KEY, Some("after-panic"));
+        assert_eq!(std::env::var(KEY).as_deref(), Ok("after-panic"));
     }
 }
 


### PR DESCRIPTION
## Summary
- hold the catalog test environment guard before clearing and reading the shared loader cache
- repeat concurrent one-entry and two-entry fixture loads to prove cache isolation
- recover the shared test environment lock after a guarded test panic to prevent secondary failures

## Validation
- `vx cargo test -p dcc-mcp-test-utils`
- catalog concurrency regression: 30/30 repeated passes
- `vx cargo test -p dcc-mcp-gateway --lib -- --test-threads=8` (547 passed)
- `vx just rust-cov`
- `vx just clippy`
- Rust formatting, diff, and file-size checks

This test-only repair does not change production behavior. No real DCC or gateway was used.

Closes #2369
Refs #2368
Refs #2367