### PR TITLE
fix(job): bound persistence cleanup and shutdown

### DIFF
--- a/crates/dcc-mcp-http/src/server/tests.rs
+++ b/crates/dcc-mcp-http/src/server/tests.rs
@@ -34,6 +34,51 @@ impl std::fmt::Debug for HttpBlockingStorage {
     }
 }
 
+struct HttpCleanupBlockingStorage {
+    entered: mpsc::SyncSender<()>,
+    release: std::sync::Mutex<mpsc::Receiver<()>>,
+}
+
+impl std::fmt::Debug for HttpCleanupBlockingStorage {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HttpCleanupBlockingStorage")
+            .finish_non_exhaustive()
+    }
+}
+
+impl crate::JobStorage for HttpCleanupBlockingStorage {
+    fn put(&self, _job: &crate::Job) -> Result<(), crate::JobStorageError> {
+        Ok(())
+    }
+
+    fn get(&self, _job_id: &str) -> Result<Option<crate::Job>, crate::JobStorageError> {
+        Ok(None)
+    }
+
+    fn list(&self, _filter: crate::JobFilter) -> Result<Vec<crate::Job>, crate::JobStorageError> {
+        Ok(Vec::new())
+    }
+
+    fn update_status(
+        &self,
+        _job_id: &str,
+        _status: crate::JobStatus,
+        _at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), crate::JobStorageError> {
+        Ok(())
+    }
+
+    fn delete_older_than(
+        &self,
+        _cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, crate::JobStorageError> {
+        self.entered.send(()).unwrap();
+        self.release.lock().unwrap().recv().unwrap();
+        Ok(1)
+    }
+}
+
 impl crate::JobStorage for HttpBlockingStorage {
     fn put(&self, _job: &crate::Job) -> Result<(), crate::JobStorageError> {
         self.entered.send(()).unwrap();
@@ -160,6 +205,116 @@ async fn dedicated_health_remains_responsive_while_job_storage_is_blocked() {
 
     let health_response = health_response.unwrap_or_else(|_| {
         panic!("/health was starved for {health_elapsed:?} by synchronous storage I/O")
+    });
+    assert_eq!(health_response.unwrap().status(), StatusCode::OK);
+    assert!(
+        health_elapsed < Duration::from_millis(100),
+        "/health took {health_elapsed:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dedicated_health_remains_responsive_while_job_cleanup_is_blocked() {
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+    let jobs = Arc::new(crate::JobManager::with_offloaded_storage(Arc::new(
+        HttpCleanupBlockingStorage {
+            entered: entered_tx,
+            release: std::sync::Mutex::new(release_rx),
+        },
+    )));
+    let old_job = jobs.create("scene.inspect.cleanup");
+    let old_job_id = old_job.read().id.clone();
+    jobs.start(&old_job_id).unwrap();
+    jobs.complete(&old_job_id, serde_json::json!({"ok": true}))
+        .unwrap();
+    old_job.write().updated_at = chrono::Utc::now() - chrono::Duration::hours(2);
+
+    let cleanup_jobs = jobs.clone();
+    let health_jobs = jobs.clone();
+    let router = Router::new()
+        .route(
+            "/cleanup",
+            routing::post(move || {
+                let jobs = cleanup_jobs.clone();
+                async move {
+                    Json(serde_json::json!({
+                        "removed": jobs.cleanup_older_than_hours(1),
+                    }))
+                }
+            }),
+        )
+        .route(
+            "/health",
+            routing::get(move || {
+                let jobs = health_jobs.clone();
+                async move { Json(health_payload(&jobs)) }
+            }),
+        );
+
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let actual_bind = listener.local_addr().unwrap().to_string();
+    let port = listener.local_addr().unwrap().port();
+    let mut config = McpHttpConfig::default();
+    config.server.spawn_mode = crate::ServerSpawnMode::Dedicated;
+    config.server.self_probe_timeout_ms = 0;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (join, serve_thread) = spawn_impl::spawn_http_server(
+        listener,
+        router,
+        &config,
+        actual_bind,
+        port,
+        shutdown_tx.clone(),
+        shutdown_rx,
+    )
+    .await
+    .unwrap();
+    assert!(join.is_none());
+
+    let client = reqwest::Client::new();
+    let cleanup_client = client.clone();
+    let cleanup_request = tokio::spawn(async move {
+        cleanup_client
+            .post(format!("http://127.0.0.1:{port}/cleanup"))
+            .send()
+            .await
+    });
+    tokio::task::spawn_blocking(move || entered_rx.recv_timeout(Duration::from_secs(2)))
+        .await
+        .unwrap()
+        .expect("storage cleanup did not start");
+    let release = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(300));
+        release_tx.send(()).unwrap();
+    });
+
+    let health_started = Instant::now();
+    let health_response = tokio::time::timeout(
+        Duration::from_millis(100),
+        client.get(format!("http://127.0.0.1:{port}/health")).send(),
+    )
+    .await;
+    let health_elapsed = health_started.elapsed();
+
+    let cleanup_response = tokio::time::timeout(Duration::from_secs(2), cleanup_request)
+        .await
+        .expect("cleanup request did not finish after storage release")
+        .unwrap()
+        .unwrap();
+    assert_eq!(cleanup_response.status(), StatusCode::OK);
+    tokio::task::spawn_blocking(move || release.join().unwrap())
+        .await
+        .unwrap();
+    let _ = shutdown_tx.send(true);
+    if let Some(thread) = serve_thread {
+        tokio::task::spawn_blocking(move || thread.join().unwrap())
+            .await
+            .unwrap();
+    }
+
+    let health_response = health_response.unwrap_or_else(|_| {
+        panic!("/health was starved for {health_elapsed:?} by synchronous cleanup storage I/O")
     });
     assert_eq!(health_response.unwrap().status(), StatusCode::OK);
     assert!(

--- a/crates/dcc-mcp-job/src/job/manager.rs
+++ b/crates/dcc-mcp-job/src/job/manager.rs
@@ -73,8 +73,9 @@ impl JobManager {
     ///
     /// Job mutations enqueue persistence in FIFO order and return without
     /// waiting for backend I/O. HTTP servers use this mode so synchronous
-    /// storage drivers cannot starve the request runtime. The worker still
-    /// flushes queued writes when the manager is dropped.
+    /// storage drivers cannot starve the request runtime. Drop gives the worker
+    /// a bounded shutdown window; a backend call that never returns cannot
+    /// block the owning runtime indefinitely.
     pub fn with_offloaded_storage(storage: Arc<dyn crate::job_storage::JobStorage>) -> Self {
         Self::with_storage_mode(storage, false)
     }
@@ -452,14 +453,9 @@ impl JobManager {
             }
         }
         if removed > 0
-            && let Some(storage) = &self.storage
+            && let Some(writer) = &self.persistence_writer
         {
-            if let Some(writer) = &self.persistence_writer {
-                writer.flush();
-            }
-            if let Err(e) = storage.delete_older_than(cutoff) {
-                tracing::warn!(error = %e, "JobStorage.delete_older_than failed during gc_stale");
-            }
+            writer.delete_older_than(cutoff);
         }
         removed
     }
@@ -469,8 +465,9 @@ impl JobManager {
     /// `older_than_hours` from both the in-process map and any attached
     /// [`JobStorage`] backend.
     ///
-    /// Returns the number of rows removed (from the in-process map —
-    /// the storage delete is authoritative for persisted rows).
+    /// Returns the number of rows removed from the in-process map. With
+    /// offloaded storage, the persisted-row delete is queued on the same FIFO
+    /// worker and may complete after this method returns.
     pub fn cleanup_older_than_hours(&self, older_than_hours: u64) -> usize {
         // Clamp to i64 to stay inside chrono's range. 1000 years is
         // more than any real caller should ever pass.

--- a/crates/dcc-mcp-job/src/job/persistence.rs
+++ b/crates/dcc-mcp-job/src/job/persistence.rs
@@ -167,11 +167,10 @@ impl PersistenceWriter {
                             }
                         }
                         PersistenceCommand::DeleteOlderThan { cutoff, completed } => {
-                            if let Err(error) = storage.delete_older_than(cutoff) {
-                                tracing::warn!(
-                                    error = %error,
-                                    "JobStorage.delete_older_than failed during gc_stale"
-                                );
+                            let can_write = worker_circuit.lock().can_write();
+                            if can_write && let Err(error) = storage.delete_older_than(cutoff)
+                            {
+                                tracing::warn!(error = %error, "JobStorage.delete_older_than failed during gc_stale");
                             }
                             if let Some(completed) = completed {
                                 let _ = completed.send(());
@@ -227,6 +226,10 @@ impl PersistenceWriter {
     }
 
     pub(super) fn delete_older_than(&self, cutoff: DateTime<Utc>) {
+        let can_write = self.circuit.lock().can_write();
+        if !can_write {
+            return;
+        }
         let Some(sender) = &self.sender else {
             self.disable("worker_unavailable");
             return;

--- a/crates/dcc-mcp-job/src/job/persistence.rs
+++ b/crates/dcc-mcp-job/src/job/persistence.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
-use std::sync::mpsc::{self, SyncSender, TrySendError};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
+use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
@@ -10,6 +12,7 @@ use crate::job_storage::JobStorageError;
 
 pub(super) const PERSISTENCE_FAILURE_THRESHOLD: u32 = 3;
 const PERSISTENCE_QUEUE_CAPACITY: usize = 64;
+const PERSISTENCE_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// Runtime state of the optional job-persistence backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -115,9 +118,18 @@ enum PersistenceCommand {
         job: Box<Job>,
         completed: Option<SyncSender<()>>,
     },
-    Flush {
-        completed: SyncSender<()>,
+    DeleteOlderThan {
+        cutoff: DateTime<Utc>,
+        completed: Option<SyncSender<()>>,
     },
+}
+
+struct WorkerDone(SyncSender<()>);
+
+impl Drop for WorkerDone {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
 }
 
 /// Single-owner persistence worker.
@@ -128,6 +140,7 @@ enum PersistenceCommand {
 pub(super) struct PersistenceWriter {
     sender: Option<SyncSender<PersistenceCommand>>,
     worker: Option<std::thread::JoinHandle<()>>,
+    worker_done: Option<Mutex<Receiver<()>>>,
     circuit: Arc<Mutex<PersistenceCircuit>>,
     wait_for_completion: bool,
 }
@@ -139,10 +152,12 @@ impl PersistenceWriter {
         wait_for_completion: bool,
     ) -> Result<Self, std::io::Error> {
         let (sender, receiver) = mpsc::sync_channel(PERSISTENCE_QUEUE_CAPACITY);
+        let (worker_done_tx, worker_done_rx) = mpsc::sync_channel(1);
         let worker_circuit = circuit.clone();
         let worker = std::thread::Builder::new()
             .name("dcc-mcp-job-persistence".to_string())
             .spawn(move || {
+                let _done = WorkerDone(worker_done_tx);
                 while let Ok(command) = receiver.recv() {
                     match command {
                         PersistenceCommand::Put { job, completed } => {
@@ -151,8 +166,16 @@ impl PersistenceWriter {
                                 let _ = completed.send(());
                             }
                         }
-                        PersistenceCommand::Flush { completed } => {
-                            let _ = completed.send(());
+                        PersistenceCommand::DeleteOlderThan { cutoff, completed } => {
+                            if let Err(error) = storage.delete_older_than(cutoff) {
+                                tracing::warn!(
+                                    error = %error,
+                                    "JobStorage.delete_older_than failed during gc_stale"
+                                );
+                            }
+                            if let Some(completed) = completed {
+                                let _ = completed.send(());
+                            }
                         }
                     }
                 }
@@ -160,6 +183,7 @@ impl PersistenceWriter {
         Ok(Self {
             sender: Some(sender),
             worker: Some(worker),
+            worker_done: Some(Mutex::new(worker_done_rx)),
             circuit,
             wait_for_completion,
         })
@@ -202,23 +226,37 @@ impl PersistenceWriter {
         }
     }
 
-    pub(super) fn flush(&self) {
+    pub(super) fn delete_older_than(&self, cutoff: DateTime<Utc>) {
         let Some(sender) = &self.sender else {
             self.disable("worker_unavailable");
             return;
         };
-        let (completed_tx, completed_rx) = mpsc::sync_channel(0);
-        if sender
-            .send(PersistenceCommand::Flush {
-                completed: completed_tx,
-            })
-            .is_err()
-        {
-            self.disable("worker_unavailable");
+
+        if self.wait_for_completion {
+            let (completed_tx, completed_rx) = mpsc::sync_channel(0);
+            if sender
+                .send(PersistenceCommand::DeleteOlderThan {
+                    cutoff,
+                    completed: Some(completed_tx),
+                })
+                .is_err()
+            {
+                self.disable("worker_unavailable");
+                return;
+            }
+            if completed_rx.recv().is_err() {
+                self.disable("worker_unavailable");
+            }
             return;
         }
-        if completed_rx.recv().is_err() {
-            self.disable("worker_unavailable");
+
+        match sender.try_send(PersistenceCommand::DeleteOlderThan {
+            cutoff,
+            completed: None,
+        }) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => self.disable("queue_full"),
+            Err(TrySendError::Disconnected(_)) => self.disable("worker_unavailable"),
         }
     }
 
@@ -237,8 +275,27 @@ impl PersistenceWriter {
 impl Drop for PersistenceWriter {
     fn drop(&mut self) {
         self.sender.take();
-        if let Some(worker) = self.worker.take() {
+        let Some(worker) = self.worker.take() else {
+            return;
+        };
+        let worker_finished = match self.worker_done.take() {
+            Some(done) => match done.lock().recv_timeout(PERSISTENCE_SHUTDOWN_TIMEOUT) {
+                Ok(()) | Err(RecvTimeoutError::Disconnected) => true,
+                Err(RecvTimeoutError::Timeout) => false,
+            },
+            None => false,
+        };
+        if worker_finished {
             let _ = worker.join();
+        } else {
+            self.disable("shutdown_timeout");
+            tracing::warn!(
+                timeout_ms = PERSISTENCE_SHUTDOWN_TIMEOUT.as_millis(),
+                "job persistence worker did not stop within the bounded shutdown window"
+            );
+            // Rust cannot pre-empt an arbitrary synchronous trait call. Dropping
+            // the JoinHandle detaches that call, while the closed sender and
+            // disabled circuit ensure it cannot accept new manager work.
         }
     }
 }

--- a/crates/dcc-mcp-job/src/job/tests.rs
+++ b/crates/dcc-mcp-job/src/job/tests.rs
@@ -1,5 +1,6 @@
 //! Unit tests for [`crate::job::JobManager`].
 
+use super::persistence::PERSISTENCE_FAILURE_THRESHOLD;
 use super::*;
 use crate::job_storage::{JobFilter, JobStorage, JobStorageError};
 use serde_json::json;
@@ -73,11 +74,101 @@ struct NeverReturningStorage {
     entered: mpsc::SyncSender<()>,
 }
 
+struct ShutdownObservingStorage {
+    put_entered: mpsc::SyncSender<()>,
+    put_release: std::sync::Mutex<mpsc::Receiver<()>>,
+    delete_called: mpsc::SyncSender<()>,
+}
+
+struct FailingDeleteObservingStorage {
+    delete_called: mpsc::SyncSender<()>,
+}
+
 impl std::fmt::Debug for NeverReturningStorage {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("NeverReturningStorage")
             .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for ShutdownObservingStorage {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ShutdownObservingStorage")
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for FailingDeleteObservingStorage {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FailingDeleteObservingStorage")
+            .finish_non_exhaustive()
+    }
+}
+
+impl JobStorage for FailingDeleteObservingStorage {
+    fn put(&self, _job: &Job) -> Result<(), JobStorageError> {
+        Err(JobStorageError::Backend("readonly".to_string()))
+    }
+
+    fn get(&self, _job_id: &str) -> Result<Option<Job>, JobStorageError> {
+        Ok(None)
+    }
+
+    fn list(&self, _filter: JobFilter) -> Result<Vec<Job>, JobStorageError> {
+        Ok(Vec::new())
+    }
+
+    fn update_status(
+        &self,
+        _job_id: &str,
+        _status: JobStatus,
+        _at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), JobStorageError> {
+        Ok(())
+    }
+
+    fn delete_older_than(
+        &self,
+        _cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, JobStorageError> {
+        self.delete_called.send(()).unwrap();
+        Ok(0)
+    }
+}
+
+impl JobStorage for ShutdownObservingStorage {
+    fn put(&self, _job: &Job) -> Result<(), JobStorageError> {
+        self.put_entered.send(()).unwrap();
+        self.put_release.lock().unwrap().recv().unwrap();
+        Ok(())
+    }
+
+    fn get(&self, _job_id: &str) -> Result<Option<Job>, JobStorageError> {
+        Ok(None)
+    }
+
+    fn list(&self, _filter: JobFilter) -> Result<Vec<Job>, JobStorageError> {
+        Ok(Vec::new())
+    }
+
+    fn update_status(
+        &self,
+        _job_id: &str,
+        _status: JobStatus,
+        _at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), JobStorageError> {
+        Ok(())
+    }
+
+    fn delete_older_than(
+        &self,
+        _cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, JobStorageError> {
+        self.delete_called.send(()).unwrap();
+        Ok(0)
     }
 }
 
@@ -773,6 +864,116 @@ fn offloaded_storage_drop_is_bounded_when_backend_never_returns() {
         }
         thread::sleep(Duration::from_millis(10));
     }
+}
+
+#[test]
+fn offloaded_storage_shutdown_timeout_cancels_queued_cleanup() {
+    let (put_entered_tx, put_entered_rx) = mpsc::sync_channel(1);
+    let (put_release_tx, put_release_rx) = mpsc::sync_channel(1);
+    let (delete_called_tx, delete_called_rx) = mpsc::sync_channel(1);
+    let storage = Arc::new(ShutdownObservingStorage {
+        put_entered: put_entered_tx,
+        put_release: std::sync::Mutex::new(put_release_rx),
+        delete_called: delete_called_tx,
+    });
+    let jobs = JobManager::with_offloaded_storage(storage);
+    let job = jobs.create("scene.inspect.queued-cleanup");
+    put_entered_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("storage worker did not enter the blocking put");
+
+    let job_id = job.read().id.clone();
+    jobs.start(&job_id).unwrap();
+    jobs.complete(&job_id, json!({"ok": true})).unwrap();
+    job.write().updated_at = chrono::Utc::now() - chrono::Duration::hours(2);
+    assert_eq!(jobs.cleanup_older_than_hours(1), 1);
+
+    let drop_started = Instant::now();
+    drop(jobs);
+    assert!(
+        drop_started.elapsed() < Duration::from_secs(1),
+        "manager drop exceeded its bounded shutdown window"
+    );
+
+    put_release_tx.send(()).unwrap();
+    assert!(
+        delete_called_rx
+            .recv_timeout(Duration::from_millis(500))
+            .is_err(),
+        "a detached disabled worker executed queued cleanup after manager drop"
+    );
+}
+
+#[test]
+fn offloaded_storage_queue_full_disable_cancels_cleanup_before_backend() {
+    let (put_entered_tx, put_entered_rx) = mpsc::sync_channel(1);
+    let (put_release_tx, put_release_rx) = mpsc::sync_channel(1);
+    let (delete_called_tx, delete_called_rx) = mpsc::sync_channel(1);
+    let storage = Arc::new(ShutdownObservingStorage {
+        put_entered: put_entered_tx,
+        put_release: std::sync::Mutex::new(put_release_rx),
+        delete_called: delete_called_tx,
+    });
+    let jobs = JobManager::with_offloaded_storage(storage);
+    let job = jobs.create("scene.inspect.queue-full-cleanup");
+    put_entered_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("storage worker did not enter the blocking put");
+
+    let job_id = job.read().id.clone();
+    jobs.start(&job_id).unwrap();
+    jobs.complete(&job_id, json!({"ok": true})).unwrap();
+    job.write().updated_at = chrono::Utc::now() - chrono::Duration::hours(2);
+    assert_eq!(jobs.cleanup_older_than_hours(1), 1);
+    for index in 0..65 {
+        jobs.create(format!("scene.inspect.queue-full-cleanup.{index}"));
+    }
+    assert_eq!(
+        jobs.persistence_status(),
+        JobPersistenceStatus {
+            state: JobPersistenceState::Disabled,
+            consecutive_failures: 0,
+            last_error_kind: Some("queue_full".to_string()),
+        }
+    );
+
+    put_release_tx.send(()).unwrap();
+    drop(jobs);
+    assert!(
+        delete_called_rx
+            .recv_timeout(Duration::from_millis(500))
+            .is_err(),
+        "queue-full disable allowed cleanup to reach the backend"
+    );
+}
+
+#[test]
+fn disabled_storage_circuit_rejects_cleanup_before_enqueue() {
+    let (delete_called_tx, delete_called_rx) = mpsc::sync_channel(1);
+    let jobs = JobManager::with_storage(Arc::new(FailingDeleteObservingStorage {
+        delete_called: delete_called_tx,
+    }));
+    for index in 0..PERSISTENCE_FAILURE_THRESHOLD {
+        jobs.create(format!("scene.inspect.disable-before-cleanup.{index}"));
+    }
+    assert_eq!(
+        jobs.persistence_status().state,
+        JobPersistenceState::Disabled
+    );
+
+    let old_job = jobs.create("scene.inspect.disabled-cleanup");
+    let old_job_id = old_job.read().id.clone();
+    jobs.start(&old_job_id).unwrap();
+    jobs.complete(&old_job_id, json!({"ok": true})).unwrap();
+    old_job.write().updated_at = chrono::Utc::now() - chrono::Duration::hours(2);
+    assert_eq!(jobs.cleanup_older_than_hours(1), 1);
+
+    assert!(
+        delete_called_rx
+            .recv_timeout(Duration::from_millis(100))
+            .is_err(),
+        "a disabled persistence circuit accepted cleanup backend I/O"
+    );
 }
 
 #[test]

--- a/crates/dcc-mcp-job/src/job/tests.rs
+++ b/crates/dcc-mcp-job/src/job/tests.rs
@@ -69,6 +69,51 @@ impl std::fmt::Debug for BlockingStorage {
     }
 }
 
+struct NeverReturningStorage {
+    entered: mpsc::SyncSender<()>,
+}
+
+impl std::fmt::Debug for NeverReturningStorage {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("NeverReturningStorage")
+            .finish_non_exhaustive()
+    }
+}
+
+impl JobStorage for NeverReturningStorage {
+    fn put(&self, _job: &Job) -> Result<(), JobStorageError> {
+        self.entered.send(()).unwrap();
+        loop {
+            thread::park();
+        }
+    }
+
+    fn get(&self, _job_id: &str) -> Result<Option<Job>, JobStorageError> {
+        Ok(None)
+    }
+
+    fn list(&self, _filter: JobFilter) -> Result<Vec<Job>, JobStorageError> {
+        Ok(Vec::new())
+    }
+
+    fn update_status(
+        &self,
+        _job_id: &str,
+        _status: JobStatus,
+        _at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), JobStorageError> {
+        Ok(())
+    }
+
+    fn delete_older_than(
+        &self,
+        _cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, JobStorageError> {
+        Ok(0)
+    }
+}
+
 impl JobStorage for BlockingStorage {
     fn put(&self, _job: &Job) -> Result<(), JobStorageError> {
         self.entered.send(()).unwrap();
@@ -656,6 +701,78 @@ fn offloaded_storage_flushes_job_lifecycle_in_fifo_order_on_drop() {
         *storage.statuses.lock().unwrap(),
         [JobStatus::Pending, JobStatus::Running, JobStatus::Completed,]
     );
+}
+
+#[test]
+fn offloaded_storage_drop_is_bounded_when_backend_never_returns() {
+    const HELPER_ENV: &str = "DCC_MCP_TEST_BLOCKED_PERSISTENCE_DROP_HELPER";
+    const READY_PATH_ENV: &str = "DCC_MCP_TEST_BLOCKED_PERSISTENCE_DROP_READY_PATH";
+    const TEST_NAME: &str =
+        "job::tests::offloaded_storage_drop_is_bounded_when_backend_never_returns";
+
+    if std::env::var_os(HELPER_ENV).is_some() {
+        let ready_path = std::path::PathBuf::from(
+            std::env::var_os(READY_PATH_ENV).expect("watchdog helper ready path is missing"),
+        );
+        let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+        let jobs = JobManager::with_offloaded_storage(Arc::new(NeverReturningStorage {
+            entered: entered_tx,
+        }));
+        jobs.create("scene.inspect.blocked-drop");
+        entered_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("storage worker did not enter the blocking put");
+        std::fs::write(ready_path, b"ready").expect("failed to publish watchdog ready marker");
+        drop(jobs);
+        return;
+    }
+
+    let ready_path = std::env::temp_dir().join(format!(
+        "dcc-mcp-persistence-drop-{}-{}.ready",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+        .arg(TEST_NAME)
+        .arg("--exact")
+        .env(HELPER_ENV, "1")
+        .env(READY_PATH_ENV, &ready_path)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to spawn persistence-drop watchdog helper");
+
+    let ready_deadline = Instant::now() + Duration::from_secs(5);
+    while !ready_path.is_file() {
+        if let Some(status) = child.try_wait().unwrap() {
+            let _ = std::fs::remove_file(&ready_path);
+            panic!("watchdog helper exited before ready with {status}");
+        }
+        if Instant::now() >= ready_deadline {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            let _ = std::fs::remove_file(&ready_path);
+            panic!("watchdog helper did not enter the blocked storage call within 5 seconds");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            let _ = std::fs::remove_file(&ready_path);
+            assert!(status.success(), "watchdog helper exited with {status}");
+            break;
+        }
+        if Instant::now() >= deadline {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            let _ = std::fs::remove_file(&ready_path);
+            panic!("dropping a blocked persistence writer did not finish within 1 second");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- queue stale-job deletion on the bounded persistence FIFO so cleanup cannot starve the HTTP runtime
- bound persistence-worker shutdown and fail closed when a synchronous backend never returns
- add an actual Dedicated Router regression and a subprocess Drop watchdog

## Validation
- `vx cargo nextest run --workspace --no-fail-fast --status-level fail` (3760 passed)
- `vx cargo test --workspace --doc`
- `vx cargo test -p dcc-mcp-job --features job-persist-sqlite`
- `vx cargo test -p dcc-mcp-http --features job-persist-sqlite`
- focused Router and Drop regressions repeated 10/10
- clippy, fmt, Hakari, diff and Rust file-size checks

`just preflight` also exposed two unrelated intermittent fixtures (CLI process-tree timing and marketplace loopback reset); both were isolated, while the full non-fail-fast workspace run passed.

No real DCC, operator gateway, or port 9765 was used. Existing write-threshold, reset, FIFO, in-memory, redaction, and blocked-put health contracts remain unchanged.

Closes #2378
Refs #2277
Refs #2376
Refs #2377