### PR TITLE
fix: isolate job persistence writes

### DIFF
--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -834,9 +834,9 @@ fn build_job_manager(config: &McpHttpConfig) -> HttpResult<Arc<crate::job::JobMa
                         path.display()
                     ))
                 })?;
-                Ok(Arc::new(crate::job::JobManager::with_storage(Arc::new(
-                    storage,
-                ))))
+                Ok(Arc::new(crate::job::JobManager::with_offloaded_storage(
+                    Arc::new(storage),
+                )))
             }
             #[cfg(not(feature = "job-persist-sqlite"))]
             {

--- a/crates/dcc-mcp-http/src/server/tests.rs
+++ b/crates/dcc-mcp-http/src/server/tests.rs
@@ -4,7 +4,8 @@ use http::{Method, Request, Response, StatusCode};
 use parking_lot::Mutex;
 use std::{
     io::{self, Write},
-    sync::Arc,
+    sync::{Arc, mpsc},
+    time::{Duration, Instant},
 };
 use tower::ServiceExt;
 use tower_http::classify::{ClassifiedResponse, ClassifyResponse, MakeClassifier};
@@ -18,6 +19,153 @@ fn health_payload_surfaces_job_persistence_state() {
     assert_eq!(payload["job_persistence"]["state"], "not_configured");
     assert_eq!(payload["job_persistence"]["consecutive_failures"], 0);
     assert!(payload["job_persistence"]["last_error_kind"].is_null());
+}
+
+struct HttpBlockingStorage {
+    entered: mpsc::SyncSender<()>,
+    release: std::sync::Mutex<mpsc::Receiver<()>>,
+}
+
+impl std::fmt::Debug for HttpBlockingStorage {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HttpBlockingStorage")
+            .finish_non_exhaustive()
+    }
+}
+
+impl crate::JobStorage for HttpBlockingStorage {
+    fn put(&self, _job: &crate::Job) -> Result<(), crate::JobStorageError> {
+        self.entered.send(()).unwrap();
+        self.release.lock().unwrap().recv().unwrap();
+        Ok(())
+    }
+
+    fn get(&self, _job_id: &str) -> Result<Option<crate::Job>, crate::JobStorageError> {
+        Ok(None)
+    }
+
+    fn list(&self, _filter: crate::JobFilter) -> Result<Vec<crate::Job>, crate::JobStorageError> {
+        Ok(Vec::new())
+    }
+
+    fn update_status(
+        &self,
+        _job_id: &str,
+        _status: crate::JobStatus,
+        _at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), crate::JobStorageError> {
+        Ok(())
+    }
+
+    fn delete_older_than(
+        &self,
+        _cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, crate::JobStorageError> {
+        Ok(0)
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dedicated_health_remains_responsive_while_job_storage_is_blocked() {
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+    let jobs = Arc::new(crate::JobManager::with_offloaded_storage(Arc::new(
+        HttpBlockingStorage {
+            entered: entered_tx,
+            release: std::sync::Mutex::new(release_rx),
+        },
+    )));
+    let writer_jobs = jobs.clone();
+    let health_jobs = jobs.clone();
+    let router = Router::new()
+        .route(
+            "/jobs",
+            routing::post(move || {
+                let jobs = writer_jobs.clone();
+                async move {
+                    jobs.create("scene.inspect");
+                    StatusCode::NO_CONTENT
+                }
+            }),
+        )
+        .route(
+            "/health",
+            routing::get(move || {
+                let jobs = health_jobs.clone();
+                async move { Json(health_payload(&jobs)) }
+            }),
+        );
+
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let actual_bind = listener.local_addr().unwrap().to_string();
+    let port = listener.local_addr().unwrap().port();
+    let mut config = McpHttpConfig::default();
+    config.server.spawn_mode = crate::ServerSpawnMode::Dedicated;
+    config.server.self_probe_timeout_ms = 0;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (join, serve_thread) = spawn_impl::spawn_http_server(
+        listener,
+        router,
+        &config,
+        actual_bind,
+        port,
+        shutdown_tx.clone(),
+        shutdown_rx,
+    )
+    .await
+    .unwrap();
+    assert!(join.is_none());
+
+    let client = reqwest::Client::new();
+    let write_client = client.clone();
+    let write_request = tokio::spawn(async move {
+        write_client
+            .post(format!("http://127.0.0.1:{port}/jobs"))
+            .send()
+            .await
+    });
+    tokio::task::spawn_blocking(move || entered_rx.recv_timeout(Duration::from_secs(2)))
+        .await
+        .unwrap()
+        .expect("storage write did not start");
+    let release = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(300));
+        release_tx.send(()).unwrap();
+    });
+
+    let health_started = Instant::now();
+    let health_response = tokio::time::timeout(
+        Duration::from_millis(100),
+        client.get(format!("http://127.0.0.1:{port}/health")).send(),
+    )
+    .await;
+    let health_elapsed = health_started.elapsed();
+
+    let write_response = tokio::time::timeout(Duration::from_secs(2), write_request)
+        .await
+        .expect("job request did not finish after storage release")
+        .unwrap()
+        .unwrap();
+    assert_eq!(write_response.status(), StatusCode::NO_CONTENT);
+    tokio::task::spawn_blocking(move || release.join().unwrap())
+        .await
+        .unwrap();
+    let _ = shutdown_tx.send(true);
+    if let Some(thread) = serve_thread {
+        tokio::task::spawn_blocking(move || thread.join().unwrap())
+            .await
+            .unwrap();
+    }
+
+    let health_response = health_response.unwrap_or_else(|_| {
+        panic!("/health was starved for {health_elapsed:?} by synchronous storage I/O")
+    });
+    assert_eq!(health_response.unwrap().status(), StatusCode::OK);
+    assert!(
+        health_elapsed < Duration::from_millis(100),
+        "/health took {health_elapsed:?}"
+    );
 }
 
 #[cfg(feature = "auto-gateway")]

--- a/crates/dcc-mcp-job/src/job/manager.rs
+++ b/crates/dcc-mcp-job/src/job/manager.rs
@@ -11,7 +11,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 use super::types::{Job, JobEvent, JobProgress, JobStatus, JobSubscriber};
-use super::{JobPersistenceStatus, persistence::PersistenceCircuit};
+use super::{
+    JobPersistenceStatus,
+    persistence::{PersistenceCircuit, PersistenceWriter},
+};
 
 /// Thread-safe registry of [`Job`]s.
 pub struct JobManager {
@@ -19,10 +22,11 @@ pub struct JobManager {
     /// Subscribers invoked on every status transition. See [`Self::subscribe`].
     subscribers: RwLock<Vec<JobSubscriber>>,
     /// Optional persistence backend (issue #328). When `Some`, every
-    /// mutation is written through to storage so the next process
-    /// incarnation can see and mark-interrupted any in-flight jobs.
+    /// mutation is submitted to the owned persistence worker so the next
+    /// process incarnation can see and mark-interrupted in-flight jobs.
     storage: Option<Arc<dyn crate::job_storage::JobStorage>>,
-    persistence: parking_lot::Mutex<PersistenceCircuit>,
+    persistence: Arc<parking_lot::Mutex<PersistenceCircuit>>,
+    persistence_writer: Option<PersistenceWriter>,
 }
 
 impl Default for JobManager {
@@ -49,31 +53,73 @@ impl JobManager {
             jobs: DashMap::new(),
             subscribers: RwLock::new(Vec::new()),
             storage: None,
-            persistence: parking_lot::Mutex::new(PersistenceCircuit::default()),
+            persistence: Arc::new(parking_lot::Mutex::new(PersistenceCircuit::default())),
+            persistence_writer: None,
         }
     }
 
     /// Create a manager that writes every mutation through to `storage`
     /// (issue #328).
     ///
-    /// Does NOT perform recovery automatically — call
+    /// This constructor waits for each serialized worker transaction before
+    /// returning from a mutation. It does NOT perform recovery automatically — call
     /// [`Self::recover_from_storage`] once after construction if the
     /// backend may already contain rows from a previous process.
     pub fn with_storage(storage: Arc<dyn crate::job_storage::JobStorage>) -> Self {
+        Self::with_storage_mode(storage, true)
+    }
+
+    /// Create a manager whose storage writes run on a single bounded worker.
+    ///
+    /// Job mutations enqueue persistence in FIFO order and return without
+    /// waiting for backend I/O. HTTP servers use this mode so synchronous
+    /// storage drivers cannot starve the request runtime. The worker still
+    /// flushes queued writes when the manager is dropped.
+    pub fn with_offloaded_storage(storage: Arc<dyn crate::job_storage::JobStorage>) -> Self {
+        Self::with_storage_mode(storage, false)
+    }
+
+    fn with_storage_mode(
+        storage: Arc<dyn crate::job_storage::JobStorage>,
+        wait_for_completion: bool,
+    ) -> Self {
+        let (persistence, persistence_writer) =
+            Self::build_persistence_runtime(&storage, wait_for_completion);
         Self {
             jobs: DashMap::new(),
             subscribers: RwLock::new(Vec::new()),
             storage: Some(storage),
-            persistence: parking_lot::Mutex::new(PersistenceCircuit::configured()),
+            persistence,
+            persistence_writer,
         }
+    }
+
+    fn build_persistence_runtime(
+        storage: &Arc<dyn crate::job_storage::JobStorage>,
+        wait_for_completion: bool,
+    ) -> (
+        Arc<parking_lot::Mutex<PersistenceCircuit>>,
+        Option<PersistenceWriter>,
+    ) {
+        let persistence = Arc::new(parking_lot::Mutex::new(PersistenceCircuit::configured()));
+        let persistence_writer =
+            PersistenceWriter::new(storage.clone(), persistence.clone(), wait_for_completion)
+                .map_err(|error| {
+                    tracing::error!(error = %error, "failed to start job persistence worker");
+                    persistence.lock().disable("worker_unavailable");
+                })
+                .ok();
+        (persistence, persistence_writer)
     }
 
     /// Attach a storage backend to an existing manager. Intended for
     /// uncommon build-up paths; the primary entry point is
     /// [`Self::with_storage`].
     pub fn set_storage(&mut self, storage: Arc<dyn crate::job_storage::JobStorage>) {
+        let (persistence, persistence_writer) = Self::build_persistence_runtime(&storage, true);
         self.storage = Some(storage);
-        self.persistence = parking_lot::Mutex::new(PersistenceCircuit::configured());
+        self.persistence = persistence;
+        self.persistence_writer = persistence_writer;
     }
 
     /// Borrow the underlying storage, if any.
@@ -130,46 +176,8 @@ impl JobManager {
     }
 
     fn persist_put(&self, job: &Job) {
-        let Some(storage) = &self.storage else {
-            return;
-        };
-        if !self.persistence.lock().can_write() {
-            return;
-        }
-        let result = storage.put(job);
-        let mut persistence = self.persistence.lock();
-        // Another in-flight write may have crossed the sticky failure
-        // threshold while this backend call was running. Do not recover or
-        // mutate a circuit that has already been disabled.
-        if !persistence.can_write() {
-            return;
-        }
-        match result {
-            Ok(()) => {
-                if persistence.record_success() {
-                    tracing::info!("job persistence recovered after a transient write failure");
-                }
-            }
-            Err(error) => {
-                let disabled = persistence.record_failure(&error);
-                let status = persistence.status();
-                drop(persistence);
-                if disabled {
-                    tracing::warn!(
-                        error = %error,
-                        error_kind = status.last_error_kind.as_deref().unwrap_or("unknown"),
-                        consecutive_failures = status.consecutive_failures,
-                        "job persistence disabled after repeated identical write failures"
-                    );
-                } else {
-                    tracing::debug!(
-                        job_id = %job.id,
-                        error = %error,
-                        consecutive_failures = status.consecutive_failures,
-                        "JobStorage.put failed"
-                    );
-                }
-            }
+        if let Some(writer) = &self.persistence_writer {
+            writer.put(job);
         }
     }
 
@@ -445,9 +453,13 @@ impl JobManager {
         }
         if removed > 0
             && let Some(storage) = &self.storage
-            && let Err(e) = storage.delete_older_than(cutoff)
         {
-            tracing::warn!(error = %e, "JobStorage.delete_older_than failed during gc_stale");
+            if let Some(writer) = &self.persistence_writer {
+                writer.flush();
+            }
+            if let Err(e) = storage.delete_older_than(cutoff) {
+                tracing::warn!(error = %e, "JobStorage.delete_older_than failed during gc_stale");
+            }
         }
         removed
     }

--- a/crates/dcc-mcp-job/src/job/persistence.rs
+++ b/crates/dcc-mcp-job/src/job/persistence.rs
@@ -1,8 +1,15 @@
+use std::sync::Arc;
+use std::sync::mpsc::{self, SyncSender, TrySendError};
+
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
+use super::Job;
+use crate::job_storage::JobStorage;
 use crate::job_storage::JobStorageError;
 
 pub(super) const PERSISTENCE_FAILURE_THRESHOLD: u32 = 3;
+const PERSISTENCE_QUEUE_CAPACITY: usize = 64;
 
 /// Runtime state of the optional job-persistence backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -76,6 +83,15 @@ impl PersistenceCircuit {
         }
     }
 
+    pub(super) fn disable(&mut self, error_kind: &str) -> bool {
+        let changed = !self.disabled;
+        self.disabled = true;
+        self.consecutive_failures = 0;
+        self.last_error = None;
+        self.last_error_kind = Some(error_kind.to_string());
+        changed
+    }
+
     pub(super) fn status(&self) -> JobPersistenceStatus {
         let state = if !self.configured {
             JobPersistenceState::NotConfigured
@@ -90,6 +106,178 @@ impl PersistenceCircuit {
             state,
             consecutive_failures: self.consecutive_failures,
             last_error_kind: self.last_error_kind.clone(),
+        }
+    }
+}
+
+enum PersistenceCommand {
+    Put {
+        job: Box<Job>,
+        completed: Option<SyncSender<()>>,
+    },
+    Flush {
+        completed: SyncSender<()>,
+    },
+}
+
+/// Single-owner persistence worker.
+///
+/// The worker owns the complete `can_write -> storage.put -> record result`
+/// transaction. That makes the failure threshold atomic across concurrent job
+/// mutations without holding the public health-state mutex during backend I/O.
+pub(super) struct PersistenceWriter {
+    sender: Option<SyncSender<PersistenceCommand>>,
+    worker: Option<std::thread::JoinHandle<()>>,
+    circuit: Arc<Mutex<PersistenceCircuit>>,
+    wait_for_completion: bool,
+}
+
+impl PersistenceWriter {
+    pub(super) fn new(
+        storage: Arc<dyn JobStorage>,
+        circuit: Arc<Mutex<PersistenceCircuit>>,
+        wait_for_completion: bool,
+    ) -> Result<Self, std::io::Error> {
+        let (sender, receiver) = mpsc::sync_channel(PERSISTENCE_QUEUE_CAPACITY);
+        let worker_circuit = circuit.clone();
+        let worker = std::thread::Builder::new()
+            .name("dcc-mcp-job-persistence".to_string())
+            .spawn(move || {
+                while let Ok(command) = receiver.recv() {
+                    match command {
+                        PersistenceCommand::Put { job, completed } => {
+                            persist_one(&storage, &worker_circuit, &job);
+                            if let Some(completed) = completed {
+                                let _ = completed.send(());
+                            }
+                        }
+                        PersistenceCommand::Flush { completed } => {
+                            let _ = completed.send(());
+                        }
+                    }
+                }
+            })?;
+        Ok(Self {
+            sender: Some(sender),
+            worker: Some(worker),
+            circuit,
+            wait_for_completion,
+        })
+    }
+
+    pub(super) fn put(&self, job: &Job) {
+        if !self.circuit.lock().can_write() {
+            return;
+        }
+        let Some(sender) = &self.sender else {
+            self.disable("worker_unavailable");
+            return;
+        };
+
+        if self.wait_for_completion {
+            let (completed_tx, completed_rx) = mpsc::sync_channel(0);
+            if sender
+                .send(PersistenceCommand::Put {
+                    job: Box::new(job.clone()),
+                    completed: Some(completed_tx),
+                })
+                .is_err()
+            {
+                self.disable("worker_unavailable");
+                return;
+            }
+            if completed_rx.recv().is_err() {
+                self.disable("worker_unavailable");
+            }
+            return;
+        }
+
+        match sender.try_send(PersistenceCommand::Put {
+            job: Box::new(job.clone()),
+            completed: None,
+        }) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => self.disable("queue_full"),
+            Err(TrySendError::Disconnected(_)) => self.disable("worker_unavailable"),
+        }
+    }
+
+    pub(super) fn flush(&self) {
+        let Some(sender) = &self.sender else {
+            self.disable("worker_unavailable");
+            return;
+        };
+        let (completed_tx, completed_rx) = mpsc::sync_channel(0);
+        if sender
+            .send(PersistenceCommand::Flush {
+                completed: completed_tx,
+            })
+            .is_err()
+        {
+            self.disable("worker_unavailable");
+            return;
+        }
+        if completed_rx.recv().is_err() {
+            self.disable("worker_unavailable");
+        }
+    }
+
+    fn disable(&self, error_kind: &'static str) {
+        let mut circuit = self.circuit.lock();
+        if circuit.disable(error_kind) {
+            tracing::warn!(
+                error_kind,
+                queue_capacity = PERSISTENCE_QUEUE_CAPACITY,
+                "job persistence disabled because its bounded worker cannot accept writes"
+            );
+        }
+    }
+}
+
+impl Drop for PersistenceWriter {
+    fn drop(&mut self) {
+        self.sender.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+fn persist_one(storage: &Arc<dyn JobStorage>, circuit: &Arc<Mutex<PersistenceCircuit>>, job: &Job) {
+    if !circuit.lock().can_write() {
+        return;
+    }
+
+    let result = storage.put(job);
+    let mut persistence = circuit.lock();
+    if !persistence.can_write() {
+        return;
+    }
+    match result {
+        Ok(()) => {
+            if persistence.record_success() {
+                tracing::info!("job persistence recovered after a transient write failure");
+            }
+        }
+        Err(error) => {
+            let disabled = persistence.record_failure(&error);
+            let status = persistence.status();
+            drop(persistence);
+            if disabled {
+                tracing::warn!(
+                    error = %error,
+                    error_kind = status.last_error_kind.as_deref().unwrap_or("unknown"),
+                    consecutive_failures = status.consecutive_failures,
+                    "job persistence disabled after repeated identical write failures"
+                );
+            } else {
+                tracing::debug!(
+                    job_id = %job.id,
+                    error = %error,
+                    consecutive_failures = status.consecutive_failures,
+                    "JobStorage.put failed"
+                );
+            }
         }
     }
 }

--- a/crates/dcc-mcp-job/src/job/tests.rs
+++ b/crates/dcc-mcp-job/src/job/tests.rs
@@ -3,11 +3,11 @@
 use super::*;
 use crate::job_storage::{JobFilter, JobStorage, JobStorageError};
 use serde_json::json;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
+use std::sync::{Arc, Barrier, Condvar};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Default)]
 struct FailingStorage {
@@ -73,6 +73,116 @@ impl JobStorage for BlockingStorage {
     fn put(&self, _job: &Job) -> Result<(), JobStorageError> {
         self.entered.send(()).unwrap();
         self.release.lock().unwrap().recv().unwrap();
+        Ok(())
+    }
+
+    fn get(&self, _job_id: &str) -> Result<Option<Job>, JobStorageError> {
+        Ok(None)
+    }
+
+    fn list(&self, _filter: JobFilter) -> Result<Vec<Job>, JobStorageError> {
+        Ok(Vec::new())
+    }
+
+    fn update_status(
+        &self,
+        _job_id: &str,
+        _status: JobStatus,
+        _at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), JobStorageError> {
+        Ok(())
+    }
+
+    fn delete_older_than(
+        &self,
+        _cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, JobStorageError> {
+        Ok(0)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ControlledFailingStorage {
+    puts: AtomicUsize,
+    entered: (std::sync::Mutex<usize>, Condvar),
+    releases: (std::sync::Mutex<usize>, Condvar),
+}
+
+impl ControlledFailingStorage {
+    fn wait_for_puts(&self, expected: usize, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let (lock, ready) = &self.entered;
+        let mut entered = lock.lock().unwrap();
+        while *entered < expected {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            let (next, result) = ready.wait_timeout(entered, remaining).unwrap();
+            entered = next;
+            if result.timed_out() && *entered < expected {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn release_one(&self) {
+        let (lock, ready) = &self.releases;
+        *lock.lock().unwrap() += 1;
+        ready.notify_one();
+    }
+}
+
+impl JobStorage for ControlledFailingStorage {
+    fn put(&self, _job: &Job) -> Result<(), JobStorageError> {
+        self.puts.fetch_add(1, Ordering::SeqCst);
+        let (entered_lock, entered_ready) = &self.entered;
+        *entered_lock.lock().unwrap() += 1;
+        entered_ready.notify_all();
+
+        let (release_lock, release_ready) = &self.releases;
+        let mut releases = release_lock.lock().unwrap();
+        while *releases == 0 {
+            releases = release_ready.wait(releases).unwrap();
+        }
+        *releases -= 1;
+        Err(JobStorageError::Backend("readonly-controlled".to_string()))
+    }
+
+    fn get(&self, _job_id: &str) -> Result<Option<Job>, JobStorageError> {
+        Ok(None)
+    }
+
+    fn list(&self, _filter: JobFilter) -> Result<Vec<Job>, JobStorageError> {
+        Ok(Vec::new())
+    }
+
+    fn update_status(
+        &self,
+        _job_id: &str,
+        _status: JobStatus,
+        _at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), JobStorageError> {
+        Ok(())
+    }
+
+    fn delete_older_than(
+        &self,
+        _cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, JobStorageError> {
+        Ok(0)
+    }
+}
+
+#[derive(Debug, Default)]
+struct RecordingStorage {
+    statuses: std::sync::Mutex<Vec<JobStatus>>,
+}
+
+impl JobStorage for RecordingStorage {
+    fn put(&self, job: &Job) -> Result<(), JobStorageError> {
+        self.statuses.lock().unwrap().push(job.status);
         Ok(())
     }
 
@@ -476,6 +586,117 @@ fn repeated_identical_put_failures_latch_persistence() {
         }
     );
     assert_eq!(jobs.list().len(), 5, "in-memory jobs must keep working");
+}
+
+#[test]
+fn concurrent_identical_failures_do_not_start_a_fourth_backend_write() {
+    let storage = Arc::new(ControlledFailingStorage::default());
+    let jobs = Arc::new(JobManager::with_storage(storage.clone()));
+    let start = Arc::new(Barrier::new(5));
+    let writers: Vec<_> = (0..4)
+        .map(|index| {
+            let jobs = jobs.clone();
+            let start = start.clone();
+            thread::spawn(move || {
+                start.wait();
+                jobs.create(format!("scene.inspect.{index}"));
+            })
+        })
+        .collect();
+
+    start.wait();
+    let all_four_started_before_any_result = storage.wait_for_puts(4, Duration::from_millis(500));
+
+    if all_four_started_before_any_result {
+        for _ in 0..4 {
+            storage.release_one();
+        }
+    } else {
+        assert!(storage.wait_for_puts(1, Duration::from_secs(2)));
+        for expected in 1..=3 {
+            storage.release_one();
+            if expected < 3 {
+                assert!(storage.wait_for_puts(expected + 1, Duration::from_secs(2)));
+            }
+        }
+    }
+
+    for writer in writers {
+        writer.join().unwrap();
+    }
+
+    assert_eq!(
+        storage.puts.load(Ordering::SeqCst),
+        3,
+        "the failure threshold must reserve write ownership before backend I/O"
+    );
+    assert_eq!(
+        jobs.list().len(),
+        4,
+        "all jobs must remain available in memory"
+    );
+    assert_eq!(
+        jobs.persistence_status().state,
+        JobPersistenceState::Disabled
+    );
+}
+
+#[test]
+fn offloaded_storage_flushes_job_lifecycle_in_fifo_order_on_drop() {
+    let storage = Arc::new(RecordingStorage::default());
+    {
+        let jobs = JobManager::with_offloaded_storage(storage.clone());
+        let job = jobs.create("scene.inspect");
+        let job_id = job.read().id.clone();
+        jobs.start(&job_id).unwrap();
+        jobs.complete(&job_id, json!({"ok": true})).unwrap();
+    }
+
+    assert_eq!(
+        *storage.statuses.lock().unwrap(),
+        [JobStatus::Pending, JobStatus::Running, JobStatus::Completed,]
+    );
+}
+
+#[test]
+fn offloaded_storage_queue_is_bounded_and_fails_closed_without_blocking_callers() {
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+    let storage = Arc::new(BlockingStorage {
+        entered: entered_tx,
+        release: std::sync::Mutex::new(release_rx),
+    });
+    let jobs = Arc::new(JobManager::with_offloaded_storage(storage));
+    jobs.create("scene.inspect.blocked");
+    entered_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("storage worker did not start the blocking write");
+
+    let flood_jobs = jobs.clone();
+    let (done_tx, done_rx) = mpsc::sync_channel(1);
+    let flood = thread::spawn(move || {
+        for index in 0..65 {
+            flood_jobs.create(format!("scene.inspect.queued.{index}"));
+        }
+        done_tx.send(()).unwrap();
+    });
+    done_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("bounded persistence queue blocked a job caller");
+
+    assert_eq!(
+        jobs.persistence_status(),
+        JobPersistenceStatus {
+            state: JobPersistenceState::Disabled,
+            consecutive_failures: 0,
+            last_error_kind: Some("queue_full".to_string()),
+        }
+    );
+    assert_eq!(jobs.list().len(), 66);
+
+    release_tx.send(()).unwrap();
+    flood.join().unwrap();
+    drop(jobs);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- serialize persistence transactions on one bounded worker so the fourth identical failure cannot reach the backend
- offload HTTP job persistence from the dedicated request runtime while preserving FIFO lifecycle writes
- fail closed when the bounded queue or worker is unavailable

## Validation
- `vx just preflight` (3,758/3,758 workspace tests plus doctests)
- focused job persistence and dedicated `/health` regressions, repeated 10 times each
- `vx cargo check -p dcc-mcp-http --all-features`
- `vx cargo hakari verify`
- Rust file-size gate and VitePress docs build

No adapter or skill guidance changes are required because this only changes internal job-persistence runtime ownership. No real DCC or operator gateway was used.

Closes #2376
Refs #2277
Refs #2328